### PR TITLE
data(playlists): put the right year in the "chart hit" fun facts

### DIFF
--- a/custom_components/beatify/playlists/2000s-pop-anthems.json
+++ b/custom_components/beatify/playlists/2000s-pop-anthems.json
@@ -6645,11 +6645,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=JmHXXf3p9lI",
       "uri_tidal": "tidal://track/43419928",
       "uri_deezer": "deezer://track/71608366",
-      "fun_fact": "A chart hit by Manu Chao (2008).",
-      "fun_fact_de": "Ein Chart-Hit von Manu Chao (2008).",
-      "fun_fact_es": "Un éxito de Manu Chao (2008).",
-      "fun_fact_fr": "Un tube de Manu Chao (2008).",
-      "fun_fact_nl": "Een chart-hit van Manu Chao (2008)."
+      "fun_fact": "A chart hit by Manu Chao (2001).",
+      "fun_fact_de": "Ein Chart-Hit von Manu Chao (2001).",
+      "fun_fact_es": "Un éxito de Manu Chao (2001).",
+      "fun_fact_fr": "Un tube de Manu Chao (2001).",
+      "fun_fact_nl": "Een chart-hit van Manu Chao (2001)."
     },
     {
       "artist": "Justin Timberlake",
@@ -6963,11 +6963,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=m2zUrruKjDQ",
       "uri_tidal": "tidal://track/23273347",
       "uri_deezer": "deezer://track/953097",
-      "fun_fact": "A chart hit by The Killers (2007).",
-      "fun_fact_de": "Ein Chart-Hit von The Killers (2007).",
-      "fun_fact_es": "Un éxito de The Killers (2007).",
-      "fun_fact_fr": "Un tube de The Killers (2007).",
-      "fun_fact_nl": "Een chart-hit van The Killers (2007)."
+      "fun_fact": "A chart hit by The Killers (2003).",
+      "fun_fact_de": "Ein Chart-Hit von The Killers (2003).",
+      "fun_fact_es": "Un éxito de The Killers (2003).",
+      "fun_fact_fr": "Un tube de The Killers (2003).",
+      "fun_fact_nl": "Een chart-hit van The Killers (2003)."
     },
     {
       "artist": "Destiny's Child",
@@ -7191,11 +7191,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=o_ZBzGlYS6g",
       "uri_tidal": "tidal://track/578434",
       "uri_deezer": "deezer://track/1399345572",
-      "fun_fact": "A chart hit by Safri Duo (2021).",
-      "fun_fact_de": "Ein Chart-Hit von Safri Duo (2021).",
-      "fun_fact_es": "Un éxito de Safri Duo (2021).",
-      "fun_fact_fr": "Un tube de Safri Duo (2021).",
-      "fun_fact_nl": "Een chart-hit van Safri Duo (2021)."
+      "fun_fact": "A chart hit by Safri Duo (2000).",
+      "fun_fact_de": "Ein Chart-Hit von Safri Duo (2000).",
+      "fun_fact_es": "Un éxito de Safri Duo (2000).",
+      "fun_fact_fr": "Un tube de Safri Duo (2000).",
+      "fun_fact_nl": "Een chart-hit van Safri Duo (2000)."
     },
     {
       "artist": "S Club",
@@ -7216,11 +7216,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=w60C081sLtI",
       "uri_tidal": "tidal://track/44814701",
       "uri_deezer": "deezer://track/98981562",
-      "fun_fact": "A chart hit by S Club (2015).",
-      "fun_fact_de": "Ein Chart-Hit von S Club (2015).",
-      "fun_fact_es": "Un éxito de S Club (2015).",
-      "fun_fact_fr": "Un tube de S Club (2015).",
-      "fun_fact_nl": "Een chart-hit van S Club (2015)."
+      "fun_fact": "A chart hit by S Club (2001).",
+      "fun_fact_de": "Ein Chart-Hit von S Club (2001).",
+      "fun_fact_es": "Un éxito de S Club (2001).",
+      "fun_fact_fr": "Un tube de S Club (2001).",
+      "fun_fact_nl": "Een chart-hit van S Club (2001)."
     },
     {
       "artist": "Daft Punk",
@@ -7233,11 +7233,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=JhulBGMA7G4",
       "uri_tidal": "tidal://track/1550549",
       "uri_deezer": "deezer://track/3135556",
-      "fun_fact": "A chart hit by Daft Punk (2022).",
-      "fun_fact_de": "Ein Chart-Hit von Daft Punk (2022).",
-      "fun_fact_es": "Un éxito de Daft Punk (2022).",
-      "fun_fact_fr": "Un tube de Daft Punk (2022).",
-      "fun_fact_nl": "Een chart-hit van Daft Punk (2022)."
+      "fun_fact": "A chart hit by Daft Punk (2001).",
+      "fun_fact_de": "Ein Chart-Hit von Daft Punk (2001).",
+      "fun_fact_es": "Un éxito de Daft Punk (2001).",
+      "fun_fact_fr": "Un tube de Daft Punk (2001).",
+      "fun_fact_nl": "Een chart-hit van Daft Punk (2001)."
     },
     {
       "artist": "Daddy DJ",
@@ -7258,11 +7258,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=QWBMCtIllEM",
       "uri_tidal": "tidal://track/111279010",
       "uri_deezer": "deezer://track/3477676331",
-      "fun_fact": "A chart hit by Daddy DJ (2022).",
-      "fun_fact_de": "Ein Chart-Hit von Daddy DJ (2022).",
-      "fun_fact_es": "Un éxito de Daddy DJ (2022).",
-      "fun_fact_fr": "Un tube de Daddy DJ (2022).",
-      "fun_fact_nl": "Een chart-hit van Daddy DJ (2022)."
+      "fun_fact": "A chart hit by Daddy DJ (2000).",
+      "fun_fact_de": "Ein Chart-Hit von Daddy DJ (2000).",
+      "fun_fact_es": "Un éxito de Daddy DJ (2000).",
+      "fun_fact_fr": "Un tube de Daddy DJ (2000).",
+      "fun_fact_nl": "Een chart-hit van Daddy DJ (2000)."
     },
     {
       "artist": "Girls Aloud",
@@ -7283,11 +7283,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=ogJJoVqfXHY",
       "uri_tidal": "tidal://track/50421567",
       "uri_deezer": "deezer://track/2321097235",
-      "fun_fact": "A chart hit by Girls Aloud (2023).",
-      "fun_fact_de": "Ein Chart-Hit von Girls Aloud (2023).",
-      "fun_fact_es": "Un éxito de Girls Aloud (2023).",
-      "fun_fact_fr": "Un tube de Girls Aloud (2023).",
-      "fun_fact_nl": "Een chart-hit van Girls Aloud (2023)."
+      "fun_fact": "A chart hit by Girls Aloud (2002).",
+      "fun_fact_de": "Ein Chart-Hit von Girls Aloud (2002).",
+      "fun_fact_es": "Un éxito de Girls Aloud (2002).",
+      "fun_fact_fr": "Un tube de Girls Aloud (2002).",
+      "fun_fact_nl": "Een chart-hit van Girls Aloud (2002)."
     },
     {
       "artist": "Counting Crows",
@@ -7308,11 +7308,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=GEo7W-uJNkc",
       "uri_tidal": "tidal://track/71943313",
       "uri_deezer": "deezer://track/145425722",
-      "fun_fact": "A chart hit by Counting Crows (2017).",
-      "fun_fact_de": "Ein Chart-Hit von Counting Crows (2017).",
-      "fun_fact_es": "Un éxito de Counting Crows (2017).",
-      "fun_fact_fr": "Un tube de Counting Crows (2017).",
-      "fun_fact_nl": "Een chart-hit van Counting Crows (2017)."
+      "fun_fact": "A chart hit by Counting Crows (2004).",
+      "fun_fact_de": "Ein Chart-Hit von Counting Crows (2004).",
+      "fun_fact_es": "Un éxito de Counting Crows (2004).",
+      "fun_fact_fr": "Un tube de Counting Crows (2004).",
+      "fun_fact_nl": "Een chart-hit van Counting Crows (2004)."
     },
     {
       "artist": "Alphabeat",
@@ -7333,11 +7333,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=ey8BvkgO4bk",
       "uri_tidal": "tidal://track/8296025",
       "uri_deezer": "deezer://track/14194027",
-      "fun_fact": "A chart hit by Alphabeat (2013).",
-      "fun_fact_de": "Ein Chart-Hit von Alphabeat (2013).",
-      "fun_fact_es": "Un éxito de Alphabeat (2013).",
-      "fun_fact_fr": "Un tube de Alphabeat (2013).",
-      "fun_fact_nl": "Een chart-hit van Alphabeat (2013)."
+      "fun_fact": "A chart hit by Alphabeat (2007).",
+      "fun_fact_de": "Ein Chart-Hit von Alphabeat (2007).",
+      "fun_fact_es": "Un éxito de Alphabeat (2007).",
+      "fun_fact_fr": "Un tube de Alphabeat (2007).",
+      "fun_fact_nl": "Een chart-hit van Alphabeat (2007)."
     },
     {
       "artist": "Alex Gaudino",
@@ -7358,11 +7358,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=oGDjI40SjrA",
       "uri_tidal": "tidal://track/79783653",
       "uri_deezer": "deezer://track/3305815511",
-      "fun_fact": "A chart hit by Alex Gaudino (2025).",
-      "fun_fact_de": "Ein Chart-Hit von Alex Gaudino (2025).",
-      "fun_fact_es": "Un éxito de Alex Gaudino (2025).",
-      "fun_fact_fr": "Un tube de Alex Gaudino (2025).",
-      "fun_fact_nl": "Een chart-hit van Alex Gaudino (2025)."
+      "fun_fact": "A chart hit by Alex Gaudino (2007).",
+      "fun_fact_de": "Ein Chart-Hit von Alex Gaudino (2007).",
+      "fun_fact_es": "Un éxito de Alex Gaudino (2007).",
+      "fun_fact_fr": "Un tube de Alex Gaudino (2007).",
+      "fun_fact_nl": "Een chart-hit van Alex Gaudino (2007)."
     },
     {
       "artist": "Akcent",
@@ -7383,11 +7383,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=Kj0wBAtCN5o",
       "uri_tidal": "tidal://track/103536544",
       "uri_deezer": "deezer://track/3432957681",
-      "fun_fact": "A chart hit by Akcent (2025).",
-      "fun_fact_de": "Ein Chart-Hit von Akcent (2025).",
-      "fun_fact_es": "Un éxito de Akcent (2025).",
-      "fun_fact_fr": "Un tube de Akcent (2025).",
-      "fun_fact_nl": "Een chart-hit van Akcent (2025)."
+      "fun_fact": "A chart hit by Akcent (2005).",
+      "fun_fact_de": "Ein Chart-Hit von Akcent (2005).",
+      "fun_fact_es": "Un éxito de Akcent (2005).",
+      "fun_fact_fr": "Un tube de Akcent (2005).",
+      "fun_fact_nl": "Een chart-hit van Akcent (2005)."
     },
     {
       "artist": "Rednex",
@@ -7408,11 +7408,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=WFGhOkCzp2g",
       "uri_tidal": "tidal://track/77267276",
       "uri_deezer": "deezer://track/393003352",
-      "fun_fact": "A chart hit by Rednex (2017).",
-      "fun_fact_de": "Ein Chart-Hit von Rednex (2017).",
-      "fun_fact_es": "Un éxito de Rednex (2017).",
-      "fun_fact_fr": "Un tube de Rednex (2017).",
-      "fun_fact_nl": "Een chart-hit van Rednex (2017)."
+      "fun_fact": "A chart hit by Rednex (2000).",
+      "fun_fact_de": "Ein Chart-Hit von Rednex (2000).",
+      "fun_fact_es": "Un éxito de Rednex (2000).",
+      "fun_fact_fr": "Un tube de Rednex (2000).",
+      "fun_fact_nl": "Een chart-hit van Rednex (2000)."
     },
     {
       "artist": "Tiësto",
@@ -7436,11 +7436,11 @@
       "alt_artists": [
         "BT"
       ],
-      "fun_fact": "A chart hit by Tiësto (2010).",
-      "fun_fact_de": "Ein Chart-Hit von Tiësto (2010).",
-      "fun_fact_es": "Un éxito de Tiësto (2010).",
-      "fun_fact_fr": "Un tube de Tiësto (2010).",
-      "fun_fact_nl": "Een chart-hit van Tiësto (2010)."
+      "fun_fact": "A chart hit by Tiësto (2004).",
+      "fun_fact_de": "Ein Chart-Hit von Tiësto (2004).",
+      "fun_fact_es": "Un éxito de Tiësto (2004).",
+      "fun_fact_fr": "Un tube de Tiësto (2004).",
+      "fun_fact_nl": "Een chart-hit van Tiësto (2004)."
     }
   ]
 }

--- a/custom_components/beatify/playlists/80er-hits.json
+++ b/custom_components/beatify/playlists/80er-hits.json
@@ -7611,11 +7611,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=Y9mPp5IZbrY",
       "uri_tidal": "tidal://track/1127288",
       "uri_deezer": "deezer://track/3168234",
-      "fun_fact": "A chart hit by The J. Geils Band (1989).",
-      "fun_fact_de": "Ein Chart-Hit von The J. Geils Band (1989).",
-      "fun_fact_es": "Un éxito de The J. Geils Band (1989).",
-      "fun_fact_fr": "Un tube de The J. Geils Band (1989).",
-      "fun_fact_nl": "Een chart-hit van The J. Geils Band (1989)."
+      "fun_fact": "A chart hit by The J. Geils Band (1981).",
+      "fun_fact_de": "Ein Chart-Hit von The J. Geils Band (1981).",
+      "fun_fact_es": "Un éxito de The J. Geils Band (1981).",
+      "fun_fact_fr": "Un tube de The J. Geils Band (1981).",
+      "fun_fact_nl": "Een chart-hit van The J. Geils Band (1981)."
     },
     {
       "artist": "George Harrison",
@@ -7661,11 +7661,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=Sik6eDQ18WE",
       "uri_tidal": "tidal://track/141174374",
       "uri_deezer": "deezer://track/958716392",
-      "fun_fact": "A chart hit by Gipsy Kings (2012).",
-      "fun_fact_de": "Ein Chart-Hit von Gipsy Kings (2012).",
-      "fun_fact_es": "Un éxito de Gipsy Kings (2012).",
-      "fun_fact_fr": "Un tube de Gipsy Kings (2012).",
-      "fun_fact_nl": "Een chart-hit van Gipsy Kings (2012)."
+      "fun_fact": "A chart hit by Gipsy Kings (1982).",
+      "fun_fact_de": "Ein Chart-Hit von Gipsy Kings (1982).",
+      "fun_fact_es": "Un éxito de Gipsy Kings (1982).",
+      "fun_fact_fr": "Un tube de Gipsy Kings (1982).",
+      "fun_fact_nl": "Een chart-hit van Gipsy Kings (1982)."
     },
     {
       "artist": "Bandolero",
@@ -7686,11 +7686,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=ruauz315oms",
       "uri_tidal": "tidal://track/45973475",
       "uri_deezer": "deezer://track/14750330",
-      "fun_fact": "A chart hit by Bandolero (2011).",
-      "fun_fact_de": "Ein Chart-Hit von Bandolero (2011).",
-      "fun_fact_es": "Un éxito de Bandolero (2011).",
-      "fun_fact_fr": "Un tube de Bandolero (2011).",
-      "fun_fact_nl": "Een chart-hit van Bandolero (2011)."
+      "fun_fact": "A chart hit by Bandolero (1983).",
+      "fun_fact_de": "Ein Chart-Hit von Bandolero (1983).",
+      "fun_fact_es": "Un éxito de Bandolero (1983).",
+      "fun_fact_fr": "Un tube de Bandolero (1983).",
+      "fun_fact_nl": "Een chart-hit van Bandolero (1983)."
     },
     {
       "artist": "Eddy Grant",
@@ -7711,11 +7711,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=ZTGOAFXUEyI",
       "uri_tidal": "tidal://track/503876008",
       "uri_deezer": "deezer://track/3878886741",
-      "fun_fact": "A chart hit by Eddy Grant (2026).",
-      "fun_fact_de": "Ein Chart-Hit von Eddy Grant (2026).",
-      "fun_fact_es": "Un éxito de Eddy Grant (2026).",
-      "fun_fact_fr": "Un tube de Eddy Grant (2026).",
-      "fun_fact_nl": "Een chart-hit van Eddy Grant (2026)."
+      "fun_fact": "A chart hit by Eddy Grant (1988).",
+      "fun_fact_de": "Ein Chart-Hit von Eddy Grant (1988).",
+      "fun_fact_es": "Un éxito de Eddy Grant (1988).",
+      "fun_fact_fr": "Un tube de Eddy Grant (1988).",
+      "fun_fact_nl": "Een chart-hit van Eddy Grant (1988)."
     },
     {
       "artist": "T.S. Monk",
@@ -7736,11 +7736,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=kgbxH-Ii6dM",
       "uri_tidal": "tidal://track/37378724",
       "uri_deezer": "deezer://track/89339263",
-      "fun_fact": "A chart hit by T.S. Monk (2014).",
-      "fun_fact_de": "Ein Chart-Hit von T.S. Monk (2014).",
-      "fun_fact_es": "Un éxito de T.S. Monk (2014).",
-      "fun_fact_fr": "Un tube de T.S. Monk (2014).",
-      "fun_fact_nl": "Een chart-hit van T.S. Monk (2014)."
+      "fun_fact": "A chart hit by T.S. Monk (1980).",
+      "fun_fact_de": "Ein Chart-Hit von T.S. Monk (1980).",
+      "fun_fact_es": "Un éxito de T.S. Monk (1980).",
+      "fun_fact_fr": "Un tube de T.S. Monk (1980).",
+      "fun_fact_nl": "Een chart-hit van T.S. Monk (1980)."
     },
     {
       "artist": "Central Line",
@@ -7761,11 +7761,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=VLt25_UFJ9U",
       "uri_tidal": "tidal://track/319063690",
       "uri_deezer": "deezer://track/2477137301",
-      "fun_fact": "A chart hit by Central Line (2015).",
-      "fun_fact_de": "Ein Chart-Hit von Central Line (2015).",
-      "fun_fact_es": "Un éxito de Central Line (2015).",
-      "fun_fact_fr": "Un tube de Central Line (2015).",
-      "fun_fact_nl": "Een chart-hit van Central Line (2015)."
+      "fun_fact": "A chart hit by Central Line (1981).",
+      "fun_fact_de": "Ein Chart-Hit von Central Line (1981).",
+      "fun_fact_es": "Un éxito de Central Line (1981).",
+      "fun_fact_fr": "Un tube de Central Line (1981).",
+      "fun_fact_nl": "Een chart-hit van Central Line (1981)."
     },
     {
       "artist": "Peter Gabriel",
@@ -7786,11 +7786,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=GYiIzez8LrM",
       "uri_tidal": "tidal://track/122120386",
       "uri_deezer": "deezer://track/540503442",
-      "fun_fact": "A chart hit by Peter Gabriel (2012).",
-      "fun_fact_de": "Ein Chart-Hit von Peter Gabriel (2012).",
-      "fun_fact_es": "Un éxito de Peter Gabriel (2012).",
-      "fun_fact_fr": "Un tube de Peter Gabriel (2012).",
-      "fun_fact_nl": "Een chart-hit van Peter Gabriel (2012)."
+      "fun_fact": "A chart hit by Peter Gabriel (1986).",
+      "fun_fact_de": "Ein Chart-Hit von Peter Gabriel (1986).",
+      "fun_fact_es": "Un éxito de Peter Gabriel (1986).",
+      "fun_fact_fr": "Un tube de Peter Gabriel (1986).",
+      "fun_fact_nl": "Een chart-hit van Peter Gabriel (1986)."
     },
     {
       "artist": "Michael Jackson",
@@ -7811,11 +7811,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=-DlMoJ2V6uk",
       "uri_tidal": "tidal://track/16951562",
       "uri_deezer": "deezer://track/59509531",
-      "fun_fact": "A chart hit by Michael Jackson (2012).",
-      "fun_fact_de": "Ein Chart-Hit von Michael Jackson (2012).",
-      "fun_fact_es": "Un éxito de Michael Jackson (2012).",
-      "fun_fact_fr": "Un tube de Michael Jackson (2012).",
-      "fun_fact_nl": "Een chart-hit van Michael Jackson (2012)."
+      "fun_fact": "A chart hit by Michael Jackson (1987).",
+      "fun_fact_de": "Ein Chart-Hit von Michael Jackson (1987).",
+      "fun_fact_es": "Un éxito de Michael Jackson (1987).",
+      "fun_fact_fr": "Un tube de Michael Jackson (1987).",
+      "fun_fact_nl": "Een chart-hit van Michael Jackson (1987)."
     },
     {
       "artist": "Michael McDonald",
@@ -7836,11 +7836,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=yvXFGUWBMHY",
       "uri_tidal": "tidal://track/188224023",
       "uri_deezer": "deezer://track/1408780112",
-      "fun_fact": "A chart hit by Michael McDonald (2021).",
-      "fun_fact_de": "Ein Chart-Hit von Michael McDonald (2021).",
-      "fun_fact_es": "Un éxito de Michael McDonald (2021).",
-      "fun_fact_fr": "Un tube de Michael McDonald (2021).",
-      "fun_fact_nl": "Een chart-hit van Michael McDonald (2021)."
+      "fun_fact": "A chart hit by Michael McDonald (1986).",
+      "fun_fact_de": "Ein Chart-Hit von Michael McDonald (1986).",
+      "fun_fact_es": "Un éxito de Michael McDonald (1986).",
+      "fun_fact_fr": "Un tube de Michael McDonald (1986).",
+      "fun_fact_nl": "Een chart-hit van Michael McDonald (1986)."
     },
     {
       "artist": "Kool & The Gang",
@@ -7861,11 +7861,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=QsppPGDrNdg",
       "uri_tidal": "tidal://track/93788078",
       "uri_deezer": "deezer://track/541624382",
-      "fun_fact": "A chart hit by Kool & The Gang (2018).",
-      "fun_fact_de": "Ein Chart-Hit von Kool & The Gang (2018).",
-      "fun_fact_es": "Un éxito de Kool & The Gang (2018).",
-      "fun_fact_fr": "Un tube de Kool & The Gang (2018).",
-      "fun_fact_nl": "Een chart-hit van Kool & The Gang (2018)."
+      "fun_fact": "A chart hit by Kool & The Gang (1982).",
+      "fun_fact_de": "Ein Chart-Hit von Kool & The Gang (1982).",
+      "fun_fact_es": "Un éxito de Kool & The Gang (1982).",
+      "fun_fact_fr": "Un tube de Kool & The Gang (1982).",
+      "fun_fact_nl": "Een chart-hit van Kool & The Gang (1982)."
     },
     {
       "artist": "Matia Bazar",
@@ -7886,11 +7886,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=_-zk_dWBmAg",
       "uri_tidal": "tidal://track/14644058",
       "uri_deezer": "deezer://track/18111574",
-      "fun_fact": "A chart hit by Matia Bazar (2012).",
-      "fun_fact_de": "Ein Chart-Hit von Matia Bazar (2012).",
-      "fun_fact_es": "Un éxito de Matia Bazar (2012).",
-      "fun_fact_fr": "Un tube de Matia Bazar (2012).",
-      "fun_fact_nl": "Een chart-hit van Matia Bazar (2012)."
+      "fun_fact": "A chart hit by Matia Bazar (1985).",
+      "fun_fact_de": "Ein Chart-Hit von Matia Bazar (1985).",
+      "fun_fact_es": "Un éxito de Matia Bazar (1985).",
+      "fun_fact_fr": "Un tube de Matia Bazar (1985).",
+      "fun_fact_nl": "Een chart-hit van Matia Bazar (1985)."
     },
     {
       "artist": "Pino D'Angiò",
@@ -7911,11 +7911,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=pqlZQIsRdmQ",
       "uri_tidal": "tidal://track/92066640",
       "uri_deezer": "deezer://track/518970902",
-      "fun_fact": "A chart hit by Pino D'Angiò (2011).",
-      "fun_fact_de": "Ein Chart-Hit von Pino D'Angiò (2011).",
-      "fun_fact_es": "Un éxito de Pino D'Angiò (2011).",
-      "fun_fact_fr": "Un tube de Pino D'Angiò (2011).",
-      "fun_fact_nl": "Een chart-hit van Pino D'Angiò (2011)."
+      "fun_fact": "A chart hit by Pino D'Angiò (1980).",
+      "fun_fact_de": "Ein Chart-Hit von Pino D'Angiò (1980).",
+      "fun_fact_es": "Un éxito de Pino D'Angiò (1980).",
+      "fun_fact_fr": "Un tube de Pino D'Angiò (1980).",
+      "fun_fact_nl": "Een chart-hit van Pino D'Angiò (1980)."
     },
     {
       "artist": "Michael Jackson",
@@ -7936,11 +7936,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=aUD0juRwb3I",
       "uri_tidal": "tidal://track/16953809",
       "uri_deezer": "deezer://track/59509611",
-      "fun_fact": "A chart hit by Michael Jackson (2012).",
-      "fun_fact_de": "Ein Chart-Hit von Michael Jackson (2012).",
-      "fun_fact_es": "Un éxito de Michael Jackson (2012).",
-      "fun_fact_fr": "Un tube de Michael Jackson (2012).",
-      "fun_fact_nl": "Een chart-hit van Michael Jackson (2012)."
+      "fun_fact": "A chart hit by Michael Jackson (1987).",
+      "fun_fact_de": "Ein Chart-Hit von Michael Jackson (1987).",
+      "fun_fact_es": "Un éxito de Michael Jackson (1987).",
+      "fun_fact_fr": "Un tube de Michael Jackson (1987).",
+      "fun_fact_nl": "Een chart-hit van Michael Jackson (1987)."
     },
     {
       "artist": "Miami Sound Machine",
@@ -7961,11 +7961,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=DPm3qb-zDqs",
       "uri_tidal": "tidal://track/33966386",
       "uri_deezer": "deezer://track/9437107",
-      "fun_fact": "A chart hit by Miami Sound Machine (2011).",
-      "fun_fact_de": "Ein Chart-Hit von Miami Sound Machine (2011).",
-      "fun_fact_es": "Un éxito de Miami Sound Machine (2011).",
-      "fun_fact_fr": "Un tube de Miami Sound Machine (2011).",
-      "fun_fact_nl": "Een chart-hit van Miami Sound Machine (2011)."
+      "fun_fact": "A chart hit by Miami Sound Machine (1985).",
+      "fun_fact_de": "Ein Chart-Hit von Miami Sound Machine (1985).",
+      "fun_fact_es": "Un éxito de Miami Sound Machine (1985).",
+      "fun_fact_fr": "Un tube de Miami Sound Machine (1985).",
+      "fun_fact_nl": "Een chart-hit van Miami Sound Machine (1985)."
     },
     {
       "artist": "Matthew Wilder",
@@ -7986,11 +7986,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=UhLDA4Wr2GU",
       "uri_tidal": "tidal://track/3493390",
       "uri_deezer": "deezer://track/5503498",
-      "fun_fact": "A chart hit by Matthew Wilder (2010).",
-      "fun_fact_de": "Ein Chart-Hit von Matthew Wilder (2010).",
-      "fun_fact_es": "Un éxito de Matthew Wilder (2010).",
-      "fun_fact_fr": "Un tube de Matthew Wilder (2010).",
-      "fun_fact_nl": "Een chart-hit van Matthew Wilder (2010)."
+      "fun_fact": "A chart hit by Matthew Wilder (1983).",
+      "fun_fact_de": "Ein Chart-Hit von Matthew Wilder (1983).",
+      "fun_fact_es": "Un éxito de Matthew Wilder (1983).",
+      "fun_fact_fr": "Un tube de Matthew Wilder (1983).",
+      "fun_fact_nl": "Een chart-hit van Matthew Wilder (1983)."
     },
     {
       "artist": "Kylie Minogue",
@@ -8011,11 +8011,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=xLq0JpDk8po",
       "uri_tidal": "tidal://track/491296838",
       "uri_deezer": "deezer://track/3785971252",
-      "fun_fact": "A chart hit by Kylie Minogue (2006).",
-      "fun_fact_de": "Ein Chart-Hit von Kylie Minogue (2006).",
-      "fun_fact_es": "Un éxito de Kylie Minogue (2006).",
-      "fun_fact_fr": "Un tube de Kylie Minogue (2006).",
-      "fun_fact_nl": "Een chart-hit van Kylie Minogue (2006)."
+      "fun_fact": "A chart hit by Kylie Minogue (1987).",
+      "fun_fact_de": "Ein Chart-Hit von Kylie Minogue (1987).",
+      "fun_fact_es": "Un éxito de Kylie Minogue (1987).",
+      "fun_fact_fr": "Un tube de Kylie Minogue (1987).",
+      "fun_fact_nl": "Een chart-hit van Kylie Minogue (1987)."
     },
     {
       "artist": "Miami Sound Machine",
@@ -8039,11 +8039,11 @@
       "alt_artists": [
         "Gloria Estefan"
       ],
-      "fun_fact": "A chart hit by Miami Sound Machine (2006).",
-      "fun_fact_de": "Ein Chart-Hit von Miami Sound Machine (2006).",
-      "fun_fact_es": "Un éxito de Miami Sound Machine (2006).",
-      "fun_fact_fr": "Un tube de Miami Sound Machine (2006).",
-      "fun_fact_nl": "Een chart-hit van Miami Sound Machine (2006)."
+      "fun_fact": "A chart hit by Miami Sound Machine (1985).",
+      "fun_fact_de": "Ein Chart-Hit von Miami Sound Machine (1985).",
+      "fun_fact_es": "Un éxito de Miami Sound Machine (1985).",
+      "fun_fact_fr": "Un tube de Miami Sound Machine (1985).",
+      "fun_fact_nl": "Een chart-hit van Miami Sound Machine (1985)."
     },
     {
       "artist": "Tom Browne",
@@ -8064,11 +8064,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=CfUuamLRsbE",
       "uri_tidal": "tidal://track/5114336",
       "uri_deezer": "deezer://track/13200806",
-      "fun_fact": "A chart hit by Tom Browne (2009).",
-      "fun_fact_de": "Ein Chart-Hit von Tom Browne (2009).",
-      "fun_fact_es": "Un éxito de Tom Browne (2009).",
-      "fun_fact_fr": "Un tube de Tom Browne (2009).",
-      "fun_fact_nl": "Een chart-hit van Tom Browne (2009)."
+      "fun_fact": "A chart hit by Tom Browne (1980).",
+      "fun_fact_de": "Ein Chart-Hit von Tom Browne (1980).",
+      "fun_fact_es": "Un éxito de Tom Browne (1980).",
+      "fun_fact_fr": "Un tube de Tom Browne (1980).",
+      "fun_fact_nl": "Een chart-hit van Tom Browne (1980)."
     },
     {
       "artist": "Huey Lewis & The News",
@@ -8089,11 +8089,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=k-6EWSnagDM",
       "uri_tidal": "tidal://track/126218",
       "uri_deezer": "deezer://track/3116051",
-      "fun_fact": "A chart hit by Huey Lewis & The News (2006).",
-      "fun_fact_de": "Ein Chart-Hit von Huey Lewis & The News (2006).",
-      "fun_fact_es": "Un éxito de Huey Lewis & The News (2006).",
-      "fun_fact_fr": "Un tube de Huey Lewis & The News (2006).",
-      "fun_fact_nl": "Een chart-hit van Huey Lewis & The News (2006)."
+      "fun_fact": "A chart hit by Huey Lewis & The News (1982).",
+      "fun_fact_de": "Ein Chart-Hit von Huey Lewis & The News (1982).",
+      "fun_fact_es": "Un éxito de Huey Lewis & The News (1982).",
+      "fun_fact_fr": "Un tube de Huey Lewis & The News (1982).",
+      "fun_fact_nl": "Een chart-hit van Huey Lewis & The News (1982)."
     },
     {
       "artist": "Gloria Estefan",
@@ -8114,11 +8114,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=-69Hhh-ez8o",
       "uri_tidal": "tidal://track/102314",
       "uri_deezer": "deezer://track/565049",
-      "fun_fact": "A chart hit by Gloria Estefan (2006).",
-      "fun_fact_de": "Ein Chart-Hit von Gloria Estefan (2006).",
-      "fun_fact_es": "Un éxito de Gloria Estefan (2006).",
-      "fun_fact_fr": "Un tube de Gloria Estefan (2006).",
-      "fun_fact_nl": "Een chart-hit van Gloria Estefan (2006)."
+      "fun_fact": "A chart hit by Gloria Estefan (1989).",
+      "fun_fact_de": "Ein Chart-Hit von Gloria Estefan (1989).",
+      "fun_fact_es": "Un éxito de Gloria Estefan (1989).",
+      "fun_fact_fr": "Un tube de Gloria Estefan (1989).",
+      "fun_fact_nl": "Een chart-hit van Gloria Estefan (1989)."
     },
     {
       "artist": "Blondie",
@@ -8139,11 +8139,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=tykf2xYPNdc",
       "uri_tidal": "tidal://track/1335096",
       "uri_deezer": "deezer://track/3104486",
-      "fun_fact": "A chart hit by Blondie (2003).",
-      "fun_fact_de": "Ein Chart-Hit von Blondie (2003).",
-      "fun_fact_es": "Un éxito de Blondie (2003).",
-      "fun_fact_fr": "Un tube de Blondie (2003).",
-      "fun_fact_nl": "Een chart-hit van Blondie (2003)."
+      "fun_fact": "A chart hit by Blondie (1980).",
+      "fun_fact_de": "Ein Chart-Hit von Blondie (1980).",
+      "fun_fact_es": "Un éxito de Blondie (1980).",
+      "fun_fact_fr": "Un tube de Blondie (1980).",
+      "fun_fact_nl": "Een chart-hit van Blondie (1980)."
     },
     {
       "artist": "Shakin' Stevens",
@@ -8164,11 +8164,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=i893TotpH0o",
       "uri_tidal": "tidal://track/3392907",
       "uri_deezer": "deezer://track/1132667092",
-      "fun_fact": "A chart hit by Shakin' Stevens (2005).",
-      "fun_fact_de": "Ein Chart-Hit von Shakin' Stevens (2005).",
-      "fun_fact_es": "Un éxito de Shakin' Stevens (2005).",
-      "fun_fact_fr": "Un tube de Shakin' Stevens (2005).",
-      "fun_fact_nl": "Een chart-hit van Shakin' Stevens (2005)."
+      "fun_fact": "A chart hit by Shakin' Stevens (1981).",
+      "fun_fact_de": "Ein Chart-Hit von Shakin' Stevens (1981).",
+      "fun_fact_es": "Un éxito de Shakin' Stevens (1981).",
+      "fun_fact_fr": "Un tube de Shakin' Stevens (1981).",
+      "fun_fact_nl": "Een chart-hit van Shakin' Stevens (1981)."
     },
     {
       "artist": "Jaki Graham",
@@ -8189,11 +8189,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=O-4OQ03mU58",
       "uri_tidal": "tidal://track/2972600",
       "uri_deezer": "deezer://track/3500793",
-      "fun_fact": "A chart hit by Jaki Graham (2009).",
-      "fun_fact_de": "Ein Chart-Hit von Jaki Graham (2009).",
-      "fun_fact_es": "Un éxito de Jaki Graham (2009).",
-      "fun_fact_fr": "Un tube de Jaki Graham (2009).",
-      "fun_fact_nl": "Een chart-hit van Jaki Graham (2009)."
+      "fun_fact": "A chart hit by Jaki Graham (1986).",
+      "fun_fact_de": "Ein Chart-Hit von Jaki Graham (1986).",
+      "fun_fact_es": "Un éxito de Jaki Graham (1986).",
+      "fun_fact_fr": "Un tube de Jaki Graham (1986).",
+      "fun_fact_nl": "Een chart-hit van Jaki Graham (1986)."
     },
     {
       "artist": "Madonna",
@@ -8214,11 +8214,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=h_r620DGoiE",
       "uri_tidal": "tidal://track/496064056",
       "uri_deezer": "deezer://track/3824997421",
-      "fun_fact": "A chart hit by Madonna (2009).",
-      "fun_fact_de": "Ein Chart-Hit von Madonna (2009).",
-      "fun_fact_es": "Un éxito de Madonna (2009).",
-      "fun_fact_fr": "Un tube de Madonna (2009).",
-      "fun_fact_nl": "Een chart-hit van Madonna (2009)."
+      "fun_fact": "A chart hit by Madonna (1989).",
+      "fun_fact_de": "Ein Chart-Hit von Madonna (1989).",
+      "fun_fact_es": "Un éxito de Madonna (1989).",
+      "fun_fact_fr": "Un tube de Madonna (1989).",
+      "fun_fact_nl": "Een chart-hit van Madonna (1989)."
     },
     {
       "artist": "Billy Ocean",
@@ -8239,11 +8239,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=VOiZC020nl0",
       "uri_tidal": "tidal://track/3728807",
       "uri_deezer": "deezer://track/2168095",
-      "fun_fact": "A chart hit by Billy Ocean (2005).",
-      "fun_fact_de": "Ein Chart-Hit von Billy Ocean (2005).",
-      "fun_fact_es": "Un éxito de Billy Ocean (2005).",
-      "fun_fact_fr": "Un tube de Billy Ocean (2005).",
-      "fun_fact_nl": "Een chart-hit van Billy Ocean (2005)."
+      "fun_fact": "A chart hit by Billy Ocean (1984).",
+      "fun_fact_de": "Ein Chart-Hit von Billy Ocean (1984).",
+      "fun_fact_es": "Un éxito de Billy Ocean (1984).",
+      "fun_fact_fr": "Un tube de Billy Ocean (1984).",
+      "fun_fact_nl": "Een chart-hit van Billy Ocean (1984)."
     },
     {
       "artist": "Paul Young",
@@ -8264,11 +8264,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=LPM1_OvqIA0",
       "uri_tidal": "tidal://track/1846772",
       "uri_deezer": "deezer://track/582418",
-      "fun_fact": "A chart hit by Paul Young (2003).",
-      "fun_fact_de": "Ein Chart-Hit von Paul Young (2003).",
-      "fun_fact_es": "Un éxito de Paul Young (2003).",
-      "fun_fact_fr": "Un tube de Paul Young (2003).",
-      "fun_fact_nl": "Een chart-hit van Paul Young (2003)."
+      "fun_fact": "A chart hit by Paul Young (1983).",
+      "fun_fact_de": "Ein Chart-Hit von Paul Young (1983).",
+      "fun_fact_es": "Un éxito de Paul Young (1983).",
+      "fun_fact_fr": "Un tube de Paul Young (1983).",
+      "fun_fact_nl": "Een chart-hit van Paul Young (1983)."
     },
     {
       "artist": "Glenn Frey",
@@ -8289,11 +8289,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=uKWgYKa2Fh0",
       "uri_tidal": "tidal://track/34004256",
       "uri_deezer": "deezer://track/2233196",
-      "fun_fact": "A chart hit by Glenn Frey (2009).",
-      "fun_fact_de": "Ein Chart-Hit von Glenn Frey (2009).",
-      "fun_fact_es": "Un éxito de Glenn Frey (2009).",
-      "fun_fact_fr": "Un tube de Glenn Frey (2009).",
-      "fun_fact_nl": "Een chart-hit van Glenn Frey (2009)."
+      "fun_fact": "A chart hit by Glenn Frey (1984).",
+      "fun_fact_de": "Ein Chart-Hit von Glenn Frey (1984).",
+      "fun_fact_es": "Un éxito de Glenn Frey (1984).",
+      "fun_fact_fr": "Un tube de Glenn Frey (1984).",
+      "fun_fact_nl": "Een chart-hit van Glenn Frey (1984)."
     },
     {
       "artist": "Lil' Louis",
@@ -8317,11 +8317,11 @@
       "alt_artists": [
         "The World"
       ],
-      "fun_fact": "A chart hit by Lil' Louis (1996).",
-      "fun_fact_de": "Ein Chart-Hit von Lil' Louis (1996).",
-      "fun_fact_es": "Un éxito de Lil' Louis (1996).",
-      "fun_fact_fr": "Un tube de Lil' Louis (1996).",
-      "fun_fact_nl": "Een chart-hit van Lil' Louis (1996)."
+      "fun_fact": "A chart hit by Lil' Louis (1989).",
+      "fun_fact_de": "Ein Chart-Hit von Lil' Louis (1989).",
+      "fun_fact_es": "Un éxito de Lil' Louis (1989).",
+      "fun_fact_fr": "Un tube de Lil' Louis (1989).",
+      "fun_fact_nl": "Een chart-hit van Lil' Louis (1989)."
     },
     {
       "artist": "Ziggy Marley & The Melody Makers",

--- a/custom_components/beatify/playlists/90er-hits.json
+++ b/custom_components/beatify/playlists/90er-hits.json
@@ -2759,11 +2759,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=fUwf21uaVvw",
       "uri_tidal": "tidal://track/490882871",
       "uri_deezer": "deezer://track/3802703102",
-      "fun_fact": "A chart hit by SNAP! (2026).",
-      "fun_fact_de": "Ein Chart-Hit von SNAP! (2026).",
-      "fun_fact_es": "Un éxito de SNAP! (2026).",
-      "fun_fact_fr": "Un tube de SNAP! (2026).",
-      "fun_fact_nl": "Een chart-hit van SNAP! (2026)."
+      "fun_fact": "A chart hit by SNAP! (1990).",
+      "fun_fact_de": "Ein Chart-Hit von SNAP! (1990).",
+      "fun_fact_es": "Un éxito de SNAP! (1990).",
+      "fun_fact_fr": "Un tube de SNAP! (1990).",
+      "fun_fact_nl": "Een chart-hit van SNAP! (1990)."
     },
     {
       "artist": "Incognito",
@@ -2787,11 +2787,11 @@
       "alt_artists": [
         "Jocelyn Brown"
       ],
-      "fun_fact": "A chart hit by Incognito (2010).",
-      "fun_fact_de": "Ein Chart-Hit von Incognito (2010).",
-      "fun_fact_es": "Un éxito de Incognito (2010).",
-      "fun_fact_fr": "Un tube de Incognito (2010).",
-      "fun_fact_nl": "Een chart-hit van Incognito (2010)."
+      "fun_fact": "A chart hit by Incognito (1991).",
+      "fun_fact_de": "Ein Chart-Hit von Incognito (1991).",
+      "fun_fact_es": "Un éxito de Incognito (1991).",
+      "fun_fact_fr": "Un tube de Incognito (1991).",
+      "fun_fact_nl": "Een chart-hit van Incognito (1991)."
     },
     {
       "artist": "Die Toten Hosen",
@@ -2812,11 +2812,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=tR4vamT51Nw",
       "uri_tidal": "tidal://track/11016866",
       "uri_deezer": "deezer://track/142393497",
-      "fun_fact": "A chart hit by Die Toten Hosen (2011).",
-      "fun_fact_de": "Ein Chart-Hit von Die Toten Hosen (2011).",
-      "fun_fact_es": "Un éxito de Die Toten Hosen (2011).",
-      "fun_fact_fr": "Un tube de Die Toten Hosen (2011).",
-      "fun_fact_nl": "Een chart-hit van Die Toten Hosen (2011)."
+      "fun_fact": "A chart hit by Die Toten Hosen (1996).",
+      "fun_fact_de": "Ein Chart-Hit von Die Toten Hosen (1996).",
+      "fun_fact_es": "Un éxito de Die Toten Hosen (1996).",
+      "fun_fact_fr": "Un tube de Die Toten Hosen (1996).",
+      "fun_fact_nl": "Een chart-hit van Die Toten Hosen (1996)."
     },
     {
       "artist": "Roxette",
@@ -2837,11 +2837,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=GX1Y7ri_0zU",
       "uri_tidal": "tidal://track/131246",
       "uri_deezer": "deezer://track/89388951",
-      "fun_fact": "A chart hit by Roxette (2014).",
-      "fun_fact_de": "Ein Chart-Hit von Roxette (2014).",
-      "fun_fact_es": "Un éxito de Roxette (2014).",
-      "fun_fact_fr": "Un tube de Roxette (2014).",
-      "fun_fact_nl": "Een chart-hit van Roxette (2014)."
+      "fun_fact": "A chart hit by Roxette (1992).",
+      "fun_fact_de": "Ein Chart-Hit von Roxette (1992).",
+      "fun_fact_es": "Un éxito de Roxette (1992).",
+      "fun_fact_fr": "Un tube de Roxette (1992).",
+      "fun_fact_nl": "Een chart-hit van Roxette (1992)."
     },
     {
       "artist": "DJ BoBo",
@@ -2862,11 +2862,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=SGeDy6txc2k",
       "uri_tidal": "tidal://track/136025744",
       "uri_deezer": "deezer://track/918091092",
-      "fun_fact": "A chart hit by DJ BoBo (2017).",
-      "fun_fact_de": "Ein Chart-Hit von DJ BoBo (2017).",
-      "fun_fact_es": "Un éxito de DJ BoBo (2017).",
-      "fun_fact_fr": "Un tube de DJ BoBo (2017).",
-      "fun_fact_nl": "Een chart-hit van DJ BoBo (2017)."
+      "fun_fact": "A chart hit by DJ BoBo (1996).",
+      "fun_fact_de": "Ein Chart-Hit von DJ BoBo (1996).",
+      "fun_fact_es": "Un éxito de DJ BoBo (1996).",
+      "fun_fact_fr": "Un tube de DJ BoBo (1996).",
+      "fun_fact_nl": "Een chart-hit van DJ BoBo (1996)."
     },
     {
       "artist": "The Adventures Of Stevie V",
@@ -2879,11 +2879,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=BlaWhtHmUw4",
       "uri_tidal": "tidal://track/40845268",
       "uri_deezer": "deezer://track/78304375",
-      "fun_fact": "A chart hit by The Adventures Of Stevie V (2013).",
-      "fun_fact_de": "Ein Chart-Hit von The Adventures Of Stevie V (2013).",
-      "fun_fact_es": "Un éxito de The Adventures Of Stevie V (2013).",
-      "fun_fact_fr": "Un tube de The Adventures Of Stevie V (2013).",
-      "fun_fact_nl": "Een chart-hit van The Adventures Of Stevie V (2013)."
+      "fun_fact": "A chart hit by The Adventures Of Stevie V (1990).",
+      "fun_fact_de": "Ein Chart-Hit von The Adventures Of Stevie V (1990).",
+      "fun_fact_es": "Un éxito de The Adventures Of Stevie V (1990).",
+      "fun_fact_fr": "Un tube de The Adventures Of Stevie V (1990).",
+      "fun_fact_nl": "Een chart-hit van The Adventures Of Stevie V (1990)."
     },
     {
       "artist": "The Offspring",
@@ -2904,11 +2904,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=BepGmpLT9HA",
       "uri_tidal": "tidal://track/67367328",
       "uri_deezer": "deezer://track/137233982",
-      "fun_fact": "A chart hit by The Offspring (2016).",
-      "fun_fact_de": "Ein Chart-Hit von The Offspring (2016).",
-      "fun_fact_es": "Un éxito de The Offspring (2016).",
-      "fun_fact_fr": "Un tube de The Offspring (2016).",
-      "fun_fact_nl": "Een chart-hit van The Offspring (2016)."
+      "fun_fact": "A chart hit by The Offspring (1998).",
+      "fun_fact_de": "Ein Chart-Hit von The Offspring (1998).",
+      "fun_fact_es": "Un éxito de The Offspring (1998).",
+      "fun_fact_fr": "Un tube de The Offspring (1998).",
+      "fun_fact_nl": "Een chart-hit van The Offspring (1998)."
     },
     {
       "artist": "Rozalla",
@@ -2929,11 +2929,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=gMKC5OfNJfs",
       "uri_tidal": "tidal://track/31499183",
       "uri_deezer": "deezer://track/12169961",
-      "fun_fact": "A chart hit by Rozalla (2010).",
-      "fun_fact_de": "Ein Chart-Hit von Rozalla (2010).",
-      "fun_fact_es": "Un éxito de Rozalla (2010).",
-      "fun_fact_fr": "Un tube de Rozalla (2010).",
-      "fun_fact_nl": "Een chart-hit van Rozalla (2010)."
+      "fun_fact": "A chart hit by Rozalla (1991).",
+      "fun_fact_de": "Ein Chart-Hit von Rozalla (1991).",
+      "fun_fact_es": "Un éxito de Rozalla (1991).",
+      "fun_fact_fr": "Un tube de Rozalla (1991).",
+      "fun_fact_nl": "Een chart-hit van Rozalla (1991)."
     },
     {
       "artist": "Reel 2 Real",
@@ -2958,11 +2958,11 @@
         "The Mad Stuntman",
         "Erick Morillo"
       ],
-      "fun_fact": "A chart hit by Reel 2 Real (2022).",
-      "fun_fact_de": "Ein Chart-Hit von Reel 2 Real (2022).",
-      "fun_fact_es": "Un éxito de Reel 2 Real (2022).",
-      "fun_fact_fr": "Un tube de Reel 2 Real (2022).",
-      "fun_fact_nl": "Een chart-hit van Reel 2 Real (2022)."
+      "fun_fact": "A chart hit by Reel 2 Real (1993).",
+      "fun_fact_de": "Ein Chart-Hit von Reel 2 Real (1993).",
+      "fun_fact_es": "Un éxito de Reel 2 Real (1993).",
+      "fun_fact_fr": "Un tube de Reel 2 Real (1993).",
+      "fun_fact_nl": "Een chart-hit van Reel 2 Real (1993)."
     },
     {
       "artist": "Scooter",
@@ -2983,11 +2983,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=TcfxxUVc20M",
       "uri_tidal": "tidal://track/279179198",
       "uri_deezer": "deezer://track/2168791217",
-      "fun_fact": "A chart hit by Scooter (2013).",
-      "fun_fact_de": "Ein Chart-Hit von Scooter (2013).",
-      "fun_fact_es": "Un éxito de Scooter (2013).",
-      "fun_fact_fr": "Un tube de Scooter (2013).",
-      "fun_fact_nl": "Een chart-hit van Scooter (2013)."
+      "fun_fact": "A chart hit by Scooter (1998).",
+      "fun_fact_de": "Ein Chart-Hit von Scooter (1998).",
+      "fun_fact_es": "Un éxito de Scooter (1998).",
+      "fun_fact_fr": "Un tube de Scooter (1998).",
+      "fun_fact_nl": "Een chart-hit van Scooter (1998)."
     },
     {
       "artist": "Fettes Brot",
@@ -3008,11 +3008,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=q-UPoJxfW0A",
       "uri_tidal": "tidal://track/461018685",
       "uri_deezer": "deezer://track/3558361541",
-      "fun_fact": "A chart hit by Fettes Brot (2016).",
-      "fun_fact_de": "Ein Chart-Hit von Fettes Brot (2016).",
-      "fun_fact_es": "Un éxito de Fettes Brot (2016).",
-      "fun_fact_fr": "Un tube de Fettes Brot (2016).",
-      "fun_fact_nl": "Een chart-hit van Fettes Brot (2016)."
+      "fun_fact": "A chart hit by Fettes Brot (1996).",
+      "fun_fact_de": "Ein Chart-Hit von Fettes Brot (1996).",
+      "fun_fact_es": "Un éxito de Fettes Brot (1996).",
+      "fun_fact_fr": "Un tube de Fettes Brot (1996).",
+      "fun_fact_nl": "Een chart-hit van Fettes Brot (1996)."
     },
     {
       "artist": "The Bucketheads",
@@ -3033,11 +3033,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=X4UGPCR3zEQ",
       "uri_tidal": "tidal://track/40845613",
       "uri_deezer": "deezer://track/73219903",
-      "fun_fact": "A chart hit by The Bucketheads (2013).",
-      "fun_fact_de": "Ein Chart-Hit von The Bucketheads (2013).",
-      "fun_fact_es": "Un éxito de The Bucketheads (2013).",
-      "fun_fact_fr": "Un tube de The Bucketheads (2013).",
-      "fun_fact_nl": "Een chart-hit van The Bucketheads (2013)."
+      "fun_fact": "A chart hit by The Bucketheads (1994).",
+      "fun_fact_de": "Ein Chart-Hit von The Bucketheads (1994).",
+      "fun_fact_es": "Un éxito de The Bucketheads (1994).",
+      "fun_fact_fr": "Un tube de The Bucketheads (1994).",
+      "fun_fact_nl": "Een chart-hit van The Bucketheads (1994)."
     },
     {
       "artist": "Tokyo Ghetto Pussy",
@@ -3058,11 +3058,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=K_t1xV6PEOU",
       "uri_tidal": "tidal://track/4673711",
       "uri_deezer": "deezer://track/7395378",
-      "fun_fact": "A chart hit by Tokyo Ghetto Pussy (2010).",
-      "fun_fact_de": "Ein Chart-Hit von Tokyo Ghetto Pussy (2010).",
-      "fun_fact_es": "Un éxito de Tokyo Ghetto Pussy (2010).",
-      "fun_fact_fr": "Un tube de Tokyo Ghetto Pussy (2010).",
-      "fun_fact_nl": "Een chart-hit van Tokyo Ghetto Pussy (2010)."
+      "fun_fact": "A chart hit by Tokyo Ghetto Pussy (1995).",
+      "fun_fact_de": "Ein Chart-Hit von Tokyo Ghetto Pussy (1995).",
+      "fun_fact_es": "Un éxito de Tokyo Ghetto Pussy (1995).",
+      "fun_fact_fr": "Un tube de Tokyo Ghetto Pussy (1995).",
+      "fun_fact_nl": "Een chart-hit van Tokyo Ghetto Pussy (1995)."
     },
     {
       "year": 1999,
@@ -3166,11 +3166,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=uWyun5JpwaU",
       "uri_tidal": "tidal://track/10395309",
       "uri_deezer": "deezer://track/857730702",
-      "fun_fact": "A chart hit by Aswad (2009).",
-      "fun_fact_de": "Ein Chart-Hit von Aswad (2009).",
-      "fun_fact_es": "Un éxito de Aswad (2009).",
-      "fun_fact_fr": "Un tube de Aswad (2009).",
-      "fun_fact_nl": "Een chart-hit van Aswad (2009)."
+      "fun_fact": "A chart hit by Aswad (1994).",
+      "fun_fact_de": "Ein Chart-Hit von Aswad (1994).",
+      "fun_fact_es": "Un éxito de Aswad (1994).",
+      "fun_fact_fr": "Un tube de Aswad (1994).",
+      "fun_fact_nl": "Een chart-hit van Aswad (1994)."
     },
     {
       "artist": "Crystal Waters",
@@ -3216,11 +3216,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=LCp77Yf54_k",
       "uri_tidal": "tidal://track/151322",
       "uri_deezer": "deezer://track/3102138",
-      "fun_fact": "A chart hit by Blur (2000).",
-      "fun_fact_de": "Ein Chart-Hit von Blur (2000).",
-      "fun_fact_es": "Un éxito de Blur (2000).",
-      "fun_fact_fr": "Un tube de Blur (2000).",
-      "fun_fact_nl": "Een chart-hit van Blur (2000)."
+      "fun_fact": "A chart hit by Blur (1994).",
+      "fun_fact_de": "Ein Chart-Hit von Blur (1994).",
+      "fun_fact_es": "Un éxito de Blur (1994).",
+      "fun_fact_fr": "Un tube de Blur (1994).",
+      "fun_fact_nl": "Een chart-hit van Blur (1994)."
     },
     {
       "artist": "Spice Girls",
@@ -3241,11 +3241,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=YQmrQzirOR4",
       "uri_tidal": "tidal://track/16389909",
       "uri_deezer": "deezer://track/45523761",
-      "fun_fact": "A chart hit by Spice Girls (2007).",
-      "fun_fact_de": "Ein Chart-Hit von Spice Girls (2007).",
-      "fun_fact_es": "Un éxito de Spice Girls (2007).",
-      "fun_fact_fr": "Un tube de Spice Girls (2007).",
-      "fun_fact_nl": "Een chart-hit van Spice Girls (2007)."
+      "fun_fact": "A chart hit by Spice Girls (1996).",
+      "fun_fact_de": "Ein Chart-Hit von Spice Girls (1996).",
+      "fun_fact_es": "Un éxito de Spice Girls (1996).",
+      "fun_fact_fr": "Un tube de Spice Girls (1996).",
+      "fun_fact_nl": "Een chart-hit van Spice Girls (1996)."
     },
     {
       "artist": "Shaggy",
@@ -3266,11 +3266,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=SA130vlAPTE",
       "uri_tidal": "tidal://track/1838950",
       "uri_deezer": "deezer://track/3159507",
-      "fun_fact": "A chart hit by Shaggy (2008).",
-      "fun_fact_de": "Ein Chart-Hit von Shaggy (2008).",
-      "fun_fact_es": "Un éxito de Shaggy (2008).",
-      "fun_fact_fr": "Un tube de Shaggy (2008).",
-      "fun_fact_nl": "Een chart-hit van Shaggy (2008)."
+      "fun_fact": "A chart hit by Shaggy (1993).",
+      "fun_fact_de": "Ein Chart-Hit von Shaggy (1993).",
+      "fun_fact_es": "Un éxito de Shaggy (1993).",
+      "fun_fact_fr": "Un tube de Shaggy (1993).",
+      "fun_fact_nl": "Een chart-hit van Shaggy (1993)."
     },
     {
       "artist": "Five",
@@ -3294,11 +3294,11 @@
       "alt_artists": [
         "Steve Mac"
       ],
-      "fun_fact": "A chart hit by Five (2003).",
-      "fun_fact_de": "Ein Chart-Hit von Five (2003).",
-      "fun_fact_es": "Un éxito de Five (2003).",
-      "fun_fact_fr": "Un tube de Five (2003).",
-      "fun_fact_nl": "Een chart-hit van Five (2003)."
+      "fun_fact": "A chart hit by Five (1999).",
+      "fun_fact_de": "Ein Chart-Hit von Five (1999).",
+      "fun_fact_es": "Un éxito de Five (1999).",
+      "fun_fact_fr": "Un tube de Five (1999).",
+      "fun_fact_nl": "Een chart-hit van Five (1999)."
     },
     {
       "year": 1990,

--- a/custom_components/beatify/playlists/hits-2010s-2020s.json
+++ b/custom_components/beatify/playlists/hits-2010s-2020s.json
@@ -975,11 +975,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=FZfj5iPy5wU",
       "uri_tidal": "tidal://track/23026756",
       "uri_deezer": "deezer://track/71444147",
-      "fun_fact": "A chart hit by Christian Steiffen (2013).",
-      "fun_fact_de": "Ein Chart-Hit von Christian Steiffen (2013).",
-      "fun_fact_es": "Un éxito de Christian Steiffen (2013).",
-      "fun_fact_fr": "Un tube de Christian Steiffen (2013).",
-      "fun_fact_nl": "Een chart-hit van Christian Steiffen (2013)."
+      "fun_fact": "A chart hit by Christian Steiffen (2012).",
+      "fun_fact_de": "Ein Chart-Hit von Christian Steiffen (2012).",
+      "fun_fact_es": "Un éxito de Christian Steiffen (2012).",
+      "fun_fact_fr": "Un tube de Christian Steiffen (2012).",
+      "fun_fact_nl": "Een chart-hit van Christian Steiffen (2012)."
     },
     {
       "artist": "Leony",

--- a/custom_components/beatify/playlists/top-songs-der-60er.json
+++ b/custom_components/beatify/playlists/top-songs-der-60er.json
@@ -1873,11 +1873,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=YrxHcSZBU38",
       "uri_tidal": "tidal://track/4102341",
       "uri_deezer": "deezer://track/6435675",
-      "fun_fact": "A chart hit by The Spencer Davis Group (2010).",
-      "fun_fact_de": "Ein Chart-Hit von The Spencer Davis Group (2010).",
-      "fun_fact_es": "Un éxito de The Spencer Davis Group (2010).",
-      "fun_fact_fr": "Un tube de The Spencer Davis Group (2010).",
-      "fun_fact_nl": "Een chart-hit van The Spencer Davis Group (2010)."
+      "fun_fact": "A chart hit by The Spencer Davis Group (1965).",
+      "fun_fact_de": "Ein Chart-Hit von The Spencer Davis Group (1965).",
+      "fun_fact_es": "Un éxito de The Spencer Davis Group (1965).",
+      "fun_fact_fr": "Un tube de The Spencer Davis Group (1965).",
+      "fun_fact_nl": "Een chart-hit van The Spencer Davis Group (1965)."
     },
     {
       "artist": "Little Eva",
@@ -1898,11 +1898,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=1Lej7aQDrGM",
       "uri_tidal": "tidal://track/57827512",
       "uri_deezer": "deezer://track/120080938",
-      "fun_fact": "A chart hit by Little Eva (2013).",
-      "fun_fact_de": "Ein Chart-Hit von Little Eva (2013).",
-      "fun_fact_es": "Un éxito de Little Eva (2013).",
-      "fun_fact_fr": "Un tube de Little Eva (2013).",
-      "fun_fact_nl": "Een chart-hit van Little Eva (2013)."
+      "fun_fact": "A chart hit by Little Eva (1962).",
+      "fun_fact_de": "Ein Chart-Hit von Little Eva (1962).",
+      "fun_fact_es": "Un éxito de Little Eva (1962).",
+      "fun_fact_fr": "Un tube de Little Eva (1962).",
+      "fun_fact_nl": "Een chart-hit van Little Eva (1962)."
     },
     {
       "artist": "The Surfaris",
@@ -1923,11 +1923,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=dBURLdhmmZ8",
       "uri_tidal": "tidal://track/28938746",
       "uri_deezer": "deezer://track/474644972",
-      "fun_fact": "A chart hit by The Surfaris (2018).",
-      "fun_fact_de": "Ein Chart-Hit von The Surfaris (2018).",
-      "fun_fact_es": "Un éxito de The Surfaris (2018).",
-      "fun_fact_fr": "Un tube de The Surfaris (2018).",
-      "fun_fact_nl": "Een chart-hit van The Surfaris (2018)."
+      "fun_fact": "A chart hit by The Surfaris (1963).",
+      "fun_fact_de": "Ein Chart-Hit von The Surfaris (1963).",
+      "fun_fact_es": "Un éxito de The Surfaris (1963).",
+      "fun_fact_fr": "Un tube de The Surfaris (1963).",
+      "fun_fact_nl": "Een chart-hit van The Surfaris (1963)."
     },
     {
       "artist": "The Crystals",
@@ -1948,11 +1948,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=q3_KgmgrUm8",
       "uri_tidal": "tidal://track/7320816",
       "uri_deezer": "deezer://track/12809345",
-      "fun_fact": "A chart hit by The Crystals (2011).",
-      "fun_fact_de": "Ein Chart-Hit von The Crystals (2011).",
-      "fun_fact_es": "Un éxito de The Crystals (2011).",
-      "fun_fact_fr": "Un tube de The Crystals (2011).",
-      "fun_fact_nl": "Een chart-hit van The Crystals (2011)."
+      "fun_fact": "A chart hit by The Crystals (1963).",
+      "fun_fact_de": "Ein Chart-Hit von The Crystals (1963).",
+      "fun_fact_es": "Un éxito de The Crystals (1963).",
+      "fun_fact_fr": "Un tube de The Crystals (1963).",
+      "fun_fact_nl": "Een chart-hit van The Crystals (1963)."
     },
     {
       "artist": "France Gall",
@@ -1973,11 +1973,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=iCrmoGujhdU",
       "uri_tidal": "tidal://track/41386583",
       "uri_deezer": "deezer://track/639971642",
-      "fun_fact": "A chart hit by France Gall (2019).",
-      "fun_fact_de": "Ein Chart-Hit von France Gall (2019).",
-      "fun_fact_es": "Un éxito de France Gall (2019).",
-      "fun_fact_fr": "Un tube de France Gall (2019).",
-      "fun_fact_nl": "Een chart-hit van France Gall (2019)."
+      "fun_fact": "A chart hit by France Gall (1965).",
+      "fun_fact_de": "Ein Chart-Hit von France Gall (1965).",
+      "fun_fact_es": "Un éxito de France Gall (1965).",
+      "fun_fact_fr": "Un tube de France Gall (1965).",
+      "fun_fact_nl": "Een chart-hit van France Gall (1965)."
     },
     {
       "artist": "Aretha Franklin",
@@ -1998,11 +1998,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=FNagYP9LIp4",
       "uri_tidal": "tidal://track/1845346",
       "uri_deezer": "deezer://track/13100388",
-      "fun_fact": "A chart hit by Aretha Franklin (2011).",
-      "fun_fact_de": "Ein Chart-Hit von Aretha Franklin (2011).",
-      "fun_fact_es": "Un éxito de Aretha Franklin (2011).",
-      "fun_fact_fr": "Un tube de Aretha Franklin (2011).",
-      "fun_fact_nl": "Een chart-hit van Aretha Franklin (2011)."
+      "fun_fact": "A chart hit by Aretha Franklin (1968).",
+      "fun_fact_de": "Ein Chart-Hit von Aretha Franklin (1968).",
+      "fun_fact_es": "Un éxito de Aretha Franklin (1968).",
+      "fun_fact_fr": "Un tube de Aretha Franklin (1968).",
+      "fun_fact_nl": "Een chart-hit van Aretha Franklin (1968)."
     },
     {
       "artist": "Martha Reeves & The Vandellas",
@@ -2023,11 +2023,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=bBgYbw_u230",
       "uri_tidal": "tidal://track/19812732",
       "uri_deezer": "deezer://track/821757832",
-      "fun_fact": "A chart hit by Martha Reeves & The Vandellas (2010).",
-      "fun_fact_de": "Ein Chart-Hit von Martha Reeves & The Vandellas (2010).",
-      "fun_fact_es": "Un éxito de Martha Reeves & The Vandellas (2010).",
-      "fun_fact_fr": "Un tube de Martha Reeves & The Vandellas (2010).",
-      "fun_fact_nl": "Een chart-hit van Martha Reeves & The Vandellas (2010)."
+      "fun_fact": "A chart hit by Martha Reeves & The Vandellas (1963).",
+      "fun_fact_de": "Ein Chart-Hit von Martha Reeves & The Vandellas (1963).",
+      "fun_fact_es": "Un éxito de Martha Reeves & The Vandellas (1963).",
+      "fun_fact_fr": "Un tube de Martha Reeves & The Vandellas (1963).",
+      "fun_fact_nl": "Een chart-hit van Martha Reeves & The Vandellas (1963)."
     },
     {
       "artist": "Arthur Conley",
@@ -2048,11 +2048,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=SaphQafq3NQ",
       "uri_tidal": "tidal://track/1205194",
       "uri_deezer": "deezer://track/137439762",
-      "fun_fact": "A chart hit by Arthur Conley (2016).",
-      "fun_fact_de": "Ein Chart-Hit von Arthur Conley (2016).",
-      "fun_fact_es": "Un éxito de Arthur Conley (2016).",
-      "fun_fact_fr": "Un tube de Arthur Conley (2016).",
-      "fun_fact_nl": "Een chart-hit van Arthur Conley (2016)."
+      "fun_fact": "A chart hit by Arthur Conley (1967).",
+      "fun_fact_de": "Ein Chart-Hit von Arthur Conley (1967).",
+      "fun_fact_es": "Un éxito de Arthur Conley (1967).",
+      "fun_fact_fr": "Un tube de Arthur Conley (1967).",
+      "fun_fact_nl": "Een chart-hit van Arthur Conley (1967)."
     },
     {
       "artist": "Helen Shapiro",
@@ -2073,11 +2073,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=QCbHubvwFs0",
       "uri_tidal": "tidal://track/1501131",
       "uri_deezer": "deezer://track/65049652",
-      "fun_fact": "A chart hit by Helen Shapiro (2013).",
-      "fun_fact_de": "Ein Chart-Hit von Helen Shapiro (2013).",
-      "fun_fact_es": "Un éxito de Helen Shapiro (2013).",
-      "fun_fact_fr": "Un tube de Helen Shapiro (2013).",
-      "fun_fact_nl": "Een chart-hit van Helen Shapiro (2013)."
+      "fun_fact": "A chart hit by Helen Shapiro (1961).",
+      "fun_fact_de": "Ein Chart-Hit von Helen Shapiro (1961).",
+      "fun_fact_es": "Un éxito de Helen Shapiro (1961).",
+      "fun_fact_fr": "Un tube de Helen Shapiro (1961).",
+      "fun_fact_nl": "Een chart-hit van Helen Shapiro (1961)."
     },
     {
       "artist": "Roy Orbison",
@@ -2098,11 +2098,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=3KFvoDDs0XM",
       "uri_tidal": "tidal://track/64851653",
       "uri_deezer": "deezer://track/78033230",
-      "fun_fact": "A chart hit by Roy Orbison (2014).",
-      "fun_fact_de": "Ein Chart-Hit von Roy Orbison (2014).",
-      "fun_fact_es": "Un éxito de Roy Orbison (2014).",
-      "fun_fact_fr": "Un tube de Roy Orbison (2014).",
-      "fun_fact_nl": "Een chart-hit van Roy Orbison (2014)."
+      "fun_fact": "A chart hit by Roy Orbison (1964).",
+      "fun_fact_de": "Ein Chart-Hit von Roy Orbison (1964).",
+      "fun_fact_es": "Un éxito de Roy Orbison (1964).",
+      "fun_fact_fr": "Un tube de Roy Orbison (1964).",
+      "fun_fact_nl": "Een chart-hit van Roy Orbison (1964)."
     },
     {
       "artist": "The Ronettes",
@@ -2123,11 +2123,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=QBDem6bffyo",
       "uri_tidal": "tidal://track/7320788",
       "uri_deezer": "deezer://track/12809317",
-      "fun_fact": "A chart hit by The Ronettes (2011).",
-      "fun_fact_de": "Ein Chart-Hit von The Ronettes (2011).",
-      "fun_fact_es": "Un éxito de The Ronettes (2011).",
-      "fun_fact_fr": "Un tube de The Ronettes (2011).",
-      "fun_fact_nl": "Een chart-hit van The Ronettes (2011)."
+      "fun_fact": "A chart hit by The Ronettes (1963).",
+      "fun_fact_de": "Ein Chart-Hit von The Ronettes (1963).",
+      "fun_fact_es": "Un éxito de The Ronettes (1963).",
+      "fun_fact_fr": "Un tube de The Ronettes (1963).",
+      "fun_fact_nl": "Een chart-hit van The Ronettes (1963)."
     },
     {
       "artist": "The Supremes",
@@ -2148,11 +2148,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=kk8tFtdHqtw",
       "uri_tidal": "tidal://track/77642587",
       "uri_deezer": "deezer://track/1182495",
-      "fun_fact": "A chart hit by The Supremes (2007).",
-      "fun_fact_de": "Ein Chart-Hit von The Supremes (2007).",
-      "fun_fact_es": "Un éxito de The Supremes (2007).",
-      "fun_fact_fr": "Un tube de The Supremes (2007).",
-      "fun_fact_nl": "Een chart-hit van The Supremes (2007)."
+      "fun_fact": "A chart hit by The Supremes (1964).",
+      "fun_fact_de": "Ein Chart-Hit von The Supremes (1964).",
+      "fun_fact_es": "Un éxito de The Supremes (1964).",
+      "fun_fact_fr": "Un tube de The Supremes (1964).",
+      "fun_fact_nl": "Een chart-hit van The Supremes (1964)."
     },
     {
       "artist": "Bobby Lewis",
@@ -2173,11 +2173,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=4zkPBwlyd4M",
       "uri_tidal": "tidal://track/346596036",
       "uri_deezer": "deezer://track/5479527",
-      "fun_fact": "A chart hit by Bobby Lewis (2009).",
-      "fun_fact_de": "Ein Chart-Hit von Bobby Lewis (2009).",
-      "fun_fact_es": "Un éxito de Bobby Lewis (2009).",
-      "fun_fact_fr": "Un tube de Bobby Lewis (2009).",
-      "fun_fact_nl": "Een chart-hit van Bobby Lewis (2009)."
+      "fun_fact": "A chart hit by Bobby Lewis (1961).",
+      "fun_fact_de": "Ein Chart-Hit von Bobby Lewis (1961).",
+      "fun_fact_es": "Un éxito de Bobby Lewis (1961).",
+      "fun_fact_fr": "Un tube de Bobby Lewis (1961).",
+      "fun_fact_nl": "Een chart-hit van Bobby Lewis (1961)."
     },
     {
       "artist": "The Rolling Stones",
@@ -2198,11 +2198,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=61jfm219ArA",
       "uri_tidal": "tidal://track/123249707",
       "uri_deezer": "deezer://track/16702525",
-      "fun_fact": "A chart hit by The Rolling Stones (2005).",
-      "fun_fact_de": "Ein Chart-Hit von The Rolling Stones (2005).",
-      "fun_fact_es": "Un éxito de The Rolling Stones (2005).",
-      "fun_fact_fr": "Un tube de The Rolling Stones (2005).",
-      "fun_fact_nl": "Een chart-hit van The Rolling Stones (2005)."
+      "fun_fact": "A chart hit by The Rolling Stones (1969).",
+      "fun_fact_de": "Ein Chart-Hit von The Rolling Stones (1969).",
+      "fun_fact_es": "Un éxito de The Rolling Stones (1969).",
+      "fun_fact_fr": "Un tube de The Rolling Stones (1969).",
+      "fun_fact_nl": "Een chart-hit van The Rolling Stones (1969)."
     },
     {
       "artist": "Lesley Gore",
@@ -2223,11 +2223,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=_NpsUiKBEes",
       "uri_tidal": "tidal://track/64495473",
       "uri_deezer": "deezer://track/24161411",
-      "fun_fact": "A chart hit by Lesley Gore (2000).",
-      "fun_fact_de": "Ein Chart-Hit von Lesley Gore (2000).",
-      "fun_fact_es": "Un éxito de Lesley Gore (2000).",
-      "fun_fact_fr": "Un tube de Lesley Gore (2000).",
-      "fun_fact_nl": "Een chart-hit van Lesley Gore (2000)."
+      "fun_fact": "A chart hit by Lesley Gore (1963).",
+      "fun_fact_de": "Ein Chart-Hit von Lesley Gore (1963).",
+      "fun_fact_es": "Un éxito de Lesley Gore (1963).",
+      "fun_fact_fr": "Un tube de Lesley Gore (1963).",
+      "fun_fact_nl": "Een chart-hit van Lesley Gore (1963)."
     },
     {
       "artist": "The Edwin Hawkins Singers",
@@ -2248,11 +2248,11 @@
       "uri_youtube_music": "https://music.youtube.com/watch?v=rUXa1-oI_ug",
       "uri_tidal": "tidal://track/2848125",
       "uri_deezer": "deezer://track/13176492",
-      "fun_fact": "A chart hit by The Edwin Hawkins Singers (2001).",
-      "fun_fact_de": "Ein Chart-Hit von The Edwin Hawkins Singers (2001).",
-      "fun_fact_es": "Un éxito de The Edwin Hawkins Singers (2001).",
-      "fun_fact_fr": "Un tube de The Edwin Hawkins Singers (2001).",
-      "fun_fact_nl": "Een chart-hit van The Edwin Hawkins Singers (2001)."
+      "fun_fact": "A chart hit by The Edwin Hawkins Singers (1968).",
+      "fun_fact_de": "Ein Chart-Hit von The Edwin Hawkins Singers (1968).",
+      "fun_fact_es": "Un éxito de The Edwin Hawkins Singers (1968).",
+      "fun_fact_fr": "Un tube de The Edwin Hawkins Singers (1968).",
+      "fun_fact_nl": "Een chart-hit van The Edwin Hawkins Singers (1968)."
     },
     {
       "artist": "Elvis Presley",
@@ -2276,11 +2276,11 @@
       "alt_artists": [
         "Junkie XL"
       ],
-      "fun_fact": "A chart hit by Elvis Presley (2002).",
-      "fun_fact_de": "Ein Chart-Hit von Elvis Presley (2002).",
-      "fun_fact_es": "Un éxito de Elvis Presley (2002).",
-      "fun_fact_fr": "Un tube de Elvis Presley (2002).",
-      "fun_fact_nl": "Een chart-hit van Elvis Presley (2002)."
+      "fun_fact": "A chart hit by Elvis Presley (1968).",
+      "fun_fact_de": "Ein Chart-Hit von Elvis Presley (1968).",
+      "fun_fact_es": "Un éxito de Elvis Presley (1968).",
+      "fun_fact_fr": "Un tube de Elvis Presley (1968).",
+      "fun_fact_nl": "Een chart-hit van Elvis Presley (1968)."
     },
     {
       "artist": "The Jackson 5",


### PR DESCRIPTION
77 songs across five playlists carried a fun fact of the shape
"A chart hit by ARTIST (YYYY)." where YYYY contradicted the song's own
`year` field. The player is asked to guess the year; the fun fact is
shown right after the reveal and named a second, different one.

The number in those brackets is not a release date. Eddy Grant's "Gimme
Hope Jo'Anna" - a 1988 song - carried **2026**, the current year.
Blondie's "Call Me" carried 2003, Michael Jackson's "Bad" 2012, Kool &
The Gang's "Let's Go Dancin'" 2018. It reads like a chart re-entry or a
compilation date that was picked up instead of the release.

Only the bracketed year moved, onto the `year` field, in all five
languages. No sentence was rewritten and no fun fact was replaced:
385 strings changed, 385 lines in and 385 out, and every changed line
is a `fun_fact*` line.

Per playlist: 80er-hits 28, 90er-hits 18, top-songs-der-60er 17,
2000s-pop-anthems 13, hits-2010s-2020s 1.

The template was matched per language, not by position - "Ein Chart-Hit
von X (YYYY).", "Un éxito de X (YYYY).", "Un tube de X (YYYY).", "Een
chart-hit van X (YYYY)." All 385 localised strings matched their
pattern; none had to be skipped.

Deliberately untouched: the 121 remaining "chart hit" fun facts whose
year is already correct. They are still not facts - "A chart hit by
Blondie (1980)." says nothing - but that is a content question, and
mixing it in would bury a diff that is currently verifiable line by line.

Also untouched: the 39 fun facts in 80er-hits that mention some other
year for a good reason - covers dating the original (UB40 naming Neil
Diamond 1968), later revivals (Kate Bush and Stranger Things in 2022),
awards in the following year (Winwood's 1987 Grammy). Every one of those
years sits in a sentence that explains it.

Verified after the change: 198 template fun facts in the catalogue,
0 with a year that contradicts its `year` field.

Tests: 2106 pytest passed, 2 skipped; 653 vitest passed.

Replaces #2414, which GitHub closed automatically when its base branch `fix/80er-hits-decade-outliers` was deleted on the merge of #2413. Same commit, rebased onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Njn3vxDz6tKKas427onhL7