### PR TITLE
data: fix 3 broken URIs in deutschrock-best-of (#2381)

### DIFF
--- a/custom_components/beatify/playlists/community/deutschrock-best-of.json
+++ b/custom_components/beatify/playlists/community/deutschrock-best-of.json
@@ -1,6 +1,6 @@
 {
   "name": "Deutschrock - Best Of",
-  "version": "0.39",
+  "version": "0.40",
   "tags": [
     "deutschrock",
     "german rock",
@@ -627,7 +627,7 @@
         "nl": "applemusic://track/1500266192",
         "it": "applemusic://track/1500266192"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=7LORRKXTvnA",
+      "uri_youtube_music": null,
       "uri_tidal": "tidal://track/133886894",
       "uri_deezer": "deezer://track/899950322",
       "alt_artists": [],
@@ -1269,13 +1269,13 @@
       "isrc": "DEZ901501941",
       "uri_apple_music": "applemusic://track/1738071871",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/1738072836",
-        "de": "applemusic://track/1738072836",
-        "gb": "applemusic://track/1738072836",
-        "fr": "applemusic://track/1738072836",
-        "es": "applemusic://track/1738072836",
-        "nl": "applemusic://track/1738072836",
-        "it": "applemusic://track/1738072836"
+        "us": "applemusic://track/1738071871",
+        "de": "applemusic://track/1738071871",
+        "gb": "applemusic://track/1738071871",
+        "fr": "applemusic://track/1738071871",
+        "es": "applemusic://track/1738071871",
+        "nl": "applemusic://track/1738071871",
+        "it": "applemusic://track/1738071871"
       },
       "uri_youtube_music": "https://music.youtube.com/watch?v=uaxTiriqLLE",
       "uri_tidal": "tidal://track/353722894",
@@ -2005,7 +2005,7 @@
         "nl": "applemusic://track/1579051018",
         "it": "applemusic://track/1579051018"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=vfxjYR_Z6qs",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9-aNYmmNyKI",
       "uri_tidal": "tidal://track/192675499",
       "uri_deezer": "deezer://track/672579152",
       "alt_artists": [],


### PR DESCRIPTION
Closes #2381.

- Themenwexel - Luft: nulled `uri_youtube_music` (URI pointed to "Der Gärtner"; track not available on YouTube Music)
- Sündflut - Gewalt der Musik: fixed `uri_youtube_music` (URI pointed to "Mach die Augen auf"; replaced with correct `9-aNYmmNyKI`)
- KrawallBrüder - Auf der Flucht - Rockversion: corrected all 7 `uri_apple_music_by_region` entries from Ballade (1738072836) to Rockversion (1738071871)

Playlist version bumped 0.39 → 0.40.