### PR TITLE
pages: bring the catalogue figures back in line with the shipped app

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,10 +98,10 @@
           <p class="tagline">Beatify is the music party game for the speakers you already own. Guests scan a QR code to join — no app, no accounts — and race to name the release year, or the title and the artist. Beats, laughs, rematches, and one friend who insists it was 1987.</p>
 
           <div class="hero-stats">
-            <span>55 playlists</span>
-            <span>6,079 songs</span>
+            <span>59 playlists</span>
+            <span>7,671 songs</span>
             <span>6 music services</span>
-            <span>5 languages</span>
+            <span>6 languages</span>
           </div>
 
           <div class="hero-cta">
@@ -135,7 +135,7 @@
             <div class="step">
               <div class="step-number" aria-hidden="true">2</div>
               <h3>Pick Music</h3>
-              <p>Choose from 55 curated playlists or connect Spotify, Apple Music, YouTube Music, Deezer, Tidal or Amazon Music.</p>
+              <p>Choose from 59 curated playlists or connect Spotify, Apple Music, YouTube Music, Deezer, Tidal or Amazon Music.</p>
             </div>
             <div class="step">
               <div class="step-number" aria-hidden="true">3</div>
@@ -164,7 +164,7 @@
             <div class="feature">
               <div class="feature-icon" aria-hidden="true">🎵</div>
               <h3>Your Music</h3>
-              <p>Spotify, Apple Music, YouTube Music, Deezer, Tidal and Amazon Music. 55 curated playlists included.</p>
+              <p>Spotify, Apple Music, YouTube Music, Deezer, Tidal and Amazon Music. 59 curated playlists included.</p>
             </div>
             <div class="feature">
               <div class="feature-icon" aria-hidden="true">✍️</div>
@@ -264,7 +264,7 @@
               <span class="speaker-check" aria-hidden="true">✅</span>
               <div>
                 <strong>Nothing to buy or reprint</strong>
-                <p>The card decks are playlists. 55 of them ship with Beatify, and you can build your own from any music service or your own library.</p>
+                <p>The card decks are playlists. 59 of them ship with Beatify, and you can build your own from any music service or your own library.</p>
               </div>
             </div>
             <div class="speaker-card">


### PR DESCRIPTION
The landing page understated the catalogue. Counted against `main` today:

- 55 playlists -> **59** (hero, two feature blurbs, and the Hitster comparison)
- 6,079 songs -> **7,671**
- 5 languages -> **6** — Italian shipped and the page never said so

`6 music services` was already right and is untouched.

Counted, not estimated: 59 files under `custom_components/beatify/playlists/**`
carrying a `songs` array, 7,671 entries across them, six locale files in
`www/i18n/`.

The last commit here is from 22 August; four playlists have landed since,
Salsa y Merengue (534 tracks) among them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Njn3vxDz6tKKas427onhL7