### PR TITLE
chore(playlists): apple backfill — +1 apple uris

### DIFF
--- a/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
+++ b/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
@@ -1,6 +1,6 @@
 {
   "name": "Tomorrowland Top 1000",
-  "version": "0.68",
+  "version": "0.69",
   "tags": [
     "edm",
     "electronic",
@@ -3872,7 +3872,8 @@
         "BUNT., Nate Traveller",
         "Madeon",
         "Bob Sinclar"
-      ]
+      ],
+      "uri_apple_music": "applemusic://track/6783301687"
     },
     {
       "artist": "Bag Raiders",


### PR DESCRIPTION
A `provider-uri-backfill` run focused on Apple Music, driven automatically by `com.beatify.apple-backfill`.

- `tomorrowland-top-1000` Apple 740 -> **741**/825

**The run stopped at its cap rather than finishing** (`reached --max-minutes 50`). The remaining tracks of the playlist are untouched and are not a catalogue gap.

**Draft on purpose** — merged only once the maintainer approves. This agent has deliberately NO auto-merge.