### PR TITLE
fix(game): let one rule decide whether a round is the last (#2421)

### DIFF
--- a/custom_components/beatify/game/state_lifecycle.py
+++ b/custom_components/beatify/game/state_lifecycle.py
@@ -289,7 +289,25 @@ class RoundLifecycleMixin:
                 return False
             return await self._start_round_locked(_retry_count + 1)
 
-        self.last_round = self._playlist_manager.get_remaining_count() <= 1
+        # #2421: one rule decides whether this is the last round, and it lives
+        # here. The flag counts what is left in the pool; the TTS announcement
+        # used to re-derive the same question from `round >= total_rounds`, and
+        # the two disagree as soon as a song is dropped mid-game — the
+        # playback-failure path below marks a song played without a round being
+        # committed, so `round` falls behind while the remaining count keeps
+        # pace with reality. Measured on a five-song game with one song
+        # dropped: round 4 really is the last, the flag said so, and the spoken
+        # cue never came.
+        #
+        # The `total_rounds > 1` guard moved here from the announcement. It is
+        # the reason a one-song game no longer raises the flag at all: opening
+        # a game with "final round!" is noise, and that judgement now applies
+        # to the banner and the announcement alike instead of only to the one
+        # that happened to carry the guard.
+        self.last_round = (
+            self.total_rounds > 1
+            and self._playlist_manager.get_remaining_count() <= 1
+        )
         self._ensure_media_player_service()
         will_defer_for_splash = self._prepare_intro_round(song)
 
@@ -533,7 +551,10 @@ class RoundLifecycleMixin:
         await self.announce_round_start()
         await self.announce_countdown()
         # Issue #841 Phase 3: flag the final round (use case 17).
-        if self.total_rounds > 1 and self.round >= self.total_rounds:
+        # #2421: read the flag rather than re-deriving the condition, so the
+        # speaker, the banner, the admin's button and the Finale Double guard
+        # all answer to the same rule.
+        if self.last_round:
             await self.announce_last_round()
         # Issue #842 Phase 4: flag an intro-mode round (use case 21).
         if self.is_intro_round:

--- a/custom_components/beatify/game/state_lifecycle.py
+++ b/custom_components/beatify/game/state_lifecycle.py
@@ -305,8 +305,7 @@ class RoundLifecycleMixin:
         # to the banner and the announcement alike instead of only to the one
         # that happened to carry the guard.
         self.last_round = (
-            self.total_rounds > 1
-            and self._playlist_manager.get_remaining_count() <= 1
+            self.total_rounds > 1 and self._playlist_manager.get_remaining_count() <= 1
         )
         self._ensure_media_player_service()
         will_defer_for_splash = self._prepare_intro_round(song)

--- a/tests/unit/test_last_round_one_rule_2421.py
+++ b/tests/unit/test_last_round_one_rule_2421.py
@@ -77,7 +77,13 @@ class TestTheFlagFollowsTheGame:
     @pytest.mark.asyncio
     async def test_clean_game_flags_only_the_final_round(self):
         gs = _make_game(5)
-        assert await _play(gs) == [(1, False), (2, False), (3, False), (4, False), (5, True)]
+        assert await _play(gs) == [
+            (1, False),
+            (2, False),
+            (3, False),
+            (4, False),
+            (5, True),
+        ]
 
     @pytest.mark.asyncio
     async def test_a_dropped_song_moves_the_last_round_forward(self):

--- a/tests/unit/test_last_round_one_rule_2421.py
+++ b/tests/unit/test_last_round_one_rule_2421.py
@@ -1,0 +1,135 @@
+"""One rule decides whether a round is the last one (#2421).
+
+Two rules used to answer that question. `last_round` counted what was left in
+the pool (`get_remaining_count() <= 1`); the TTS announcement re-derived it
+from `round >= total_rounds`. They agree in a clean game and part ways as soon
+as a song is dropped: the playback-failure path marks a song played **without
+committing a round**, so `round` falls behind `total_rounds` while the
+remaining count keeps pace with reality.
+
+Measured before the fix, on a five-song game with one song dropped after round
+one: round 4 really was the last, the flag said so — and the spoken cue never
+came. It failed in the quietest possible direction. Nothing looked wrong; a
+cue was simply missing, and only in games where a song happened to be
+unavailable.
+
+The `total_rounds > 1` guard moved onto the flag, so a one-song game now stays
+quiet on the banner as well, not only on the speaker.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.conftest import make_game_state, make_songs
+
+
+def _stub_media_service() -> MagicMock:
+    svc = MagicMock()
+    svc.is_available.return_value = True
+    svc.play_song = AsyncMock(return_value=True)
+    svc.verify_responsive = AsyncMock(return_value=(True, None))
+    svc.restore_volume = AsyncMock(return_value=True)
+    svc.restore_queue = AsyncMock(return_value=True)
+    svc.stop = AsyncMock(return_value=True)
+    return svc
+
+
+def _make_game(songs: int = 5):
+    gs = make_game_state()
+    gs.create_game(
+        playlists=["t.json"],
+        songs=make_songs(songs),
+        media_player="media_player.x",
+        base_url="http://h",
+    )
+    gs._media_player_service = _stub_media_service()
+    gs.platform = "music_assistant"
+    ws = MagicMock()
+    ws.closed = False
+    gs.add_player("Alice", ws)
+    gs.get_player("Alice").connected = True
+    return gs
+
+
+def _drop_one_song(gs) -> None:
+    """Simulate the playback-failure path: a song is marked played, no round."""
+    pm = gs._playlist_manager
+    unplayed = [s for s in pm._songs if s["_precomputed_uri"] not in pm._played_uris]
+    pm.mark_played(unplayed[0]["_precomputed_uri"])
+
+
+async def _play(gs, *, drop_after: int | None = None) -> list[tuple[int, bool]]:
+    """Run the game out; return (round number, flag) for each round played."""
+    seen: list[tuple[int, bool]] = []
+    while await gs.start_round():
+        seen.append((gs.round, gs.last_round))
+        if drop_after is not None and len(seen) == drop_after:
+            _drop_one_song(gs)
+        if len(seen) > 50:  # pragma: no cover — runaway guard
+            raise AssertionError("game never ended")
+    return seen
+
+
+class TestTheFlagFollowsTheGame:
+    @pytest.mark.asyncio
+    async def test_clean_game_flags_only_the_final_round(self):
+        gs = _make_game(5)
+        assert await _play(gs) == [(1, False), (2, False), (3, False), (4, False), (5, True)]
+
+    @pytest.mark.asyncio
+    async def test_a_dropped_song_moves_the_last_round_forward(self):
+        # The case that exposed the second rule. Five songs, one dropped after
+        # round 1 → the game really ends after four rounds, and round 4 is the
+        # one to announce.
+        gs = _make_game(5)
+        seen = await _play(gs, drop_after=1)
+        assert seen == [(1, False), (2, False), (3, False), (4, True)]
+
+    @pytest.mark.asyncio
+    async def test_the_old_rule_would_have_missed_it(self):
+        # `round >= total_rounds` — the condition the announcement used to
+        # re-derive — is false on every round of that game. Kept as a test so
+        # the reason for the change cannot quietly stop being true.
+        gs = _make_game(5)
+        seen = await _play(gs, drop_after=1)
+        assert gs.total_rounds == 5
+        assert all(rnd < gs.total_rounds for rnd, _ in seen)
+        assert any(flag for _, flag in seen)
+
+    @pytest.mark.asyncio
+    async def test_a_one_song_game_stays_quiet(self):
+        # The guard moved from the announcement onto the flag, so the banner
+        # follows the same judgement the speaker always did.
+        gs = _make_game(1)
+        assert await _play(gs) == [(1, False)]
+
+
+class TestTheAnnouncementAndTheFlagAgree:
+    @pytest.mark.asyncio
+    async def test_the_cue_fires_exactly_on_the_flagged_round(self):
+        gs = _make_game(5)
+        fired: list[int] = []
+
+        async def _record():
+            fired.append(gs.round)
+
+        gs.announce_last_round = _record  # type: ignore[method-assign]
+        seen = await _play(gs, drop_after=1)
+
+        flagged = [rnd for rnd, flag in seen if flag]
+        assert fired == flagged == [4]
+
+    @pytest.mark.asyncio
+    async def test_the_cue_stays_silent_in_a_one_song_game(self):
+        gs = _make_game(1)
+        fired: list[int] = []
+
+        async def _record():
+            fired.append(gs.round)
+
+        gs.announce_last_round = _record  # type: ignore[method-assign]
+        await _play(gs)
+        assert fired == []


### PR DESCRIPTION
Two rules answered the same question. `last_round` counted what was left
in the pool (`get_remaining_count() <= 1`); the TTS announcement
re-derived it from `round >= total_rounds`.

They agree in a clean game and part ways as soon as a song is dropped.
The playback-failure path marks a song played **without committing a
round** — a track unavailable in the provider's catalogue is skipped and
the next one tried — so `round` falls behind `total_rounds` while the
remaining count keeps pace with reality.

Measured on a five-song game with one song dropped after round one:

| Round | last_round | round >= total_rounds |
|---|---|---|
| 1 | False | False |
| 2 | False | False |
| 3 | False | False |
| 4 | **True** | **False** |

Round 4 really is the last. The flag has it right, so the banner shows,
Finale Double doubles, and the admin's button reads "final results" — but
the spoken cue never comes. One dropped song is enough, and it fails in
the quietest possible direction: nothing looks wrong, a cue is simply
missing, and only in games where a song happened to be unavailable.

The announcement now reads the flag. The `total_rounds > 1` guard moved
onto the flag with it, which is the one deliberate behaviour change: a
one-song game no longer raises the flag at all, so the banner follows the
same judgement the speaker always made. Opening a game with "final
round!" is noise on screen as much as in the room.

Tests: six new. Two of them fail against the unfixed code — the silent
cue and the one-song game. The other four cover the flag itself, which
already worked; they are here so the rule that survived cannot drift
either.

2121 pytest passed, 2 skipped.

Closes #2421

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Njn3vxDz6tKKas427onhL7