### PR TITLE
data(salsa-y-merengue): three more Apple links the artist fix exposed

### DIFF
--- a/custom_components/beatify/playlists/community/salsa-y-merengue.json
+++ b/custom_components/beatify/playlists/community/salsa-y-merengue.json
@@ -1,6 +1,6 @@
 {
   "name": "Salsa y Merengue",
-  "version": "1.7",
+  "version": "1.8",
   "tags": [
     "salsa",
     "merengue",
@@ -5705,8 +5705,7 @@
       "fun_fact_es": "\"Nada de Nada\" de Marc Anthony, publicada por primera vez en 2022 en el álbum \"Pa'lla Voy\".",
       "fun_fact_fr": "\"Nada de Nada\" de Marc Anthony, sortie pour la première fois en 2022 sur l'album \"Pa'lla Voy\".",
       "fun_fact_nl": "\"Nada de Nada\" van Marc Anthony, voor het eerst uitgebracht in 2022 op het album \"Pa'lla Voy\".",
-      "uri_deezer": "deezer://track/1658479112",
-      "uri_apple_music": "applemusic://track/27067192"
+      "uri_deezer": "deezer://track/1658479112"
     },
     {
       "year": 2021,
@@ -6121,8 +6120,7 @@
       "fun_fact_es": "\"LA RONDA\" de Myke Towers, publicada por primera vez en 2023 en el álbum \"LVEU: VIVE LA TUYA...NO LA MIA\".",
       "fun_fact_fr": "\"LA RONDA\" de Myke Towers, sortie pour la première fois en 2023 sur l'album \"LVEU: VIVE LA TUYA...NO LA MIA\".",
       "fun_fact_nl": "\"LA RONDA\" van Myke Towers, voor het eerst uitgebracht in 2023 op het album \"LVEU: VIVE LA TUYA...NO LA MIA\".",
-      "uri_deezer": "deezer://track/2542594551",
-      "uri_apple_music": "applemusic://track/1378638736"
+      "uri_deezer": "deezer://track/2542594551"
     },
     {
       "year": 2023,
@@ -6694,8 +6692,7 @@
       "fun_fact_es": "\"DESPECHÁ\" de ROSALÍA, publicada por primera vez en 2022 en el álbum \"DESPECHÁ\".",
       "fun_fact_fr": "\"DESPECHÁ\" de ROSALÍA, sortie pour la première fois en 2022 sur l'album \"DESPECHÁ\".",
       "fun_fact_nl": "\"DESPECHÁ\" van ROSALÍA, voor het eerst uitgebracht in 2022 op het album \"DESPECHÁ\".",
-      "uri_deezer": "deezer://track/1841999507",
-      "uri_apple_music": "applemusic://track/1658437693"
+      "uri_deezer": "deezer://track/1841999507"
     },
     {
       "year": 1995,


### PR DESCRIPTION
Correcting the four `E` artists in #2431 made three of their Apple links
verifiably wrong. Looked up by id:

- Marc Anthony "Nada de Nada" was playing **Frank Reyes**
- Myke Towers "LA RONDA" was playing **Mala Fama el Hijo de la Calle**
- ROSALÍA "DESPECHÁ" was playing **KIDZ BOP Kids**

None of these appeared in the health check that produced #2430, and the
reason is worth recording: `validate_uris.py` reports a `wrong_track` on
a **title** mismatch. All three titles match exactly. The artist was `E`
at validation time, so there was nothing to compare it against — a wrong
recording with the right title passes the check.

No replacement for any of them. Apple's catalogue returns only remixes of
DESPECHÁ, nothing for LA RONDA by Myke Towers, and no Marc Anthony
recording of "Nada de Nada"; a remix is a different edition and cannot
stand in. Each song keeps Spotify and Deezer.

Version 1.7 → 1.8.

Refs #2430

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Njn3vxDz6tKKas427onhL7