### PR TITLE
data: fix 1 broken URI in quebecois-1990-2020 (#2383)

### DIFF
--- a/custom_components/beatify/playlists/community/quebecois-1990-2020.json
+++ b/custom_components/beatify/playlists/community/quebecois-1990-2020.json
@@ -1,6 +1,6 @@
 {
   "name": "🍁 Québécois 1990-2020",
-  "version": "0.17",
+  "version": "0.18",
   "tags": [
     "quebecois",
     "quebec",
@@ -2902,7 +2902,7 @@
       "uri": "spotify:track:2p3O33eThnhhq1dMWlvR7M",
       "year": 1990,
       "isrc": "CAA509003706",
-      "uri_apple_music": "applemusic://track/1621195978",
+      "uri_apple_music": "applemusic://track/1551615863",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/6781751915",
         "de": "applemusic://track/6781751915",


### PR DESCRIPTION
Closes #2383. Replaced 1 dead Apple Music URI for Vilain Pingouin - Le train and bumped playlist version to 0.18.

Note: Only the legacy `uri_apple_music` fallback field was updated; the per-region map (`uri_apple_music_by_region`) was already healthy across all 7 storefronts.