### PR TITLE
fix(game): make the round cap hold across playlists (#2418)

### DIFF
--- a/custom_components/beatify/game/playlist.py
+++ b/custom_components/beatify/game/playlist.py
@@ -171,12 +171,29 @@ class PlaylistManager:
         self._max_rounds = max(max_rounds, MIN_ROUNDS) if max_rounds else 0
         if self._max_rounds and len(self._songs) > self._max_rounds:
             self._songs = random.sample(self._songs, self._max_rounds)
+            # #2418: regroup the buckets from the sampled pool. Until this line
+            # existed the cap applied to `self._songs` alone, while
+            # `self._buckets` — assigned above, before the sample — kept every
+            # song of every selected playlist. get_next_song() reads the pool
+            # only in the single-playlist case; the balanced path taken for two
+            # or more playlists reads the buckets, so the cap did nothing there.
+            # Measured before the fix: two playlists of 150 with a cap of 10
+            # served all 300, while get_total_count() went on reporting 10.
+            #
+            # Regrouped rather than trimmed separately, so the pool stays the
+            # single source of truth and the two paths cannot drift apart again.
+            self._buckets = {}
+            for song in self._songs:
+                source = song.get("_playlist_source", "__default__")
+                self._buckets.setdefault(source, []).append(song)
             _LOGGER.info(
                 "Round cap active: %d of %d playable songs will be played (#1475)",
                 self._max_rounds,
                 total_count,
             )
-        self._multi_playlist = len(buckets) > 1
+        # Derived from the buckets that are actually played from — after the
+        # regroup above, not from the pre-cap grouping (#2418).
+        self._multi_playlist = len(self._buckets) > 1
 
         deduped = sum(len(v) for v in buckets.values())
         _LOGGER.info(

--- a/tests/unit/test_round_cap_multi_playlist_2418.py
+++ b/tests/unit/test_round_cap_multi_playlist_2418.py
@@ -1,0 +1,143 @@
+"""The round cap has to hold for a multi-playlist selection too (#2418).
+
+@boardnick0815 reported a game running past the round count he had chosen: the
+setup screen showed 10 selected, the game-over screen showed 11 rounds played.
+
+`PlaylistManager` capped `self._songs` with `random.sample`, but assigned
+`self._buckets` before that and never regrouped them. `get_next_song()` reads
+the pool only in the single-playlist case; with two or more playlists it takes
+the balanced path, which reads the buckets — so the cap did nothing there.
+
+Measured before the fix: two playlists of 150 with a cap of 10 served **all
+300**, while `get_total_count()` went on reporting 10.
+
+The existing cap tests all use a single playlist, which is exactly where both
+paths agree — which is why this went unnoticed. These tests therefore **drain**
+the manager until it is empty and count what it served, rather than asking
+`get_total_count()`. That number was right the whole time; what it claimed
+about the rest of the game was not.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from custom_components.beatify.game.playlist import MIN_ROUNDS, PlaylistManager
+
+
+def _songs(prefix: str, count: int, source: str) -> list[dict[str, Any]]:
+    """Playable Spotify songs tagged with a playlist source."""
+    return [
+        {
+            "title": f"{prefix} {i}",
+            "artist": "Test Artist",
+            "year": 1990,
+            "uri": f"spotify:track:{prefix}{i:04d}",
+            "_playlist_source": source,
+        }
+        for i in range(count)
+    ]
+
+
+def _drain(pm: PlaylistManager, limit: int = 5000) -> int:
+    """Serve songs until the manager runs out; return how many it served."""
+    served = 0
+    while served <= limit:
+        song = pm.get_next_song()
+        if song is None:
+            return served
+        pm.mark_played(song["_resolved_uri"])
+        served += 1
+    raise AssertionError(f"manager served more than {limit} songs — no end in sight")
+
+
+class TestRoundCapAcrossPlaylists:
+    """What the cap promises: the game stops after that many rounds."""
+
+    def test_two_playlists_stop_at_the_cap(self) -> None:
+        pm = PlaylistManager(
+            _songs("a", 150, "one.json") + _songs("b", 150, "two.json"),
+            provider="spotify",
+            max_rounds=10,
+        )
+        assert _drain(pm) == 10
+
+    def test_three_playlists_stop_at_the_cap(self) -> None:
+        pm = PlaylistManager(
+            _songs("a", 100, "one.json")
+            + _songs("b", 100, "two.json")
+            + _songs("c", 100, "three.json"),
+            provider="spotify",
+            max_rounds=20,
+        )
+        assert _drain(pm) == 20
+
+    def test_single_playlist_still_stops_at_the_cap(self) -> None:
+        # The case that always worked — kept so the regroup cannot break it.
+        pm = PlaylistManager(
+            _songs("a", 150, "one.json"), provider="spotify", max_rounds=10
+        )
+        assert _drain(pm) == 10
+
+    def test_no_cap_still_plays_everything_across_playlists(self) -> None:
+        # A fix that shortens uncapped games would be worse than the bug.
+        pm = PlaylistManager(
+            _songs("a", 40, "one.json") + _songs("b", 40, "two.json"),
+            provider="spotify",
+            max_rounds=0,
+        )
+        assert _drain(pm) == 80
+
+    def test_cap_above_the_pool_leaves_it_alone(self) -> None:
+        pm = PlaylistManager(
+            _songs("a", 12, "one.json") + _songs("b", 12, "two.json"),
+            provider="spotify",
+            max_rounds=100,
+        )
+        assert _drain(pm) == 24
+
+    def test_cap_below_the_floor_is_raised_to_it(self) -> None:
+        # MIN_ROUNDS is enforced in the manager, so a hand-crafted request
+        # cannot undercut it either — that holds across playlists as well.
+        pm = PlaylistManager(
+            _songs("a", 100, "one.json") + _songs("b", 100, "two.json"),
+            provider="spotify",
+            max_rounds=3,
+        )
+        assert _drain(pm) == MIN_ROUNDS
+
+
+class TestPoolAndBucketsAgree:
+    """The contract that broke: the announced count is the played count."""
+
+    def test_total_count_matches_what_is_served(self) -> None:
+        pm = PlaylistManager(
+            _songs("a", 150, "one.json") + _songs("b", 150, "two.json"),
+            provider="spotify",
+            max_rounds=10,
+        )
+        announced = pm.get_total_count()
+        assert _drain(pm) == announced
+
+    def test_buckets_hold_exactly_the_pool(self) -> None:
+        pm = PlaylistManager(
+            _songs("a", 150, "one.json") + _songs("b", 150, "two.json"),
+            provider="spotify",
+            max_rounds=10,
+        )
+        in_buckets = [s for bucket in pm._buckets.values() for s in bucket]
+        assert len(in_buckets) == len(pm._songs)
+        assert {s["uri"] for s in in_buckets} == {s["uri"] for s in pm._songs}
+
+    def test_balanced_mode_still_draws_from_both_playlists(self) -> None:
+        # The balanced path exists to keep the mix; capping must not turn a
+        # two-playlist game into a one-playlist game.
+        sources = set()
+        for _ in range(20):
+            pm = PlaylistManager(
+                _songs("a", 150, "one.json") + _songs("b", 150, "two.json"),
+                provider="spotify",
+                max_rounds=10,
+            )
+            sources.update(s["_playlist_source"] for s in pm._songs)
+        assert sources == {"one.json", "two.json"}


### PR DESCRIPTION
Selecting a round count did nothing once more than one playlist was
selected. @boardnick0815 chose 10 and the game-over screen counted 11
rounds, with the game still willing to continue.

`PlaylistManager.__init__` caps `self._songs` with `random.sample`, but
it assigns `self._buckets` fourteen lines earlier and never regroups
them. `get_next_song()` reads the pool only in the single-playlist case;
with two or more playlists it takes the balanced path, which reads the
buckets — so the cap applied to a list that path never consults.

Measured before the fix, draining the manager until it ran dry:

| Selection | max_rounds | get_total_count() | served |
|---|---|---|---|
| 1 playlist, 150 songs | 10 | 10 | 10 |
| 2 playlists, 150 each | 10 | 10 | **300** |
| 3 playlists, 100 each | 20 | 20 | **300** |

The buckets are now regrouped from the sampled pool, and
`_multi_playlist` is derived from the regrouped buckets rather than the
pre-cap grouping. Regrouped rather than trimmed separately, so the pool
stays the single source of truth and the two paths cannot drift apart
again.

This also explains a detail of the report. `total_rounds` is the capped
number, so the "last round" announcement at `round >= total_rounds`
(state_lifecycle.py) fired on round 10 and the game then carried on —
which is what "you can continue playing when the maximum is exceeded"
looks like from the sofa.

Ramp-up ordering was never affected: `_build_rampup_order()` iterates
`self._songs` and inherits the cap.

Left alone on purpose: the sample stays uniform rather than being
stratified per playlist, so a cap of 10 over two playlists of 150 may
land 7/3. That is the existing promise of the line above it ("Sampling
keeps the mix"), and changing it is a design decision, not a bug fix.
A test pins that both playlists still appear across repeated runs.

The existing cap tests all use a single playlist — exactly where both
paths agree, which is why this went unnoticed. The nine new tests
therefore **drain** the manager and count what it served instead of
asking `get_total_count()`: that number was right the whole time, what
it implied about the rest of the game was not. Five of the nine fail
against the unfixed manager; the other four are the regression guards
(single playlist, no cap, cap above the pool) and pass either way.

Tests: 2115 pytest passed, 2 skipped; 661 vitest passed; build:check
clean.

Closes #2418

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Njn3vxDz6tKKas427onhL7