### PR TITLE
chore(playlists): youtube backfill — +12 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/community/salsa-y-merengue.json
+++ b/custom_components/beatify/playlists/community/salsa-y-merengue.json
@@ -1,6 +1,6 @@
 {
   "name": "Salsa y Merengue",
-  "version": "1.0",
+  "version": "1.5",
   "tags": [
     "salsa",
     "merengue",
@@ -27,7 +27,8 @@
       "fun_fact_fr": "« Ché Ché Colé » de Willie Colón, Héctor Lavoe, parue pour la première fois en 1969.",
       "fun_fact_nl": "\"Ché Ché Colé\" van Willie Colón, Héctor Lavoe, voor het eerst uitgebracht in 1969.",
       "uri_deezer": "deezer://track/686077012",
-      "uri_apple_music": "applemusic://track/1508050955"
+      "uri_apple_music": "applemusic://track/1508050955",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XgId1N1UbLs"
     },
     {
       "year": 1970,
@@ -41,7 +42,8 @@
       "fun_fact_fr": "« La Murga » de Héctor Lavoe, Willie Colón, parue pour la première fois en 1970 sur l'album « Asalto Navideño: Vol. 1 & 2 ».",
       "fun_fact_nl": "\"La Murga\" van Héctor Lavoe, Willie Colón, voor het eerst uitgebracht in 1970 op het album \"Asalto Navideño: Vol. 1 & 2\".",
       "uri_deezer": "deezer://track/686087482",
-      "uri_apple_music": "applemusic://track/1464288858"
+      "uri_apple_music": "applemusic://track/1464288858",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XKCD99urScc"
     },
     {
       "year": 1969,
@@ -55,7 +57,8 @@
       "fun_fact_fr": "« Periodico De Ayer » de Héctor Lavoe, parue pour la première fois en 1969 sur l'album « A Man And His Music: La Voz ».",
       "fun_fact_nl": "\"Periodico De Ayer\" van Héctor Lavoe, voor het eerst uitgebracht in 1969 op het album \"A Man And His Music: La Voz\".",
       "uri_deezer": "deezer://track/688751902",
-      "uri_apple_music": "applemusic://track/1766860330"
+      "uri_apple_music": "applemusic://track/1766860330",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=kwCV6OZI5GM"
     },
     {
       "year": 1969,
@@ -69,7 +72,8 @@
       "fun_fact_fr": "« El Cantante » de Héctor Lavoe, parue pour la première fois en 1969 sur l'album « Comedia ».",
       "fun_fact_nl": "\"El Cantante\" van Héctor Lavoe, voor het eerst uitgebracht in 1969 op het album \"Comedia\".",
       "uri_deezer": "deezer://track/689033892",
-      "uri_apple_music": "applemusic://track/1701025846"
+      "uri_apple_music": "applemusic://track/1701025846",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BNo0vkEYWRc"
     },
     {
       "year": 2006,
@@ -97,7 +101,8 @@
       "fun_fact_fr": "« Triste Y Vacía » de Héctor Lavoe, Willie Colón, parue pour la première fois en 1982.",
       "fun_fact_nl": "\"Triste Y Vacía\" van Héctor Lavoe, Willie Colón, voor het eerst uitgebracht in 1982.",
       "uri_deezer": "deezer://track/687772602",
-      "uri_apple_music": "applemusic://track/1466317245"
+      "uri_apple_music": "applemusic://track/1466317245",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nShuNc2XkJI"
     },
     {
       "year": 1969,
@@ -111,7 +116,8 @@
       "fun_fact_fr": "« Calle Luna Calle Sol » de Willie Colón, Héctor Lavoe, parue pour la première fois en 1969 sur l'album « Lo Mato ».",
       "fun_fact_nl": "\"Calle Luna Calle Sol\" van Willie Colón, Héctor Lavoe, voor het eerst uitgebracht in 1969 op het album \"Lo Mato\".",
       "uri_deezer": "deezer://track/686101012",
-      "uri_apple_music": "applemusic://track/1464272281"
+      "uri_apple_music": "applemusic://track/1464272281",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Z7fYCZtaJwo"
     },
     {
       "year": 1973,
@@ -265,7 +271,8 @@
       "fun_fact_fr": "« Pedro Navaja » de Willie Colón, Rubén Blades, parue pour la première fois en 1978 sur l'album « Siembra ».",
       "fun_fact_nl": "\"Pedro Navaja\" van Willie Colón, Rubén Blades, voor het eerst uitgebracht in 1978 op het album \"Siembra\".",
       "uri_deezer": "deezer://track/686098802",
-      "uri_apple_music": "applemusic://track/1464957419"
+      "uri_apple_music": "applemusic://track/1464957419",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0hcoNykaI3k"
     },
     {
       "year": 1978,
@@ -293,7 +300,8 @@
       "fun_fact_fr": "« Lloraras » de Oscar D'León, La Dimensión Latina, parue pour la première fois en 1974 sur l'album « Oscar D'León En México ».",
       "fun_fact_nl": "\"Lloraras\" van Oscar D'León, La Dimensión Latina, voor het eerst uitgebracht in 1974 op het album \"Oscar D'León En México\".",
       "uri_deezer": "deezer://track/861158912",
-      "uri_apple_music": "applemusic://track/1495520388"
+      "uri_apple_music": "applemusic://track/1495520388",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Y9xD2rd2ukI"
     },
     {
       "year": 1991,
@@ -405,7 +413,8 @@
       "fun_fact_fr": "« Conciencia » de Gilberto Santa Rosa, parue pour la première fois en 1991 sur l'album « Mis Favoritas ».",
       "fun_fact_nl": "\"Conciencia\" van Gilberto Santa Rosa, voor het eerst uitgebracht in 1991 op het album \"Mis Favoritas\".",
       "uri_deezer": "deezer://track/6720628",
-      "uri_apple_music": "applemusic://track/170115102"
+      "uri_apple_music": "applemusic://track/170115102",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7kbjKCj-rMQ"
     },
     {
       "year": 1999,
@@ -433,7 +442,8 @@
       "fun_fact_fr": "« Un Montón de Estrellas » de Gilberto Santa Rosa, parue pour la première fois en 1998 sur l'album « El Caballero De La Salsa - La Historia Tropical ».",
       "fun_fact_nl": "\"Un Montón de Estrellas\" van Gilberto Santa Rosa, voor het eerst uitgebracht in 1998 op het album \"El Caballero De La Salsa - La Historia Tropical\".",
       "uri_deezer": "deezer://track/13204940",
-      "uri_apple_music": "applemusic://track/303411300"
+      "uri_apple_music": "applemusic://track/303411300",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=H5qWtG7cziE"
     },
     {
       "year": 2001,
@@ -531,7 +541,8 @@
       "fun_fact_fr": "« Te Propongo » de Gilberto Santa Rosa, parue pour la première fois en 1994 sur l'album « De Cara Al Viento ».",
       "fun_fact_nl": "\"Te Propongo\" van Gilberto Santa Rosa, voor het eerst uitgebracht in 1994 op het album \"De Cara Al Viento\".",
       "uri_deezer": "deezer://track/13264588",
-      "uri_apple_music": "applemusic://track/163345163"
+      "uri_apple_music": "applemusic://track/163345163",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wh21tFCmzV0"
     },
     {
       "year": 2001,
@@ -851,7 +862,8 @@
       "fun_fact_fr": "« La Rueda » de Frankie Ruiz, parue pour la première fois en 1979 sur l'album « Tú Me Vuelves Loco (Baile Total) ».",
       "fun_fact_nl": "\"La Rueda\" van Frankie Ruiz, voor het eerst uitgebracht in 1979 op het album \"Tú Me Vuelves Loco (Baile Total)\".",
       "uri_deezer": "deezer://track/429987902",
-      "uri_apple_music": "applemusic://track/1478922776"
+      "uri_apple_music": "applemusic://track/1478922776",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=pEEa4wl_BZM"
     },
     {
       "year": 1985,


### PR DESCRIPTION
A `provider-uri-backfill` run, driven automatically by `com.beatify.youtube-backfill`.

- `salsa-y-merengue` YouTube 0 -> **12**/534

**Draft on purpose** — merged only once the maintainer approves.