### PR TITLE
chore(playlists): youtube backfill — +574 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
+++ b/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
@@ -1,6 +1,6 @@
 {
   "name": "Tomorrowland Top 1000",
-  "version": "0.44",
+  "version": "0.52",
   "tags": [
     "edm",
     "electronic",
@@ -11450,7 +11450,7 @@
       "year": 2016,
       "isrc": "GB9TP1500674",
       "uri": "spotify:track:0n88HmRZGQew4UN1QaVY3A",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=OyDg-VeCz6I",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/118168904",
       "fun_fact": "“Exhale - Original Mix” appears on Amelie Lens’s release “Exhale”.",
@@ -11474,7 +11474,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1445033600"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cwVAwISmI08",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/353141091",
       "fun_fact": "“Down - Franky Rizardo Remix” is the title track of Marian Hill’s release of the same name.",
@@ -11498,7 +11498,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440829541"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=JDglMK9sgIQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/90632835",
       "fun_fact": "“The Days” appears on Avicii’s release “The Days / Nights (EP)”.",
@@ -11522,7 +11522,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1711713806"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=b4ZuXajqL8M",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2516525761",
       "fun_fact": "“If U Need It” is the title track of Sammy Virji’s release of the same name.",
@@ -11546,7 +11546,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/736759055"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cXTgrHruvoo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/72164207",
       "fun_fact": "“Exceeder” is the title track of Mason’s release of the same name.",
@@ -11570,7 +11570,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1470939103"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UXY_27JJpeY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/705139962",
       "fun_fact": "“Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) - Tiësto Remix” appears on Martin Garrix’s release “Summer Days (feat. Macklemore & Patrick Stump of Fall Out Boy) (Remixes)”.",
@@ -11594,7 +11594,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1680178523"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cAjtVN6QJ-M",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2225841857",
       "fun_fact": "“So Much In Love” is the title track of D.O.D’s release of the same name.",
@@ -11614,7 +11614,7 @@
       "year": 2022,
       "isrc": "GBEWA2201970",
       "uri": "spotify:track:0KU8W0lHfsNlH7lfV1dz29",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=h8KXcIedur8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1711594307",
       "fun_fact": "“Gratitude” is the title track of Above & Beyond’s release of the same name.",
@@ -11634,7 +11634,7 @@
       "year": 2006,
       "isrc": "DEBE71400074",
       "uri": "spotify:track:0IvBzwnja9ElmpWKYfBz7i",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VaQXQdh3698",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1914504267",
       "fun_fact": "“Body Language” appears on M.A.N.D.Y.’s release “Get Physical, Vol II. - 4th Anniversary”.",
@@ -11662,7 +11662,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1712042703"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=V775PPuBc7Y",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/489393822",
       "fun_fact": "“Riverside” is the title track of Sidney Samson’s release of the same name.",
@@ -11682,7 +11682,7 @@
       "year": 2024,
       "isrc": "NL8RL2409745",
       "uri": "spotify:track:5vASuVQkngtFoCOczem52V",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=OsYwX5WSj0w",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2713318481",
       "fun_fact": "“On Again” is the title track of Mau P’s release of the same name.",
@@ -11702,7 +11702,7 @@
       "year": 2019,
       "isrc": "CYA221900072",
       "uri": "spotify:track:6JieX6GcqcsXtaKK0OewXI",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TY1JoFjIGyY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/648099672",
       "fun_fact": "“Bring It Back - Afrojack x Sunnery James & Ryan Marciano Edit” is the title track of Jewelz & Sparks’s release of the same name.",
@@ -11726,7 +11726,7 @@
       "year": 2007,
       "isrc": "BEP010700002",
       "uri": "spotify:track:0tdxwIjvZq1SXuyghptjRO",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9d4yRb4HOgE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3842078",
       "fun_fact": "“You Gonna Want Me - Tocadisco Remix” appears on Tiga’s release “You Gonna Want Me Remixes”.",
@@ -11746,7 +11746,7 @@
       "year": 2019,
       "isrc": "NLF711909593",
       "uri": "spotify:track:1Q7FZie2f2sJjfI5svBjGR",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=R9_TlvhMmxU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/742337762",
       "fun_fact": "“Mr. Navigator” is the title track of Armin van Buuren’s release of the same name.",
@@ -11770,7 +11770,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1816495432"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UgiqJxYCuh8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/614229602",
       "fun_fact": "“Southern Sun - Tiësto Remix” appears on Paul Oakenfold’s release “Trance Top 1000 - The Legends”.",
@@ -11794,7 +11794,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1824492347"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=MEQMkzjcLEA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/7703889",
       "fun_fact": "“Some Chords” appears on deadmau5’s release “4x4=12”.",
@@ -11818,7 +11818,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1671893661"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=OvW5y3lZ7rc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2140510037",
       "fun_fact": "“Rhyme Dust” is the title track of MK’s release of the same name.",
@@ -11842,7 +11842,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1616792067"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0nS0accElcA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1702170497",
       "fun_fact": "“Intro” appears on Alan Braxe’s release “Running”.",
@@ -11862,7 +11862,7 @@
       "year": 2005,
       "isrc": "GBKCF0500001",
       "uri": "spotify:track:4PQCrz4sk00dIEmkwmmJCr",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0ln4sXiogT8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/73460554",
       "fun_fact": "“Together - Radio Edit” appears on Axwell’s release “Together”.",
@@ -11886,7 +11886,7 @@
       "year": 2022,
       "isrc": "NLQ8D2200576",
       "uri": "spotify:track:3Y6CWrNdkuaJ5iW2Y829fU",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Dau970LiXik",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1754979757",
       "fun_fact": "“INTO THE UNKNOWN” is the title track of Hardwell’s release of the same name.",
@@ -11914,7 +11914,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1335982355"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SlbVgjFvE3I",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/453070472",
       "fun_fact": "“It Makes You Forget (Itgehane)” is the title track of Peggy Gou’s release of the same name.",
@@ -11938,7 +11938,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1008376256"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6xRVHGW1p6g",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/102517920",
       "fun_fact": "“Cloud Rider - Radio Edit” is the title track of Paul Kalkbrenner’s release of the same name.",
@@ -11958,7 +11958,7 @@
       "year": 2013,
       "isrc": "NLF711302154",
       "uri": "spotify:track:1RDSc1VEq75TxyFOMgtWTu",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VVoiG8LEQ8c",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/73161904",
       "fun_fact": "“D# Fat - Original Mix” appears on Armin van Buuren’s release “Armin van Buuren's 2013 Top 20”.",
@@ -11982,7 +11982,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1783796586"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=aeBaSrJmTMk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3130053941",
       "fun_fact": "“WACUKA” is the title track of AVAION’s release of the same name.",
@@ -12006,7 +12006,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1522307425"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Cbvqv19Nf0E",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/459402542",
       "fun_fact": "“Chemicals (feat. Thomas Troelsen)” is the title track of Tiësto’s release of the same name.",
@@ -12030,7 +12030,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/27516016"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=82nnEv_f3jQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3752089",
       "fun_fact": "“Stupidisco - Radio Edit” appears on Junior Jack’s release “Stupidisco”.",
@@ -12050,7 +12050,7 @@
       "year": 2003,
       "isrc": "DEW760300013",
       "uri": "spotify:track:5qwtQRNEhvzSEX4hrdDmRT",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BuxM6OQKIOw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/107189498",
       "fun_fact": "“Nothing but You” appears on Paul van Dyk’s release “Reflections”.",
@@ -12070,7 +12070,7 @@
       "year": 2025,
       "isrc": "GBARL2500597",
       "uri": "spotify:track:6PTgSuFz9JqQ1o0jTYOuvX",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qXnqZo03PHY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3346153791",
       "fun_fact": "“Dior (feat. Chrystal)” is the title track of MK’s release of the same name.",
@@ -12098,7 +12098,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1439646399"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cC--BM0nS_g",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2458905765",
       "fun_fact": "“Offspring” is the title track of Deorro’s release of the same name.",
@@ -12122,7 +12122,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1700707219"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=peIBCNTY8hA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2387490225",
       "fun_fact": "“adore u” is the title track of Fred again..’s release of the same name.",
@@ -12146,7 +12146,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1522568457"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=3c2nTiN152I",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1021141692",
       "fun_fact": "“Kill Me Slow” appears on David Guetta’s release “New Rave”.",
@@ -12170,7 +12170,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1529897576"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zzS3QEs5OYc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/617706652",
       "fun_fact": "“No Good” is the title track of Zonderling’s release of the same name.",
@@ -12194,7 +12194,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1545486756"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uXW_KO_ibpw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1157163952",
       "fun_fact": "“On The Beach - Kryder Remix” is the title track of YORK’s release of the same name.",
@@ -12214,7 +12214,7 @@
       "year": 2014,
       "isrc": "DEU671400168",
       "uri": "spotify:track:15Kj9518XjY106556JirJN",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xOraZdM-5qU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/114019834",
       "fun_fact": "“Cassiopeia” appears on Kölsch’s release “Chalet Beat No.3 - The Sound of Kitz Alps @ Maierl (Compiled by DJ Hoody)”.",
@@ -12238,7 +12238,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1491498703"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=3sg69ZVaB0k",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1856132307",
       "fun_fact": "“Tomorrowland Anthem 2012” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
@@ -12262,7 +12262,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1646563203"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=sO2-iFjjht4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1939641377",
       "fun_fact": "“Go Deep” appears on Janet Jackson’s release “The Velvet Rope (Deluxe Edition)”.",
@@ -12282,7 +12282,7 @@
       "year": 2022,
       "isrc": "USUG12106541",
       "uri": "spotify:track:7kfOEMJBJwdCYqyJeEnNhr",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=u9n7Cw-4_HQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1713175757",
       "fun_fact": "“Moth To A Flame (with The Weeknd)” appears on Swedish House Mafia’s release “Moth To A Flame (Extended Mix)”.",
@@ -12306,7 +12306,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1714356981"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=caGqOq1C84A",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2423179905",
       "fun_fact": "“Stop It” appears on FISHER’s release “Oi Oi”.",
@@ -12330,7 +12330,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1605836514"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ApKn4tObiw8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1638044832",
       "fun_fact": "“Human Touch - Club Mix” appears on Armin van Buuren’s release “A State Of Trance Top 20 - 2022, Vol. 1 (Selected by Armin van Buuren)”.",
@@ -12354,7 +12354,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1821679624"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7GUUSOn_fMQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3422311161",
       "fun_fact": "“At Night - Anyma x Layton Giordani Remix” is the title track of Shakedown’s release of the same name.",
@@ -12378,7 +12378,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1540621480"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gedVVorMdTw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/730452542",
       "fun_fact": "“Sorry - James Hype Remix” is the title track of Joel Corry’s release of the same name.",
@@ -12398,7 +12398,7 @@
       "year": 2012,
       "isrc": "USUM71210665",
       "uri": "spotify:track:6xzCQrXrn0uOOKBQZK1zsF",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ZLDv3ONUbE0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/60904703",
       "fun_fact": "“Fall Into The Sky” appears on Zedd’s release “Clarity”.",
@@ -12422,7 +12422,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1492468715"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=sFtdC_bnpOw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/899944182",
       "fun_fact": "“Do It For You” is the title track of W&W’s release of the same name.",
@@ -12446,7 +12446,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1710919875"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=tmsnfW9WVws",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2489733441",
       "fun_fact": "“Sunshine - Original Mix” appears on Tomaz’s release “Sunshine (Remixes 2012)”.",
@@ -12470,7 +12470,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1712706732"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ie2RI2dvuqY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/121592908",
       "fun_fact": "“Higher” is the title track of Jauz’s release of the same name.",
@@ -12490,7 +12490,7 @@
       "year": 2009,
       "isrc": "DEBL60823924",
       "uri": "spotify:track:2Jq1MiIjBwTmMbSWhTqKGj",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=21SYFRu_2BI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3045641",
       "fun_fact": "“Last Forever - Original Vocal Mix” appears on Tristan Garner’s release “French Dancefloor, Vol. 1”.",
@@ -12514,7 +12514,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1522568459"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=n0oyk2kOz3A",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1021141702",
       "fun_fact": "“Nothing” appears on David Guetta’s release “New Rave”.",
@@ -12538,7 +12538,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1713313597"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=RHnVcEubpUA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2722493482",
       "fun_fact": "“Higher Power” appears on Anyma’s release “Genesys II”.",
@@ -12562,7 +12562,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1433857703"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=EzSurD5iwtg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3495343691",
       "fun_fact": "“1998 - Paul van Dyk Remix” appears on Binary Finary’s release “Reactivate 13 (Beats, Chance & Liquid Trance)”.",
@@ -12586,7 +12586,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1394018252"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VKtTSoC7o2I",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/508544952",
       "fun_fact": "“Your Love” is the title track of David Guetta’s release of the same name.",
@@ -12610,7 +12610,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1846394100"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Fhg67yJGAFg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3604108432",
       "fun_fact": "“Positive” is the title track of Jamback’s release of the same name.",
@@ -12630,7 +12630,7 @@
       "year": 2025,
       "isrc": "NLF712506043",
       "uri": "spotify:track:10CqUpXoP0EK9ElNWtG4yD",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mXW08LeXgRY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3549735831",
       "fun_fact": "“It Feels So Good - The Conductor & The Cowboy Amnesia Mix” appears on Sonique’s release “It Feels So Good (The Conductor & The Cowboy Mixes)”.",
@@ -12658,7 +12658,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1757932090"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ZI03raH_EhQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2894989171",
       "fun_fact": "“Dun Dun” is the title track of Cassian’s release of the same name.",
@@ -12682,7 +12682,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1495693993"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=iuLuWeq45_0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/857196092",
       "fun_fact": "“Halfway There (feat. Lena Leon)” appears on Tiësto’s release “Together”.",
@@ -12706,7 +12706,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1668459118"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HvvECHLHKrM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2127304097",
       "fun_fact": "“Clouds” is the title track of BUNT.’s release of the same name.",
@@ -12726,7 +12726,7 @@
       "year": 2022,
       "isrc": "GBCPZ2221055",
       "uri": "spotify:track:1KbLVz3ZcdUOt2wBXqU2cG",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=a6nw8XxdDu4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3156144391",
       "fun_fact": "“What A Life” is the title track of John Summit’s release of the same name.",
@@ -12750,7 +12750,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1756123461"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=JE4WUGzU76I",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2881740792",
       "fun_fact": "“Say Yeah” is the title track of James Hype’s release of the same name.",
@@ -12770,7 +12770,7 @@
       "year": 2024,
       "isrc": "USZ4V2300296",
       "uri": "spotify:track:66K8ybDmccnR9sLlDQuU3g",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UjQQ9jg5JHU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3470988611",
       "fun_fact": "“Stay High (feat. Julia Church) - Extended” appears on Diplo’s release “Stay High (feat. Julia Church) (Remixes)”.",
@@ -12794,7 +12794,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1755071026"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=3dBFTf8jWYg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2871918512",
       "fun_fact": "“Never Walk Alone” is the title track of BLOND:ISH’s release of the same name.",
@@ -12814,7 +12814,7 @@
       "year": 2022,
       "isrc": "USUG12206712",
       "uri": "spotify:track:1bgKMxPQU7JIZEhNsM1vFs",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zIJEOEZdLzE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1896638567",
       "fun_fact": "“Words (feat. Zara Larsson)” appears on Alesso’s release “Words (Remixes)”.",
@@ -12834,7 +12834,7 @@
       "year": 2018,
       "isrc": "NLZ541801677",
       "uri": "spotify:track:5WxtmHAcrDbghHVGupu18h",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=M_PXXaubbyc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/606882782",
       "fun_fact": "“Save Me (feat. MKLA)” is the title track of Vintage Culture’s release of the same name.",
@@ -12858,7 +12858,7 @@
       "year": 1997,
       "isrc": "GBAJH0602036",
       "uri": "spotify:track:0e8C9dPERvvARURkNOFrrC",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=NLCHARjjrws",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3806165162",
       "fun_fact": "“Go” appears on Moby’s release “Go - The Very Best of Moby (Deluxe)”.",
@@ -12886,7 +12886,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1637861831"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=iOqPxhV3Km0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1851048117",
       "fun_fact": "“I Want You” is the title track of La Fuente’s release of the same name.",
@@ -12906,7 +12906,7 @@
       "year": 1999,
       "isrc": "NLF710801523",
       "uri": "spotify:track:3Xoqg8LNJaGYvnpdsIYmOh",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=bn1ycNxQMvk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/88824755",
       "fun_fact": "“Communication” appears on Armin van Buuren’s release “Armin Anthems (Ultimate Singles Collected)”.",
@@ -12934,7 +12934,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1744599886"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nfpmMNU-CpY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2782517712",
       "fun_fact": "“Desire” is the title track of CHRIS STASSY’s release of the same name.",
@@ -12954,7 +12954,7 @@
       "year": 2019,
       "isrc": "NLZ541900920",
       "uri": "spotify:track:55EiIt05opIWOahPsVMswf",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=bwN9sFNmhBo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/708664602",
       "fun_fact": "“My Best Life (feat. Mike Waters)” is the title track of KSHMR’s release of the same name.",
@@ -12978,7 +12978,7 @@
       "year": 2013,
       "isrc": "GBTDG1302507",
       "uri": "spotify:track:68lTEhMEx4MxDCJypT6bXE",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qceiRQrdwFU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1951192377",
       "fun_fact": "“Escape - John Summit Remix” is the title track of deadmau5’s release of the same name.",
@@ -13002,7 +13002,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1828200670"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mqC_MXE83ck",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3472405361",
       "fun_fact": "“Yosemite” is the title track of KETTAMA’s release of the same name.",
@@ -13022,7 +13022,7 @@
       "year": 2018,
       "isrc": "NLM5S1800332",
       "uri": "spotify:track:7IWTIkiWGWNQyYfOLdMrGD",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=DylzGXE_ibU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/554315042",
       "fun_fact": "“Burn Out (feat. Dewain Whitmore)” is the title track of Martin Garrix’s release of the same name.",
@@ -13046,7 +13046,7 @@
       "year": 2024,
       "isrc": "UKWLG2400013",
       "uri": "spotify:track:331l3xABO0HMr1Kkyh2LZq",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=dSDbwfXX5_I",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2715243342",
       "fun_fact": "“I Don't Wanna Wait” is the title track of David Guetta’s release of the same name.",
@@ -13074,7 +13074,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1711795423"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=A3zVutltCT8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/454471802",
       "fun_fact": "“The Girl You Lost To Cocaine - Sander van Doorn Remix” appears on Sia’s release “Big Room Bangers, Vol. 23”.",
@@ -13094,7 +13094,7 @@
       "year": 2017,
       "isrc": "NLF711706976",
       "uri": "spotify:track:05GvwwTLLID738BbKN1ze0",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=s3O8-vodvKI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/378940811",
       "fun_fact": "“Because You Move Me” is the title track of Tinlicker’s release of the same name.",
@@ -13122,7 +13122,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1696160175"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=bE3Kvqyef_E",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2358398035",
       "fun_fact": "“Disconnect” is the title track of Becky Hill’s release of the same name.",
@@ -13142,7 +13142,7 @@
       "year": 2019,
       "isrc": "SENAA1900201",
       "uri": "spotify:track:1o8ppmUhxi6d5qZF1NKIub",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=RKoI35jZhCE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/706758732",
       "fun_fact": "“American Boy - Lost Frequencies Remix” is the title track of Estelle’s release of the same name.",
@@ -13162,7 +13162,7 @@
       "year": 2013,
       "isrc": "DENZ71300062",
       "uri": "spotify:track:6eIzXu8Wt69bMgRYIcGPZ3",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=IwCUnmqwr_s",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1761983437",
       "fun_fact": "“Square 1” appears on Paul Kalkbrenner’s release “Berlin Calling (The Soundtrack by Paul Kalkbrenner)”.",
@@ -13190,7 +13190,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1336611719"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=W46raxKFk2Y",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/452699282",
       "fun_fact": "“AnyTime” is the title track of Don Diablo’s release of the same name.",
@@ -13210,7 +13210,7 @@
       "year": 2023,
       "isrc": "USUG12303579",
       "uri": "spotify:track:4NH496Sf2JEOvDRxEuIBc4",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FsJ8zB2yAig",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2300219515",
       "fun_fact": "“Without You” is the title track of Alesso’s release of the same name.",
@@ -13238,7 +13238,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1735803279"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=NbY-cZApCSQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2702569332",
       "fun_fact": "“Kisses (feat. bbyclose)” is the title track of BL3SS’s release of the same name.",
@@ -13262,7 +13262,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1650248631"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nCTmUMGgwu0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2000315707",
       "fun_fact": "“Brighter Days - Marco Lys Remix” appears on Cajmere’s release “Brighter Days (30 Year Anniversary Remixes)”.",
@@ -13286,7 +13286,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1856648159"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=2fH7NNKphgQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2346264355",
       "fun_fact": "“Magenta - Radio Edit” appears on Arno Cost’s release “Magenta”.",
@@ -13306,7 +13306,7 @@
       "year": 2006,
       "isrc": "AUVC00604311",
       "uri": "spotify:track:2WMur8xCATjMHLgpPHdosc",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=eO9WyBdWZPc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1496284002",
       "fun_fact": "“It's Too Late - Dirty South Radio Edit” appears on Dirty South’s release “It's Too Late”.",
@@ -13334,7 +13334,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1575570551"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YOYCOs_4b0U",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1426994352",
       "fun_fact": "“Paper Planes” is the title track of Lucas & Steve’s release of the same name.",
@@ -13358,7 +13358,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1834455173"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1ZjkfZ6v6v4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3517242671",
       "fun_fact": "“Concorde” is the title track of Miss Monique’s release of the same name.",
@@ -13378,7 +13378,7 @@
       "year": 2001,
       "isrc": "FRZ020182380",
       "uri": "spotify:track:5h1xmefdnY2Y4zld4jnvoE",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=MelyDrP8WEw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/956264572",
       "fun_fact": "“Madan - Remix” appears on Salif Keita’s release “Moffou”.",
@@ -13402,7 +13402,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1744030898"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6ba3tOZl8KI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2780960761",
       "fun_fact": "“Hypnotize” appears on Alesso’s release “Hypnotize EP”.",
@@ -13422,7 +13422,7 @@
       "year": 2021,
       "isrc": "USZ4V2100192",
       "uri": "spotify:track:50YQaQXog18lS11wGCl77u",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XuGPLqjqeGE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1489483142",
       "fun_fact": "“Promises” is the title track of Diplo’s release of the same name.",
@@ -13450,7 +13450,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1741634639"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=LmFfiXI0P84",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2757424031",
       "fun_fact": "“Summertime Blues (feat. Nathan Nicholson)” appears on Chris Lake’s release “Summertime Blues”.",
@@ -13474,7 +13474,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1349390936"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qTGnaB7bi7w",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/462500082",
       "fun_fact": "“Sensational - Zonderling Remix” appears on Sam Feldt’s release “After The Sunset”.",
@@ -13498,7 +13498,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1572313320"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=aVTalm2VjDc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1496292952",
       "fun_fact": "“Beyond Beliefs” appears on Ben Böhmer’s release “Begin Again”.",
@@ -13522,7 +13522,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1838005011"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vo8SyrrTtsY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3635742072",
       "fun_fact": "“crystallized (feat. Inéz)” appears on John Summit’s release “crystallized (feat. Inéz) - Subtronics Remix”.",
@@ -13542,7 +13542,7 @@
       "year": 2014,
       "isrc": "NLF711502765",
       "uri": "spotify:track:1Mys1gf9SkMBAVGGxpkJ7d",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qOol3U6KOTk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/100654376",
       "fun_fact": "“Reality” is the title track of Lost Frequencies’s release of the same name.",
@@ -13566,7 +13566,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1735975299"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=b_aFZXTGZeM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2703793952",
       "fun_fact": "“The Scientist” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
@@ -13590,7 +13590,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1888486791"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=OtC5OgHUT5k",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3925291921",
       "fun_fact": "“Thanks To You (ft. Bonn)” appears on Steve Aoki’s release “HiROQUEST 3: Paragon”.",
@@ -13614,7 +13614,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1833096250"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=KSrOYPQiyFA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/459413432",
       "fun_fact": "“Can't Stop Playing (Makes Me High) [feat. Ane Brun] - Oliver Heldens & Gregor Salto Vocal Mix Edit” appears on DR. KUCHO!’s release “Can't Stop Playing (Remixes)”.",
@@ -13638,7 +13638,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1566331892"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mnj7kpuK9L0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1365164262",
       "fun_fact": "“Piano Banana” is the title track of Krystal Klear’s release of the same name.",
@@ -13662,7 +13662,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1577507503"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=5cJhtbNEEYo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/767730962",
       "fun_fact": "“Carte Blanche - FM Edit” appears on Veracocha’s release “Carte Blanche”.",

--- a/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
+++ b/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
@@ -1,6 +1,6 @@
 {
   "name": "Tomorrowland Top 1000",
-  "version": "0.60",
+  "version": "0.68",
   "tags": [
     "edm",
     "electronic",
@@ -15945,7 +15945,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1811354631"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=dKACYQWuaJM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3344814521",
       "fun_fact": "“Sweet Disposition (a moment, a love)” is the title track of Lost Frequencies’s release of the same name.",
@@ -15969,7 +15969,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1613029099"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-HO3Nx9enTA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1675401917",
       "fun_fact": "“Finder - Radio-Edit” appears on Ninetoes’s release “Finder”.",
@@ -15989,7 +15989,7 @@
       "year": 2020,
       "isrc": "GBCPZ2017509",
       "uri": "spotify:track:3z1liIZgam8CRi8CaNKyrJ",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-6xzyJPhwFk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3156086611",
       "fun_fact": "“Mvinline” is the title track of Boys Noize’s release of the same name.",
@@ -16013,7 +16013,7 @@
       "year": 2004,
       "isrc": "FR1HA0407110",
       "uri": "spotify:track:6M3dYowAaxq2oSPHp1ctwM",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=2qzEEISZYbI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/6556777",
       "fun_fact": "“Les Djinns - Trentemoeller Remix” appears on Djuma Soundsystem’s release “Kumharas Ibiza vol.2”.",
@@ -16033,7 +16033,7 @@
       "year": 2013,
       "isrc": "GBUM71504757",
       "uri": "spotify:track:0OpcI3rARLsNWgVbPdwHD9",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wgQo6kB17aw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/105355288",
       "fun_fact": "“You Know You Like It - Tchami Remix” appears on AlunaGeorge’s release “We Are Your Friends (Music From The Original Motion Picture)”.",
@@ -16061,7 +16061,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1452627120"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Gpspgp3QQqo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/79727550",
       "fun_fact": "“Avaritia” appears on deadmau5’s release “while(1<2)”.",
@@ -16081,7 +16081,7 @@
       "year": 2025,
       "isrc": "NL8RL2530184",
       "uri": "spotify:track:6qJhrI2BMuA8qHcmycD3fL",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rVp454wjqls",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3412358741",
       "fun_fact": "“TESLA” is the title track of Mau P’s release of the same name.",
@@ -16105,7 +16105,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/720164944"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=j1nIjW5OkQ0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/71301806",
       "fun_fact": "“Got A Feeling - Bontan Remix / Pleasurekraft Edit” appears on Josh Butler’s release “Songs for Clubs 2”.",
@@ -16129,7 +16129,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1600252153"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8oT4NWfrZ1g",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1590238412",
       "fun_fact": "“Anywhere With You - Festival Mix” appears on AFROJACK’s release “Anywhere With You”.",
@@ -16149,7 +16149,7 @@
       "year": 1997,
       "isrc": "GBCPZ1408130",
       "uri": "spotify:track:4xZNOqID5j9vu2kjSK95il",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=J7rItS9oXpQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3157347101",
       "fun_fact": "“Work - Original Mix” appears on Masters At Work’s release “Defected presents House Masters - Masters At Work”.",
@@ -16173,7 +16173,7 @@
       "year": 2010,
       "isrc": "GBCPZ1004170",
       "uri": "spotify:track:3PPbRrWqas3IjoFZTTTPkn",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uKbBpx8fJhM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3155502691",
       "fun_fact": "“Hey Hey - Radio Edit” appears on Dennis Ferrer’s release “Hey Hey”.",
@@ -16201,7 +16201,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/6767014741"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uVhi7XbHjGE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3670988772",
       "fun_fact": "“I Run” is the title track of HAVEN.’s release of the same name.",
@@ -16221,7 +16221,7 @@
       "year": 2000,
       "isrc": "NLS240600254",
       "uri": "spotify:track:3P4WggZjuyThPXzVUHay17",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Zu4XQXf7w5M",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1584444782",
       "fun_fact": "“Janeiro - Original Mix” appears on Solid Sessions’s release “Janeiro”.",
@@ -16249,7 +16249,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1711795897"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zdeP1PTg9cI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/22502021",
       "fun_fact": "“Hustle Up” appears on John Dahlbäck’s release “Hustle Up / Watch Me”.",
@@ -16273,7 +16273,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1762715188"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=N9RrlA69WvU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1665611132",
       "fun_fact": "“Sun Came Up” appears on SOFI TUKKER’s release “WET TENNIS”.",
@@ -16293,7 +16293,7 @@
       "year": 2024,
       "isrc": "DEEC33501671",
       "uri": "spotify:track:2GwsSbo6IbNDVvcm9rtmal",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1EVeFp-oKZg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3026091641",
       "fun_fact": "“Say What” is the title track of Rampa’s release of the same name.",
@@ -16317,7 +16317,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1400673010"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ums8n8tTL6M",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/515304252",
       "fun_fact": "“The Space In Between - Ben Böhmer Remix” is the title track of Jan Blomqvist’s release of the same name.",
@@ -16341,7 +16341,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1532019310"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nCg3ufihKyU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1087667882",
       "fun_fact": "“The Business” is the title track of Tiësto’s release of the same name.",
@@ -16361,7 +16361,7 @@
       "year": 2018,
       "isrc": "NLM5S1800414",
       "uri": "spotify:track:58ctD8HaEUXJkdv7TTsmG8",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9FYxOEb8HJE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/594373472",
       "fun_fact": "“Dreamer - Nicky Romero Remix” appears on Martin Garrix’s release “Dreamer (Remixes Vol. 1)”.",
@@ -16389,7 +16389,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1336554980"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=souJM4aCk6w",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/452689552",
       "fun_fact": "“Drop That Low (When I Dip)” is the title track of Tujamo’s release of the same name.",
@@ -16413,7 +16413,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1832008809"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XEkrCrWw6sc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3519927181",
       "fun_fact": "“Body” is the title track of Topic’s release of the same name.",
@@ -16433,7 +16433,7 @@
       "year": 2013,
       "isrc": "GBAHT1300264",
       "uri": "spotify:track:4ce29VAx1D8f3HULOHHA3K",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=2aEBlLMyN_0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/66890889",
       "fun_fact": "“LRAD” appears on Knife Party’s release “Haunted House”.",
@@ -16457,7 +16457,7 @@
       "year": 2024,
       "isrc": "UKWLG2400113",
       "uri": "spotify:track:2FI0dWAzVHaZtaZv8pWS8s",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_AfmgOpoCHI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3060347951",
       "fun_fact": "“Forever Young (feat. Ava Max) - Hypaton Remix” appears on David Guetta’s release “Forever Young (Hypaton Remix)”.",
@@ -16481,7 +16481,7 @@
       "year": 2015,
       "isrc": "GBCEN1401100",
       "uri": "spotify:track:7BhoFVTlo0gZeG7CNzcbRL",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wmAmTN_Pda8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2347317135",
       "fun_fact": "“Promesses - Radio Edit” appears on Tchami’s release “Promesses”.",
@@ -16505,7 +16505,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1797756367"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=IBU3ai0oN3E",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3244352251",
       "fun_fact": "“una noche con hugel” is the title track of HUGEL’s release of the same name.",
@@ -16529,7 +16529,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/500886602"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VjEzaV2JmcU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/16501711",
       "fun_fact": "“Breakn' a Sweat - Zedd Remix” is the title track of Skrillex’s release of the same name.",
@@ -16549,7 +16549,7 @@
       "year": 2014,
       "isrc": "GBD581400001",
       "uri": "spotify:track:3PgSGAq2cOat72laH7uKFn",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8wRW57nBLMI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3806585392",
       "fun_fact": "“I Wanna Feel - Radio Edit” appears on Secondcity’s release “I Wanna Feel”.",
@@ -16573,7 +16573,7 @@
       "year": 2010,
       "isrc": "GBTDG1000190",
       "uri": "spotify:track:4qty2H7nROmfs2K6aols1I",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SNXuQJo94pc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/7164536",
       "fun_fact": "“Animal Rights - Radio Edit” appears on deadmau5’s release “Animal Rights”.",
@@ -16593,7 +16593,7 @@
       "year": 2024,
       "isrc": "NLRD52350359",
       "uri": "spotify:track:5ZUIPLoTLJZrPQh2kFZEUM",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ROhlsgTOsgc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2687704402",
       "fun_fact": "“Addicted” is the title track of Zerb’s release of the same name.",
@@ -16613,7 +16613,7 @@
       "year": 2020,
       "isrc": "CYA112000447",
       "uri": "spotify:track:0uH5ORp6Ai5PP0SUofxoc7",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Qcr1ddJ7_gk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/986669402",
       "fun_fact": "“Tomorrow (feat. 433)” is the title track of Tiësto’s release of the same name.",
@@ -16641,7 +16641,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1585687101"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=DdVX1QtZSZU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1492935642",
       "fun_fact": "“Dancing” is the title track of James Hype’s release of the same name.",
@@ -16661,7 +16661,7 @@
       "year": 2013,
       "isrc": "NLZ541300932",
       "uri": "spotify:track:2HBe1hMofcMQV2n5mhV8zu",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=e-U1lj57pv8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1518476172",
       "fun_fact": "“Flute - Radio Mix” is the title track of New World Sound’s release of the same name.",
@@ -16685,7 +16685,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1783935842"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7w93eMxlMZI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3155417691",
       "fun_fact": "“Strings of Life - Danny Krivit Re-Edit” appears on Soul Central’s release “Strings Of Life”.",
@@ -16709,7 +16709,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1714515537"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=yFdbueklpwY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/771050902",
       "fun_fact": "“Move Your Body” is the title track of Marshall Jefferson’s release of the same name.",
@@ -16729,7 +16729,7 @@
       "year": 2023,
       "isrc": "NLZ542301810",
       "uri": "spotify:track:0h3Xy4V4apMraB5NuM8U7Z",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=57VMB1IzLKY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2537448451",
       "fun_fact": "“Stumblin' In” is the title track of CYRIL’s release of the same name.",
@@ -16753,7 +16753,7 @@
       "year": 2010,
       "isrc": "GBCPZ1004245",
       "uri": "spotify:track:7fvZVcQBOD6XbIRUew7Ztq",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SINeSWxCsSc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3155501701",
       "fun_fact": "“La Tromba” appears on Chris Lake’s release “La Tromba Risin'”.",
@@ -16781,7 +16781,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1318803149"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lJh_Qwlcg5s",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/435504002",
       "fun_fact": "“Stay With Me” is the title track of Pryda’s release of the same name.",
@@ -16805,7 +16805,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1350837675"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XVYHt5in2Hw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/463375272",
       "fun_fact": "“Stampede” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
@@ -16829,7 +16829,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1754198966"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=MlwBZ2MSNtE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2400113255",
       "fun_fact": "“Atmosphere” is the title track of FISHER’s release of the same name.",
@@ -16853,7 +16853,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1791662127"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=82s0wDOy_R4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2283159247",
       "fun_fact": "“Heaven Scent” is the title track of Bedrock’s release of the same name.",
@@ -16873,7 +16873,7 @@
       "year": 2022,
       "isrc": "BE4JP2200022",
       "uri": "spotify:track:7jhnbFPjiETsnctO3eCkVU",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=QKNBlxXR_Lo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2202189517",
       "fun_fact": "“Diabla” appears on Indira Paganotto’s release “Lions of God EP”.",
@@ -16897,7 +16897,7 @@
       "year": 2014,
       "isrc": "USUG11401849",
       "uri": "spotify:track:4l6CWRDyGu7mw3UEXXUtls",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vLU2T03iWPs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/437979132",
       "fun_fact": "“Can't Hold Us Down” appears on Axwell /\\ Ingrosso’s release “More Than You Know”.",
@@ -16921,7 +16921,7 @@
       "year": 2019,
       "isrc": "NLF711901964",
       "uri": "spotify:track:0eDI4488gNLeA7pssOZHOD",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=kivuDS-6HbQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/637734852",
       "fun_fact": "“Turn It Up” is the title track of Armin van Buuren’s release of the same name.",
@@ -16945,7 +16945,7 @@
       "year": 2018,
       "isrc": "NLF711811875",
       "uri": "spotify:track:73nYqSz1U08iCWfdnG65KV",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=e4mUroCa5I4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/587097462",
       "fun_fact": "“Like I Love You - Keanu Silva Remix” appears on Lost Frequencies’s release “Like I Love You (Remixes)”.",
@@ -16969,7 +16969,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/891369990"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gBtLPKLYYus",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3528021801",
       "fun_fact": "“The Beauty Of Silence” is the title track of Svenson & Gielen’s release of the same name.",
@@ -16989,7 +16989,7 @@
       "year": 2025,
       "isrc": "US38Y2512970",
       "uri": "spotify:track:5bdKaYnig6IqBsQQqBUjHm",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Ls76ISA-4hc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3264440221",
       "fun_fact": "“Back It Up” is the title track of Josh Baker’s release of the same name.",
@@ -17013,7 +17013,7 @@
       "year": 2020,
       "isrc": "NLF712007928",
       "uri": "spotify:track:2c1BSmrSeBEY9FxhzSiFWh",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8fkXcd0DnRM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1017778342",
       "fun_fact": "“Life After You” is the title track of Sunnery James & Ryan Marciano’s release of the same name.",
@@ -17041,7 +17041,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/6769267879"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=t4HfbN75lFs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3881255511",
       "fun_fact": "“In White Rooms” appears on Booka Shade’s release “In White Rooms (2023 Remix)”.",
@@ -17065,7 +17065,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1784012082"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=IhMw2BE1Vls",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3155552441",
       "fun_fact": "“MERTHER” is the title track of Mau P’s release of the same name.",
@@ -17085,7 +17085,7 @@
       "year": 1992,
       "isrc": "GBARL9200055",
       "uri": "spotify:track:1pDhEcCl0d2SAQMKljdbys",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=bj8xF2bnxp0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/7779520",
       "fun_fact": "“Don't You Want Me” appears on Felix’s release “Pure... 90s Dance Party”.",
@@ -17109,7 +17109,7 @@
       "year": 2025,
       "isrc": "GBUM72501973",
       "uri": "spotify:track:5pa2ZyJ3dIEmxRDW74msQi",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rKFYeod_1Fo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3380052561",
       "fun_fact": "“Cops & Robbers” is the title track of Sammy Virji’s release of the same name.",
@@ -17137,7 +17137,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1173548129"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0fdEUA5VVBI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/135627940",
       "fun_fact": "“Alone” is the title track of Cristoph’s release of the same name.",
@@ -17161,7 +17161,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1599726178"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9KnxqniMiLA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1585938412",
       "fun_fact": "“Age of Love - ARTBAT Rave Mix” is the title track of ARTBAT’s release of the same name.",
@@ -17185,7 +17185,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1591326861"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-4iJ8aCH_oc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3265468971",
       "fun_fact": "“Punk” is the title track of Ferry Corsten’s release of the same name.",
@@ -17205,7 +17205,7 @@
       "year": 2023,
       "isrc": "DEUM72305198",
       "uri": "spotify:track:3ec1mgb7R6yhRvzp3DaTus",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_JjBlmXBYpQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2290906725",
       "fun_fact": "“All For Love” is the title track of felix jaehn’s release of the same name.",
@@ -17229,7 +17229,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/627442768"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=c0e9wALeTvw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/73460670",
       "fun_fact": "“One Look” is the title track of David Tort’s release of the same name.",
@@ -17249,7 +17249,7 @@
       "year": 2009,
       "isrc": "USTWR0900003",
       "uri": "spotify:track:4n8YdXETqQ3NvWs5XNpvar",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ZkPhIIESof8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/12076558",
       "fun_fact": "“Music Is the Answer - Original Extended 12-Inch Mix” appears on Celeda’s release “Music Is the Answer (Part 2)”.",
@@ -17273,7 +17273,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1639997595"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zBp7KBmgsdU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1782377777",
       "fun_fact": "“Jungle” is the title track of Fred again..’s release of the same name.",
@@ -17297,7 +17297,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1425338283"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vu1QsEUVLQs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/540179602",
       "fun_fact": "“Drive (feat. Delilah Montagu)” is the title track of Black Coffee’s release of the same name.",
@@ -17321,7 +17321,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1458852076"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BUOXnv0tono",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/757592722",
       "fun_fact": "“La Résistance De L'Amour” appears on Armin van Buuren’s release “Balance”.",
@@ -17345,7 +17345,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1449604190"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0fe3tPUxgyc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/624588692",
       "fun_fact": "“Teenage Crime” is the title track of Yves V’s release of the same name.",
@@ -17365,7 +17365,7 @@
       "year": 2024,
       "isrc": "GBCPZ2423413",
       "uri": "spotify:track:5PL7k9QH7Kj7B4527dHvon",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=D_gl2sFL_5w",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3156247951",
       "fun_fact": "“La Verdolaga” is the title track of HUGEL’s release of the same name.",
@@ -17385,7 +17385,7 @@
       "year": 2025,
       "isrc": "QT47L2500008",
       "uri": "spotify:track:74y1VgzL668hynrvA59WQB",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wUvrLsPVRss",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3245560861",
       "fun_fact": "“Stay” is the title track of FISHER’s release of the same name.",
@@ -17413,7 +17413,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1620334184"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=IskTIty19Tw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/510689692",
       "fun_fact": "“The Awakening” appears on YORK’s release “The Awakening 2018”.",
@@ -17437,7 +17437,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1780514143"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6QFNIrm9aF0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3099615151",
       "fun_fact": "“Told You So” is the title track of Martin Garrix’s release of the same name.",
@@ -17461,7 +17461,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1678181925"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uxNjgtFTkLE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2201970427",
       "fun_fact": "“Apollo” appears on Charlotte de Witte’s release “Apollo EP”.",
@@ -17485,7 +17485,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1783935433"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=2zn6uKNW-FM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3155856791",
       "fun_fact": "“Lovelee Dae” is the title track of Amine Edge & DANCE’s release of the same name.",
@@ -17505,7 +17505,7 @@
       "year": 2017,
       "isrc": "US7NS1700006",
       "uri": "spotify:track:4DG3zMviPoLrBfOErhxgcv",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=n4zjPR5HjCg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3614894002",
       "fun_fact": "“Tarantula” is the title track of Pleasurekraft’s release of the same name.",
@@ -17533,7 +17533,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1610406429"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=D64a2fb72sE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1713175847",
       "fun_fact": "“Redlight” appears on Swedish House Mafia’s release “Paradise Again”.",
@@ -17553,7 +17553,7 @@
       "year": 2014,
       "isrc": "NLZ541400814",
       "uri": "spotify:track:5gKcbaxdSpI67Q1O3gRyFm",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XG_2HrwNoEM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/463375092",
       "fun_fact": "“Ghosts (feat. Lauren Mason) - Radio Edit” appears on Higher Self’s release “Ghosts (feat. Lauren Mason)”.",
@@ -17577,7 +17577,7 @@
       "year": 2014,
       "isrc": "SE22J1300131",
       "uri": "spotify:track:4Jp3wkHmYKXu6a0EvHLg4n",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ZqzrRqAOCsU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/76187768",
       "fun_fact": "“Born To Rage - Radio Edit” appears on Dada Life’s release “Born To Rage”.",
@@ -17601,7 +17601,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1840664788"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vp8qL6kfjQs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3561947741",
       "fun_fact": "“To The Moon” is the title track of Alok’s release of the same name.",
@@ -17625,7 +17625,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1766557249"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=69li9HWqUNQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2981831311",
       "fun_fact": "“Another World” is the title track of MEDUZA’s release of the same name.",
@@ -17645,7 +17645,7 @@
       "year": 2010,
       "isrc": "BEK010901657",
       "uri": "spotify:track:72qTaNhKoepn3TOOnijb5p",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jKc-gpi244I",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/123820280",
       "fun_fact": "“Salinas - White Island Original” appears on Dimitri Vegas & Like Mike’s release “Salinas”.",
@@ -17669,7 +17669,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1641184858"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=l73z7BaS-D8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1899431937",
       "fun_fact": "“Take Me High” is the title track of Kx5’s release of the same name.",
@@ -17693,7 +17693,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1696578374"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=5D-D_B0akWU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2367685785",
       "fun_fact": "“Won't Forget This Time ft. John Martin” is the title track of Steve Aoki’s release of the same name.",
@@ -17717,7 +17717,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1672155116"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_PEe6TP1kCc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1366419422",
       "fun_fact": "“Butterflies” is the title track of Skrillex’s release of the same name.",
@@ -17741,7 +17741,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1777381999"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=A6nzvVJ2beU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3097107781",
       "fun_fact": "“Heaven Knows” is the title track of Kaskade’s release of the same name.",
@@ -17765,7 +17765,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1599966125"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Sfo2Xg0Md7s",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3387956991",
       "fun_fact": "“Shed My Skin - Pete Hellers Stylus Vocal Mix” appears on D*Note’s release “Shed My Skin”.",
@@ -17789,7 +17789,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/217753235"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ghDlYgvod9k",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/97361280",
       "fun_fact": "“The First Rebirth” appears on Jones & Stephenson’s release “Trance Top 1000 - Selection 002”.",
@@ -17809,7 +17809,7 @@
       "year": 2024,
       "isrc": "NLF712406443",
       "uri": "spotify:track:4Z6W8iMLWY5uuMsAheztBm",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=2PhnVy9ntmQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2898245361",
       "fun_fact": "“Es Vedrà” is the title track of Armin van Buuren’s release of the same name.",
@@ -17837,7 +17837,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1529496583"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_3eJi3yPgY4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3156117741",
       "fun_fact": "“Deep End” appears on John Summit’s release “Deep End (Black V Neck Remix)”.",
@@ -17861,7 +17861,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1090983104"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=KNOS0MELEPE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/120536258",
       "fun_fact": "“The Sound of Violence (Narcotic Thrust Remix)” appears on Cassius’s release “Au Rêve (Deluxe Edition)”.",
@@ -17885,7 +17885,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1804467568"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Tdo1KPY7Mig",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3302923111",
       "fun_fact": "“Surrender” is the title track of Alesso’s release of the same name.",
@@ -17909,7 +17909,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1426605696"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=97lwSry3hs0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/541200222",
       "fun_fact": "“Otherside” is the title track of Tom Staar’s release of the same name.",
@@ -17929,7 +17929,7 @@
       "year": 2013,
       "isrc": "GBAHS1300200",
       "uri": "spotify:track:3kWHCjPkAP5x9ZEs6SlXk9",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SfenudgI4P8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3156208691",
       "fun_fact": "“Jack - Radio Edit” appears on Breach’s release “Jack (DC Jack Track)”.",
@@ -17957,7 +17957,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1355051008"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=pw_PJ6YJdfo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/468392592",
       "fun_fact": "“Constellations - Radio Edit” is the title track of CamelPhat’s release of the same name.",
@@ -17981,7 +17981,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/561557579"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7M15gNZfK-8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/911117",
       "fun_fact": "“My Moon My Man - Boys Noize Remix” appears on Feist’s release “My Moon My Man”.",
@@ -18005,7 +18005,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1749336837"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=CuisEZDuO5I",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2825761562",
       "fun_fact": "“girl$” is the title track of Dom Dolla’s release of the same name.",
@@ -18029,7 +18029,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1362779131"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=R7g2YRe5vnI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/476596932",
       "fun_fact": "“Magnolia” is the title track of Yves V’s release of the same name.",
@@ -18053,7 +18053,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1445870855"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=s72EOmSVmeM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/601054032",
       "fun_fact": "“Glitch” is the title track of Martin Garrix’s release of the same name.",
@@ -18073,7 +18073,7 @@
       "year": 2017,
       "isrc": "GBWWP1703295",
       "uri": "spotify:track:7vAVQMCwSKEVmol4wJvqUO",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=bBnUgWc7k-k",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1952547247",
       "fun_fact": "“You Can't Change Me” appears on Don Diablo’s release “FUTURE (Deluxe Edition)”.",
@@ -18101,7 +18101,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1607400982"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=KLu7QyEpdBM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1641834132",
       "fun_fact": "“Don’t Forget My Love” is the title track of Diplo’s release of the same name.",
@@ -18125,7 +18125,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1793494684"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=KDIEVdlvUmE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3212122851",
       "fun_fact": "“So Good” is the title track of Nosi’s release of the same name.",
@@ -18149,7 +18149,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1488848175"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xqbEDvQGjvQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/822658282",
       "fun_fact": "“Juliet & Romeo” is the title track of Martin Solveig’s release of the same name.",
@@ -18173,7 +18173,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/603925210"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UaPUFDMtEuA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/64760930",
       "fun_fact": "“Alright - Brad Carter Radio Edit” appears on Red Carpet’s release “50 Best Trance Hits Ever, Vol. 2”.",

--- a/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
+++ b/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
@@ -1,6 +1,6 @@
 {
   "name": "Tomorrowland Top 1000",
-  "version": "0.52",
+  "version": "0.60",
   "tags": [
     "edm",
     "electronic",
@@ -13686,7 +13686,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1810702937"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rSiHmtZbG-s",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3340111711",
       "fun_fact": "“Like I Like It” appears on Mau P’s release “Too Big For B-Side”.",
@@ -13706,7 +13706,7 @@
       "year": 2022,
       "isrc": "DEEC33500811",
       "uri": "spotify:track:58kUEj9sd9Z2XIPh3BhJRR",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jAOiRIOll4c",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2395987995",
       "fun_fact": "“The Sign (with CamelPhat)” appears on Anyma’s release “Genesys”.",
@@ -13730,7 +13730,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/626207768"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=G50MvzN92bA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/61858806",
       "fun_fact": "“Open Your Heart - Vocal Mix” appears on Axwell’s release “Sirup House Sessions (2009)”.",
@@ -13754,7 +13754,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1684584572"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6vnbCkzPgNk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2255185497",
       "fun_fact": "“Call Me” is the title track of Marlon Hoffstadt’s release of the same name.",
@@ -13778,7 +13778,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1691565215"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=iosaSwiYp4E",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2637478372",
       "fun_fact": "“All That Matters (feat. Troels Abrahamsen) - [ARTBAT Remix] [Mixed]” appears on Kölsch’s release “Global Underground: Select #9 (Mixed)”.",
@@ -13802,7 +13802,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1575824358"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=3J15zWQ8clg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/15790351",
       "fun_fact": "“Another Chance - Radio Edit” appears on Roger Sanchez’s release “Another Chance”.",
@@ -13826,7 +13826,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1688696901"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BCC_AvmHpR4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2929252061",
       "fun_fact": "“Iron Heart” appears on Netsky’s release “Netsky”.",
@@ -13850,7 +13850,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1724268061"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Rjw-mHRDsto",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2585146062",
       "fun_fact": "“Universal Nation - Charlotte de Witte Rework” is the title track of Push’s release of the same name.",
@@ -13874,7 +13874,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1697465189"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uR3Vw8J8vUo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3808858922",
       "fun_fact": "“RIP Groove (Radio Edit)” appears on Double 99’s release “RIP Groove”.",
@@ -13898,7 +13898,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1552344232"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=JGtlP0Vzuq4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1233536262",
       "fun_fact": "“Leave A Little Love” is the title track of Alesso’s release of the same name.",
@@ -13922,7 +13922,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1667381083"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=g2VZ5NOtx20",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2121748347",
       "fun_fact": "“Sunsleeper” is the title track of Barry Can't Swim’s release of the same name.",
@@ -13946,7 +13946,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1716121731"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VxWqco0PlOU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/585994092",
       "fun_fact": "“Nobody Else” is the title track of Axwell’s release of the same name.",
@@ -13970,7 +13970,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1698290969"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zEwo9ib8cVg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2200543787",
       "fun_fact": "“Be Sharp Say Nowt - Edit” appears on Patrick Topping’s release “Be Sharp Say Nowt”.",
@@ -13990,7 +13990,7 @@
       "year": 2022,
       "isrc": "GBENL2203380",
       "uri": "spotify:track:2HWx4iA8e9ynY7LlCyfelO",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=MU8b5s-NkcM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1843202567",
       "fun_fact": "“Mind Dimension - Kölsch Remix” is the title track of Tiga’s release of the same name.",
@@ -14014,7 +14014,7 @@
       "year": 2009,
       "isrc": "NLE800900054",
       "uri": "spotify:track:6IRPB3rtIhHBjHd701QwrO",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=aA6d27dwLDY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/119131488",
       "fun_fact": "“Float My Boat - Radio Edit” appears on Lazy Jay’s release “Float My Boat”.",
@@ -14038,7 +14038,7 @@
       "year": 2019,
       "isrc": "USUG11902428",
       "uri": "spotify:track:2UJQmwF0yShE7pHcjSzX4X",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8ZnatzNRmjI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/712066792",
       "fun_fact": "“Sad Song (feat. TINI) (Alesso Remix)” appears on Alesso’s release “Sad Song (Alesso Remix)”.",
@@ -14066,7 +14066,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1165345742"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uA51eLELZqE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/134440452",
       "fun_fact": "“Together” is the title track of Martin Garrix’s release of the same name.",
@@ -14086,7 +14086,7 @@
       "year": 2007,
       "isrc": "FR0NT0700510",
       "uri": "spotify:track:1hFy8aVf25oH4Jqri3u09L",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Q6O6cNntQGA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/10284993",
       "fun_fact": "“Phantom Pt II - Soulwax Remix” appears on Justice’s release “Phantom - EP”.",
@@ -14114,7 +14114,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1457692164"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=QVHkqSulQB8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/654915792",
       "fun_fact": "“Avalanche” is the title track of ARTY’s release of the same name.",
@@ -14138,7 +14138,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1484687356"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=3YZgu0nHImA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/790090972",
       "fun_fact": "“Pieces” is the title track of AVAION’s release of the same name.",
@@ -14162,7 +14162,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1536464803"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Cp9ZueNgVYE",
       "uri_tidal": null,
       "fun_fact": "“Raining Again (Steve Angello's Vocal Mix)” appears on Moby’s release “Raining Again”.",
       "fun_fact_de": "„Raining Again (Steve Angello's Vocal Mix)“ erschien auf der Veröffentlichung „Raining Again“ von Moby.",
@@ -14185,7 +14185,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1690875583"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=oz_Zxd-iIdI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2395987905",
       "fun_fact": "“Welcome To The Opera (with Grimes)” appears on Anyma’s release “Genesys”.",
@@ -14205,7 +14205,7 @@
       "year": 2013,
       "isrc": "NLDD61300111",
       "uri": "spotify:track:4O799OM270z43L7pKzNqrt",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1Bs3FZXhmAY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/483374982",
       "fun_fact": "“We Like to Party - Original Mix” appears on Showtek’s release “We Like to Party”.",
@@ -14229,7 +14229,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1818382781"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=5HQCs82Q7us",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3412428671",
       "fun_fact": "“Miracle” is the title track of Sub Focus’s release of the same name.",
@@ -14249,7 +14249,7 @@
       "year": 2018,
       "isrc": "CYA111800241",
       "uri": "spotify:track:3qPXWPkEZgUhUgPifbE99z",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Gj0v9IRvujs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/938717382",
       "fun_fact": "“WOW” is the title track of Tiësto’s release of the same name.",
@@ -14277,7 +14277,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/6764864571"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Ed-r5SsBLx0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3719324372",
       "fun_fact": "“Makina Time” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
@@ -14301,7 +14301,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1350837076"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fyeojFLQLNY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1493620222",
       "fun_fact": "“When I Dip” appears on Bingo Players’s release “When I Dip (feat. J2K & MC Dynamite) (The Remixes)”.",
@@ -14325,7 +14325,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1548999214"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6F3PC5v74BY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1208434992",
       "fun_fact": "“Sleepless” is the title track of D.O.D’s release of the same name.",
@@ -14345,7 +14345,7 @@
       "year": 2005,
       "isrc": "DEAE60500477",
       "uri": "spotify:track:47X4O5S1uOHv7crhB7XeEY",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=DpKD-ufujsk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/486432372",
       "fun_fact": "“Gebrünn Gebrünn” appears on Paul Kalkbrenner’s release “Tatü-Tata”.",
@@ -14373,7 +14373,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/920536338"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Cc07eonFLUE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/86611613",
       "fun_fact": "“Tivoli” is the title track of Steve Angello’s release of the same name.",
@@ -14397,7 +14397,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1814833151"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=4oSjO9FP5t4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3370485331",
       "fun_fact": "“Can't Decide” is the title track of Max Dean’s release of the same name.",
@@ -14417,7 +14417,7 @@
       "year": 2006,
       "isrc": "GBEWA0600621",
       "uri": "spotify:track:7imdlxmN8ORoiwbje4KcDy",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VuYk-fIf1Ds",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/101321498",
       "fun_fact": "“Can't Sleep - Radio Edit” appears on Above & Beyond’s release “Can't Sleep”.",
@@ -14437,7 +14437,7 @@
       "year": 2021,
       "isrc": "NLZ542100012",
       "uri": "spotify:track:4S5uBAB6Jl4IsMzwBpt2Rf",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YQ6Yss-DX1c",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1222285582",
       "fun_fact": "“Cali Dreams (feat. The Beach)” is the title track of Vintage Culture’s release of the same name.",
@@ -14465,7 +14465,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1472273911"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VL-TIXPivpQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/709596432",
       "fun_fact": "“XTC” is the title track of Solardo’s release of the same name.",
@@ -14489,7 +14489,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1641740273"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lu7lJ5okjyo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1881452677",
       "fun_fact": "“Sacrifice (Remix) (feat. Swedish House Mafia)” appears on The Weeknd’s release “Dawn FM (Alternate World)”.",
@@ -14513,7 +14513,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1258127028"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XlX_pOn5tE8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/382235621",
       "fun_fact": "“You Are” is the title track of Armin van Buuren’s release of the same name.",
@@ -14537,7 +14537,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1786856061"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9VQdVA2hjsA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3157769181",
       "fun_fact": "“Barbra Streisand - Radio Edit” appears on Duck Sauce’s release “Barbra Streisand”.",
@@ -14557,7 +14557,7 @@
       "year": 2013,
       "isrc": "GBBZH1391803",
       "uri": "spotify:track:6LW3Z1GqbL78TIjfDyg4zp",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=I9QGpHScGug",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/88449443",
       "fun_fact": "“Afterglow” appears on Wilkinson’s release “Lazers Not Included (Extended Edition)”.",
@@ -14581,7 +14581,7 @@
       "year": 2024,
       "isrc": "GBARL2401346",
       "uri": "spotify:track:3NxB1jubUWY6zit9rOk8ZC",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=NAVv00ZbAdc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2906712841",
       "fun_fact": "“Free (with Ellie Goulding)” appears on Calvin Harris’s release “Free (Arielle Free Remix)”.",
@@ -14601,7 +14601,7 @@
       "year": 2018,
       "isrc": "QMDA61831832",
       "uri": "spotify:track:42CMeHqi0S8sbKvrzLyixS",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=E_wxPpRSgho",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3031056271",
       "fun_fact": "“Turn off the Lights” is the title track of Chris Lake’s release of the same name.",
@@ -14629,7 +14629,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1709656884"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Ej0WpJ9XR6w",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2477720371",
       "fun_fact": "“Luvstruck” is the title track of Southside Spinners’s release of the same name.",
@@ -14653,7 +14653,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1821113842"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=PGC4eGW25lA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3410703621",
       "fun_fact": "“Edge of Desire” is the title track of Jonas Blue’s release of the same name.",
@@ -14673,7 +14673,7 @@
       "year": 2022,
       "isrc": "NLCK42223782",
       "uri": "spotify:track:43OMUa5jouGCZEz9k9vooo",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mNrzmpA8JU4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2190795587",
       "fun_fact": "“Push Up - Original Mix” is the title track of Creeds’s release of the same name.",
@@ -14697,7 +14697,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1724318208"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8DQYdS5XxI4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1926389657",
       "fun_fact": "“Whole Again (feat. John Martin)” appears on Steve Aoki’s release “HiROQUEST: Genesis”.",
@@ -14717,7 +14717,7 @@
       "year": 2014,
       "isrc": "USWB11508774",
       "uri": "spotify:track:6SKkN6yuQFnzMEHMQR3sWw",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=h7w4sUNw6tI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/107472746",
       "fun_fact": "“A Little More (feat. Sansa)” appears on Kaskade’s release “Automatic”.",
@@ -14745,7 +14745,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1684480208"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0IoU5aq0tXY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2254329837",
       "fun_fact": "“Zodiac” is the title track of Agents Of Time’s release of the same name.",
@@ -14769,7 +14769,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1503415448"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1ULfSL-HztE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/914174522",
       "fun_fact": "“Wanna Go Dancin'” appears on FISHER’s release “Freaks (EP)”.",
@@ -14793,7 +14793,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1823646005"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Jg56z6J0KJE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3437335761",
       "fun_fact": "“Versatile” is the title track of L.P. Rhythm’s release of the same name.",
@@ -14813,7 +14813,7 @@
       "year": 2021,
       "isrc": "FRZID2000472",
       "uri": "spotify:track:59o6ojGNGJOYiVJSzC6Lsa",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mg94Y43yiNU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1197592562",
       "fun_fact": "“Memories (feat. Kid Cudi) - 2021 Remix” is the title track of David Guetta’s release of the same name.",
@@ -14833,7 +14833,7 @@
       "year": 2022,
       "isrc": "USUG12201165",
       "uri": "spotify:track:7mXNYEVh9FW72c12qBaO3p",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=OP-bXPcqCCQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1682735327",
       "fun_fact": "“Only You” is the title track of Alesso’s release of the same name.",
@@ -14857,7 +14857,7 @@
       "year": 1999,
       "isrc": "NLF711302724",
       "uri": "spotify:track:3x55ruWsb6QtuufuCTxymf",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uuH_nYKXqHM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/64760941",
       "fun_fact": "“Madagascar - Ferry Corsten Remix” appears on Art Of Trance’s release “50 Best Trance Hits Ever, Vol. 2”.",
@@ -14881,7 +14881,7 @@
       "year": 2010,
       "isrc": "NLC281011060",
       "uri": "spotify:track:1NXQgcoRONCcxpBlMWuAQc",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TKflMtAi0EE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/489399542",
       "fun_fact": "“Mary Go Wild - Nicky Romero Remix” is the title track of Grooveyard’s release of the same name.",
@@ -14905,7 +14905,7 @@
       "year": 2017,
       "isrc": "GBAYE1700565",
       "uri": "spotify:track:5Xc74Dn1ZKH6H8XaVGOHXG",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=z_1WcUAcbgQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/4157792382",
       "fun_fact": "“On My Mind” appears on Disciples’s release “Golden Hour House”.",
@@ -14929,7 +14929,7 @@
       "year": 2013,
       "isrc": "GBKCF1300228",
       "uri": "spotify:track:7M2t0mMSjLJSweu8BwrY2R",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=d4VxFjHFcZ8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/113783762",
       "fun_fact": "“Wakanda” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
@@ -14957,7 +14957,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/555199299"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BGpzGu9Yp6Y",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/25746431",
       "fun_fact": "“Make It Bun Dem” is the title track of Skrillex’s release of the same name.",
@@ -14981,7 +14981,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/992482616"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=sUoWkRggVig",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3762430162",
       "fun_fact": "“Imprint of Pleasure” is the title track of Tube & Berger’s release of the same name.",
@@ -15005,7 +15005,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1445305132"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=iWiilOH4cQE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/104274582",
       "fun_fact": "“Liquid Spirit - Claptone Remix” is the title track of Gregory Porter’s release of the same name.",
@@ -15029,7 +15029,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1164247047"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=B0m5fxiN38Y",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/134279760",
       "fun_fact": "“Spotless” is the title track of Martin Garrix’s release of the same name.",
@@ -15053,7 +15053,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1052352915"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YolMcZ7Hb-Q",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/81258036",
       "fun_fact": "“Teasing Mr. Charlie - Short Edit” appears on Steve Angello’s release “Teasing Mr. Charlie / Straight”.",
@@ -15077,7 +15077,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1676086003"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7x5lqqji9ww",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2180342597",
       "fun_fact": "“Substitution (feat. Julian Perretta)” is the title track of Purple Disco Machine’s release of the same name.",
@@ -15101,7 +15101,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1544453964"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=svJvT6ruolA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/620495822",
       "fun_fact": "“No Good (Start the Dance)” appears on The Prodigy’s release “Music for the Jilted Generation”.",
@@ -15125,7 +15125,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1819789227"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cWdaDM6ZnSM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3422807521",
       "fun_fact": "“Everlight” is the title track of Tiësto’s release of the same name.",
@@ -15149,7 +15149,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1019219785"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=tqlHzjolyIY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/73133570",
       "fun_fact": "“Like Home - Radio Edit” appears on Nicky Romero’s release “Like Home”.",
@@ -15169,7 +15169,7 @@
       "year": 2020,
       "isrc": "GBKCF2000946",
       "uri": "spotify:track:01jdO8lv02Qqrejkopan7M",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uZ8WMLdsB5M",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1111082782",
       "fun_fact": "“Losing Focus - Marcus Santoro & David Pietras Mix” appears on Marc Benjamin’s release “Losing Focus”.",
@@ -15197,7 +15197,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1535686154"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=efCUMvwo6Tk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1114694492",
       "fun_fact": "“Let's Love - David Guetta & MORTEN Future Rave Remix” is the title track of David Guetta’s release of the same name.",
@@ -15221,7 +15221,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/493000280"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cAS8kzMF_9I",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/16087973",
       "fun_fact": "“Delight” appears on Dimension’s release “Delight / Death Row”.",
@@ -15241,7 +15241,7 @@
       "year": 1998,
       "isrc": "NLML69800004",
       "uri": "spotify:track:1V88ZtojKFHgP3YYo5MPps",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=PjoMQ9z_fp8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2664162732",
       "fun_fact": "“Let Me Show You - Original Mix” appears on Camisra’s release “Let Me Show You”.",
@@ -15261,7 +15261,7 @@
       "year": 2001,
       "isrc": "GBCPZ0100363",
       "uri": "spotify:track:5Ec3ROZqvqgwKVgCwzHK7C",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=syPi_HXY1e0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3155445671",
       "fun_fact": "“Finally - Original Extended Mix” appears on Kings Of Tomorrow’s release “Finally”.",
@@ -15289,7 +15289,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1798798516"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1LCxZfZVGSo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3282833161",
       "fun_fact": "“Never Forget You” is the title track of AFROJACK’s release of the same name.",
@@ -15309,7 +15309,7 @@
       "year": 2022,
       "isrc": "DEDH72200073",
       "uri": "spotify:track:3AYRPb2JAD4GZ6L6LeHoj5",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=p4Antebo5uc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2110249107",
       "fun_fact": "“Yumi” appears on Notre Dame’s release “Yumi EP”.",
@@ -15337,7 +15337,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1773621800"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HPssThWONWk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3043878541",
       "fun_fact": "“2 Million Ways - Axwell Remix” appears on C-Mos’s release “2 Million Ways”.",
@@ -15357,7 +15357,7 @@
       "year": 1996,
       "isrc": "FRV229700030",
       "uri": "spotify:track:3PQGdUJ9GTKv0EttfvPlii",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=4jEsu51QHtY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3780534",
       "fun_fact": "“Crispy Bacon” appears on Laurent Garnier’s release “30”.",
@@ -15381,7 +15381,7 @@
       "year": 2016,
       "isrc": "UK98Q1600001",
       "uri": "spotify:track:2uMbCJ8lxF7hqpQUaeo42D",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wQRV5omnBBU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/124992576",
       "fun_fact": "“Do It Right” is the title track of Martin Solveig’s release of the same name.",
@@ -15405,7 +15405,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1632332146"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=geFuxeHeZlk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3212473631",
       "fun_fact": "“Just Be (feat. Kirsty Hawkshaw)” appears on Tiësto’s release “Just Be”.",
@@ -15429,7 +15429,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/948362155"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=kbz8qA314Hs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/91579846",
       "fun_fact": "“Take Ü There (feat. Kiesza) - Tchami Remix” appears on Jack Ü’s release “Take Ü There (feat. Kiesza) (Remixes)”.",
@@ -15449,7 +15449,7 @@
       "year": 2019,
       "isrc": "NLF711900036",
       "uri": "spotify:track:1nufXiTCTTAeJfO9hLHvO8",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=LuyamglQkdw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/617796402",
       "fun_fact": "“Save Me Tonight” is the title track of ARTY’s release of the same name.",
@@ -15477,7 +15477,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1732751442"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=L_GFS1yhWhM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2676359802",
       "fun_fact": "“Save Our Soul” appears on Bob Sinclar’s release “Champs Elysées”.",
@@ -15501,7 +15501,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1796387710"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Gvnw2CSUts8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3234082101",
       "fun_fact": "“Be My Lover” is the title track of MALUGI’s release of the same name.",
@@ -15525,7 +15525,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1824462364"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6qAu4mbgArY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3443343751",
       "fun_fact": "“Blackberries” is the title track of FISHER’s release of the same name.",
@@ -15549,7 +15549,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1834540113"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0bj4i-sW44s",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3517854781",
       "fun_fact": "“Long Way Home” appears on Gareth Emery’s release “Drive”.",
@@ -15569,7 +15569,7 @@
       "year": 2025,
       "isrc": "USQX92500893",
       "uri": "spotify:track:7MtmQJPiZiyNbp8Pnjv5e5",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=r_Plv8zPx1U",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3279213741",
       "fun_fact": "“Dreamin (feat. Daya) - Anyma Remix” is the title track of Dom Dolla’s release of the same name.",
@@ -15597,7 +15597,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1677869070"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HGR6Qe81SA4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2202505457",
       "fun_fact": "“Forget” appears on Patrick Topping’s release “Boxed Off”.",
@@ -15617,7 +15617,7 @@
       "year": 2003,
       "isrc": "NLE710316553",
       "uri": "spotify:track:5hcshdvZJcEdipndIXUwzL",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=LatAo9Srfko",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/62397182",
       "fun_fact": "“Beautiful Things - Radio Edit” appears on Andain’s release “Beautiful Things”.",
@@ -15645,7 +15645,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1838942984"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lnEz3HSjv5s",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3549628231",
       "fun_fact": "“Voodoo” is the title track of Martin Garrix’s release of the same name.",
@@ -15665,7 +15665,7 @@
       "year": 2022,
       "isrc": "DEZC62269331",
       "uri": "spotify:track:4tRhRLBxIZ34Iw0eCuiC03",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=LL-z0yqCA3s",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1847938107",
       "fun_fact": "“Miss You” is the title track of southstar’s release of the same name.",
@@ -15689,7 +15689,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1444270836"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=STmLv9pLuX0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/373219601",
       "fun_fact": "“All Stars” is the title track of Martin Solveig’s release of the same name.",
@@ -15713,7 +15713,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1799939402"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ZVXOb2Cv-ho",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3278045671",
       "fun_fact": "“Magnet” is the title track of Miss Monique’s release of the same name.",
@@ -15733,7 +15733,7 @@
       "year": 2018,
       "isrc": "USRC11803472",
       "uri": "spotify:track:0M0FvSNRZmDz0Z769rewlI",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=l86Y7zRDtUw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/570030402",
       "fun_fact": "“Fire In My Soul” appears on Oliver Heldens’s release “Fire In My Soul (feat. Shungudzo)”.",
@@ -15757,7 +15757,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1445850974"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=yO_HEa9adn4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/600991982",
       "fun_fact": "“Get Dumb - Radio Edit” appears on Axwell’s release “Get Dumb”.",
@@ -15777,7 +15777,7 @@
       "year": 2024,
       "isrc": "NLF712407066",
       "uri": "spotify:track:2U6nirXZWhSFFe1NfFQ7Ly",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=EbOEjhasKas",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2947287451",
       "fun_fact": "“Love Is Eternity” is the title track of Armin van Buuren’s release of the same name.",
@@ -15805,7 +15805,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1796448782"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6ayiOciWuto",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3234442241",
       "fun_fact": "“This Rhythm (feat. RAHH)” is the title track of Prospa’s release of the same name.",
@@ -15829,7 +15829,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1678403898"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zvVRlhFetRI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2201976827",
       "fun_fact": "“Asura” appears on Charlotte de Witte’s release “Asura EP”.",
@@ -15853,7 +15853,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1087288641"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=44pRo58DV_4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/119865260",
       "fun_fact": "“Dark Side Of The Moon - Radio Mix” appears on Ernesto vs. Bastian’s release “Dark Side Of The Moon”.",
@@ -15873,7 +15873,7 @@
       "year": 2025,
       "isrc": "CYA112400023",
       "uri": "spotify:track:1aGXmfXBq4koas7v3277P3",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lEy7d460_y4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3185112831",
       "fun_fact": "“I Follow Rivers” appears on Tiësto’s release “Prismatic: Pack One”.",
@@ -15897,7 +15897,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1750872144"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fKDl64KEj9o",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2836735212",
       "fun_fact": "“Don't Stop (The Music)” is the title track of Dimitri Vegas’s release of the same name.",
@@ -15921,7 +15921,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1658771254"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SRVxRUJxITY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2247350867",
       "fun_fact": "“So U Kno” appears on Overmono’s release “Good Lies”.",

--- a/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
+++ b/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
@@ -1,6 +1,6 @@
 {
   "name": "Tomorrowland Top 1000",
-  "version": "0.28",
+  "version": "0.36",
   "tags": [
     "edm",
     "electronic",
@@ -6932,7 +6932,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1711642972"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=2URsD6vULew",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/459401112",
       "fun_fact": "“Calabria - Firebeatz Remix” is the title track of Rune RK’s release of the same name.",
@@ -6956,7 +6956,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1749175517"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=CprWhVqZFPA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2826480192",
       "fun_fact": "“Lioness” is the title track of Swedish House Mafia’s release of the same name.",
@@ -6980,7 +6980,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1714495177"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=y3OzHBEcymw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3424170731",
       "fun_fact": "“Turbulence” is the title track of Laidback Luke’s release of the same name.",
@@ -7004,7 +7004,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1543037572"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=l3fUEyv9RLg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1163136562",
       "fun_fact": "“Summer 91 (Looking Back)” is the title track of Noizu’s release of the same name.",
@@ -7024,7 +7024,7 @@
       "year": 2012,
       "isrc": "GBXGT1200233",
       "uri": "spotify:track:4EoHnRqDHIpRJCiFuL3VJH",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=CrMczah2jaM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/61427204",
       "fun_fact": "“Lights” appears on Steve Angello’s release “Until Now”.",
@@ -7045,7 +7045,7 @@
       "year": 2023,
       "isrc": "DEUM72302181",
       "uri": "spotify:track:3mjpUhSiUbEvaPdxikuEZI",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ll_6Z3lO_IE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2216994887",
       "fun_fact": "“Yoyoyo” is the title track of Pegassi’s release of the same name.",
@@ -7073,7 +7073,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1472498511"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nPvq_9ptLHA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/716940982",
       "fun_fact": "“No Goodbye” is the title track of Paul Kalkbrenner’s release of the same name.",
@@ -7093,7 +7093,7 @@
       "year": 2015,
       "isrc": "NLZ541500590",
       "uri": "spotify:track:5nwcPl5fG6Rx1IWPsaUJI9",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=QMssNXBCCl0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1406260312",
       "fun_fact": "“Say My Name (feat. Zyra) - Remix Edit” appears on ODESZA’s release “Say My Name (feat. Zyra) (Remix)”.",
@@ -7117,7 +7117,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1266015035"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=MoGdusJNrlk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2215971117",
       "fun_fact": "“A Bit Patchy - Eric Prydz Remix” appears on Switch’s release “La Rocca (Club Classics)”.",
@@ -7141,7 +7141,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1678835626"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1-ZU3bCEGqQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2206349367",
       "fun_fact": "“Doppler” appears on Charlotte de Witte’s release “Formula EP”.",
@@ -7165,7 +7165,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/947442600"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hBbaV_h3soY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/91185505",
       "fun_fact": "“Nillionaire” appears on Alesso’s release “Dynamite”.",
@@ -7185,7 +7185,7 @@
       "year": 2016,
       "isrc": "BEDX21600001",
       "uri": "spotify:track:61VEcQZQZUF4o7QgXsOFjB",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=5wJdcatC7bQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/134523166",
       "fun_fact": "“Until the End (feat. Raphaella)” is the title track of Henri PFR’s release of the same name.",
@@ -7213,7 +7213,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1476924807"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TVdoHzh010Q",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/734273642",
       "fun_fact": "“The Flight” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
@@ -7233,7 +7233,7 @@
       "year": 2009,
       "isrc": "DELM40900834",
       "uri": "spotify:track:2zWawHWvesDYHXDyKf0ENx",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FEJF2fyq8xk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3477966851",
       "fun_fact": "“Sometimes I Feel - Avicii's Out of Miami Mix” appears on Dim Chris’s release “House Is a Feeling, Vol. 4”.",
@@ -7257,7 +7257,7 @@
       "year": 2025,
       "isrc": "GBARL2500591",
       "uri": "spotify:track:78nx0HDJIFD5xDq2L5420Z",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=JEmbyx8NLxA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3344642921",
       "fun_fact": "“Blessings” is the title track of Calvin Harris’s release of the same name.",
@@ -7281,7 +7281,7 @@
       "year": 2009,
       "isrc": "USGUM0910150",
       "uri": "spotify:track:3xxARypr8NdEMesYUHSsGK",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ZcC3vVh3cOE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/11899030",
       "fun_fact": "“Knights of the Jaguar” appears on Rolando’s release “Somewhere In Detroit Mix Series Vol.1”.",
@@ -7309,7 +7309,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/446739874"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=txLVsv1ECes",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1916682377",
       "fun_fact": "“Around The World - Original Mix” appears on ARTY’s release “ALPHA 9: The Story So Far”.",
@@ -7333,7 +7333,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1727362089"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=IZ36b3q1elI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2633773772",
       "fun_fact": "“World Hold On (Children of the Sky) - Radio Edit” is the title track of Bob Sinclar’s release of the same name.",
@@ -7353,7 +7353,7 @@
       "year": 2019,
       "isrc": "USA2P1916081",
       "uri": "spotify:track:6yFr1EttdGjMuqLEkZbVQi",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=F2p0XLjS-ks",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1564802162",
       "fun_fact": "“Higher” appears on Third Party’s release “TOGETHER”.",
@@ -7381,7 +7381,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1586652842"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Aosr_W2KLUg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1498985822",
       "fun_fact": "“Lauren (I Can't Stay Forever)” is the title track of Oden & Fatzo’s release of the same name.",
@@ -7401,7 +7401,7 @@
       "year": 2012,
       "isrc": "NLC281211989",
       "uri": "spotify:track:2CYXttmf0SMgzJ0lODtnBT",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-34cBHy0B6M",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2463022925",
       "fun_fact": "“Cannonball - Radio Edit” appears on Showtek’s release “Cannonball”.",
@@ -7421,7 +7421,7 @@
       "year": 2015,
       "isrc": "GBARL1501087",
       "uri": "spotify:track:7foafyqmJYUdhGBpIusueW",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Rvs9FzGzf8A",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/105278286",
       "fun_fact": "“How Deep Is Your Love - Chris Lake Remix” appears on Calvin Harris’s release “How Deep Is Your Love (Remixes)”.",
@@ -7449,7 +7449,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/533804034"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TBHucXOBlrU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/46678171",
       "fun_fact": "“Cascade - Original Mix” appears on Tommy Trash’s release “We Are Planet Perfecto, Vol. 2 (Mixed By Paul Oakenfold)”.",
@@ -7469,7 +7469,7 @@
       "year": 2024,
       "isrc": "DEEC33501609",
       "uri": "spotify:track:5EkSIWWEX7zkFTtSO28vT7",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6tLVI3d6X4U",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2946079901",
       "fun_fact": "“Along Came Polly (Konstantin Sibold, ZAC, CARMEE Remix)” is the title track of Rebūke’s release of the same name.",
@@ -7497,7 +7497,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1350851534"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rRry3DEaCgE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/463377172",
       "fun_fact": "“Dragon - Radio Edit” appears on Martin Garrix’s release “Break Through The Silence EP”.",
@@ -7521,7 +7521,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1444240382"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rnlp_avexYQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/603415762",
       "fun_fact": "“You Don't Know Me (feat. Duane Harden) - Radio Edit” appears on Armand Van Helden’s release “You Don't Know Me (feat. Duane Harden)”.",
@@ -7541,7 +7541,7 @@
       "year": 2022,
       "isrc": "ITFGO2200044",
       "uri": "spotify:track:6tE5zuD7eC7cV2O1IyjRLX",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=AFKJXuZeU4w",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2161608047",
       "fun_fact": "“Anchor Point” appears on Ahmed Spins’s release “Anchor Point EP”.",
@@ -7565,7 +7565,7 @@
       "year": 2016,
       "isrc": "SEBGA1600374",
       "uri": "spotify:track:7MDobIiZKLbDDibHDA1fl8",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=k8GRwt0Aa-A",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/140295639",
       "fun_fact": "“Faded - Tiesto's Northern Lights Remix” appears on Alan Walker’s release “Faded (Remixes)”.",
@@ -7589,7 +7589,7 @@
       "year": 2007,
       "isrc": "FR0NT0600380",
       "uri": "spotify:track:3gcmn2CtOE9SjBevmvGVEk",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=EU5xgjmvIXc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/10284847",
       "fun_fact": "“D.A.N.C.E - Radio Edit” appears on Justice’s release “D.A.N.C.E”.",
@@ -7617,7 +7617,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1676442470"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=odI4cpFXhq8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2183959307",
       "fun_fact": "“Baby again..” is the title track of Fred again..’s release of the same name.",
@@ -7637,7 +7637,7 @@
       "year": 2013,
       "isrc": "GBBMQ1300118",
       "uri": "spotify:track:3D4WLyMljoc05H9GbgEUxR",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=NIcW36J-h7Q",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3782910842",
       "fun_fact": "“Eat Sleep Rave Repeat - feat. Beardyman - Calvin Harris Remix” appears on Fatboy Slim’s release “Eat Sleep Rave Repeat”.",
@@ -7661,7 +7661,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/907493618"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Mo4cmTaEDIk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/84908531",
       "fun_fact": "“Sun Goes Down (feat. Jasmine Thompson) - Radio Mix” appears on Robin Schulz’s release “Prayer”.",
@@ -7685,7 +7685,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1884591384"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Ptf3y_yN_LA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1157163962",
       "fun_fact": "“On The Beach - Mauro Picotto's CRW Remix” appears on YORK’s release “On The Beach (Kryder Remix)”.",
@@ -7709,7 +7709,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/657430383"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=RsYSIKunDC4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/68788680",
       "fun_fact": "“Goldfisch” appears on Kölsch’s release “1977”.",
@@ -7733,7 +7733,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1708588826"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=y6iMvNkAQt4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2461506635",
       "fun_fact": "“Mwaki” appears on Zerb’s release “SURRENDER”.",
@@ -7757,7 +7757,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1521975290"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=EObtNz9BqcI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1010098372",
       "fun_fact": "“Love To Go - Deluxe Mix” appears on Lost Frequencies’s release “Love To Go (Remixes)”.",
@@ -7777,7 +7777,7 @@
       "year": 2014,
       "isrc": "GB01A1400005",
       "uri": "spotify:track:7J67mKTpZvq7mEWP6nWMyP",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VlY_CBN2l8o",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2986367971",
       "fun_fact": "“Sunlight (feat. Years and Years) - Watermät Remix” appears on The Magician’s release “Sunlight (feat. Years and Years) (Remixes)”.",
@@ -7801,7 +7801,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1444855628"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=KSs0ih3A3ZI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/468391472",
       "fun_fact": "“Bounce Generation - Radio Edit” appears on TJR’s release “Bounce Generation”.",
@@ -7825,7 +7825,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1454818194"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uluaU17xFkc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/642028102",
       "fun_fact": "“Take It” is the title track of Dom Dolla’s release of the same name.",
@@ -7845,7 +7845,7 @@
       "year": 2013,
       "isrc": "GBUM71302855",
       "uri": "spotify:track:7ANO3LRdvefIongRYm5Smz",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=bkk2H3Ztrfk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/75526537",
       "fun_fact": "“White Noise” appears on Disclosure’s release “Settle (Special Edition)”.",
@@ -7866,7 +7866,7 @@
       "year": 2016,
       "isrc": "SEUM71600764",
       "uri": "spotify:track:4GoqbpOhKuCRNBq7fW2B7S",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0Cqj1dkHH7A",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1091018482",
       "fun_fact": "“Dark River” appears on Sebastian Ingrosso’s release “Zwift Workout”.",
@@ -7894,7 +7894,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1570848230"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=bPF2vwYBAnA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1394988992",
       "fun_fact": "“Talamanca” is the title track of BURNS’s release of the same name.",
@@ -7918,7 +7918,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1296253944"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ScNsBpQ8KIg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/417565092",
       "fun_fact": "“Forever” is the title track of Martin Garrix’s release of the same name.",
@@ -7942,7 +7942,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/496764213"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=AHC302BjEhY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/82668730",
       "fun_fact": "“Can't Get Better Than This - Radio Edit” appears on Parachute Youth’s release “Can't Get Better Than This”.",
@@ -7966,7 +7966,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1443133343"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Bi4ISWYsICA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/124183404",
       "fun_fact": "“Alive - Zedd Remix” appears on Empire Of The Sun’s release “Body By Jake: Tough, Tight And Toned Workout (BPM 118-128)”.",
@@ -7990,7 +7990,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1674124880"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=tb5MYhF2nwE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2174326127",
       "fun_fact": "“Giving Me” is the title track of Jazzy’s release of the same name.",
@@ -8010,7 +8010,7 @@
       "year": 2003,
       "isrc": "NLC281011778",
       "uri": "spotify:track:7t020iFDoAjNgc4mjUMBAS",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mzikX_gsHJA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/461011162",
       "fun_fact": "“Plastic Dreams - Radio Edit” appears on Jaydee’s release “Plastic Dreams”.",
@@ -8038,7 +8038,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1506106173"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=I-p04gEaIog",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/920549052",
       "fun_fact": "“Proper Education - Radio Edit” appears on Eric Prydz’s release “Proper Education - EP”.",
@@ -8062,7 +8062,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1743232241"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=eChdxmjHoMw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/468825872",
       "fun_fact": "“The Way We See The World - Tomorrowland Anthem Radio Edit” appears on AFROJACK’s release “The Way We See The World (Tomorrowland Anthem Instrumental)”.",
@@ -8086,7 +8086,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1714694295"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=c1y_wo_4fuQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/13131863",
       "fun_fact": "“Flashback” appears on Calvin Harris’s release “Ready For The Weekend”.",
@@ -8106,7 +8106,7 @@
       "year": 2022,
       "isrc": "GBAHS2301465",
       "uri": "spotify:track:1MVqeIAwhD4T44AKVkIfic",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rNv8K8AYGi8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2573922082",
       "fun_fact": "“leavemealone” is the title track of Fred again..’s release of the same name.",
@@ -8126,7 +8126,7 @@
       "year": 2018,
       "isrc": "CYA111800123",
       "uri": "spotify:track:4kWO6O1BUXcZmaxitpVUwp",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=OWz3rQQaf_Q",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/499994962",
       "fun_fact": "“Jackie Chan” is the title track of Tiësto’s release of the same name.",
@@ -8151,7 +8151,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1453086323"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=z-W6Wqy_WSw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/641406892",
       "fun_fact": "“Recognise” is the title track of Lost Frequencies’s release of the same name.",
@@ -8175,7 +8175,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1538711924"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8vNN6PXm5q8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2115239597",
       "fun_fact": "“E Samba” appears on Junior Jack’s release “[PIAS] 40”.",
@@ -8199,7 +8199,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1535810091"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nj-MuUsulMU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1108824212",
       "fun_fact": "“NOPUS” is the title track of Eric Prydz’s release of the same name.",
@@ -8223,7 +8223,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1504484138"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UbYQErtM9Zk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/914108092",
       "fun_fact": "“Hypnotized” is the title track of Purple Disco Machine’s release of the same name.",
@@ -8247,7 +8247,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1702091217"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=N343lBRin4s",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2405850825",
       "fun_fact": "“Bittersweet Goodbye - Tiësto’s Hardcore Remix” is the title track of Issey Cross’s release of the same name.",
@@ -8271,7 +8271,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1691761049"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hzo1_maqV_w",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2367722725",
       "fun_fact": "“Hey Now - ARTY Remix” appears on London Grammar’s release “The Remixes”.",
@@ -8291,7 +8291,7 @@
       "year": 2015,
       "isrc": "NLF711501933",
       "uri": "spotify:track:44EbX1Cuwpq3hdnpTHsmfO",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6Xf038zEVvM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/99827630",
       "fun_fact": "“Another You” is the title track of Armin van Buuren’s release of the same name.",
@@ -8312,7 +8312,7 @@
       "year": 2019,
       "isrc": "USQX91901124",
       "uri": "spotify:track:2oejEp50ZzPuQTQ6v54Evp",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=3XCVM3G3pns",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/717723352",
       "fun_fact": "“Call You Mine” appears on The Chainsmokers’s release “World War Joy...Takeaway”.",
@@ -8333,7 +8333,7 @@
       "year": 2018,
       "isrc": "NLZ541800374",
       "uri": "spotify:track:6dzFe2IgWQ5nDrgbf6AHiR",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nDi5h6ACNIw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/472421032",
       "fun_fact": "“Feels Like Yesterday (feat. Robin Valo)” is the title track of Mike Williams’s release of the same name.",
@@ -8357,7 +8357,7 @@
       "year": 2025,
       "isrc": "NLF712502308",
       "uri": "spotify:track:1nXJn2Sy4d1fdu1VHeJOnd",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=d6rpwINn1L4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3324116581",
       "fun_fact": "“Day 'N' Night” is the title track of Konstantin Sibold’s release of the same name.",
@@ -8385,7 +8385,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1638388862"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0-_bCbCc6lY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1850060617",
       "fun_fact": "“Satisfaction” is the title track of David Guetta’s release of the same name.",
@@ -8409,7 +8409,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1445322038"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xoUVtthd7gY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/855971922",
       "fun_fact": "“Pompeii - Audien Remix” appears on Bastille’s release “Running Workout”.",
@@ -8429,7 +8429,7 @@
       "year": 2014,
       "isrc": "FR6V82390196",
       "uri": "spotify:track:5FDn1oWUD5BXL2HCfmCk2F",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=tTWQRchgFp0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/77118136",
       "fun_fact": "“Man With The Red Face - Radio Edit” appears on Mark Knight’s release “Elektika Miami, Vol.1”.",
@@ -8457,7 +8457,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1679316677"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-SLc9v10wV4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2210691877",
       "fun_fact": "“Relax My Eyes” is the title track of ANOTR’s release of the same name.",
@@ -8477,7 +8477,7 @@
       "year": 2014,
       "isrc": "GB2CT1400391",
       "uri": "spotify:track:2zM1zEjv2JX1qTmSDeB8IL",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0dFz10R529g",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/90919855",
       "fun_fact": "“Concrete Angel - Radio Edit” appears on Gareth Emery’s release “Grotesque Indoor Festival 2014”.",
@@ -8505,7 +8505,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1719866219"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=J6smxHDKafc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2572591112",
       "fun_fact": "“Make Me - Franky Rizardo Remix” is the title track of Borai & Denham Audio’s release of the same name.",
@@ -8525,7 +8525,7 @@
       "year": 2025,
       "isrc": "US38Y2502570",
       "uri": "spotify:track:4MKqROsy64whz0A1YyCXGE",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7gvKrSON5lo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3194171421",
       "fun_fact": "“Bad Boy - GENESI Remix” is the title track of Linska’s release of the same name.",
@@ -8553,7 +8553,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/946844829"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=N6WEPj9PTy8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/91185507",
       "fun_fact": "“Swedish Beauty” is the title track of AN21’s release of the same name.",
@@ -8573,7 +8573,7 @@
       "year": 2022,
       "isrc": "CYA222200014",
       "uri": "spotify:track:70ztDWxwMLHje4L7QUyu5d",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zOLJrkn4zpY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1883583937",
       "fun_fact": "“Feels Like Home - Official Song F1 Dutch Grand Prix” is the title track of DubVision’s release of the same name.",
@@ -8598,7 +8598,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1524646216"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=JzNGptL7C7c",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1035333462",
       "fun_fact": "“Last Call” is the title track of Michael Calfan’s release of the same name.",
@@ -8622,7 +8622,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1552308473"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8tcYQEk1EVQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1228452582",
       "fun_fact": "“Fireworks (feat. Moss Kena & The Knocks)” is the title track of Purple Disco Machine’s release of the same name.",
@@ -8646,7 +8646,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1641051946"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=H3RZ8rJqsZg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1818071467",
       "fun_fact": "“Fifteen - Hardwell Radio Edit” appears on Blasterjaxx’s release “Fifteen (Hardwell Edit)”.",
@@ -8670,7 +8670,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/557219597"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8m0yz1M9qvY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/119252048",
       "fun_fact": "“Bombs Over Capitals” appears on AN21’s release “Bombs Over Capitals (feat. Julie McKnight)”.",
@@ -8690,7 +8690,7 @@
       "year": 2019,
       "isrc": "GBEWA1900550",
       "uri": "spotify:track:0lgHrv9qcVhwII3aW9aMZJ",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=PwM50brEX-g",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/637266152",
       "fun_fact": "“Walls - Joris Voorn Remix” is the title track of YOTTO’s release of the same name.",
@@ -8718,7 +8718,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1555370252"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FQFfI9cC35w",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1235304042",
       "fun_fact": "“Don't Leave Me Now” appears on Lost Frequencies’s release “Don't Leave Me Now (Remix Pack)”.",
@@ -8738,7 +8738,7 @@
       "year": 2016,
       "isrc": "USQX91600502",
       "uri": "spotify:track:4s2rzq6ZpCfg5ODq0z79QG",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ziknZ0psDI8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/122885994",
       "fun_fact": "“Don't Let Me Down - W&W Remix” appears on The Chainsmokers’s release “Don't Let Me Down (Remixes)”.",
@@ -8766,7 +8766,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1793159120"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=C3uhKNDCbZA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3215554981",
       "fun_fact": "“Dreamin (feat. Daya)” is the title track of Dom Dolla’s release of the same name.",
@@ -8790,7 +8790,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1445298941"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=KDxJlW6cxRk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/104847438",
       "fun_fact": "“Ocean Drive” is the title track of Duke Dumont’s release of the same name.",
@@ -8814,7 +8814,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1795765087"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=S2fSojJqyNY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3229131161",
       "fun_fact": "“Beautiful People” is the title track of David Guetta’s release of the same name.",
@@ -8838,7 +8838,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/656951677"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zfLn5Vkq2B0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/718335942",
       "fun_fact": "“Center Of The Universe - Original Radio Edit” appears on Axwell’s release “Center Of The Universe”.",
@@ -8858,7 +8858,7 @@
       "year": 2011,
       "isrc": "GBENL1000466",
       "uri": "spotify:track:5iYLNquuwN4VzJROkA6yjY",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=j6SSTMpIRFI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/9808783",
       "fun_fact": "“C'Mon (Catch 'Em by Surprise)” is the title track of Tiesto v Diplo’s release of the same name.",
@@ -8878,7 +8878,7 @@
       "year": 2023,
       "isrc": "QMRSZ2302091",
       "uri": "spotify:track:49wEdWGkL2CcOrXEKklXtJ",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7o9B4zTJuNI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3804157712",
       "fun_fact": "“Milkshake 20 - Alex Wann Remix” is the title track of Kelis’s release of the same name.",
@@ -8906,7 +8906,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1445933331"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=bjQbthr6N_I",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/607484382",
       "fun_fact": "“Repeat After Me” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
@@ -8930,7 +8930,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1223347695"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zH9sXggRlxc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/346578511",
       "fun_fact": "“Byte” is the title track of Martin Garrix’s release of the same name.",
@@ -8954,7 +8954,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1827379987"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=G-VVVGALi1A",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3574795411",
       "fun_fact": "“Waterfalls (feat. Sam Harper & Bobby Harvey)” appears on James Hype’s release “Waterfalls (Samurai Jay Remix)”.",
@@ -8974,7 +8974,7 @@
       "year": 2021,
       "isrc": "ZZOPM2105395",
       "uri": "spotify:track:5Kpqr7t4KCI8vrnWrQ4H7B",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hxVviJsgfok",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1355594372",
       "fun_fact": "“Sideways” is the title track of ILLENIUM’s release of the same name.",
@@ -9002,7 +9002,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/513030940"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=5n-_9ZjwRC4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3803546532",
       "fun_fact": "“The Night Out - Madeon Remix” appears on Martin Solveig’s release “The Night Out”.",
@@ -9022,7 +9022,7 @@
       "year": 2020,
       "isrc": "USZ4V2000222",
       "uri": "spotify:track:2KYnSFIrSbaKUXWetW7Klt",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=estW7sfx-8Y",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/964219992",
       "fun_fact": "“Looking For Me” is the title track of Paul Woolford’s release of the same name.",
@@ -9050,7 +9050,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/662136067"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Psab256_RP0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/86000229",
       "fun_fact": "“Three Triangles (Losing My Religion)” is the title track of Hardwell’s release of the same name.",
@@ -9074,7 +9074,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1202254004"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uOFTqVi-qp4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/141822553",
       "fun_fact": "“Light” is the title track of San Holo’s release of the same name.",
@@ -9098,7 +9098,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1080608741"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VuGcIOPJ8MM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/118516574",
       "fun_fact": "“Pasilda” is the title track of Afro Medusa’s release of the same name.",
@@ -9122,7 +9122,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1683710992"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=4RETMHLh9wc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2269935937",
       "fun_fact": "“Good Love” is the title track of Hannah Laing’s release of the same name.",
@@ -9142,7 +9142,7 @@
       "year": 2021,
       "isrc": "QMEU32108721",
       "uri": "spotify:track:5WVf0NhzUJlXASdLgjb6vh",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XZ586YHaFvk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1360514932",
       "fun_fact": "“Morumbi” appears on Tocadisco’s release “Legacy Part 1”.",
@@ -9166,7 +9166,7 @@
       "year": 2018,
       "isrc": "GBCFB1800028",
       "uri": "spotify:track:3VtTuQ6lypMoOBcm6VMzdh",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XTw-NrqKigs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/470137032",
       "fun_fact": "“Opal - Four Tet Remix” is the title track of BICEP’s release of the same name.",

--- a/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
+++ b/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
@@ -1,6 +1,6 @@
 {
   "name": "Tomorrowland Top 1000",
-  "version": "0.36",
+  "version": "0.44",
   "tags": [
     "edm",
     "electronic",
@@ -9190,7 +9190,7 @@
       "year": 2018,
       "isrc": "FR2PA1800100",
       "uri": "spotify:track:7pZ00FeIkpuzHskuDWQnU5",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=tP6aPgZ0FKE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/518483152",
       "fun_fact": "“My Love” is the title track of Martin Solveig’s release of the same name.",
@@ -9218,7 +9218,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1683405363"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=dD40VXFkusw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/69000046",
       "fun_fact": "“Everyday - Netsky Remix” appears on Rusko’s release “Everyday”.",
@@ -9242,7 +9242,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1459399470"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BxaR42Vy2LI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/663258512",
       "fun_fact": "“Carry On (from the Original Motion Picture \"POKÉMON Detective Pikachu\")” is the title track of Kygo’s release of the same name.",
@@ -9262,7 +9262,7 @@
       "year": 2019,
       "isrc": "GBARL1900161",
       "uri": "spotify:track:7kLWq3Z9XSs8cHTLB9nl0w",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ir6nk2zrMG0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2436205725",
       "fun_fact": "“Giant (with Rag'n'Bone Man) - Robin Schulz Remix” appears on Calvin Harris’s release “Giant (Remixes)”.",
@@ -9282,7 +9282,7 @@
       "year": 2020,
       "isrc": "USUS11900410",
       "uri": "spotify:track:3oWWPvrKwFF8gNOv6tOXZd",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=3nbY4kpCF5w",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/759015352",
       "fun_fact": "“Happinezz (feat. Ginger)” appears on Boris Brejcha’s release “Space Diver”.",
@@ -9310,7 +9310,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1688025984"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=yff6RXa_vEc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2285549067",
       "fun_fact": "“Pump” is the title track of Chris Lorenzo’s release of the same name.",
@@ -9330,7 +9330,7 @@
       "year": 2019,
       "isrc": "NLQ8D1900466",
       "uri": "spotify:track:3jq5IrHLNYoWg57xYrqVaU",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-6WAa2pBf8s",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1755258847",
       "fun_fact": "“Summer Air - Sunnery James & Ryan Marciano Remix” appears on Hardwell’s release “Hardwell presents Revealed Vol. 10”.",
@@ -9350,7 +9350,7 @@
       "year": 2024,
       "isrc": "NLM5S2402316",
       "uri": "spotify:track:1vMMwDCd1Hnb91a3x9MdfX",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6_XqQieMuKs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3036450081",
       "fun_fact": "“Gravity” is the title track of Martin Garrix’s release of the same name.",
@@ -9378,7 +9378,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/696885792"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=PwILkY9gRrc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3129772",
       "fun_fact": "“Da Funk” appears on Daft Punk’s release “Homework”.",
@@ -9398,7 +9398,7 @@
       "year": 1999,
       "isrc": "NLQ880800264",
       "uri": "spotify:track:6xl5vg5rhmbGI7kNML1IP4",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7ZMZHbAKvGA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/978167882",
       "fun_fact": "“Gouryella” appears on Gouryella’s release “A State Of Trance Top 20 - June 2020 (Selected by Armin van Buuren)”.",
@@ -9418,7 +9418,7 @@
       "year": 2022,
       "isrc": "GBAHS2101176",
       "uri": "spotify:track:5UatawMsGULDVG2h8wE1KS",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0-_Q4hhqSo0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1622182282",
       "fun_fact": "“Lights Out” is the title track of Fred again..’s release of the same name.",
@@ -9442,7 +9442,7 @@
       "year": 2024,
       "isrc": "GBCPZ2422741",
       "uri": "spotify:track:7rXke3ttpL2uXel9Nesf4u",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=WStAm_BrkGI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3156150631",
       "fun_fact": "“Sweet Disposition - John Summit & Silver Panda Remix” is the title track of The Temper Trap’s release of the same name.",
@@ -9470,7 +9470,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1538815598"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=MWTU-Dkwj5M",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3623153202",
       "fun_fact": "“Clarity (feat. Foxes) - Tiësto Remix” appears on Zedd’s release “Move Mode”.",
@@ -9494,7 +9494,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1745370712"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=PuH-7swYK5c",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2789828922",
       "fun_fact": "“Last Night - Anyma x Layton Giordani Remix” is the title track of Loofy’s release of the same name.",
@@ -9518,7 +9518,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1744921732"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Qy6othaPI80",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2785441732",
       "fun_fact": "“Heaven” is the title track of Sara Landry’s release of the same name.",
@@ -9542,7 +9542,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/362491548"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=65HkE_8wSSs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1712190177",
       "fun_fact": "“Calypso” is the title track of Round Table Knights’s release of the same name.",
@@ -9566,7 +9566,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1633500612"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ZzCMLgV8zrI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1817055667",
       "fun_fact": "“You Got The Love (Mark Knight Remix) / One” appears on Florence + The Machine’s release “EDM Party”.",
@@ -9590,7 +9590,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1478353597"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=aYUY0q6dwoY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/750113612",
       "fun_fact": "“Illuminate - Sub Focus & Wilkinson” is the title track of Sub Focus’s release of the same name.",
@@ -9614,7 +9614,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1570736952"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=NhCxrUEW3PM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1402072202",
       "fun_fact": "“Remember” is the title track of Becky Hill’s release of the same name.",
@@ -9634,7 +9634,7 @@
       "year": 2011,
       "isrc": "USQY51142734",
       "uri": "spotify:track:75T1xBaarYAqYdNtFZxUaZ",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Y_J3WWYp8Gc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/96532734",
       "fun_fact": "“Unison” appears on Porter Robinson’s release “Spitfire EP”.",
@@ -9662,7 +9662,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1842942827"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=kYHoSET3SGU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1883583657",
       "fun_fact": "“Heaven Takes You Home (feat. Connie Constance)” appears on Swedish House Mafia’s release “Heaven Takes You Home (Alternative Mix)”.",
@@ -9682,7 +9682,7 @@
       "year": 2011,
       "isrc": "NLC281112191",
       "uri": "spotify:track:0vRtd0t9CP7FjXKUCXUCLo",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XYgSHOWNE0M",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/466013612",
       "fun_fact": "“Rattle - Radio Edit” appears on Bingo Players’s release “Rattle”.",
@@ -9703,7 +9703,7 @@
       "year": 2019,
       "isrc": "NLF711907649",
       "uri": "spotify:track:44slXqFpvRojqlppLDcV07",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=V-5Daa7QJJg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/714966692",
       "fun_fact": "“Sun Is Shining” is the title track of Lost Frequencies’s release of the same name.",
@@ -9727,7 +9727,7 @@
       "year": 2011,
       "isrc": "NLC731100002",
       "uri": "spotify:track:2myHNhz3bFcKcUZHuoEh1k",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=bgQXAkz8LzE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/475222882",
       "fun_fact": "“The Sound of Goodbye - Armin's Tribal Feel Radio Edit” appears on Armin van Buuren’s release “Trance Classics - The Best Of”.",
@@ -9755,7 +9755,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/835895899"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uHZGDj-F-pA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/75819429",
       "fun_fact": "“One Day (Vandaag) - Radio Edit” is the title track of Bakermat’s release of the same name.",
@@ -9779,7 +9779,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1820942640"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=i7OaDY8gFk8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3689521382",
       "fun_fact": "“WHO - Radio Edit” appears on Tujamo’s release “WHO (FatSync & R3ckzet Remix)”.",
@@ -9799,7 +9799,7 @@
       "year": 2020,
       "isrc": "GBARL2000333",
       "uri": "spotify:track:1wjQEAV31X26Za9KRAmqwz",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fg21FNkNtYQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/931449452",
       "fun_fact": "“For a Feeling (feat. RHODES)” is the title track of CamelPhat’s release of the same name.",
@@ -9827,7 +9827,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1473664929"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=__Gb0RDwrdM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/716094692",
       "fun_fact": "“Back To Life” is the title track of DubVision’s release of the same name.",
@@ -9851,7 +9851,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1885599347"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uijZ9JroFow",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3903989971",
       "fun_fact": "“The Renegade” appears on Friend Within’s release “The Renegade EP”.",
@@ -9871,7 +9871,7 @@
       "year": 2013,
       "isrc": "NLZ541300620",
       "uri": "spotify:track:33saa6gZxyaMNpT9VGuhM2",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=MYKhtRelTiA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3458603571",
       "fun_fact": "“Project T” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
@@ -9899,7 +9899,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1524619864"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cABm1SlrtDY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1013432442",
       "fun_fact": "“Carry You Home (feat. StarGate & Aloe Blacc)” is the title track of Tiësto’s release of the same name.",
@@ -9923,7 +9923,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1679958206"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=k3DBmAlUh1A",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2216207477",
       "fun_fact": "“Baby Don't Hurt Me” is the title track of David Guetta’s release of the same name.",
@@ -9943,7 +9943,7 @@
       "year": 2024,
       "isrc": "US38Y2405797",
       "uri": "spotify:track:6Yimrlg9ndHZUy1hGm6uQ9",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_kFKqY9oCUc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2693901392",
       "fun_fact": "“Wild” is the title track of James Hype’s release of the same name.",
@@ -9967,7 +9967,7 @@
       "year": 2022,
       "isrc": "GBAHT2200492",
       "uri": "spotify:track:40SBS57su9xLiE1WqkXOVr",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=EPVdGy9SBHI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1703521177",
       "fun_fact": "“Afraid To Feel” is the title track of LF SYSTEM’s release of the same name.",
@@ -9995,7 +9995,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1292960937"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gKzKG0W1HKs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/413490782",
       "fun_fact": "“Body Funk” appears on Purple Disco Machine’s release “Soulmatic”.",
@@ -10019,7 +10019,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1608631145"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=N-4YMlihRf4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1645703942",
       "fun_fact": "“When I'm Gone (with Katy Perry) [VIP Mix]” appears on Alesso’s release “When I'm Gone (VIP Mix)”.",
@@ -10043,7 +10043,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1519480916"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=DmUZfB6UFLs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/997537362",
       "fun_fact": "“Tell Me Why - Radio Edit” appears on Supermode’s release “Tell Me Why”.",
@@ -10063,7 +10063,7 @@
       "year": 2017,
       "isrc": "NLF711710457",
       "uri": "spotify:track:21RzyxY3EFaxVy6K4RqaU9",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=IetIg7y5k3A",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/417131852",
       "fun_fact": "“Body” is the title track of Loud Luxury’s release of the same name.",
@@ -10088,7 +10088,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1443809112"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=LYZ6gXWZfZM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/61142295",
       "fun_fact": "“Let's Go (feat. Ne-Yo)” appears on Calvin Harris’s release “18 Months”.",
@@ -10112,7 +10112,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1375539233"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=oRVeF5KPngE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/490680972",
       "fun_fact": "“Neutron Dance - Edit” is the title track of Krystal Klear’s release of the same name.",
@@ -10136,7 +10136,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1790534561"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=CGBJVlY_yAY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/72149970",
       "fun_fact": "“Domino” appears on Oxia’s release “Cafe Ole Ibiza (Mixed By Rafha Madrid and Rebecca & Fiona)”.",
@@ -10160,7 +10160,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1818408731"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ycO9XkjxPhA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3413895351",
       "fun_fact": "“Wait So Long (Why Do I Have To)” is the title track of Swedish House Mafia’s release of the same name.",
@@ -10184,7 +10184,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1712581186"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FRjOSmc01-M",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/470287772",
       "fun_fact": "“Remind Me to Forget” is the title track of Kygo’s release of the same name.",
@@ -10204,7 +10204,7 @@
       "year": 2024,
       "isrc": "NLP762300246",
       "uri": "spotify:track:5OFVzqSeFxGpvDGyHvVeLj",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jr8Sj-8ikNY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2589549242",
       "fun_fact": "“It's Not Right But It's Okay” is the title track of Mr. Belt & Wezol’s release of the same name.",
@@ -10232,7 +10232,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1356606917"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HoMzLLWNV1g",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/470076662",
       "fun_fact": "“Bullit” is the title track of Watermät’s release of the same name.",
@@ -10252,7 +10252,7 @@
       "year": 2002,
       "isrc": "BEP010310085",
       "uri": "spotify:track:2unIXIeXCYSVte41IuRHTz",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=95eBJ-gYfzM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/57840221",
       "fun_fact": "“Thrill Me” appears on Junior Jack’s release “Trust It”.",
@@ -10273,7 +10273,7 @@
       "year": 2011,
       "isrc": "NLC281111567",
       "uri": "spotify:track:3PXamtUEGjrl9vaFxZ318n",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=KXdUsQoOzak",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/481407932",
       "fun_fact": "“Cry (Just A Little) - Radio Edit” is the title track of Bingo Players’s release of the same name.",
@@ -10294,7 +10294,7 @@
       "year": 2009,
       "isrc": "CAPA31700076",
       "uri": "spotify:track:04DkXrnJlKxc1hk2pOXHlo",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=W_Mg_jbJqMc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/449243492",
       "fun_fact": "“Faxing Berlin - Radio Edit” appears on deadmau5’s release “Faxing Berlin x4”.",
@@ -10318,7 +10318,7 @@
       "year": 2006,
       "isrc": "GBCPZ0501363",
       "uri": "spotify:track:5rcuVUo0IQu77SY06QdxF9",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VuZRO1vUVyI",
       "uri_tidal": null,
       "fun_fact": "“Swimming Places - Sebastien Ingrosso Re-Edit” appears on Julien Jabre’s release “Swimming Places”.",
       "fun_fact_de": "„Swimming Places - Sebastien Ingrosso Re-Edit“ erschien auf der Veröffentlichung „Swimming Places“ von Julien Jabre.",
@@ -10342,7 +10342,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1709178108"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=yAl6yiQHHNw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2472925871",
       "fun_fact": "“Saving Up” is the title track of Dom Dolla’s release of the same name.",
@@ -10366,7 +10366,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1681863554"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=90h5GMM4iB8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2233622397",
       "fun_fact": "“Be My Lover (feat. La Bouche) - 2023 Mix” is the title track of Hypaton’s release of the same name.",
@@ -10390,7 +10390,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1125593814"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=eaGoT3mFmVw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/127073863",
       "fun_fact": "“Hungry For The Power - Jamie Jones Ridge Street Remix” appears on AZARI’s release “Azari & III Remixed”.",
@@ -10414,7 +10414,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1501525410"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=RuN7o9ay20c",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/894555532",
       "fun_fact": "“Pulverturm - Tiësto's Big Room Remix” is the title track of Niels Van Gogh’s release of the same name.",
@@ -10438,7 +10438,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1594208607"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_WkzhhO21s8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1470880972",
       "fun_fact": "“Billie (loving arms)” is the title track of Fred again..’s release of the same name.",
@@ -10462,7 +10462,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1682128802"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=aFdM0f8Pi5o",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2184237717",
       "fun_fact": "“On & On” appears on Armin van Buuren’s release “Feel Again”.",
@@ -10486,7 +10486,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1675895162"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=NazVKnD-_sQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/592771082",
       "fun_fact": "“I <3 U SO” appears on Cassius’s release “The Rawkers (I <3 U SO Edition)”.",
@@ -10510,7 +10510,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1214500802"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lFREEtKRGr0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/144735090",
       "fun_fact": "“I Want You” is the title track of Chris Lake’s release of the same name.",
@@ -10530,7 +10530,7 @@
       "year": 2019,
       "isrc": "NLF711904534",
       "uri": "spotify:track:1wTgNpgoZ3g36bsy3sTxqz",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=tCrjxRY5Evo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/677552282",
       "fun_fact": "“Sunshine” is the title track of ARTY’s release of the same name.",
@@ -10558,7 +10558,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1489676132"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ztncn8fTRrY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3704877162",
       "fun_fact": "“Ringo” appears on Joris Voorn’s release “Michiel Borstlap Plays Joris Voorn, Pt. 1”.",
@@ -10578,7 +10578,7 @@
       "year": 2014,
       "isrc": "BEK011400214",
       "uri": "spotify:track:1Olbk1sJPSwnQUt55yAFS6",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=PsnQxMG_cY8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2104890137",
       "fun_fact": "“Waves (Tomorrowland 2014 Anthem)” is the title track of Dimitri Vegas & Like Mike’s release of the same name.",
@@ -10606,7 +10606,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1148608952"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=k6boob7deG0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1505157572",
       "fun_fact": "“Move It 2 The Drum” appears on Chuckie’s release “Destination Ibiza (Deluxe Edition)”.",
@@ -10626,7 +10626,7 @@
       "year": 2000,
       "isrc": "GBEBP0610063",
       "uri": "spotify:track:6j8nh1kHwezw8pkC2eU87F",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fUM1ADtR0WY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/11663132",
       "fun_fact": "“Touch Me (Radio Edit) [feat. Cassandra]” appears on Rui Da Silva’s release “Kismet Records Presents Touch Me (feat. Cassandra)”.",
@@ -10650,7 +10650,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1684602178"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=2hsoXTZbhBo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2255146707",
       "fun_fact": "“Moon Rocks” is the title track of Enrico Sangiuliano’s release of the same name.",
@@ -10674,7 +10674,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1711636194"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=C4arY25J6k8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/70513547",
       "fun_fact": "“My head is a Jungle - MK Remix [Radio Edit]” appears on Wankelmut’s release “My Head Is A Jungle (The Remixes)”.",
@@ -10694,7 +10694,7 @@
       "year": 2020,
       "isrc": "USUG12000675",
       "uri": "spotify:track:17kleFbwU5STT8AiR1EXOT",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uWN-SLVR69Q",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/891177062",
       "fun_fact": "“One Last Time” is the title track of Alesso’s release of the same name.",
@@ -10722,7 +10722,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1512816626"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rp31_j9knMI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/957925932",
       "fun_fact": "“Higher Ground (feat. John Martin)” is the title track of Martin Garrix’s release of the same name.",
@@ -10746,7 +10746,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/765477672"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ps2om-ZcEJE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/73092674",
       "fun_fact": "“Starlight (Could You Be Mine) - Radio Edit” appears on Don Diablo’s release “Starlight (Could You Be Mine)”.",
@@ -10770,7 +10770,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/282040868"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=kivQQoFMPQw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1506463612",
       "fun_fact": "“Woz Not Woz - Club Mix” appears on Eric Prydz’s release “Woz Not Woz”.",
@@ -10794,7 +10794,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1693371172"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Jckql0mdf_c",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2333553245",
       "fun_fact": "“Asking” is the title track of Sonny Fodera’s release of the same name.",
@@ -10814,7 +10814,7 @@
       "year": 2007,
       "isrc": "GBTDG0700005",
       "uri": "spotify:track:7gdJHtnAqy58RV61EpRBLo",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YTcopp-mpmo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/89844275",
       "fun_fact": "“Not Exactly” appears on deadmau5’s release “5 years of mau5”.",
@@ -10842,7 +10842,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1678047028"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jqLVlYc47GM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2198145737",
       "fun_fact": "“I Go - Soulwax Remix” appears on Peggy Gou’s release “I Go (Remixes)”.",
@@ -10862,7 +10862,7 @@
       "year": 2026,
       "isrc": "NL8FJ2600143",
       "uri": "spotify:track:5YrZ5hbfxPurBSEYunVeBL",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TWytoa9ut8o",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/4035366421",
       "fun_fact": "“Stringer” is the title track of Riva’s release of the same name.",
@@ -10890,7 +10890,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1730209074"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=tuMgJrFoAFY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2650103752",
       "fun_fact": "“Walking With Elephants” is the title track of Ten Walls’s release of the same name.",
@@ -10910,7 +10910,7 @@
       "year": 2004,
       "isrc": "NLE710480322",
       "uri": "spotify:track:3gBcC4Tdeq6RAa0xxCSxwf",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Jbh3GlrRcQ4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3212473561",
       "fun_fact": "“Love Comes Again (feat. BT)” appears on Tiësto’s release “Just Be”.",
@@ -10938,7 +10938,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1650658608"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=3aFF09jjZwk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1974590787",
       "fun_fact": "“Strong” is the title track of Romy’s release of the same name.",
@@ -10962,7 +10962,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/478341293"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cRKhrD-MuW4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/68788681",
       "fun_fact": "“Opa” appears on Kölsch’s release “1977”.",
@@ -10986,7 +10986,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/376643203"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=89etSg2gRYs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/60827191",
       "fun_fact": "“Yimanya - Original Mix” appears on Filterheadz’s release “50 Best Trance Hits Ever (Extended Versions)”.",
@@ -11006,7 +11006,7 @@
       "year": 2009,
       "isrc": "GBLTF0900021",
       "uri": "spotify:track:7rIsr8YjCdbCftGSrT6d9B",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TEtBg6od_mA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2804378412",
       "fun_fact": "“Strange (To Stability) - Len Faki Remix” appears on Dustin Zahn’s release “Stefano Noferini Club Edition Winter Session 2013”.",
@@ -11026,7 +11026,7 @@
       "year": 2024,
       "isrc": "GBKQU2462686",
       "uri": "spotify:track:6KqM3xmPIDonsTjCSGrrr5",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=LhxjP0hsQE8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2862125622",
       "fun_fact": "“TOO COOL TO BE CARELESS” is the title track of PAWSA’s release of the same name.",
@@ -11054,7 +11054,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1656100702"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=tQvBbX88V8U",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2031868327",
       "fun_fact": "“Sandstorm” is the title track of Freejak’s release of the same name.",
@@ -11078,7 +11078,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1346715477"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TWSP78g5HVw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/459830092",
       "fun_fact": "“Find Your Soul” is the title track of Yves V’s release of the same name.",
@@ -11098,7 +11098,7 @@
       "year": 2007,
       "isrc": "GBUM71207141",
       "uri": "spotify:track:05JHQRBFjhTTH9DGDM8Iwy",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=tRgRbWFr9Mg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2692037762",
       "fun_fact": "“Zdarlight” appears on Digitalism’s release “Idealism”.",
@@ -11126,7 +11126,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1728329796"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YnHJCs0Yjoo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2642151722",
       "fun_fact": "“Famax” is the title track of RAFFA GUIDO’s release of the same name.",
@@ -11150,7 +11150,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1687656897"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=WXy10sY3BlU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2305911755",
       "fun_fact": "“How It Feels” appears on Barry Can't Swim’s release “When Will We Land?”.",
@@ -11174,7 +11174,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1231948329"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vfgnh7Thp-A",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2992147511",
       "fun_fact": "“Blue Fear” is the title track of Armin van Buuren’s release of the same name.",
@@ -11194,7 +11194,7 @@
       "year": 2008,
       "isrc": "GBJAJ0700378",
       "uri": "spotify:track:0Nm6ukwBZHAtxgENSu3naG",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HZ5bo5Jr2gw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/68893339",
       "fun_fact": "“Roadkill - Original Club Mix” appears on Dubfire’s release “Toolroom Ten”.",
@@ -11222,7 +11222,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1712042835"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fUeCQ2T2ALI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/488667532",
       "fun_fact": "“Rocker - Eric Prydz Remix” appears on Alter Ego’s release “Rocker”.",
@@ -11246,7 +11246,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1544504688"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=AFH4jGuiW7w",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1048015732",
       "fun_fact": "“Coffee (Give Me Something)” is the title track of Tiësto’s release of the same name.",
@@ -11266,7 +11266,7 @@
       "year": 1998,
       "isrc": "NLD681801752",
       "uri": "spotify:track:0xTySVrQi5Li96Wu7pCp80",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Nsa-e47pHHk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/501067312",
       "fun_fact": "“Ayla - Original 1995 Mix” appears on Ayla’s release “Magik Three (Far from Earth) mixed by DJ Tiësto”.",
@@ -11290,7 +11290,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1822817275"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=GMqnQqr9Jic",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3430840701",
       "fun_fact": "“Number 1” is the title track of James Hype’s release of the same name.",
@@ -11314,7 +11314,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1489203183"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=p6ULvPFPLIY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/653689002",
       "fun_fact": "“All Day And Night” appears on Jax Jones’s release “All Day And Night (Jax Jones & Martin Solveig Present Europa)”.",
@@ -11338,7 +11338,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1678184581"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-kLvsKZMLh4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2201836177",
       "fun_fact": "“Along Came Polly” is the title track of Rebūke’s release of the same name.",
@@ -11358,7 +11358,7 @@
       "year": 2024,
       "isrc": "FRUM72400728",
       "uri": "spotify:track:480j122Gpi252OIfy4SNzm",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_IcH8afC_D8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2826343892",
       "fun_fact": "“Yamore” is the title track of MoBlack’s release of the same name.",
@@ -11382,7 +11382,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1715687669"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=g1qDIMD8kws",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/673165832",
       "fun_fact": "“How Soon Is Now - Dirty South Remix” appears on David Guetta’s release “One More Love”.",
@@ -11406,7 +11406,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/696887206"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=B38CY-4Rd6s",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3129783",
       "fun_fact": "“Alive” appears on Daft Punk’s release “Homework”.",
@@ -11430,7 +11430,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1673798699"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=961v0E3b01g",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2182322087",
       "fun_fact": "“Miracle (with Ellie Goulding)” appears on Calvin Harris’s release “Miracle (Remixes)”.",

--- a/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
+++ b/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
@@ -2215,7 +2215,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1826812710"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=JEmbyx8NLxA",
+      "uri_youtube_music": null,
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3443845841",
       "fun_fact": "“Blessings - Cassian Remix” is the title track of Calvin Harris’s release of the same name.",
@@ -7333,7 +7333,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1727362089"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=IZ36b3q1elI",
+      "uri_youtube_music": null,
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2633773772",
       "fun_fact": "“World Hold On (Children of the Sky) - Radio Edit” is the title track of Bob Sinclar’s release of the same name.",

--- a/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
+++ b/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
@@ -1,6 +1,6 @@
 {
   "name": "Tomorrowland Top 1000",
-  "version": "0.20",
+  "version": "0.28",
   "tags": [
     "edm",
     "electronic",
@@ -4681,7 +4681,7 @@
       "year": 2022,
       "isrc": "GBAHS2300107",
       "uri": "spotify:track:4ptnQ0kQnN1U1Ig8TSslj6",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=e5yZaepGx3A",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2148297997",
       "fun_fact": "“Turn On The Lights again.. (feat. Future & Fred again..) - Anyma Remix” appears on Swedish House Mafia’s release “Turn On The Lights again.. (feat. Future & Fred again..) (Remixes)”.",
@@ -4705,7 +4705,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1826822532"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=QkFJ0yqEtWk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3460671751",
       "fun_fact": "“Inside Our Hearts” is the title track of Martin Garrix’s release of the same name.",
@@ -4725,7 +4725,7 @@
       "year": 2022,
       "isrc": "GBUM72203666",
       "uri": "spotify:track:5Na0wKS46WV0pOhXzmQ0vz",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=T-jNkwesjpk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1826426337",
       "fun_fact": "“Bad Memories” is the title track of MEDUZA’s release of the same name.",
@@ -4746,7 +4746,7 @@
       "year": 2012,
       "isrc": "USCN31200018",
       "uri": "spotify:track:5ope2MtxN8VUaghZOkoZwk",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=DKdeBpn6PRw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/924642512",
       "fun_fact": "“You're Gonna Love Again” appears on NERVO’s release “House Party”.",
@@ -4770,7 +4770,7 @@
       "year": 2022,
       "isrc": "NLZ542200513",
       "uri": "spotify:track:76A1RRDEyHKtmV3Vh6PeVN",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=EfLxlGxZqEk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1720194137",
       "fun_fact": "“Savage” is the title track of Tiësto’s release of the same name.",
@@ -4794,7 +4794,7 @@
       "year": 2008,
       "isrc": "USUS10800150",
       "uri": "spotify:track:5HNZPGZFyGG4za71FVLkCC",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ZQTedx7l8wg",
       "uri_tidal": null,
       "fun_fact": "“Move For Me - Radio Edit” appears on Kaskade’s release “Ultra Music Festival 2008”.",
       "fun_fact_de": "„Move For Me - Radio Edit“ erschien auf der Veröffentlichung „Ultra Music Festival 2008“ von Kaskade.",
@@ -4819,7 +4819,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440873120"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Qc9c12q3mrc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/70266759",
       "fun_fact": "“Addicted To You” appears on Avicii’s release “True”.",
@@ -4839,7 +4839,7 @@
       "year": 2014,
       "isrc": "USZ4V1400159",
       "uri": "spotify:track:03IxJiB8ZOH9hEQZF5mCNY",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hkYq02183fc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/90262929",
       "fun_fact": "“Feel The Volume” is the title track of Jauz’s release of the same name.",
@@ -4867,7 +4867,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1658872584"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uJ6m44TRDxw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2060732447",
       "fun_fact": "“This Feeling” appears on Vintage Culture’s release “This Feeling (Remixes)”.",
@@ -4891,7 +4891,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/394874874"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Y0dUwjZNLjw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/7395324",
       "fun_fact": "“Time To Burn” appears on Storm’s release “Stormjunkie”.",
@@ -4915,7 +4915,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1337751485"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Oy9V_4im0wg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/452768722",
       "fun_fact": "“Cutting Shapes” is the title track of Don Diablo’s release of the same name.",
@@ -4939,7 +4939,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1771820847"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9NixMYOdiOE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3030924981",
       "fun_fact": "“Woops” is the title track of Dj Bountyhunter’s release of the same name.",
@@ -4963,7 +4963,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1778288336"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vP-Z0VEC0RA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3076269681",
       "fun_fact": "“Dirty Cash (Money Talks)” is the title track of PAWSA’s release of the same name.",
@@ -4983,7 +4983,7 @@
       "year": 2011,
       "isrc": "GBCPZ1004288",
       "uri": "spotify:track:0e2wt90jnekKbozAxV5LIX",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=peMFXG2oY2g",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/104104834",
       "fun_fact": "“Phazing - [Tomorrowland 2019 Streaming Mix]” appears on Dirty South’s release “In Bed With Space - Ibiza Club Sounds, Vol. 14 (Compiled By Dabruck & Klein and Kid Chris)”.",
@@ -5003,7 +5003,7 @@
       "year": 2021,
       "isrc": "NLM5S2101507",
       "uri": "spotify:track:5UZA39t4lX42ApegVubl7f",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uEOSEW9LSJ4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1558078362",
       "fun_fact": "“Won’t Let You Go” is the title track of Martin Garrix’s release of the same name.",
@@ -5027,7 +5027,7 @@
       "year": 2022,
       "isrc": "USQX92201881",
       "uri": "spotify:track:6txvQu0zUbiqG24A8XMLnK",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vhMAcPrt1LU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1793904837",
       "fun_fact": "“Miracle Maker” is the title track of Dom Dolla’s release of the same name.",
@@ -5051,7 +5051,7 @@
       "year": 2010,
       "isrc": "GBXGT1000095",
       "uri": "spotify:track:6Wqk68h7bjH0ZAsmwaQIWo",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=GGMEpE88trE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/86001351",
       "fun_fact": "“Knas” is the title track of Steve Angello’s release of the same name.",
@@ -5079,7 +5079,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1699495047"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=5YqG9-ViFSg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2386559845",
       "fun_fact": "“Ray Of Solar” is the title track of Swedish House Mafia’s release of the same name.",
@@ -5099,7 +5099,7 @@
       "year": 2019,
       "isrc": "NLZ541901628",
       "uri": "spotify:track:3K16ZsnNjOTY1Esnrx0rQg",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jM7ap2md3HQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/781731362",
       "fun_fact": "“In The Dark” is the title track of Vintage Culture’s release of the same name.",
@@ -5123,7 +5123,7 @@
       "year": 2009,
       "isrc": "GB6CP0900022",
       "uri": "spotify:track:4scUsV40AYlpiXCb4s7UnN",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=3_pRpxA71Cc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1055126352",
       "fun_fact": "“On Off” appears on Cirez D’s release “On Off / Fast Forward”.",
@@ -5147,7 +5147,7 @@
       "year": 2010,
       "isrc": "NLBV21100013",
       "uri": "spotify:track:4RIcLrQ7qzUaZuU279xUZK",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vaC8EMWUdNA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2831671892",
       "fun_fact": "“Tung!” is the title track of Deniz Koyu’s release of the same name.",
@@ -5171,7 +5171,7 @@
       "year": 2014,
       "isrc": "GBUM71308955",
       "uri": "spotify:track:023H4I7HJnxRqsc9cqeFKV",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FHCYHldJi_g",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/74085452",
       "fun_fact": "“I Got U” is the title track of Duke Dumont’s release of the same name.",
@@ -5196,7 +5196,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1712923020"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=W3cvJoAd7vU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2507935731",
       "fun_fact": "“Run Free (Countdown)” is the title track of Tiësto’s release of the same name.",
@@ -5216,7 +5216,7 @@
       "year": 2016,
       "isrc": "CYA221600029",
       "uri": "spotify:track:7uy7DFEulOcaO7w3fiOZxK",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=I5z2--4O7sA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/128099021",
       "fun_fact": "“Hey - Matisse & Sadko Remix” appears on FÄIS’s release “Hey (Remixes)”.",
@@ -5240,7 +5240,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1727256702"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=a9vUIc3lFEk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2722493472",
       "fun_fact": "“Pictures Of You” appears on Anyma’s release “Genesys II”.",
@@ -5260,7 +5260,7 @@
       "year": 2014,
       "isrc": "NLZ541400816",
       "uri": "spotify:track:6NCqGm4FydIHey3CMa7obx",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=IMi5MP_BeK0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3149222951",
       "fun_fact": "“Treasured Soul - Original Mix” appears on Michael Calfan’s release “Treasured Soul (Club Collection)”.",
@@ -5288,7 +5288,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1753774219"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=dX8orLrVwtY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2862271732",
       "fun_fact": "“Somedays” is the title track of Sonny Fodera’s release of the same name.",
@@ -5308,7 +5308,7 @@
       "year": 2014,
       "isrc": "USUG11401855",
       "uri": "spotify:track:5C4NMi4fPpdFPnMZVsyG8H",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=eCH9gClZprM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/437979062",
       "fun_fact": "“Something New” appears on Axwell /\\ Ingrosso’s release “More Than You Know”.",
@@ -5332,7 +5332,7 @@
       "year": 2023,
       "isrc": "QM24S2305899",
       "uri": "spotify:track:0aVrpFRLlrd5zVyPXWP3mS",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=4oYrQt_zRFg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2401560475",
       "fun_fact": "“Miracle” is the title track of Adriatique’s release of the same name.",
@@ -5356,7 +5356,7 @@
       "year": 2010,
       "isrc": "CH3131000315",
       "uri": "spotify:track:2bcYHFk3XWcPnDXYY3tdJX",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=GbVxvITmwIc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/42569851",
       "fun_fact": "“Rapture - Avicii New Generation Mix” appears on Nadia Ali’s release “Rapture”.",
@@ -5380,7 +5380,7 @@
       "year": 2020,
       "isrc": "ITH642005105",
       "uri": "spotify:track:4vJIXqQKOTGpcp5RGOOxPN",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=LIOL2AoE40M",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3208041201",
       "fun_fact": "“The Feeling” is the title track of Massano’s release of the same name.",
@@ -5404,7 +5404,7 @@
       "year": 2015,
       "isrc": "UK98Q1500201",
       "uri": "spotify:track:1Lt4t4pHow1DGBY6Mtvy5X",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=aXMNRLNqvE4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/468391442",
       "fun_fact": "“+1 (feat. Sam White) - Radio Edit” is the title track of Martin Solveig’s release of the same name.",
@@ -5428,7 +5428,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1694793501"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=86ISrXSdMU4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/143261144",
       "fun_fact": "“Adieu” appears on Tchami’s release “No Redemption”.",
@@ -5448,7 +5448,7 @@
       "year": 2025,
       "isrc": "BE5KW2500717",
       "uri": "spotify:track:2OP7UAuQF1OJbjeYXa5fhm",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XSKweg0app8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3355164441",
       "fun_fact": "“Silence - John Summit Remix” is the title track of Delerium’s release of the same name.",
@@ -5476,7 +5476,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1617280597"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=CgeleP7nWN0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1705986647",
       "fun_fact": "“Ferrari” is the title track of James Hype’s release of the same name.",
@@ -5500,7 +5500,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/736115391"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=n2Ea6FO19gk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/64627716",
       "fun_fact": "“Come With Me - Radio Mix” appears on Nora En Pure’s release “Come with Me”.",
@@ -5524,7 +5524,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1412728922"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=znRHcQXToVM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/528674741",
       "fun_fact": "“Ocean (feat. Khalid) - DubVision Remix” appears on Martin Garrix’s release “Ocean (feat. Khalid) (Remixes Vol. 1)”.",
@@ -5548,7 +5548,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1716722471"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nMVbfoteKdY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2543654701",
       "fun_fact": "“Dance With Me” appears on Kevin de Vries’s release “Dance With Me EP”.",
@@ -5572,7 +5572,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/516569496"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0z7omu2UNVA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2280370857",
       "fun_fact": "“Come Alive” appears on Netsky’s release “2 Deluxe”.",
@@ -5596,7 +5596,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1817292592"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ZTEHNRGqcxA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3389345631",
       "fun_fact": "“Show Me Love - EDX's Indian Summer Remix” appears on Sam Feldt’s release “Show Me Love (EDX's Indian Summer & Quintino Remix)”.",
@@ -5620,7 +5620,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1643698514"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0YVvcTIGy40",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1902157797",
       "fun_fact": "“The Age Of Love - Radio Edit” appears on Age Of Love’s release “The Age Of Love (Remixes)”.",
@@ -5644,7 +5644,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1751742618"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=GDWdul0nrYw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2843812632",
       "fun_fact": "“It's That Time - FISHER Remix” is the title track of Marlon Hoffstadt’s release of the same name.",
@@ -5668,7 +5668,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1052536593"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=4p_WxAA-OcQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3781914",
       "fun_fact": "“The Man With the Red Face - Video Edit” appears on Laurent Garnier’s release “The Man With The Red Face”.",
@@ -5692,7 +5692,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/984746637"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-y11kJzwe4Y",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/75069801",
       "fun_fact": "“You” is the title track of Galantis’s release of the same name.",
@@ -5716,7 +5716,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1458852081"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=iaMkI1z3q4Y",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/530117301",
       "fun_fact": "“Our Origin - Extended Mix” appears on Armin van Buuren’s release “Our Origin”.",
@@ -5740,7 +5740,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1481872810"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-3P2USPFDcE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/769757652",
       "fun_fact": "“Lose Control” is the title track of MEDUZA’s release of the same name.",
@@ -5764,7 +5764,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1787190407"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wgY6zj-HMsE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3157820001",
       "fun_fact": "“Break The House Down” is the title track of Laidback Luke’s release of the same name.",
@@ -5788,7 +5788,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1432624804"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=WfPu9Jrcpuk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/459955592",
       "fun_fact": "“Like I Do” is the title track of David Guetta’s release of the same name.",
@@ -5812,7 +5812,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1467425122"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=X4xF5ymdQG8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/694844122",
       "fun_fact": "“You Little Beauty” is the title track of FISHER’s release of the same name.",
@@ -5832,7 +5832,7 @@
       "year": 2011,
       "isrc": "CYA111100001",
       "uri": "spotify:track:5E5uT5ZokaWpXzo7DgL7ms",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=4BTdp1IHa74",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/771701712",
       "fun_fact": "“Zero 76 - Radio Edit” appears on Tiësto’s release “Zero 76”.",
@@ -5853,7 +5853,7 @@
       "year": 2012,
       "isrc": "USUM71206271",
       "uri": "spotify:track:0Qv6D0PaNKZHepRct8kbyX",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=m0oJ3TVAXA0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1762568467",
       "fun_fact": "“Where Have You Been - The Calvin Harris Extended Remix” is the title track of Rihanna’s release of the same name.",
@@ -5881,7 +5881,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1541882774"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Tr7C0nBHOHI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/132560814",
       "fun_fact": "“Till The Sky Falls Down” appears on Dash Berlin’s release “A State Of Trance - 15 Years”.",
@@ -5905,7 +5905,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/945816846"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=elBb_oHNKA8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/91267450",
       "fun_fact": "“The Moment - Steve Angello Edit” appears on Tim Mason’s release “The Moment”.",
@@ -5929,7 +5929,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1645308143"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zFmInGUS0gs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1914502307",
       "fun_fact": "“Best of Me - Radio Edit” is the title track of ARTBAT’s release of the same name.",
@@ -5953,7 +5953,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1701891628"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HPc8QMycGno",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2404408815",
       "fun_fact": "“Ghost Voices” appears on Virtual Self’s release “Virtual Self”.",
@@ -5973,7 +5973,7 @@
       "year": 2021,
       "isrc": "QZFPL2100100",
       "uri": "spotify:track:7cyGxmLnHWlwt41cr2RZzG",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6wwuEXlIniU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3482503451",
       "fun_fact": "“Do It To It” appears on ACRAZE’s release “Do It To It (Remixes)”.",
@@ -5998,7 +5998,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1639317826"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=KtGFByAJRQQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1862856447",
       "fun_fact": "“B.O.T.A. (Baddest Of Them All) - Edit” appears on Eliza Rose’s release “B.O.T.A. (Baddest Of Them All)”.",
@@ -6022,7 +6022,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/430649596"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ypDtUUtuNzQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/633661602",
       "fun_fact": "“Airwave - Original Mix” appears on Rank 1’s release “Airwave”.",
@@ -6042,7 +6042,7 @@
       "year": 2024,
       "isrc": "BEIW12400461",
       "uri": "spotify:track:5nsGwIGBNcwYVAPNdZCYQV",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=dYD0TsO9Qko",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2845478952",
       "fun_fact": "“Papi” is the title track of KAAZE’s release of the same name.",
@@ -6063,7 +6063,7 @@
       "year": 2005,
       "isrc": "GBKCF0500080",
       "uri": "spotify:track:2Et2nCcAnsl2KDrGZtsO7U",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7W8QERGvax0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/73460558",
       "fun_fact": "“(Can You) Feel The Vibe - Radio Edit” appears on Axwell’s release “Feel The Vibe”.",
@@ -6087,7 +6087,7 @@
       "year": 2020,
       "isrc": "GBUM72005075",
       "uri": "spotify:track:40FUdLENDY3sZmHEM25lpE",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=e7HBypw4lhY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1118064072",
       "fun_fact": "“Paradise” is the title track of MEDUZA’s release of the same name.",
@@ -6112,7 +6112,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1513189643"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=dB_pB2v1FZQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/960115192",
       "fun_fact": "“Home” is the title track of Adriatique’s release of the same name.",
@@ -6132,7 +6132,7 @@
       "year": 2024,
       "isrc": "USSM12403173",
       "uri": "spotify:track:6sFriHsWdq31GcaHdgFHoY",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Xg0AvNZkERM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2757385381",
       "fun_fact": "“FE!N - CHASE B REMIX” is the title track of Travis Scott’s release of the same name.",
@@ -6156,7 +6156,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1337757558"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=flDt8TC6Fok",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/452769012",
       "fun_fact": "“Momentum” is the title track of Don Diablo’s release of the same name.",
@@ -6176,7 +6176,7 @@
       "year": 2025,
       "isrc": "US38Y2509305",
       "uri": "spotify:track:0JFNTfRWLqQ09z9ZHldX8d",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=g-mo2gHdiiY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3245588751",
       "fun_fact": "“Where I'm From” is the title track of Cassian’s release of the same name.",
@@ -6200,7 +6200,7 @@
       "year": 2019,
       "isrc": "NLF711906508",
       "uri": "spotify:track:6BwClo5W3VvTzJv8bvZXDD",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=2H7QaOSGJhU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/757592592",
       "fun_fact": "“Something Real” appears on Armin van Buuren’s release “Balance”.",
@@ -6225,7 +6225,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/598054296"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jJhw37ovN7U",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/64327520",
       "fun_fact": "“Locked out of Heaven - Sultan and Ned Shepard Remix” appears on Bruno Mars’s release “Locked out of Heaven (Remix)”.",
@@ -6249,7 +6249,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1444862281"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HzCazh3raN0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/113946622",
       "fun_fact": "“Wombass” is the title track of Tiësto’s release of the same name.",
@@ -6269,7 +6269,7 @@
       "year": 2010,
       "isrc": "USYBL1000568",
       "uri": "spotify:track:4JZKj6yp5EAah53ryDClq4",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mKP4SGZHvkQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3335368191",
       "fun_fact": "“Babylon” appears on Congorock’s release “Babylon (Remixes)”.",
@@ -6290,7 +6290,7 @@
       "year": 2023,
       "isrc": "GBUM72310662",
       "uri": "spotify:track:0xoYZ45fgTfyQYREZPN7Sa",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rO5UDrIoTTs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2585655882",
       "fun_fact": "“You & Me - Rivo Remix” is the title track of Disclosure’s release of the same name.",
@@ -6314,7 +6314,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1346095388"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HRCP2PBtAUc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/459401082",
       "fun_fact": "“Turn It Up - Tchami Remix” appears on DJ MERCER’s release “Turn It Up (The Remixes)”.",
@@ -6334,7 +6334,7 @@
       "year": 2010,
       "isrc": "GBAHT1000244",
       "uri": "spotify:track:2RS9TJTiHvg0guy8hSmiAF",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=evwlr16PoLY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/8040814",
       "fun_fact": "“The Island - Steve Angello, AN21, Max Vangeli Remix” is the title track of Pendulum’s release of the same name.",
@@ -6362,7 +6362,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1443146805"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=U8D9xCBcfzw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/6057178",
       "fun_fact": "“Acapella” appears on Kelis’s release “Flesh Tone”.",
@@ -6386,7 +6386,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/207928116"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=yuFI5KSPAt4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/680518",
       "fun_fact": "“Snow (Hey Oh)” appears on Red Hot Chili Peppers’s release “Stadium Arcadium”.",
@@ -6410,7 +6410,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1820146735"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-5vm733LwCw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3411361911",
       "fun_fact": "“Our Time” is the title track of AFROJACK’s release of the same name.",
@@ -6434,7 +6434,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1505589067"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0mWEMPO_b3c",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/917189842",
       "fun_fact": "“Hold That Sucker Down - Charlotte de Witte Trance Remix Edit” appears on Jerome Isma-Ae’s release “Hold That Sucker Down (Charlotte de Witte Remix)”.",
@@ -6458,7 +6458,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1308821701"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=z-87KHrwXQc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/995973",
       "fun_fact": "“Xpander” appears on Sasha’s release “The Xpander E.P.”.",
@@ -6482,7 +6482,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1454069265"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nzQLz8QcyqQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/642705612",
       "fun_fact": "“PROGRESSO” appears on Alesso’s release “ALESSO MIXTAPE - PROGRESSO VOLUME 1”.",
@@ -6502,7 +6502,7 @@
       "year": 2011,
       "isrc": "CYA111100052",
       "uri": "spotify:track:3cHyzEpemYlq62PWCEFqGR",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xFwyaiOpeO4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/18063177",
       "fun_fact": "“Maximal Crazy - Original Mix” appears on Tiësto’s release “Club Life: Vol. Two Miami”.",
@@ -6527,7 +6527,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1518217747"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hBaYYHAU_tg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/990358982",
       "fun_fact": "“Hypercolour” is the title track of CamelPhat’s release of the same name.",
@@ -6547,7 +6547,7 @@
       "year": 2024,
       "isrc": "USUG12401003",
       "uri": "spotify:track:32VIrOsJmwvqRm4rWFBCsi",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=LlTkluUkbLk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2877072812",
       "fun_fact": "“Shiver” appears on John Summit’s release “Comfort In Chaos”.",
@@ -6575,7 +6575,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1610154676"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Wx3gRx0Fyzk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1659968202",
       "fun_fact": "“Run” is the title track of Becky Hill’s release of the same name.",
@@ -6599,7 +6599,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1408685591"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=s_8gG-7Djns",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/524827952",
       "fun_fact": "“Tim” is the title track of ARTY’s release of the same name.",
@@ -6623,7 +6623,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1566539919"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=QH2a6V-W87U",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1372169352",
       "fun_fact": "“Never Going Home” is the title track of Kungs’s release of the same name.",
@@ -6643,7 +6643,7 @@
       "year": 2014,
       "isrc": "NLZ541301022",
       "uri": "spotify:track:4soJPaN3etpZC72tHZztw3",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XrMssQ2JB48",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/463375482",
       "fun_fact": "“Flashlight” is the title track of R3HAB’s release of the same name.",
@@ -6671,7 +6671,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1714741682"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TAxXRmwA40o",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/759015342",
       "fun_fact": "“Gravity (feat. Laura Korinth)” appears on Boris Brejcha’s release “Space Diver”.",
@@ -6695,7 +6695,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1589095808"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UfiYPq7-M3E",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1514340882",
       "fun_fact": "“Move Your Body” is the title track of Öwnboss’s release of the same name.",
@@ -6715,7 +6715,7 @@
       "year": 2022,
       "isrc": "GBUM72208256",
       "uri": "spotify:track:7DCdoJx9mCpdxcyk5CtbBM",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xENmcMSvZFI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2082295697",
       "fun_fact": "“Ready To Fly” appears on Sub Focus’s release “Ready To Fly (Hardcore Mix)”.",
@@ -6743,7 +6743,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/925691346"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fAxFgzTXluI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/78304458",
       "fun_fact": "“Yeah Yeah - D Ramirez Vocal Radio Edit” appears on Bodyrox’s release “Yeah Yeah”.",
@@ -6763,7 +6763,7 @@
       "year": 2018,
       "isrc": "CYA111800373",
       "uri": "spotify:track:3bYLRndI3qoLQqgPalT8CY",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=D4boxpPPhFA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/933168402",
       "fun_fact": "“Grapevine” is the title track of Tiësto’s release of the same name.",
@@ -6787,7 +6787,7 @@
       "year": 2015,
       "isrc": "USUG11500056",
       "uri": "spotify:track:2ToIksTPpJ4csKPEOdUEyM",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-aWtrEFfS4E",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/100068942",
       "fun_fact": "“Cool” appears on Alesso’s release “Forever”.",
@@ -6812,7 +6812,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1491189215"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Akblh02CRns",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/853614092",
       "fun_fact": "“Deep Inside Of Me (feat. MKLA)” is the title track of Vintage Culture’s release of the same name.",
@@ -6832,7 +6832,7 @@
       "year": 2025,
       "isrc": "USNRS2543977",
       "uri": "spotify:track:7lDGg8CFySbkKUrjgzcLlY",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=IIsm0ADh09U",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3205781411",
       "fun_fact": "“The Less I Know The Better” is the title track of Mau P’s release of the same name.",
@@ -6860,7 +6860,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1688990932"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=QX21I1LhlJo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2300123815",
       "fun_fact": "“Hurricane” is the title track of Martin Garrix’s release of the same name.",
@@ -6884,7 +6884,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1479872574"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VFQ87_g41ZA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/753716852",
       "fun_fact": "“San Frandisco” is the title track of Dom Dolla’s release of the same name.",
@@ -6908,7 +6908,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1114633426"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=DPHsToh4z3Y",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/452697612",
       "fun_fact": "“Untrue” is the title track of Tchami’s release of the same name.",


### PR DESCRIPTION
Six nightly `provider-uri-backfill` runs by `com.beatify.youtube-backfill`, all landed on this branch because it stayed in draft.

- `tomorrowland-top-1000` YouTube 156 -> **730**/825

Each nightly run added exactly 96 URIs (25.08 through 30.08). The title and description of this PR described only the first of them until now.

**Two URIs were removed again before merging.** The backfill gave one video to two different songs in two cases:

- `JEmbyx8NLxA` is "Blessings (Official Video)", so it stays on `Blessings` and was dropped from `Blessings - Cassian Remix`.
- `IZ36b3q1elI` is "World Hold On (Fisher Rework) (Official Video)", so it stays on the 2022 FISHER Rework and was dropped from the 2006 Radio Edit. That one would have made the game accept 2022 as the year of a 2006 track.

Both fields are `null` again and a later run can retry them. Net effect is +574 URIs and no duplicate video in the playlist.

93 songs still have no YouTube URI; one more nightly run covers them.