### PR TITLE
feat(providers): play through the free YouTube Music provider (#2426)

### DIFF
--- a/custom_components/beatify/const.py
+++ b/custom_components/beatify/const.py
@@ -242,6 +242,14 @@ URI_PATTERN_YOUTUBE_MUSIC = r"^https://music\.youtube\.com/watch\?v=[a-zA-Z0-9_-
 URI_PATTERN_TIDAL = r"^tidal://track/\d+$"
 URI_PATTERN_DEEZER = r"^deezer://track/\d+$"
 URI_PATTERN_MA_LIBRARY = r"^[a-z0-9_]+(--[^:]+)?://track/.+$"
+# #2426: sproft/music-assistant-ytmusic registers as `ytmusic_free` and streams
+# YouTube Music without a Premium account. Its track item_id IS the YouTube
+# video id (`_encode_track_id` in the provider returns it unchanged unless a
+# trim window is set), so Beatify derives the URI from the `uri_youtube_music`
+# the catalogue already carries rather than storing a second copy of the same
+# id. `multi_instance` is true for that provider, hence the optional
+# `--<suffix>` on the instance name.
+URI_PATTERN_YTMUSIC_FREE = r"^ytmusic_free(--[^:]+)?://track/[a-zA-Z0-9_-]{11}$"
 
 # Provider identifiers (Story 17.1)
 PROVIDER_SPOTIFY = "spotify"
@@ -251,4 +259,5 @@ PROVIDER_TIDAL = "tidal"
 PROVIDER_DEEZER = "deezer"
 PROVIDER_MA_LIBRARY = "ma_library"
 PROVIDER_AMAZON_MUSIC = "amazon_music"
+PROVIDER_YTMUSIC_FREE = "ytmusic_free"  # #2426, third-party MA provider
 PROVIDER_DEFAULT = PROVIDER_SPOTIFY

--- a/custom_components/beatify/game/playlist.py
+++ b/custom_components/beatify/game/playlist.py
@@ -20,6 +20,7 @@ from custom_components.beatify.const import (
     PROVIDER_DEEZER,
     PROVIDER_MA_LIBRARY,
     PROVIDER_SPOTIFY,
+    PROVIDER_YTMUSIC_FREE,
     PROVIDER_TIDAL,
     PROVIDER_YOUTUBE_MUSIC,
     URI_PATTERN_APPLE_MUSIC,
@@ -782,6 +783,21 @@ def summarize_rejected_songs(
     return "; ".join(parts)
 
 
+def _ytmusic_free_uri(youtube_music_uri: str | None) -> str | None:
+    """Build a `ytmusic_free://track/<video id>` URI from a YouTube Music link.
+
+    Returns ``None`` when there is no link or the link carries no ``v=``
+    parameter, so a song without YouTube data is simply not playable on this
+    provider rather than producing a malformed URI that fails at the speaker.
+    """
+    if not youtube_music_uri:
+        return None
+    match = re.search(r"[?&]v=([a-zA-Z0-9_-]{11})(?:&|$)", youtube_music_uri)
+    if not match:
+        return None
+    return f"ytmusic_free://track/{match.group(1)}"
+
+
 def get_song_uri(
     song: dict[str, Any],
     provider: str,
@@ -828,6 +844,18 @@ def get_song_uri(
     if provider == PROVIDER_YOUTUBE_MUSIC:
         # For YouTube Music, only use uri_youtube_music
         return song.get("uri_youtube_music") or None
+    if provider == PROVIDER_YTMUSIC_FREE:
+        # #2426: derived, not stored. The third-party `ytmusic_free` provider
+        # keys tracks by the YouTube video id, which is exactly what sits in
+        # `uri_youtube_music` — so the URI is built here instead of adding a
+        # second catalogue field holding a copy of the same id that could then
+        # drift out of step with it.
+        #
+        # Deriving in this one function is enough for the whole stack:
+        # `filter_songs_for_provider` calls it, `PlaylistManager` caches the
+        # result as `_precomputed_uri`, and `_get_ma_uri_candidates` always
+        # tries `_resolved_uri` first — so nothing downstream needs a branch.
+        return _ytmusic_free_uri(song.get("uri_youtube_music"))
     if provider == PROVIDER_TIDAL:
         # For Tidal, only use uri_tidal
         return song.get("uri_tidal") or None

--- a/custom_components/beatify/server/game_views.py
+++ b/custom_components/beatify/server/game_views.py
@@ -29,6 +29,7 @@ from custom_components.beatify.const import (
     PROVIDER_DEFAULT,
     PROVIDER_MA_LIBRARY,
     PROVIDER_SPOTIFY,
+    PROVIDER_YTMUSIC_FREE,
     PROVIDER_TIDAL,
     PROVIDER_YOUTUBE_MUSIC,
     ROUND_DURATION_MAX,
@@ -85,6 +86,10 @@ def _validate_provider(provider: str) -> str:
         # create-game answered 400 with no log line — the same failure mode
         # this docstring records for Apple Music in #808.
         PROVIDER_MA_LIBRARY,
+        # #2426: third-party MA provider. Same reason it has to be listed here
+        # as the line above — an unlisted provider is coerced to the default
+        # and then fails the "no playlists" guard with a 400 and no log line.
+        PROVIDER_YTMUSIC_FREE,
     )
     return provider if provider in valid_providers else PROVIDER_DEFAULT
 

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -142,7 +142,7 @@ _TITLE_TOKEN_MIN_LEN = 3
 # Crate Digger work; `tidal` joins because its URIs can no longer be refreshed —
 # Odesli's public API, the only source they ever came from, was retired on
 # 2026-07-31 and now answers 401.
-_NAME_FALLBACK_PROVIDERS = frozenset({"ma_library", "tidal"})
+_NAME_FALLBACK_PROVIDERS = frozenset({"ma_library", "tidal", "ytmusic_free"})
 
 # Words that mark a *different recording of the same song*. A name search is
 # free to return any of them, which is exactly the risk this fallback carries:
@@ -288,6 +288,13 @@ _PROVIDER_URI_FIELDS: dict[str, tuple[str, ...]] = {
     # Amazon Music uses Alexa text search — no URI fields; playback via
     # _play_via_alexa() with content_type="AMAZON_MUSIC".
     "amazon_music": (),
+    # #2426: the ytmusic_free URI is DERIVED from uri_youtube_music by
+    # get_song_uri(), so there is no catalogue field to walk. The empty tuple
+    # is deliberate rather than an omission: a missing key would log the
+    # "unknown provider" warning below and imply a mapping bug, while an empty
+    # one says the provider has no stored fields and lets _resolved_uri — which
+    # already holds the derived URI — do the work.
+    "ytmusic_free": (),
 }
 
 

--- a/custom_components/beatify/www/i18n/de.json
+++ b/custom_components/beatify/www/i18n/de.json
@@ -1236,7 +1236,8 @@
       "title": "Stimme dein Bibliotheks-Spiel ab",
       "sub": "Der Scan läuft im Hintergrund — du kannst das Setup währenddessen abschließen."
     },
-    "providerLibrarySub": "Deine persönliche Music-Assistant-Bibliothek"
+    "providerLibrarySub": "Deine persönliche Music-Assistant-Bibliothek",
+    "providerYtmusicFreeSub": "Braucht den ytmusic_free-Provider in Music Assistant"
   },
   "onboarding": {
     "stepLabel": "Schritt",

--- a/custom_components/beatify/www/i18n/en.json
+++ b/custom_components/beatify/www/i18n/en.json
@@ -1236,7 +1236,8 @@
       "title": "Tune your library game",
       "sub": "Scan runs in the background — you can keep going and finish setup while it works."
     },
-    "providerLibrarySub": "Your personal Music Assistant library"
+    "providerLibrarySub": "Your personal Music Assistant library",
+    "providerYtmusicFreeSub": "Needs the ytmusic_free provider in Music Assistant"
   },
   "onboarding": {
     "stepLabel": "Step",

--- a/custom_components/beatify/www/i18n/es.json
+++ b/custom_components/beatify/www/i18n/es.json
@@ -1236,7 +1236,8 @@
       "title": "Configura tu partida de biblioteca",
       "sub": "Scan runs in the background — you can keep going and finish setup while it works."
     },
-    "providerLibrarySub": "Tu biblioteca personal de Music Assistant"
+    "providerLibrarySub": "Tu biblioteca personal de Music Assistant",
+    "providerYtmusicFreeSub": "Necesita el proveedor ytmusic_free en Music Assistant"
   },
   "onboarding": {
     "stepLabel": "Paso",

--- a/custom_components/beatify/www/i18n/fr.json
+++ b/custom_components/beatify/www/i18n/fr.json
@@ -1236,7 +1236,8 @@
       "title": "Configurez votre partie bibliothèque",
       "sub": "Scan runs in the background — you can keep going and finish setup while it works."
     },
-    "providerLibrarySub": "Votre bibliothèque Music Assistant personnelle"
+    "providerLibrarySub": "Votre bibliothèque Music Assistant personnelle",
+    "providerYtmusicFreeSub": "Nécessite le fournisseur ytmusic_free dans Music Assistant"
   },
   "onboarding": {
     "stepLabel": "Étape",

--- a/custom_components/beatify/www/i18n/it.json
+++ b/custom_components/beatify/www/i18n/it.json
@@ -1236,7 +1236,8 @@
       "title": "Regola la partita sulla tua libreria",
       "sub": "La scansione va avanti in background: puoi proseguire e completare la configurazione mentre lavora."
     },
-    "providerLibrarySub": "La tua libreria personale di Music Assistant"
+    "providerLibrarySub": "La tua libreria personale di Music Assistant",
+    "providerYtmusicFreeSub": "Richiede il provider ytmusic_free in Music Assistant"
   },
   "onboarding": {
     "stepLabel": "Passo",

--- a/custom_components/beatify/www/i18n/nl.json
+++ b/custom_components/beatify/www/i18n/nl.json
@@ -1236,7 +1236,8 @@
       "title": "Stel je bibliotheekspel in",
       "sub": "Scan runs in the background — you can keep going and finish setup while it works."
     },
-    "providerLibrarySub": "Je persoonlijke Music Assistant-bibliotheek"
+    "providerLibrarySub": "Je persoonlijke Music Assistant-bibliotheek",
+    "providerYtmusicFreeSub": "Vereist de ytmusic_free-provider in Music Assistant"
   },
   "onboarding": {
     "stepLabel": "Stap",

--- a/custom_components/beatify/www/js/wizard.js
+++ b/custom_components/beatify/www/js/wizard.js
@@ -607,6 +607,18 @@ const PROVIDERS = [
         sub: 'Your personal Music Assistant library',
         subKey: 'wizard.providerLibrarySub',
     },
+    // #2426: a third-party Music Assistant provider, not part of MA itself.
+    // Listed last, and the subtitle carries the prerequisite rather than the
+    // selling point: the dimmed-chip explainer below only opens for options
+    // the selected speaker cannot serve, and this one is selectable on any MA
+    // speaker whether or not the provider is actually installed. The subtitle
+    // is therefore the only place the user is told what to install.
+    {
+        id: 'ytmusic_free',
+        label: 'YouTube Music (Free)',
+        sub: 'Needs the ytmusic_free provider in Music Assistant',
+        subKey: 'wizard.providerYtmusicFreeSub',
+    },
 ];
 
 // Lock icon SVG for dimmed provider chips (#772 UX).

--- a/tests/unit/test_ytmusic_free_provider_2426.py
+++ b/tests/unit/test_ytmusic_free_provider_2426.py
@@ -1,0 +1,114 @@
+"""The `ytmusic_free` provider derives its URIs (#2426).
+
+@ipalomo asked whether Beatify could play through
+sproft/music-assistant-ytmusic, a third-party Music Assistant provider that
+streams YouTube Music without a Premium account.
+
+It can, and without a single new catalogue field. The provider keys tracks by
+the YouTube video id (`_encode_track_id` returns it unchanged unless a trim
+window is set), and that id already sits inside every `uri_youtube_music` the
+catalogue carries. So the URI is derived in `get_song_uri` rather than stored
+a second time where the copy could drift.
+
+Deriving it there is enough for the whole stack: `filter_songs_for_provider`
+calls the same function, `PlaylistManager` caches the result as
+`_precomputed_uri`, and `_get_ma_uri_candidates` always tries `_resolved_uri`
+first.
+"""
+
+from __future__ import annotations
+
+import re
+
+from custom_components.beatify.const import (
+    PROVIDER_YTMUSIC_FREE,
+    URI_PATTERN_MA_LIBRARY,
+    URI_PATTERN_YTMUSIC_FREE,
+)
+from custom_components.beatify.game.playlist import (
+    filter_songs_for_provider,
+    get_song_uri,
+)
+from custom_components.beatify.server.game_views import _validate_provider
+
+
+def _song(**over):
+    song = {
+        "title": "Test Song",
+        "artist": "Test Artist",
+        "year": 1990,
+        "uri": "spotify:track:0000000000000000000000",
+        "uri_youtube_music": "https://music.youtube.com/watch?v=dQw4w9WgXcQ",
+    }
+    song.update(over)
+    return song
+
+
+class TestTheDerivation:
+    def test_builds_the_uri_from_the_youtube_link(self):
+        assert (
+            get_song_uri(_song(), PROVIDER_YTMUSIC_FREE)
+            == "ytmusic_free://track/dQw4w9WgXcQ"
+        )
+
+    def test_no_youtube_link_means_not_playable(self):
+        assert (
+            get_song_uri(_song(uri_youtube_music=None), PROVIDER_YTMUSIC_FREE) is None
+        )
+        assert get_song_uri(_song(uri_youtube_music=""), PROVIDER_YTMUSIC_FREE) is None
+
+    def test_a_link_without_a_video_id_is_refused(self):
+        # Better no URI than a malformed one that fails at the speaker.
+        assert (
+            get_song_uri(
+                _song(uri_youtube_music="https://music.youtube.com/playlist?list=X"),
+                PROVIDER_YTMUSIC_FREE,
+            )
+            is None
+        )
+
+    def test_extra_query_parameters_do_not_confuse_it(self):
+        song = _song(
+            uri_youtube_music="https://music.youtube.com/watch?v=dQw4w9WgXcQ&list=RDX"
+        )
+        assert (
+            get_song_uri(song, PROVIDER_YTMUSIC_FREE)
+            == "ytmusic_free://track/dQw4w9WgXcQ"
+        )
+
+    def test_it_does_not_disturb_the_other_providers(self):
+        song = _song()
+        assert get_song_uri(song, "spotify") == song["uri"]
+        assert get_song_uri(song, "youtube_music") == song["uri_youtube_music"]
+
+
+class TestTheUriIsAcceptedDownstream:
+    def test_it_matches_its_own_pattern(self):
+        uri = get_song_uri(_song(), PROVIDER_YTMUSIC_FREE)
+        assert re.match(URI_PATTERN_YTMUSIC_FREE, uri)
+
+    def test_it_also_matches_the_generic_ma_pattern(self):
+        # The Crate Digger pattern was written provider-neutral, and it carries
+        # this case without a change.
+        uri = get_song_uri(_song(), PROVIDER_YTMUSIC_FREE)
+        assert re.match(URI_PATTERN_MA_LIBRARY, uri)
+
+    def test_the_pattern_accepts_a_multi_instance_name(self):
+        # The provider declares multi_instance, so MA may name the instance
+        # `ytmusic_free--<suffix>`.
+        assert re.match(
+            URI_PATTERN_YTMUSIC_FREE, "ytmusic_free--abc123://track/dQw4w9WgXcQ"
+        )
+
+
+class TestTheProviderReachesTheGame:
+    def test_the_request_is_not_coerced_to_the_default(self):
+        # An unlisted provider is silently coerced to Spotify, after which the
+        # "no playlists" guard answers 400 with no log line. That is the bug
+        # Crate Digger hit, and the reason this test exists.
+        assert _validate_provider(PROVIDER_YTMUSIC_FREE) == PROVIDER_YTMUSIC_FREE
+
+    def test_songs_without_youtube_data_are_filtered_out(self):
+        songs = [_song(), _song(uri_youtube_music=None)]
+        kept, _ = filter_songs_for_provider(songs, PROVIDER_YTMUSIC_FREE)
+        assert len(kept) == 1


### PR DESCRIPTION
@ipalomo asked whether Beatify could use
sproft/music-assistant-ytmusic, a third-party Music Assistant provider
that streams YouTube Music without a Premium account. Every provider
Beatify supports today needs a paid plan, which the README names twice as
a requirement.

It can, and without a new catalogue field. The provider keys tracks by
the YouTube video id — `_encode_track_id` in its source returns the video
id unchanged unless a trim window is set — and that id already sits in
every `uri_youtube_music` the catalogue carries. 6,935 songs are playable
on it the moment this ships, with no backfill.

**The URI is derived in one place.** `get_song_uri()` builds
`ytmusic_free://track/<video id>` from the YouTube link. That is enough
for the whole stack: `filter_songs_for_provider` calls the same function,
`PlaylistManager` caches the result as `_precomputed_uri`, and
`_get_ma_uri_candidates` always tries `_resolved_uri` first. Nothing
downstream needed a branch.

A second `uri_ytmusic_free` field would have been a copy of an id we
already store, free to drift out of step with the original.

**`_PROVIDER_URI_FIELDS` gets an empty tuple**, like `amazon_music`. The
empty entry is deliberate rather than an omission: a missing key logs the
"unknown provider" warning and implies a mapping bug, while an empty one
says the provider has no stored fields.

**And it is listed in `_validate_provider`.** An unlisted provider is
coerced to the default, after which the "no playlists" guard answers 400
with no log line. The comment beside that list records Crate Digger
hitting exactly this; a test now pins it.

The provider joins `_NAME_FALLBACK_PROVIDERS`, so a video that has gone
private falls back to an artist+title lookup in MA rather than ending the
round.

In the wizard it is listed last, and its subtitle carries the
prerequisite instead of the selling point: the dimmed-chip explainer only
opens for options the selected speaker cannot serve, and this one is
selectable on any Music Assistant speaker whether or not the provider is
installed. The subtitle is the only place the user learns what to
install, in all six languages.

Tests: 10 new. Build clean (18 artifacts), 2131 pytest passed, 661
vitest, ruff clean.

Closes #2426

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Njn3vxDz6tKKas427onhL7