### PR TITLE
docs(readme): refresh the catalogue figures (59 playlists, 7,671 songs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ Playlists are displayed on the main Beatify admin screen:
 
 ### Included Playlists
 
-Beatify comes with 5,980 songs across 54 curated playlists:
+Beatify comes with 7,671 songs across 59 curated playlists:
 
 - 🎬 **100 Greatest Movie Themes** — 162 iconic film soundtracks
 - 🎸 **100 Greatest Rock Songs** — 122 rock essentials spanning 1964–2026


### PR DESCRIPTION
The README's catalogue line said 5,980 songs across 54 curated playlists. Counted against `main` today: **7,671 songs across 59 playlists**.

Counted, not estimated — 59 files under `custom_components/beatify/playlists/**` carrying a `songs` array, 7,671 entries across them.

The same figures on the landing page are in #2422 (against `gh-pages`, which is where the published site actually comes from).

The release-notes line further down ("catalogue 46 → 54 playlists") is left alone on purpose: it describes what a past release did and was true when written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Njn3vxDz6tKKas427onhL7