### PR TITLE
data(salsa-y-merengue): fix nine wrong links and four lost artists (#2430)

### DIFF
--- a/custom_components/beatify/playlists/community/salsa-y-merengue.json
+++ b/custom_components/beatify/playlists/community/salsa-y-merengue.json
@@ -1,6 +1,6 @@
 {
   "name": "Salsa y Merengue",
-  "version": "1.6",
+  "version": "1.7",
   "tags": [
     "salsa",
     "merengue",
@@ -256,8 +256,7 @@
       "fun_fact_es": "\"Oh Que Será\" de Willie Colón, Rubén Blades, publicada por primera vez en 2004 en el álbum \"Live in the Netherlands\".",
       "fun_fact_fr": "« Oh Que Será » de Willie Colón, Rubén Blades, parue pour la première fois en 2004 sur l'album « Live in the Netherlands ».",
       "fun_fact_nl": "\"Oh Que Será\" van Willie Colón, Rubén Blades, voor het eerst uitgebracht in 2004 op het album \"Live in the Netherlands\".",
-      "uri_deezer": "deezer://track/14190980",
-      "uri_apple_music": "applemusic://track/1464957419"
+      "uri_deezer": "deezer://track/14190980"
     },
     {
       "year": 1978,
@@ -2935,8 +2934,7 @@
       "fun_fact_es": "\"El Gorila\" de Rikarena, publicada por primera vez en 1997 en el álbum \"Sin Medir Distancia\".",
       "fun_fact_fr": "« El Gorila » de Rikarena, parue pour la première fois en 1997 sur l'album « Sin Medir Distancia ».",
       "fun_fact_nl": "\"El Gorila\" van Rikarena, voor het eerst uitgebracht in 1997 op het album \"Sin Medir Distancia\".",
-      "uri_deezer": "deezer://track/11532596",
-      "uri_apple_music": "applemusic://track/20845244"
+      "uri_deezer": "deezer://track/11532596"
     },
     {
       "year": 2015,
@@ -3557,7 +3555,7 @@
     {
       "year": 2025,
       "uri": "spotify:track:5MIWYWguyDnxBlCQT9V4Kt",
-      "artist": "E",
+      "artist": "El General",
       "title": "Tu Pun Pun",
       "isrc": "QT6F82509230",
       "fun_fact": "\"Tu Pun Pun\" by E, first released in 2025 on the album \"Tu Pun Pun (feat. Futuro Record)\".",
@@ -3565,8 +3563,7 @@
       "fun_fact_es": "\"Tu Pun Pun\" de E, publicada por primera vez en 2025 en el álbum \"Tu Pun Pun (feat. Futuro Record)\".",
       "fun_fact_fr": "« Tu Pun Pun » de E, parue pour la première fois en 2025 sur l'album « Tu Pun Pun (feat. Futuro Record) ».",
       "fun_fact_nl": "\"Tu Pun Pun\" van E, voor het eerst uitgebracht in 2025 op het album \"Tu Pun Pun (feat. Futuro Record)\".",
-      "uri_deezer": "deezer://track/3685205772",
-      "uri_apple_music": "applemusic://track/324742894"
+      "uri_deezer": "deezer://track/3685205772"
     },
     {
       "year": 1991,
@@ -4775,8 +4772,7 @@
       "fun_fact_de": "„Calambre\" von Conjunto Barbacoa, erstmals 2000 auf dem Album „Händel: Serse - The Sony Opera House\" erschienen.",
       "fun_fact_es": "\"Calambre\" de Conjunto Barbacoa, publicada por primera vez en 2000 en el álbum \"Händel: Serse - The Sony Opera House\".",
       "fun_fact_fr": "« Calambre » de Conjunto Barbacoa, parue pour la première fois en 2000 sur l'album « Händel: Serse - The Sony Opera House ».",
-      "fun_fact_nl": "\"Calambre\" van Conjunto Barbacoa, voor het eerst uitgebracht in 2000 op het album \"Händel: Serse - The Sony Opera House\".",
-      "uri_deezer": "deezer://track/71884899"
+      "fun_fact_nl": "\"Calambre\" van Conjunto Barbacoa, voor het eerst uitgebracht in 2000 op het album \"Händel: Serse - The Sony Opera House\"."
     },
     {
       "year": 1993,
@@ -5027,7 +5023,7 @@
       "fun_fact_fr": "« I Like It Like That » de Pete Rodriguez, parue pour la première fois en 1966 sur l'album « I Like It Like That ».",
       "fun_fact_nl": "\"I Like It Like That\" van Pete Rodriguez, voor het eerst uitgebracht in 1966 op het album \"I Like It Like That\".",
       "uri_deezer": "deezer://track/686070052",
-      "uri_apple_music": "applemusic://track/1450695872"
+      "uri_apple_music": "applemusic://track/1465799115"
     },
     {
       "year": 1972,
@@ -5701,7 +5697,7 @@
     {
       "year": 2002,
       "uri": "spotify:track:4CX96IInUaO0d6COMz62Qp",
-      "artist": "E",
+      "artist": "Marc Anthony",
       "title": "Nada de Nada",
       "isrc": "BCFSL2600060",
       "fun_fact": "\"Nada de Nada\" by E, first released in 2002 on the album \"Não É Nada de Pega Pega X Ela Ké Cavucadinha\".",
@@ -5709,7 +5705,7 @@
       "fun_fact_es": "\"Nada de Nada\" de E, publicada por primera vez en 2002 en el álbum \"Não É Nada de Pega Pega X Ela Ké Cavucadinha\".",
       "fun_fact_fr": "« Nada de Nada » de E, parue pour la première fois en 2002 sur l'album « Não É Nada de Pega Pega X Ela Ké Cavucadinha ».",
       "fun_fact_nl": "\"Nada de Nada\" van E, voor het eerst uitgebracht in 2002 op het album \"Não É Nada de Pega Pega X Ela Ké Cavucadinha\".",
-      "uri_deezer": "deezer://track/4105954481",
+      "uri_deezer": "deezer://track/1658479112",
       "uri_apple_music": "applemusic://track/27067192"
     },
     {
@@ -6056,9 +6052,7 @@
       "fun_fact_de": "„Alo Alo\" von Wayne Gorbea, erstmals 2007 auf dem Album „Introducing Wayne Gorbea's Salsa Picante\" erschienen.",
       "fun_fact_es": "\"Alo Alo\" de Wayne Gorbea, publicada por primera vez en 2007 en el álbum \"Introducing Wayne Gorbea's Salsa Picante\".",
       "fun_fact_fr": "« Alo Alo » de Wayne Gorbea, parue pour la première fois en 2007 sur l'album « Introducing Wayne Gorbea's Salsa Picante ».",
-      "fun_fact_nl": "\"Alo Alo\" van Wayne Gorbea, voor het eerst uitgebracht in 2007 op het album \"Introducing Wayne Gorbea's Salsa Picante\".",
-      "uri_deezer": "deezer://track/10973342",
-      "uri_apple_music": "applemusic://track/1367228722"
+      "fun_fact_nl": "\"Alo Alo\" van Wayne Gorbea, voor het eerst uitgebracht in 2007 op het album \"Introducing Wayne Gorbea's Salsa Picante\"."
     },
     {
       "year": 1981,
@@ -6119,7 +6113,7 @@
     {
       "year": 1975,
       "uri": "spotify:track:6LsXU5cUoOqC2YnUCu7b5E",
-      "artist": "E",
+      "artist": "Myke Towers",
       "title": "LA RONDA",
       "isrc": "COC017510359",
       "fun_fact": "\"LA RONDA\" by E, first released in 1975 on the album \"Los 60 Mejores Canticuentos\".",
@@ -6692,7 +6686,7 @@
     {
       "year": 2022,
       "uri": "spotify:track:53tfEupEzQRtVFOeZvk7xq",
-      "artist": "E",
+      "artist": "ROSALÍA",
       "title": "DESPECHÁ",
       "isrc": "QZWDE2344304",
       "fun_fact": "\"DESPECHÁ\" by E, first released in 2022 on the album \"DESPECHÁ\".",
@@ -7383,8 +7377,7 @@
       "fun_fact_es": "\"Ganas\" de Grupo Niche, publicada por primera vez en 2002 en el álbum \"Control Absoluto\".",
       "fun_fact_fr": "« Ganas » de Grupo Niche, parue pour la première fois en 2002 sur l'album « Control Absoluto ».",
       "fun_fact_nl": "\"Ganas\" van Grupo Niche, voor het eerst uitgebracht in 2002 op het album \"Control Absoluto\".",
-      "uri_deezer": "deezer://track/1001031902",
-      "uri_apple_music": "applemusic://track/1644165877"
+      "uri_deezer": "deezer://track/1001031902"
     },
     {
       "year": 1996,

--- a/custom_components/beatify/playlists/community/salsa-y-merengue.json
+++ b/custom_components/beatify/playlists/community/salsa-y-merengue.json
@@ -3553,17 +3553,17 @@
       "uri_apple_music": "applemusic://track/1460608788"
     },
     {
-      "year": 2025,
+      "year": 1991,
       "uri": "spotify:track:5MIWYWguyDnxBlCQT9V4Kt",
       "artist": "El General",
       "title": "Tu Pun Pun",
       "isrc": "QT6F82509230",
-      "fun_fact": "\"Tu Pun Pun\" by E, first released in 2025 on the album \"Tu Pun Pun (feat. Futuro Record)\".",
-      "fun_fact_de": "„Tu Pun Pun\" von E, erstmals 2025 auf dem Album „Tu Pun Pun (feat. Futuro Record)\" erschienen.",
-      "fun_fact_es": "\"Tu Pun Pun\" de E, publicada por primera vez en 2025 en el álbum \"Tu Pun Pun (feat. Futuro Record)\".",
-      "fun_fact_fr": "« Tu Pun Pun » de E, parue pour la première fois en 2025 sur l'album « Tu Pun Pun (feat. Futuro Record) ».",
-      "fun_fact_nl": "\"Tu Pun Pun\" van E, voor het eerst uitgebracht in 2025 op het album \"Tu Pun Pun (feat. Futuro Record)\".",
-      "uri_deezer": "deezer://track/3685205772"
+      "fun_fact": "\"Tu Pun Pun\" by El General, first released in 1991 on the album \"Estas Buena\".",
+      "fun_fact_de": "\"Tu Pun Pun\" von El General, erstmals 1991 auf dem Album \"Estas Buena\" veröffentlicht.",
+      "fun_fact_es": "\"Tu Pun Pun\" de El General, publicada por primera vez en 1991 en el álbum \"Estas Buena\".",
+      "fun_fact_fr": "\"Tu Pun Pun\" de El General, sortie pour la première fois en 1991 sur l'album \"Estas Buena\".",
+      "fun_fact_nl": "\"Tu Pun Pun\" van El General, voor het eerst uitgebracht in 1991 op het album \"Estas Buena\".",
+      "uri_deezer": "deezer://track/11897729"
     },
     {
       "year": 1991,
@@ -5695,16 +5695,16 @@
       "uri_apple_music": "applemusic://track/167014580"
     },
     {
-      "year": 2002,
+      "year": 2022,
       "uri": "spotify:track:4CX96IInUaO0d6COMz62Qp",
       "artist": "Marc Anthony",
       "title": "Nada de Nada",
       "isrc": "BCFSL2600060",
-      "fun_fact": "\"Nada de Nada\" by E, first released in 2002 on the album \"Não É Nada de Pega Pega X Ela Ké Cavucadinha\".",
-      "fun_fact_de": "„Nada de Nada\" von E, erstmals 2002 auf dem Album „Não É Nada de Pega Pega X Ela Ké Cavucadinha\" erschienen.",
-      "fun_fact_es": "\"Nada de Nada\" de E, publicada por primera vez en 2002 en el álbum \"Não É Nada de Pega Pega X Ela Ké Cavucadinha\".",
-      "fun_fact_fr": "« Nada de Nada » de E, parue pour la première fois en 2002 sur l'album « Não É Nada de Pega Pega X Ela Ké Cavucadinha ».",
-      "fun_fact_nl": "\"Nada de Nada\" van E, voor het eerst uitgebracht in 2002 op het album \"Não É Nada de Pega Pega X Ela Ké Cavucadinha\".",
+      "fun_fact": "\"Nada de Nada\" by Marc Anthony, first released in 2022 on the album \"Pa'lla Voy\".",
+      "fun_fact_de": "\"Nada de Nada\" von Marc Anthony, erstmals 2022 auf dem Album \"Pa'lla Voy\" veröffentlicht.",
+      "fun_fact_es": "\"Nada de Nada\" de Marc Anthony, publicada por primera vez en 2022 en el álbum \"Pa'lla Voy\".",
+      "fun_fact_fr": "\"Nada de Nada\" de Marc Anthony, sortie pour la première fois en 2022 sur l'album \"Pa'lla Voy\".",
+      "fun_fact_nl": "\"Nada de Nada\" van Marc Anthony, voor het eerst uitgebracht in 2022 op het album \"Pa'lla Voy\".",
       "uri_deezer": "deezer://track/1658479112",
       "uri_apple_music": "applemusic://track/27067192"
     },
@@ -6111,17 +6111,17 @@
       "uri_apple_music": "applemusic://track/1464959207"
     },
     {
-      "year": 1975,
+      "year": 2023,
       "uri": "spotify:track:6LsXU5cUoOqC2YnUCu7b5E",
       "artist": "Myke Towers",
       "title": "LA RONDA",
       "isrc": "COC017510359",
-      "fun_fact": "\"LA RONDA\" by E, first released in 1975 on the album \"Los 60 Mejores Canticuentos\".",
-      "fun_fact_de": "„LA RONDA\" von E, erstmals 1975 auf dem Album „Los 60 Mejores Canticuentos\" erschienen.",
-      "fun_fact_es": "\"LA RONDA\" de E, publicada por primera vez en 1975 en el álbum \"Los 60 Mejores Canticuentos\".",
-      "fun_fact_fr": "« LA RONDA » de E, parue pour la première fois en 1975 sur l'album « Los 60 Mejores Canticuentos ».",
-      "fun_fact_nl": "\"LA RONDA\" van E, voor het eerst uitgebracht in 1975 op het album \"Los 60 Mejores Canticuentos\".",
-      "uri_deezer": "deezer://track/69880895",
+      "fun_fact": "\"LA RONDA\" by Myke Towers, first released in 2023 on the album \"LVEU: VIVE LA TUYA...NO LA MIA\".",
+      "fun_fact_de": "\"LA RONDA\" von Myke Towers, erstmals 2023 auf dem Album \"LVEU: VIVE LA TUYA...NO LA MIA\" veröffentlicht.",
+      "fun_fact_es": "\"LA RONDA\" de Myke Towers, publicada por primera vez en 2023 en el álbum \"LVEU: VIVE LA TUYA...NO LA MIA\".",
+      "fun_fact_fr": "\"LA RONDA\" de Myke Towers, sortie pour la première fois en 2023 sur l'album \"LVEU: VIVE LA TUYA...NO LA MIA\".",
+      "fun_fact_nl": "\"LA RONDA\" van Myke Towers, voor het eerst uitgebracht in 2023 op het album \"LVEU: VIVE LA TUYA...NO LA MIA\".",
+      "uri_deezer": "deezer://track/2542594551",
       "uri_apple_music": "applemusic://track/1378638736"
     },
     {
@@ -6689,12 +6689,12 @@
       "artist": "ROSALÍA",
       "title": "DESPECHÁ",
       "isrc": "QZWDE2344304",
-      "fun_fact": "\"DESPECHÁ\" by E, first released in 2022 on the album \"DESPECHÁ\".",
-      "fun_fact_de": "„DESPECHÁ\" von E, erstmals 2022 auf dem Album „DESPECHÁ\" erschienen.",
-      "fun_fact_es": "\"DESPECHÁ\" de E, publicada por primera vez en 2022 en el álbum \"DESPECHÁ\".",
-      "fun_fact_fr": "« DESPECHÁ » de E, parue pour la première fois en 2022 sur l'album « DESPECHÁ ».",
-      "fun_fact_nl": "\"DESPECHÁ\" van E, voor het eerst uitgebracht in 2022 op het album \"DESPECHÁ\".",
-      "uri_deezer": "deezer://track/2472841641",
+      "fun_fact": "\"DESPECHÁ\" by ROSALÍA, first released in 2022 on the album \"DESPECHÁ\".",
+      "fun_fact_de": "\"DESPECHÁ\" von ROSALÍA, erstmals 2022 auf dem Album \"DESPECHÁ\" veröffentlicht.",
+      "fun_fact_es": "\"DESPECHÁ\" de ROSALÍA, publicada por primera vez en 2022 en el álbum \"DESPECHÁ\".",
+      "fun_fact_fr": "\"DESPECHÁ\" de ROSALÍA, sortie pour la première fois en 2022 sur l'album \"DESPECHÁ\".",
+      "fun_fact_nl": "\"DESPECHÁ\" van ROSALÍA, voor het eerst uitgebracht in 2022 op het album \"DESPECHÁ\".",
+      "uri_deezer": "deezer://track/1841999507",
       "uri_apple_music": "applemusic://track/1658437693"
     },
     {


### PR DESCRIPTION
The daily health check validated all 1,594 URIs in this playlist: 1,585
ok, 0 dead, 9 playing another recording. Spotify, YouTube Music and Tidal
are clean across all 534 songs; the nine are six Apple Music and three
Deezer.

**Two had a correct link to point at instead.** Pete Rodríguez's "I Like
It Like That" was serving Billie Eilish's "when the party's over"; Apple
has the 1966 original at `1465799115`. "Nada de Nada" was serving a
Brazilian funk track on Deezer; the Marc Anthony recording is
`1658479112`.

**Seven had none, so the link is gone rather than replaced.** Searching
Apple for "Oh Que Será", "El Gorila", "Ganas", "Alo Alo" and "Tu Pun Pun"
returns nothing matching, and Deezer has no "Calambre" by Conjunto
Barbacoa. A missing provider link is the honest answer when the track is
not in that catalogue; the alternative is another link that plays
something else. Every one of those songs still has at least one working
provider.

`applemusic://track/1464957419` needed care: it sat on three rows, and on
the two "Pedro Navaja" rows it is correct — that really is the track. It
was removed only from "Oh Que Será", which is why the fix matches on
title and artist rather than on the URI alone.

**Four songs carried the artist `E`.** They came in with the playlist
(#2410) from `spotify_playlist_harvest.py`, which truncated the name
while scraping. Corrected against Spotify: El General "Tu Pun Pun", Marc
Anthony "Nada de Nada", Myke Towers "LA RONDA", ROSALÍA "DESPECHÁ". Two
of the nine wrong links were these same rows, which is not a coincidence
— a provider lookup keyed on a one-letter artist has nothing to match
against.

Version 1.6 → 1.7, so existing installs actually receive the change:
`_copy_bundled_playlists` only refreshes a local copy when the bundled
version compares newer.

Closes #2430

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Njn3vxDz6tKKas427onhL7