### PR TITLE
chore(release): v4.4.0-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [4.4.0-rc1] - 2026-08-31
+
+### Added
+- **Collected row (#2324, #2368).** A year guess that lands inside the difficulty's close range pins the song to a row the player keeps for the rest of the game. The row ships in the reveal payload and in the final leaderboard, and the share card gains a line with the count and the year span it covers. Shape E of the five discussed on the issue: it touches no scoring path, because swapping the question is cheap and swapping the currency is not.
+
+### Fixed
+- **The game-over screen keeps its contents inside its boxes (#2130, #2417).** The winner's name broke mid-word and left the podium card, the award row wrote its values outside the card border, and a two-player game rendered a third, empty stand. Three causes, all horizontal: `.podium-place` could shrink under its stand's fixed width, the award cards had no `min-width: 0` against their `1fr` track, and `renderEndView()` filled all three podium slots unconditionally. The reveal standings from #2133 and #2157 are untouched. Reported by @boardnick0815 on v4.3.0 with a screencast and screenshots.
+- **The round cap holds across playlists (#2418, #2419).** Selecting a round count did nothing once more than one playlist was picked: `PlaylistManager` capped `self._songs` but assigned `self._buckets` before the sample and never regrouped them, and the balanced path that serves a multi-playlist game reads the buckets. Measured before the fix, two playlists of 150 songs with a cap of 10 served all 300.
+- **One rule decides whether a round is the last (#2421, #2424).** The flag counted what was left in the pool while the TTS announcement re-derived the question from `round >= total_rounds`. A song dropped on the playback-failure path is marked played without a round being committed, so the two disagreed and the spoken cue never came. The announcement now reads the flag, and the `total_rounds > 1` guard moved onto it.
+
+### Changed
+- **Salsa y Merengue, 534 songs (#2392, #2410).** The second-largest playlist in the catalogue. Latin America was previously covered by `fiesta-latina-90s` and fifty songs.
+- **The decade playlists contain only their decade (#2403, #2411, #2413).** Nineteen songs sat outside their playlist's range. Eleven moved to the playlist of their own decade; the other eight already existed there and were removed rather than duplicated.
+- **Seventy-seven fun facts stopped contradicting the answer (#2415).** They followed the template `A chart hit by ARTIST (YEAR)`, where the bracketed year was not a release date: a 1988 Eddy Grant song carried 2026. Corrected in all five languages.
+- **Eighteen more provider links (#2409, #2412, #2416)** across Apple Music, YouTube Music and Deezer.
+- **The catalogue figures in the README and on the landing page (#2422, #2423)** now say 59 playlists and 7,671 songs.
+
 ## [4.3.1-rc2] - 2026-08-23
 
 ### Added

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -20,5 +20,5 @@
     "num2words==0.5.14"
   ],
   "single_config_entry": true,
-  "version": "4.3.1-rc2"
+  "version": "4.4.0-rc1"
 }

--- a/docs/release-notes-v4.4.0-rc1.md
+++ b/docs/release-notes-v4.4.0-rc1.md
@@ -1,0 +1,32 @@
+## Beatify v4.4.0-rc1 — "Keep What You Catch"
+
+Songs you guess close enough now stay with you. Four things that could spoil an evening are fixed.
+
+> **Numbered 4.4.0, not 4.3.1.** The work began as `v4.3.1-rc1` and `rc2`, but a patch number promises bug fixes and this adds a game mechanic.
+
+### 🎴 Keep what you catch
+
+Guess a year close enough and the song pins to a row you keep for the rest of the game. It goes into the final standings and onto the share card.
+
+### 📺 What is fixed
+
+The end screen fits. The winner's name stays inside the podium card, the award values stay inside their cards, and a two-player game shows two stands instead of three. Reported by **@boardnick0815** with a screencast.
+
+Ten rounds means ten rounds. The cap used to do nothing once you picked more than one playlist: two playlists with a cap of ten played all 300 songs in them.
+
+The final round announces itself again, including in games where a track turned out to be unavailable.
+
+A reload no longer drops you out. The submit button no longer sticks when a reply is slow. Tidal plays without a stored link, resolved by name instead.
+
+### ⚖️ Two unfair edges
+
+The status endpoint no longer hands out the running round's answer, and the round deadline now applies to power-ups.
+
+### 🎧 The catalogue
+
+**55 playlists and 6,079 songs became 59 and 7,671.**
+
+- **Salsa y Merengue, 534 songs.** Second largest in the catalogue. Latin America had fifty songs before this.
+- **The decade playlists contain only their decade.** Nineteen songs sat in the wrong one.
+- **Seventy-seven fun facts** stopped naming a year that contradicted the answer.
+- **Eighteen more provider links** across Apple, YouTube Music and Deezer.


### PR DESCRIPTION
Cuts `v4.4.0-rc1` — *Keep What You Catch*.

**Numbered 4.4.0, not 4.3.1.** The work began as `v4.3.1-rc1` and `rc2`, but a patch number promises bug fixes and this adds a game mechanic (#2368). The release candidates keep their names in the history.

Contents: version bump in `manifest.json`, a changelog section covering the 22 commits since `v4.3.1-rc2`, and `docs/release-notes-v4.4.0-rc1.md`.

Headline items: the collected row (#2368), the game-over screen fitting its own boxes (#2417), the round cap holding across playlists (#2419), and the final-round cue firing again (#2424). Catalogue 55/6,079 → 59/7,671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Njn3vxDz6tKKas427onhL7