### PR TITLE
data(playlists): MGMT — Kids is from 2005, not 2007

### DIFF
--- a/custom_components/beatify/playlists/2000s-pop-anthems.json
+++ b/custom_components/beatify/playlists/2000s-pop-anthems.json
@@ -2985,7 +2985,7 @@
       }
     },
     {
-      "year": 2007,
+      "year": 2005,
       "uri": "spotify:track:1jJci4qxiYcOHhQR247rEU",
       "artist": "MGMT",
       "alt_artists": [


### PR DESCRIPTION
A player reported the year on MGMT's `Kids` in `2000s-pop-anthems.json`. Checked, and the report is right.

- `Kids` first appeared on MGMT's self-released **Time to Pretend** EP, **2005-08-30**. That is the earliest release MusicBrainz carries for the recording, and iTunes lists the same EP with a 2005 date.
- The **2007** currently in the playlist is the date of *Oracular Spectacular*, which is where most people met the song.

Our convention is the original release year of the song, and a later re-recording by the same artist never sets it — so 2005 is the answer the game should accept.

One line changed, schema validates.

Closes #2404