### PR TITLE
data: fix 10 broken URIs in eurodance-90s (#2399)

### DIFF
--- a/custom_components/beatify/playlists/community/eurodance-90s.json
+++ b/custom_components/beatify/playlists/community/eurodance-90s.json
@@ -1,6 +1,6 @@
 {
   "name": "Eurodance 90s 💥",
-  "version": "1.18",
+  "version": "1.19",
   "tags": [
     "1990s",
     "eurodance",
@@ -1848,7 +1848,7 @@
       "fun_fact_de": "Guru Joshs Trance-Hymne erlebte 2008 ein Revival, als der 'Klaas Remix' weltweit die Charts anführte.",
       "fun_fact_es": "El himno trance de Guru Josh experimentó un renacimiento masivo en 2008.",
       "fun_fact_fr": "L'hymne trance de Guru Josh a connu un renouveau spectaculaire en 2008 lorsque le 'Klaas Remix' a dominé les classements mondiaux, faisant découvrir le morceau à une nouvelle génération.",
-      "uri_apple_music": "applemusic://track/943232484",
+      "uri_apple_music": "applemusic://track/338322430",
       "uri_youtube_music": "https://music.youtube.com/watch?v=tGBlIJPYWqA",
       "uri_tidal": "tidal://track/564885",
       "uri_deezer": "deezer://track/61686264",
@@ -1856,13 +1856,13 @@
       "awards_nl": [],
       "isrc": "GBARL9100115",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/943232484",
-        "de": "applemusic://track/852614431",
-        "gb": "applemusic://track/852614431",
-        "fr": "applemusic://track/852614431",
-        "es": "applemusic://track/852614431",
-        "nl": "applemusic://track/852614431",
-        "it": "applemusic://track/852614431"
+        "us": "applemusic://track/338322430",
+        "de": "applemusic://track/338322430",
+        "gb": "applemusic://track/338322430",
+        "fr": "applemusic://track/338322430",
+        "es": "applemusic://track/338322430",
+        "nl": "applemusic://track/338322430",
+        "it": "applemusic://track/338322430"
       }
     },
     {
@@ -3422,7 +3422,7 @@
       "fun_fact_nl": "De stadionhymne van 2 Unlimited werd een vaste waarde tijdens sportevenementen en wordt tientallen jaren later nog steeds gedraaid tijdens wedstrijden over de hele wereld. De agressieve energie van het nummer maakte het perfect voor oppepmomenten.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/389498081",
-      "uri_deezer": "deezer://track/1484325492"
+      "uri_deezer": "deezer://track/131708882"
     },
     {
       "year": 1995,
@@ -3757,7 +3757,7 @@
       "uri_tidal": "tidal://track/3551604",
       "fun_fact_nl": "2 Unlimited's opvolger van 'No Limit' zette hun energieke Eurodance-formule voort met op tribals geïnspireerde beats.",
       "awards_nl": [],
-      "uri_deezer": "deezer://track/77198154"
+      "uri_deezer": null
     },
     {
       "year": 1995,


### PR DESCRIPTION
Closes #2399.

**Changes:**
- Guru Josh Infinity: dead Apple Music URIs replaced with track/338322430 (available in all 7 storefronts)
- 2 Unlimited Get Ready for This - Orchestral Version Deezer: wrong Yves Deruyter Remix → Orchestra Mix (131708882)
- 2 Unlimited Tribal Dance 2.4 - Long Version Deezer: nulled out wrong 2 Chains Club Mix (Long Version not on Deezer)
- Version bumped 1.18 → 1.19

19 wrong_track flags reviewed and dismissed as false positives.