### PR TITLE
data(playlists): Italian song trivia where the text is a template

### DIFF
--- a/custom_components/beatify/playlists/2000s-pop-anthems.json
+++ b/custom_components/beatify/playlists/2000s-pop-anthems.json
@@ -6574,7 +6574,8 @@
       "fun_fact_de": "Ein Chart-Hit von Sean Paul (2005).",
       "fun_fact_es": "Un éxito de Sean Paul (2005).",
       "fun_fact_fr": "Un tube de Sean Paul (2005).",
-      "fun_fact_nl": "Een chart-hit van Sean Paul (2005)."
+      "fun_fact_nl": "Een chart-hit van Sean Paul (2005).",
+      "fun_fact_it": "Un successo in classifica di Sean Paul (2005)."
     },
     {
       "artist": "Peter Fox",
@@ -6599,7 +6600,8 @@
       "fun_fact_de": "Ein Chart-Hit von Peter Fox (2008).",
       "fun_fact_es": "Un éxito de Peter Fox (2008).",
       "fun_fact_fr": "Un tube de Peter Fox (2008).",
-      "fun_fact_nl": "Een chart-hit van Peter Fox (2008)."
+      "fun_fact_nl": "Een chart-hit van Peter Fox (2008).",
+      "fun_fact_it": "Un successo in classifica di Peter Fox (2008)."
     },
     {
       "artist": "MIKA",
@@ -6624,7 +6626,8 @@
       "fun_fact_de": "Ein Chart-Hit von MIKA (2007).",
       "fun_fact_es": "Un éxito de MIKA (2007).",
       "fun_fact_fr": "Un tube de MIKA (2007).",
-      "fun_fact_nl": "Een chart-hit van MIKA (2007)."
+      "fun_fact_nl": "Een chart-hit van MIKA (2007).",
+      "fun_fact_it": "Un successo in classifica di MIKA (2007)."
     },
     {
       "artist": "Manu Chao",
@@ -6649,7 +6652,8 @@
       "fun_fact_de": "Ein Chart-Hit von Manu Chao (2001).",
       "fun_fact_es": "Un éxito de Manu Chao (2001).",
       "fun_fact_fr": "Un tube de Manu Chao (2001).",
-      "fun_fact_nl": "Een chart-hit van Manu Chao (2001)."
+      "fun_fact_nl": "Een chart-hit van Manu Chao (2001).",
+      "fun_fact_it": "Un successo in classifica di Manu Chao (2001)."
     },
     {
       "artist": "Justin Timberlake",
@@ -6677,7 +6681,8 @@
       "fun_fact_de": "Ein Chart-Hit von Justin Timberlake (2006).",
       "fun_fact_es": "Un éxito de Justin Timberlake (2006).",
       "fun_fact_fr": "Un tube de Justin Timberlake (2006).",
-      "fun_fact_nl": "Een chart-hit van Justin Timberlake (2006)."
+      "fun_fact_nl": "Een chart-hit van Justin Timberlake (2006).",
+      "fun_fact_it": "Un successo in classifica di Justin Timberlake (2006)."
     },
     {
       "artist": "Steps",
@@ -6702,7 +6707,8 @@
       "fun_fact_de": "Ein Chart-Hit von Steps (2001).",
       "fun_fact_es": "Un éxito de Steps (2001).",
       "fun_fact_fr": "Un tube de Steps (2001).",
-      "fun_fact_nl": "Een chart-hit van Steps (2001)."
+      "fun_fact_nl": "Een chart-hit van Steps (2001).",
+      "fun_fact_it": "Un successo in classifica di Steps (2001)."
     },
     {
       "artist": "Daft Punk",
@@ -6719,7 +6725,8 @@
       "fun_fact_de": "Ein Chart-Hit von Daft Punk (2002).",
       "fun_fact_es": "Un éxito de Daft Punk (2002).",
       "fun_fact_fr": "Un tube de Daft Punk (2002).",
-      "fun_fact_nl": "Een chart-hit van Daft Punk (2002)."
+      "fun_fact_nl": "Een chart-hit van Daft Punk (2002).",
+      "fun_fact_it": "Un successo in classifica di Daft Punk (2002)."
     },
     {
       "artist": "Fedde Le Grand",
@@ -6744,7 +6751,8 @@
       "fun_fact_de": "Ein Chart-Hit von Fedde Le Grand (2006).",
       "fun_fact_es": "Un éxito de Fedde Le Grand (2006).",
       "fun_fact_fr": "Un tube de Fedde Le Grand (2006).",
-      "fun_fact_nl": "Een chart-hit van Fedde Le Grand (2006)."
+      "fun_fact_nl": "Een chart-hit van Fedde Le Grand (2006).",
+      "fun_fact_it": "Un successo in classifica di Fedde Le Grand (2006)."
     },
     {
       "artist": "Katy Perry",
@@ -6769,7 +6777,8 @@
       "fun_fact_de": "Ein Chart-Hit von Katy Perry (2008).",
       "fun_fact_es": "Un éxito de Katy Perry (2008).",
       "fun_fact_fr": "Un tube de Katy Perry (2008).",
-      "fun_fact_nl": "Een chart-hit van Katy Perry (2008)."
+      "fun_fact_nl": "Een chart-hit van Katy Perry (2008).",
+      "fun_fact_it": "Un successo in classifica di Katy Perry (2008)."
     },
     {
       "artist": "Vengaboys",
@@ -6794,7 +6803,8 @@
       "fun_fact_de": "Ein Chart-Hit von Vengaboys (2000).",
       "fun_fact_es": "Un éxito de Vengaboys (2000).",
       "fun_fact_fr": "Un tube de Vengaboys (2000).",
-      "fun_fact_nl": "Een chart-hit van Vengaboys (2000)."
+      "fun_fact_nl": "Een chart-hit van Vengaboys (2000).",
+      "fun_fact_it": "Un successo in classifica di Vengaboys (2000)."
     },
     {
       "artist": "Bob Sinclar",
@@ -6822,7 +6832,8 @@
       "fun_fact_de": "Ein Chart-Hit von Bob Sinclar (2005).",
       "fun_fact_es": "Un éxito de Bob Sinclar (2005).",
       "fun_fact_fr": "Un tube de Bob Sinclar (2005).",
-      "fun_fact_nl": "Een chart-hit van Bob Sinclar (2005)."
+      "fun_fact_nl": "Een chart-hit van Bob Sinclar (2005).",
+      "fun_fact_it": "Un successo in classifica di Bob Sinclar (2005)."
     },
     {
       "artist": "Flo Rida",
@@ -6850,7 +6861,8 @@
       "fun_fact_de": "Ein Chart-Hit von Flo Rida (2008).",
       "fun_fact_es": "Un éxito de Flo Rida (2008).",
       "fun_fact_fr": "Un tube de Flo Rida (2008).",
-      "fun_fact_nl": "Een chart-hit van Flo Rida (2008)."
+      "fun_fact_nl": "Een chart-hit van Flo Rida (2008).",
+      "fun_fact_it": "Un successo in classifica di Flo Rida (2008)."
     },
     {
       "artist": "MadHouse",
@@ -6867,7 +6879,8 @@
       "fun_fact_de": "Ein Chart-Hit von MadHouse (2000).",
       "fun_fact_es": "Un éxito de MadHouse (2000).",
       "fun_fact_fr": "Un tube de MadHouse (2000).",
-      "fun_fact_nl": "Een chart-hit van MadHouse (2000)."
+      "fun_fact_nl": "Een chart-hit van MadHouse (2000).",
+      "fun_fact_it": "Un successo in classifica di MadHouse (2000)."
     },
     {
       "artist": "Sugababes",
@@ -6892,7 +6905,8 @@
       "fun_fact_de": "Ein Chart-Hit von Sugababes (2002).",
       "fun_fact_es": "Un éxito de Sugababes (2002).",
       "fun_fact_fr": "Un tube de Sugababes (2002).",
-      "fun_fact_nl": "Een chart-hit van Sugababes (2002)."
+      "fun_fact_nl": "Een chart-hit van Sugababes (2002).",
+      "fun_fact_it": "Un successo in classifica di Sugababes (2002)."
     },
     {
       "artist": "Christina Aguilera",
@@ -6917,7 +6931,8 @@
       "fun_fact_de": "Ein Chart-Hit von Christina Aguilera (2006).",
       "fun_fact_es": "Un éxito de Christina Aguilera (2006).",
       "fun_fact_fr": "Un tube de Christina Aguilera (2006).",
-      "fun_fact_nl": "Een chart-hit van Christina Aguilera (2006)."
+      "fun_fact_nl": "Een chart-hit van Christina Aguilera (2006).",
+      "fun_fact_it": "Un successo in classifica di Christina Aguilera (2006)."
     },
     {
       "artist": "Juanes",
@@ -6942,7 +6957,8 @@
       "fun_fact_de": "Ein Chart-Hit von Juanes (2002).",
       "fun_fact_es": "Un éxito de Juanes (2002).",
       "fun_fact_fr": "Un tube de Juanes (2002).",
-      "fun_fact_nl": "Een chart-hit van Juanes (2002)."
+      "fun_fact_nl": "Een chart-hit van Juanes (2002).",
+      "fun_fact_it": "Un successo in classifica di Juanes (2002)."
     },
     {
       "artist": "The Killers",
@@ -6967,7 +6983,8 @@
       "fun_fact_de": "Ein Chart-Hit von The Killers (2003).",
       "fun_fact_es": "Un éxito de The Killers (2003).",
       "fun_fact_fr": "Un tube de The Killers (2003).",
-      "fun_fact_nl": "Een chart-hit van The Killers (2003)."
+      "fun_fact_nl": "Een chart-hit van The Killers (2003).",
+      "fun_fact_it": "Un successo in classifica di The Killers (2003)."
     },
     {
       "artist": "Destiny's Child",
@@ -6992,7 +7009,8 @@
       "fun_fact_de": "Ein Chart-Hit von Destiny's Child (2001).",
       "fun_fact_es": "Un éxito de Destiny's Child (2001).",
       "fun_fact_fr": "Un tube de Destiny's Child (2001).",
-      "fun_fact_nl": "Een chart-hit van Destiny's Child (2001)."
+      "fun_fact_nl": "Een chart-hit van Destiny's Child (2001).",
+      "fun_fact_it": "Un successo in classifica di Destiny's Child (2001)."
     },
     {
       "artist": "Kylie Minogue",
@@ -7017,7 +7035,8 @@
       "fun_fact_de": "Ein Chart-Hit von Kylie Minogue (2000).",
       "fun_fact_es": "Un éxito de Kylie Minogue (2000).",
       "fun_fact_fr": "Un tube de Kylie Minogue (2000).",
-      "fun_fact_nl": "Een chart-hit van Kylie Minogue (2000)."
+      "fun_fact_nl": "Een chart-hit van Kylie Minogue (2000).",
+      "fun_fact_it": "Un successo in classifica di Kylie Minogue (2000)."
     },
     {
       "artist": "Rihanna",
@@ -7042,7 +7061,8 @@
       "fun_fact_de": "Ein Chart-Hit von Rihanna (2005).",
       "fun_fact_es": "Un éxito de Rihanna (2005).",
       "fun_fact_fr": "Un tube de Rihanna (2005).",
-      "fun_fact_nl": "Een chart-hit van Rihanna (2005)."
+      "fun_fact_nl": "Een chart-hit van Rihanna (2005).",
+      "fun_fact_it": "Un successo in classifica di Rihanna (2005)."
     },
     {
       "artist": "Black Eyed Peas",
@@ -7067,7 +7087,8 @@
       "fun_fact_de": "Ein Chart-Hit von Black Eyed Peas (2006).",
       "fun_fact_es": "Un éxito de Black Eyed Peas (2006).",
       "fun_fact_fr": "Un tube de Black Eyed Peas (2006).",
-      "fun_fact_nl": "Een chart-hit van Black Eyed Peas (2006)."
+      "fun_fact_nl": "Een chart-hit van Black Eyed Peas (2006).",
+      "fun_fact_it": "Un successo in classifica di Black Eyed Peas (2006)."
     },
     {
       "artist": "Beyoncé",
@@ -7092,7 +7113,8 @@
       "fun_fact_de": "Ein Chart-Hit von Beyoncé (2008).",
       "fun_fact_es": "Un éxito de Beyoncé (2008).",
       "fun_fact_fr": "Un tube de Beyoncé (2008).",
-      "fun_fact_nl": "Een chart-hit van Beyoncé (2008)."
+      "fun_fact_nl": "Een chart-hit van Beyoncé (2008).",
+      "fun_fact_it": "Un successo in classifica di Beyoncé (2008)."
     },
     {
       "artist": "Hilary Duff",
@@ -7117,7 +7139,8 @@
       "fun_fact_de": "Ein Chart-Hit von Hilary Duff (2005).",
       "fun_fact_es": "Un éxito de Hilary Duff (2005).",
       "fun_fact_fr": "Un tube de Hilary Duff (2005).",
-      "fun_fact_nl": "Een chart-hit van Hilary Duff (2005)."
+      "fun_fact_nl": "Een chart-hit van Hilary Duff (2005).",
+      "fun_fact_it": "Un successo in classifica di Hilary Duff (2005)."
     },
     {
       "artist": "The Pussycat Dolls",
@@ -7145,7 +7168,8 @@
       "fun_fact_de": "Ein Chart-Hit von The Pussycat Dolls (2005).",
       "fun_fact_es": "Un éxito de The Pussycat Dolls (2005).",
       "fun_fact_fr": "Un tube de The Pussycat Dolls (2005).",
-      "fun_fact_nl": "Een chart-hit van The Pussycat Dolls (2005)."
+      "fun_fact_nl": "Een chart-hit van The Pussycat Dolls (2005).",
+      "fun_fact_it": "Un successo in classifica di The Pussycat Dolls (2005)."
     },
     {
       "artist": "Danzel",
@@ -7170,7 +7194,8 @@
       "fun_fact_de": "Ein Chart-Hit von Danzel (2004).",
       "fun_fact_es": "Un éxito de Danzel (2004).",
       "fun_fact_fr": "Un tube de Danzel (2004).",
-      "fun_fact_nl": "Een chart-hit van Danzel (2004)."
+      "fun_fact_nl": "Een chart-hit van Danzel (2004).",
+      "fun_fact_it": "Un successo in classifica di Danzel (2004)."
     },
     {
       "artist": "Safri Duo",
@@ -7195,7 +7220,8 @@
       "fun_fact_de": "Ein Chart-Hit von Safri Duo (2000).",
       "fun_fact_es": "Un éxito de Safri Duo (2000).",
       "fun_fact_fr": "Un tube de Safri Duo (2000).",
-      "fun_fact_nl": "Een chart-hit van Safri Duo (2000)."
+      "fun_fact_nl": "Een chart-hit van Safri Duo (2000).",
+      "fun_fact_it": "Un successo in classifica di Safri Duo (2000)."
     },
     {
       "artist": "S Club",
@@ -7220,7 +7246,8 @@
       "fun_fact_de": "Ein Chart-Hit von S Club (2001).",
       "fun_fact_es": "Un éxito de S Club (2001).",
       "fun_fact_fr": "Un tube de S Club (2001).",
-      "fun_fact_nl": "Een chart-hit van S Club (2001)."
+      "fun_fact_nl": "Een chart-hit van S Club (2001).",
+      "fun_fact_it": "Un successo in classifica di S Club (2001)."
     },
     {
       "artist": "Daft Punk",
@@ -7237,7 +7264,8 @@
       "fun_fact_de": "Ein Chart-Hit von Daft Punk (2001).",
       "fun_fact_es": "Un éxito de Daft Punk (2001).",
       "fun_fact_fr": "Un tube de Daft Punk (2001).",
-      "fun_fact_nl": "Een chart-hit van Daft Punk (2001)."
+      "fun_fact_nl": "Een chart-hit van Daft Punk (2001).",
+      "fun_fact_it": "Un successo in classifica di Daft Punk (2001)."
     },
     {
       "artist": "Daddy DJ",
@@ -7262,7 +7290,8 @@
       "fun_fact_de": "Ein Chart-Hit von Daddy DJ (2000).",
       "fun_fact_es": "Un éxito de Daddy DJ (2000).",
       "fun_fact_fr": "Un tube de Daddy DJ (2000).",
-      "fun_fact_nl": "Een chart-hit van Daddy DJ (2000)."
+      "fun_fact_nl": "Een chart-hit van Daddy DJ (2000).",
+      "fun_fact_it": "Un successo in classifica di Daddy DJ (2000)."
     },
     {
       "artist": "Girls Aloud",
@@ -7287,7 +7316,8 @@
       "fun_fact_de": "Ein Chart-Hit von Girls Aloud (2002).",
       "fun_fact_es": "Un éxito de Girls Aloud (2002).",
       "fun_fact_fr": "Un tube de Girls Aloud (2002).",
-      "fun_fact_nl": "Een chart-hit van Girls Aloud (2002)."
+      "fun_fact_nl": "Een chart-hit van Girls Aloud (2002).",
+      "fun_fact_it": "Un successo in classifica di Girls Aloud (2002)."
     },
     {
       "artist": "Counting Crows",
@@ -7312,7 +7342,8 @@
       "fun_fact_de": "Ein Chart-Hit von Counting Crows (2004).",
       "fun_fact_es": "Un éxito de Counting Crows (2004).",
       "fun_fact_fr": "Un tube de Counting Crows (2004).",
-      "fun_fact_nl": "Een chart-hit van Counting Crows (2004)."
+      "fun_fact_nl": "Een chart-hit van Counting Crows (2004).",
+      "fun_fact_it": "Un successo in classifica di Counting Crows (2004)."
     },
     {
       "artist": "Alphabeat",
@@ -7337,7 +7368,8 @@
       "fun_fact_de": "Ein Chart-Hit von Alphabeat (2007).",
       "fun_fact_es": "Un éxito de Alphabeat (2007).",
       "fun_fact_fr": "Un tube de Alphabeat (2007).",
-      "fun_fact_nl": "Een chart-hit van Alphabeat (2007)."
+      "fun_fact_nl": "Een chart-hit van Alphabeat (2007).",
+      "fun_fact_it": "Un successo in classifica di Alphabeat (2007)."
     },
     {
       "artist": "Alex Gaudino",
@@ -7362,7 +7394,8 @@
       "fun_fact_de": "Ein Chart-Hit von Alex Gaudino (2007).",
       "fun_fact_es": "Un éxito de Alex Gaudino (2007).",
       "fun_fact_fr": "Un tube de Alex Gaudino (2007).",
-      "fun_fact_nl": "Een chart-hit van Alex Gaudino (2007)."
+      "fun_fact_nl": "Een chart-hit van Alex Gaudino (2007).",
+      "fun_fact_it": "Un successo in classifica di Alex Gaudino (2007)."
     },
     {
       "artist": "Akcent",
@@ -7387,7 +7420,8 @@
       "fun_fact_de": "Ein Chart-Hit von Akcent (2005).",
       "fun_fact_es": "Un éxito de Akcent (2005).",
       "fun_fact_fr": "Un tube de Akcent (2005).",
-      "fun_fact_nl": "Een chart-hit van Akcent (2005)."
+      "fun_fact_nl": "Een chart-hit van Akcent (2005).",
+      "fun_fact_it": "Un successo in classifica di Akcent (2005)."
     },
     {
       "artist": "Rednex",
@@ -7412,7 +7446,8 @@
       "fun_fact_de": "Ein Chart-Hit von Rednex (2000).",
       "fun_fact_es": "Un éxito de Rednex (2000).",
       "fun_fact_fr": "Un tube de Rednex (2000).",
-      "fun_fact_nl": "Een chart-hit van Rednex (2000)."
+      "fun_fact_nl": "Een chart-hit van Rednex (2000).",
+      "fun_fact_it": "Un successo in classifica di Rednex (2000)."
     },
     {
       "artist": "Tiësto",
@@ -7440,7 +7475,8 @@
       "fun_fact_de": "Ein Chart-Hit von Tiësto (2004).",
       "fun_fact_es": "Un éxito de Tiësto (2004).",
       "fun_fact_fr": "Un tube de Tiësto (2004).",
-      "fun_fact_nl": "Een chart-hit van Tiësto (2004)."
+      "fun_fact_nl": "Een chart-hit van Tiësto (2004).",
+      "fun_fact_it": "Un successo in classifica di Tiësto (2004)."
     }
   ]
 }

--- a/custom_components/beatify/playlists/70s-hits.json
+++ b/custom_components/beatify/playlists/70s-hits.json
@@ -4111,7 +4111,8 @@
       "fun_fact_de": "Ein Chart-Hit von Bachman-Turner Overdrive (1974).",
       "fun_fact_es": "Un éxito de Bachman-Turner Overdrive (1974).",
       "fun_fact_fr": "Un tube de Bachman-Turner Overdrive (1974).",
-      "fun_fact_nl": "Een chart-hit van Bachman-Turner Overdrive (1974)."
+      "fun_fact_nl": "Een chart-hit van Bachman-Turner Overdrive (1974).",
+      "fun_fact_it": "Un successo in classifica di Bachman-Turner Overdrive (1974)."
     },
     {
       "artist": "KC",
@@ -4139,7 +4140,8 @@
       "fun_fact_de": "Ein Chart-Hit von KC (1976).",
       "fun_fact_es": "Un éxito de KC (1976).",
       "fun_fact_fr": "Un tube de KC (1976).",
-      "fun_fact_nl": "Een chart-hit van KC (1976)."
+      "fun_fact_nl": "Een chart-hit van KC (1976).",
+      "fun_fact_it": "Un successo in classifica di KC (1976)."
     },
     {
       "artist": "The Osmonds",
@@ -4164,7 +4166,8 @@
       "fun_fact_de": "Ein Chart-Hit von The Osmonds (1973).",
       "fun_fact_es": "Un éxito de The Osmonds (1973).",
       "fun_fact_fr": "Un tube de The Osmonds (1973).",
-      "fun_fact_nl": "Een chart-hit van The Osmonds (1973)."
+      "fun_fact_nl": "Een chart-hit van The Osmonds (1973).",
+      "fun_fact_it": "Un successo in classifica di The Osmonds (1973)."
     },
     {
       "artist": "Middle Of The Road",
@@ -4189,7 +4192,8 @@
       "fun_fact_de": "Ein Chart-Hit von Middle Of The Road (1971).",
       "fun_fact_es": "Un éxito de Middle Of The Road (1971).",
       "fun_fact_fr": "Un tube de Middle Of The Road (1971).",
-      "fun_fact_nl": "Een chart-hit van Middle Of The Road (1971)."
+      "fun_fact_nl": "Een chart-hit van Middle Of The Road (1971).",
+      "fun_fact_it": "Un successo in classifica di Middle Of The Road (1971)."
     },
     {
       "year": 1975,

--- a/custom_components/beatify/playlists/80er-hits.json
+++ b/custom_components/beatify/playlists/80er-hits.json
@@ -7590,7 +7590,8 @@
       "fun_fact_de": "Ein Chart-Hit von The B-52's (1989).",
       "fun_fact_es": "Un éxito de The B-52's (1989).",
       "fun_fact_fr": "Un tube de The B-52's (1989).",
-      "fun_fact_nl": "Een chart-hit van The B-52's (1989)."
+      "fun_fact_nl": "Een chart-hit van The B-52's (1989).",
+      "fun_fact_it": "Un successo in classifica di The B-52's (1989)."
     },
     {
       "artist": "The J. Geils Band",
@@ -7615,7 +7616,8 @@
       "fun_fact_de": "Ein Chart-Hit von The J. Geils Band (1981).",
       "fun_fact_es": "Un éxito de The J. Geils Band (1981).",
       "fun_fact_fr": "Un tube de The J. Geils Band (1981).",
-      "fun_fact_nl": "Een chart-hit van The J. Geils Band (1981)."
+      "fun_fact_nl": "Een chart-hit van The J. Geils Band (1981).",
+      "fun_fact_it": "Un successo in classifica di The J. Geils Band (1981)."
     },
     {
       "artist": "George Harrison",
@@ -7640,7 +7642,8 @@
       "fun_fact_de": "Ein Chart-Hit von George Harrison (1987).",
       "fun_fact_es": "Un éxito de George Harrison (1987).",
       "fun_fact_fr": "Un tube de George Harrison (1987).",
-      "fun_fact_nl": "Een chart-hit van George Harrison (1987)."
+      "fun_fact_nl": "Een chart-hit van George Harrison (1987).",
+      "fun_fact_it": "Un successo in classifica di George Harrison (1987)."
     },
     {
       "artist": "Gipsy Kings",
@@ -7665,7 +7668,8 @@
       "fun_fact_de": "Ein Chart-Hit von Gipsy Kings (1982).",
       "fun_fact_es": "Un éxito de Gipsy Kings (1982).",
       "fun_fact_fr": "Un tube de Gipsy Kings (1982).",
-      "fun_fact_nl": "Een chart-hit van Gipsy Kings (1982)."
+      "fun_fact_nl": "Een chart-hit van Gipsy Kings (1982).",
+      "fun_fact_it": "Un successo in classifica di Gipsy Kings (1982)."
     },
     {
       "artist": "Bandolero",
@@ -7690,7 +7694,8 @@
       "fun_fact_de": "Ein Chart-Hit von Bandolero (1983).",
       "fun_fact_es": "Un éxito de Bandolero (1983).",
       "fun_fact_fr": "Un tube de Bandolero (1983).",
-      "fun_fact_nl": "Een chart-hit van Bandolero (1983)."
+      "fun_fact_nl": "Een chart-hit van Bandolero (1983).",
+      "fun_fact_it": "Un successo in classifica di Bandolero (1983)."
     },
     {
       "artist": "Eddy Grant",
@@ -7715,7 +7720,8 @@
       "fun_fact_de": "Ein Chart-Hit von Eddy Grant (1988).",
       "fun_fact_es": "Un éxito de Eddy Grant (1988).",
       "fun_fact_fr": "Un tube de Eddy Grant (1988).",
-      "fun_fact_nl": "Een chart-hit van Eddy Grant (1988)."
+      "fun_fact_nl": "Een chart-hit van Eddy Grant (1988).",
+      "fun_fact_it": "Un successo in classifica di Eddy Grant (1988)."
     },
     {
       "artist": "T.S. Monk",
@@ -7740,7 +7746,8 @@
       "fun_fact_de": "Ein Chart-Hit von T.S. Monk (1980).",
       "fun_fact_es": "Un éxito de T.S. Monk (1980).",
       "fun_fact_fr": "Un tube de T.S. Monk (1980).",
-      "fun_fact_nl": "Een chart-hit van T.S. Monk (1980)."
+      "fun_fact_nl": "Een chart-hit van T.S. Monk (1980).",
+      "fun_fact_it": "Un successo in classifica di T.S. Monk (1980)."
     },
     {
       "artist": "Central Line",
@@ -7765,7 +7772,8 @@
       "fun_fact_de": "Ein Chart-Hit von Central Line (1981).",
       "fun_fact_es": "Un éxito de Central Line (1981).",
       "fun_fact_fr": "Un tube de Central Line (1981).",
-      "fun_fact_nl": "Een chart-hit van Central Line (1981)."
+      "fun_fact_nl": "Een chart-hit van Central Line (1981).",
+      "fun_fact_it": "Un successo in classifica di Central Line (1981)."
     },
     {
       "artist": "Peter Gabriel",
@@ -7790,7 +7798,8 @@
       "fun_fact_de": "Ein Chart-Hit von Peter Gabriel (1986).",
       "fun_fact_es": "Un éxito de Peter Gabriel (1986).",
       "fun_fact_fr": "Un tube de Peter Gabriel (1986).",
-      "fun_fact_nl": "Een chart-hit van Peter Gabriel (1986)."
+      "fun_fact_nl": "Een chart-hit van Peter Gabriel (1986).",
+      "fun_fact_it": "Un successo in classifica di Peter Gabriel (1986)."
     },
     {
       "artist": "Michael Jackson",
@@ -7815,7 +7824,8 @@
       "fun_fact_de": "Ein Chart-Hit von Michael Jackson (1987).",
       "fun_fact_es": "Un éxito de Michael Jackson (1987).",
       "fun_fact_fr": "Un tube de Michael Jackson (1987).",
-      "fun_fact_nl": "Een chart-hit van Michael Jackson (1987)."
+      "fun_fact_nl": "Een chart-hit van Michael Jackson (1987).",
+      "fun_fact_it": "Un successo in classifica di Michael Jackson (1987)."
     },
     {
       "artist": "Michael McDonald",
@@ -7840,7 +7850,8 @@
       "fun_fact_de": "Ein Chart-Hit von Michael McDonald (1986).",
       "fun_fact_es": "Un éxito de Michael McDonald (1986).",
       "fun_fact_fr": "Un tube de Michael McDonald (1986).",
-      "fun_fact_nl": "Een chart-hit van Michael McDonald (1986)."
+      "fun_fact_nl": "Een chart-hit van Michael McDonald (1986).",
+      "fun_fact_it": "Un successo in classifica di Michael McDonald (1986)."
     },
     {
       "artist": "Kool & The Gang",
@@ -7865,7 +7876,8 @@
       "fun_fact_de": "Ein Chart-Hit von Kool & The Gang (1982).",
       "fun_fact_es": "Un éxito de Kool & The Gang (1982).",
       "fun_fact_fr": "Un tube de Kool & The Gang (1982).",
-      "fun_fact_nl": "Een chart-hit van Kool & The Gang (1982)."
+      "fun_fact_nl": "Een chart-hit van Kool & The Gang (1982).",
+      "fun_fact_it": "Un successo in classifica di Kool & The Gang (1982)."
     },
     {
       "artist": "Matia Bazar",
@@ -7890,7 +7902,8 @@
       "fun_fact_de": "Ein Chart-Hit von Matia Bazar (1985).",
       "fun_fact_es": "Un éxito de Matia Bazar (1985).",
       "fun_fact_fr": "Un tube de Matia Bazar (1985).",
-      "fun_fact_nl": "Een chart-hit van Matia Bazar (1985)."
+      "fun_fact_nl": "Een chart-hit van Matia Bazar (1985).",
+      "fun_fact_it": "Un successo in classifica di Matia Bazar (1985)."
     },
     {
       "artist": "Pino D'Angiò",
@@ -7915,7 +7928,8 @@
       "fun_fact_de": "Ein Chart-Hit von Pino D'Angiò (1980).",
       "fun_fact_es": "Un éxito de Pino D'Angiò (1980).",
       "fun_fact_fr": "Un tube de Pino D'Angiò (1980).",
-      "fun_fact_nl": "Een chart-hit van Pino D'Angiò (1980)."
+      "fun_fact_nl": "Een chart-hit van Pino D'Angiò (1980).",
+      "fun_fact_it": "Un successo in classifica di Pino D'Angiò (1980)."
     },
     {
       "artist": "Michael Jackson",
@@ -7940,7 +7954,8 @@
       "fun_fact_de": "Ein Chart-Hit von Michael Jackson (1987).",
       "fun_fact_es": "Un éxito de Michael Jackson (1987).",
       "fun_fact_fr": "Un tube de Michael Jackson (1987).",
-      "fun_fact_nl": "Een chart-hit van Michael Jackson (1987)."
+      "fun_fact_nl": "Een chart-hit van Michael Jackson (1987).",
+      "fun_fact_it": "Un successo in classifica di Michael Jackson (1987)."
     },
     {
       "artist": "Miami Sound Machine",
@@ -7965,7 +7980,8 @@
       "fun_fact_de": "Ein Chart-Hit von Miami Sound Machine (1985).",
       "fun_fact_es": "Un éxito de Miami Sound Machine (1985).",
       "fun_fact_fr": "Un tube de Miami Sound Machine (1985).",
-      "fun_fact_nl": "Een chart-hit van Miami Sound Machine (1985)."
+      "fun_fact_nl": "Een chart-hit van Miami Sound Machine (1985).",
+      "fun_fact_it": "Un successo in classifica di Miami Sound Machine (1985)."
     },
     {
       "artist": "Matthew Wilder",
@@ -7990,7 +8006,8 @@
       "fun_fact_de": "Ein Chart-Hit von Matthew Wilder (1983).",
       "fun_fact_es": "Un éxito de Matthew Wilder (1983).",
       "fun_fact_fr": "Un tube de Matthew Wilder (1983).",
-      "fun_fact_nl": "Een chart-hit van Matthew Wilder (1983)."
+      "fun_fact_nl": "Een chart-hit van Matthew Wilder (1983).",
+      "fun_fact_it": "Un successo in classifica di Matthew Wilder (1983)."
     },
     {
       "artist": "Kylie Minogue",
@@ -8015,7 +8032,8 @@
       "fun_fact_de": "Ein Chart-Hit von Kylie Minogue (1987).",
       "fun_fact_es": "Un éxito de Kylie Minogue (1987).",
       "fun_fact_fr": "Un tube de Kylie Minogue (1987).",
-      "fun_fact_nl": "Een chart-hit van Kylie Minogue (1987)."
+      "fun_fact_nl": "Een chart-hit van Kylie Minogue (1987).",
+      "fun_fact_it": "Un successo in classifica di Kylie Minogue (1987)."
     },
     {
       "artist": "Miami Sound Machine",
@@ -8043,7 +8061,8 @@
       "fun_fact_de": "Ein Chart-Hit von Miami Sound Machine (1985).",
       "fun_fact_es": "Un éxito de Miami Sound Machine (1985).",
       "fun_fact_fr": "Un tube de Miami Sound Machine (1985).",
-      "fun_fact_nl": "Een chart-hit van Miami Sound Machine (1985)."
+      "fun_fact_nl": "Een chart-hit van Miami Sound Machine (1985).",
+      "fun_fact_it": "Un successo in classifica di Miami Sound Machine (1985)."
     },
     {
       "artist": "Tom Browne",
@@ -8068,7 +8087,8 @@
       "fun_fact_de": "Ein Chart-Hit von Tom Browne (1980).",
       "fun_fact_es": "Un éxito de Tom Browne (1980).",
       "fun_fact_fr": "Un tube de Tom Browne (1980).",
-      "fun_fact_nl": "Een chart-hit van Tom Browne (1980)."
+      "fun_fact_nl": "Een chart-hit van Tom Browne (1980).",
+      "fun_fact_it": "Un successo in classifica di Tom Browne (1980)."
     },
     {
       "artist": "Huey Lewis & The News",
@@ -8093,7 +8113,8 @@
       "fun_fact_de": "Ein Chart-Hit von Huey Lewis & The News (1982).",
       "fun_fact_es": "Un éxito de Huey Lewis & The News (1982).",
       "fun_fact_fr": "Un tube de Huey Lewis & The News (1982).",
-      "fun_fact_nl": "Een chart-hit van Huey Lewis & The News (1982)."
+      "fun_fact_nl": "Een chart-hit van Huey Lewis & The News (1982).",
+      "fun_fact_it": "Un successo in classifica di Huey Lewis & The News (1982)."
     },
     {
       "artist": "Gloria Estefan",
@@ -8118,7 +8139,8 @@
       "fun_fact_de": "Ein Chart-Hit von Gloria Estefan (1989).",
       "fun_fact_es": "Un éxito de Gloria Estefan (1989).",
       "fun_fact_fr": "Un tube de Gloria Estefan (1989).",
-      "fun_fact_nl": "Een chart-hit van Gloria Estefan (1989)."
+      "fun_fact_nl": "Een chart-hit van Gloria Estefan (1989).",
+      "fun_fact_it": "Un successo in classifica di Gloria Estefan (1989)."
     },
     {
       "artist": "Blondie",
@@ -8143,7 +8165,8 @@
       "fun_fact_de": "Ein Chart-Hit von Blondie (1980).",
       "fun_fact_es": "Un éxito de Blondie (1980).",
       "fun_fact_fr": "Un tube de Blondie (1980).",
-      "fun_fact_nl": "Een chart-hit van Blondie (1980)."
+      "fun_fact_nl": "Een chart-hit van Blondie (1980).",
+      "fun_fact_it": "Un successo in classifica di Blondie (1980)."
     },
     {
       "artist": "Shakin' Stevens",
@@ -8168,7 +8191,8 @@
       "fun_fact_de": "Ein Chart-Hit von Shakin' Stevens (1981).",
       "fun_fact_es": "Un éxito de Shakin' Stevens (1981).",
       "fun_fact_fr": "Un tube de Shakin' Stevens (1981).",
-      "fun_fact_nl": "Een chart-hit van Shakin' Stevens (1981)."
+      "fun_fact_nl": "Een chart-hit van Shakin' Stevens (1981).",
+      "fun_fact_it": "Un successo in classifica di Shakin' Stevens (1981)."
     },
     {
       "artist": "Jaki Graham",
@@ -8193,7 +8217,8 @@
       "fun_fact_de": "Ein Chart-Hit von Jaki Graham (1986).",
       "fun_fact_es": "Un éxito de Jaki Graham (1986).",
       "fun_fact_fr": "Un tube de Jaki Graham (1986).",
-      "fun_fact_nl": "Een chart-hit van Jaki Graham (1986)."
+      "fun_fact_nl": "Een chart-hit van Jaki Graham (1986).",
+      "fun_fact_it": "Un successo in classifica di Jaki Graham (1986)."
     },
     {
       "artist": "Madonna",
@@ -8218,7 +8243,8 @@
       "fun_fact_de": "Ein Chart-Hit von Madonna (1989).",
       "fun_fact_es": "Un éxito de Madonna (1989).",
       "fun_fact_fr": "Un tube de Madonna (1989).",
-      "fun_fact_nl": "Een chart-hit van Madonna (1989)."
+      "fun_fact_nl": "Een chart-hit van Madonna (1989).",
+      "fun_fact_it": "Un successo in classifica di Madonna (1989)."
     },
     {
       "artist": "Billy Ocean",
@@ -8243,7 +8269,8 @@
       "fun_fact_de": "Ein Chart-Hit von Billy Ocean (1984).",
       "fun_fact_es": "Un éxito de Billy Ocean (1984).",
       "fun_fact_fr": "Un tube de Billy Ocean (1984).",
-      "fun_fact_nl": "Een chart-hit van Billy Ocean (1984)."
+      "fun_fact_nl": "Een chart-hit van Billy Ocean (1984).",
+      "fun_fact_it": "Un successo in classifica di Billy Ocean (1984)."
     },
     {
       "artist": "Paul Young",
@@ -8268,7 +8295,8 @@
       "fun_fact_de": "Ein Chart-Hit von Paul Young (1983).",
       "fun_fact_es": "Un éxito de Paul Young (1983).",
       "fun_fact_fr": "Un tube de Paul Young (1983).",
-      "fun_fact_nl": "Een chart-hit van Paul Young (1983)."
+      "fun_fact_nl": "Een chart-hit van Paul Young (1983).",
+      "fun_fact_it": "Un successo in classifica di Paul Young (1983)."
     },
     {
       "artist": "Glenn Frey",
@@ -8293,7 +8321,8 @@
       "fun_fact_de": "Ein Chart-Hit von Glenn Frey (1984).",
       "fun_fact_es": "Un éxito de Glenn Frey (1984).",
       "fun_fact_fr": "Un tube de Glenn Frey (1984).",
-      "fun_fact_nl": "Een chart-hit van Glenn Frey (1984)."
+      "fun_fact_nl": "Een chart-hit van Glenn Frey (1984).",
+      "fun_fact_it": "Un successo in classifica di Glenn Frey (1984)."
     },
     {
       "artist": "Lil' Louis",
@@ -8321,7 +8350,8 @@
       "fun_fact_de": "Ein Chart-Hit von Lil' Louis (1989).",
       "fun_fact_es": "Un éxito de Lil' Louis (1989).",
       "fun_fact_fr": "Un tube de Lil' Louis (1989).",
-      "fun_fact_nl": "Een chart-hit van Lil' Louis (1989)."
+      "fun_fact_nl": "Een chart-hit van Lil' Louis (1989).",
+      "fun_fact_it": "Un successo in classifica di Lil' Louis (1989)."
     },
     {
       "artist": "Ziggy Marley & The Melody Makers",
@@ -8346,7 +8376,8 @@
       "fun_fact_de": "Ein Chart-Hit von Ziggy Marley & The Melody Makers (1988).",
       "fun_fact_es": "Un éxito de Ziggy Marley & The Melody Makers (1988).",
       "fun_fact_fr": "Un tube de Ziggy Marley & The Melody Makers (1988).",
-      "fun_fact_nl": "Een chart-hit van Ziggy Marley & The Melody Makers (1988)."
+      "fun_fact_nl": "Een chart-hit van Ziggy Marley & The Melody Makers (1988).",
+      "fun_fact_it": "Un successo in classifica di Ziggy Marley & The Melody Makers (1988)."
     },
     {
       "artist": "Run–D.M.C.",
@@ -8366,7 +8397,8 @@
       "fun_fact_de": "Ein Chart-Hit von Run–D.M.C. (1983).",
       "fun_fact_es": "Un éxito de Run–D.M.C. (1983).",
       "fun_fact_fr": "Un tube de Run–D.M.C. (1983).",
-      "fun_fact_nl": "Een chart-hit van Run–D.M.C. (1983)."
+      "fun_fact_nl": "Een chart-hit van Run–D.M.C. (1983).",
+      "fun_fact_it": "Un successo in classifica di Run–D.M.C. (1983)."
     },
     {
       "artist": "Eros Ramazzotti",
@@ -8391,7 +8423,8 @@
       "fun_fact_de": "Ein Chart-Hit von Eros Ramazzotti (1987).",
       "fun_fact_es": "Un éxito de Eros Ramazzotti (1987).",
       "fun_fact_fr": "Un tube de Eros Ramazzotti (1987).",
-      "fun_fact_nl": "Een chart-hit van Eros Ramazzotti (1987)."
+      "fun_fact_nl": "Een chart-hit van Eros Ramazzotti (1987).",
+      "fun_fact_it": "Un successo in classifica di Eros Ramazzotti (1987)."
     }
   ]
 }

--- a/custom_components/beatify/playlists/90er-hits.json
+++ b/custom_components/beatify/playlists/90er-hits.json
@@ -1278,7 +1278,8 @@
       "fun_fact_de": "Ein Chart-Hit von Captain Hollywood Project (1994).",
       "fun_fact_es": "Un éxito de Captain Hollywood Project (1994).",
       "fun_fact_fr": "Un tube de Captain Hollywood Project (1994).",
-      "fun_fact_nl": "Een chart-hit van Captain Hollywood Project (1994)."
+      "fun_fact_nl": "Een chart-hit van Captain Hollywood Project (1994).",
+      "fun_fact_it": "Un successo in classifica di Captain Hollywood Project (1994)."
     },
     {
       "artist": "The Mavericks",
@@ -1303,7 +1304,8 @@
       "fun_fact_de": "Ein Chart-Hit von The Mavericks (1999).",
       "fun_fact_es": "Un éxito de The Mavericks (1999).",
       "fun_fact_fr": "Un tube de The Mavericks (1999).",
-      "fun_fact_nl": "Een chart-hit van The Mavericks (1999)."
+      "fun_fact_nl": "Een chart-hit van The Mavericks (1999).",
+      "fun_fact_it": "Un successo in classifica di The Mavericks (1999)."
     },
     {
       "artist": "Oleta Adams",
@@ -1328,7 +1330,8 @@
       "fun_fact_de": "Ein Chart-Hit von Oleta Adams (1993).",
       "fun_fact_es": "Un éxito de Oleta Adams (1993).",
       "fun_fact_fr": "Un tube de Oleta Adams (1993).",
-      "fun_fact_nl": "Een chart-hit van Oleta Adams (1993)."
+      "fun_fact_nl": "Een chart-hit van Oleta Adams (1993).",
+      "fun_fact_it": "Un successo in classifica di Oleta Adams (1993)."
     },
     {
       "artist": "iNi Kamoze",
@@ -1353,7 +1356,8 @@
       "fun_fact_de": "Ein Chart-Hit von iNi Kamoze (1995).",
       "fun_fact_es": "Un éxito de iNi Kamoze (1995).",
       "fun_fact_fr": "Un tube de iNi Kamoze (1995).",
-      "fun_fact_nl": "Een chart-hit van iNi Kamoze (1995)."
+      "fun_fact_nl": "Een chart-hit van iNi Kamoze (1995).",
+      "fun_fact_it": "Un successo in classifica di iNi Kamoze (1995)."
     },
     {
       "artist": "Ace of Base",
@@ -1378,7 +1382,8 @@
       "fun_fact_de": "Ein Chart-Hit von Ace of Base (1993).",
       "fun_fact_es": "Un éxito de Ace of Base (1993).",
       "fun_fact_fr": "Un tube de Ace of Base (1993).",
-      "fun_fact_nl": "Een chart-hit van Ace of Base (1993)."
+      "fun_fact_nl": "Een chart-hit van Ace of Base (1993).",
+      "fun_fact_it": "Un successo in classifica di Ace of Base (1993)."
     },
     {
       "artist": "Salt-N-Pepa",
@@ -1403,7 +1408,8 @@
       "fun_fact_de": "Ein Chart-Hit von Salt-N-Pepa (1992).",
       "fun_fact_es": "Un éxito de Salt-N-Pepa (1992).",
       "fun_fact_fr": "Un tube de Salt-N-Pepa (1992).",
-      "fun_fact_nl": "Een chart-hit van Salt-N-Pepa (1992)."
+      "fun_fact_nl": "Een chart-hit van Salt-N-Pepa (1992).",
+      "fun_fact_it": "Un successo in classifica di Salt-N-Pepa (1992)."
     },
     {
       "artist": "Right Said Fred",
@@ -1428,7 +1434,8 @@
       "fun_fact_de": "Ein Chart-Hit von Right Said Fred (1991).",
       "fun_fact_es": "Un éxito de Right Said Fred (1991).",
       "fun_fact_fr": "Un tube de Right Said Fred (1991).",
-      "fun_fact_nl": "Een chart-hit van Right Said Fred (1991)."
+      "fun_fact_nl": "Een chart-hit van Right Said Fred (1991).",
+      "fun_fact_it": "Un successo in classifica di Right Said Fred (1991)."
     },
     {
       "artist": "Snow",
@@ -1453,7 +1460,8 @@
       "fun_fact_de": "Ein Chart-Hit von Snow (1992).",
       "fun_fact_es": "Un éxito de Snow (1992).",
       "fun_fact_fr": "Un tube de Snow (1992).",
-      "fun_fact_nl": "Een chart-hit van Snow (1992)."
+      "fun_fact_nl": "Een chart-hit van Snow (1992).",
+      "fun_fact_it": "Un successo in classifica di Snow (1992)."
     },
     {
       "artist": "Sailor",
@@ -1478,7 +1486,8 @@
       "fun_fact_de": "Ein Chart-Hit von Sailor (1993).",
       "fun_fact_es": "Un éxito de Sailor (1993).",
       "fun_fact_fr": "Un tube de Sailor (1993).",
-      "fun_fact_nl": "Een chart-hit van Sailor (1993)."
+      "fun_fact_nl": "Een chart-hit van Sailor (1993).",
+      "fun_fact_it": "Un successo in classifica di Sailor (1993)."
     },
     {
       "artist": "Funkstar De Luxe",
@@ -1503,7 +1512,8 @@
       "fun_fact_de": "Ein Chart-Hit von Funkstar De Luxe (1999).",
       "fun_fact_es": "Un éxito de Funkstar De Luxe (1999).",
       "fun_fact_fr": "Un tube de Funkstar De Luxe (1999).",
-      "fun_fact_nl": "Een chart-hit van Funkstar De Luxe (1999)."
+      "fun_fact_nl": "Een chart-hit van Funkstar De Luxe (1999).",
+      "fun_fact_it": "Un successo in classifica di Funkstar De Luxe (1999)."
     },
     {
       "artist": "Lou Bega",
@@ -1528,7 +1538,8 @@
       "fun_fact_de": "Ein Chart-Hit von Lou Bega (1999).",
       "fun_fact_es": "Un éxito de Lou Bega (1999).",
       "fun_fact_fr": "Un tube de Lou Bega (1999).",
-      "fun_fact_nl": "Een chart-hit van Lou Bega (1999)."
+      "fun_fact_nl": "Een chart-hit van Lou Bega (1999).",
+      "fun_fact_it": "Un successo in classifica di Lou Bega (1999)."
     },
     {
       "artist": "Britney Spears",
@@ -1553,7 +1564,8 @@
       "fun_fact_de": "Ein Chart-Hit von Britney Spears (1999).",
       "fun_fact_es": "Un éxito de Britney Spears (1999).",
       "fun_fact_fr": "Un tube de Britney Spears (1999).",
-      "fun_fact_nl": "Een chart-hit van Britney Spears (1999)."
+      "fun_fact_nl": "Een chart-hit van Britney Spears (1999).",
+      "fun_fact_it": "Un successo in classifica di Britney Spears (1999)."
     },
     {
       "artist": "The Kelly Family",
@@ -1578,7 +1590,8 @@
       "fun_fact_de": "Ein Chart-Hit von The Kelly Family (1996).",
       "fun_fact_es": "Un éxito de The Kelly Family (1996).",
       "fun_fact_fr": "Un tube de The Kelly Family (1996).",
-      "fun_fact_nl": "Een chart-hit van The Kelly Family (1996)."
+      "fun_fact_nl": "Een chart-hit van The Kelly Family (1996).",
+      "fun_fact_it": "Un successo in classifica di The Kelly Family (1996)."
     },
     {
       "artist": "Aqua",
@@ -1603,7 +1616,8 @@
       "fun_fact_de": "Ein Chart-Hit von Aqua (1997).",
       "fun_fact_es": "Un éxito de Aqua (1997).",
       "fun_fact_fr": "Un tube de Aqua (1997).",
-      "fun_fact_nl": "Een chart-hit van Aqua (1997)."
+      "fun_fact_nl": "Een chart-hit van Aqua (1997).",
+      "fun_fact_it": "Un successo in classifica di Aqua (1997)."
     },
     {
       "artist": "The Bangles",
@@ -1628,7 +1642,8 @@
       "fun_fact_de": "Ein Chart-Hit von The Bangles (1990).",
       "fun_fact_es": "Un éxito de The Bangles (1990).",
       "fun_fact_fr": "Un tube de The Bangles (1990).",
-      "fun_fact_nl": "Een chart-hit van The Bangles (1990)."
+      "fun_fact_nl": "Een chart-hit van The Bangles (1990).",
+      "fun_fact_it": "Un successo in classifica di The Bangles (1990)."
     },
     {
       "artist": "Gigi D'Agostino",
@@ -2763,7 +2778,8 @@
       "fun_fact_de": "Ein Chart-Hit von SNAP! (1990).",
       "fun_fact_es": "Un éxito de SNAP! (1990).",
       "fun_fact_fr": "Un tube de SNAP! (1990).",
-      "fun_fact_nl": "Een chart-hit van SNAP! (1990)."
+      "fun_fact_nl": "Een chart-hit van SNAP! (1990).",
+      "fun_fact_it": "Un successo in classifica di SNAP! (1990)."
     },
     {
       "artist": "Incognito",
@@ -2791,7 +2807,8 @@
       "fun_fact_de": "Ein Chart-Hit von Incognito (1991).",
       "fun_fact_es": "Un éxito de Incognito (1991).",
       "fun_fact_fr": "Un tube de Incognito (1991).",
-      "fun_fact_nl": "Een chart-hit van Incognito (1991)."
+      "fun_fact_nl": "Een chart-hit van Incognito (1991).",
+      "fun_fact_it": "Un successo in classifica di Incognito (1991)."
     },
     {
       "artist": "Die Toten Hosen",
@@ -2816,7 +2833,8 @@
       "fun_fact_de": "Ein Chart-Hit von Die Toten Hosen (1996).",
       "fun_fact_es": "Un éxito de Die Toten Hosen (1996).",
       "fun_fact_fr": "Un tube de Die Toten Hosen (1996).",
-      "fun_fact_nl": "Een chart-hit van Die Toten Hosen (1996)."
+      "fun_fact_nl": "Een chart-hit van Die Toten Hosen (1996).",
+      "fun_fact_it": "Un successo in classifica di Die Toten Hosen (1996)."
     },
     {
       "artist": "Roxette",
@@ -2841,7 +2859,8 @@
       "fun_fact_de": "Ein Chart-Hit von Roxette (1992).",
       "fun_fact_es": "Un éxito de Roxette (1992).",
       "fun_fact_fr": "Un tube de Roxette (1992).",
-      "fun_fact_nl": "Een chart-hit van Roxette (1992)."
+      "fun_fact_nl": "Een chart-hit van Roxette (1992).",
+      "fun_fact_it": "Un successo in classifica di Roxette (1992)."
     },
     {
       "artist": "DJ BoBo",
@@ -2866,7 +2885,8 @@
       "fun_fact_de": "Ein Chart-Hit von DJ BoBo (1996).",
       "fun_fact_es": "Un éxito de DJ BoBo (1996).",
       "fun_fact_fr": "Un tube de DJ BoBo (1996).",
-      "fun_fact_nl": "Een chart-hit van DJ BoBo (1996)."
+      "fun_fact_nl": "Een chart-hit van DJ BoBo (1996).",
+      "fun_fact_it": "Un successo in classifica di DJ BoBo (1996)."
     },
     {
       "artist": "The Adventures Of Stevie V",
@@ -2883,7 +2903,8 @@
       "fun_fact_de": "Ein Chart-Hit von The Adventures Of Stevie V (1990).",
       "fun_fact_es": "Un éxito de The Adventures Of Stevie V (1990).",
       "fun_fact_fr": "Un tube de The Adventures Of Stevie V (1990).",
-      "fun_fact_nl": "Een chart-hit van The Adventures Of Stevie V (1990)."
+      "fun_fact_nl": "Een chart-hit van The Adventures Of Stevie V (1990).",
+      "fun_fact_it": "Un successo in classifica di The Adventures Of Stevie V (1990)."
     },
     {
       "artist": "The Offspring",
@@ -2908,7 +2929,8 @@
       "fun_fact_de": "Ein Chart-Hit von The Offspring (1998).",
       "fun_fact_es": "Un éxito de The Offspring (1998).",
       "fun_fact_fr": "Un tube de The Offspring (1998).",
-      "fun_fact_nl": "Een chart-hit van The Offspring (1998)."
+      "fun_fact_nl": "Een chart-hit van The Offspring (1998).",
+      "fun_fact_it": "Un successo in classifica di The Offspring (1998)."
     },
     {
       "artist": "Rozalla",
@@ -2933,7 +2955,8 @@
       "fun_fact_de": "Ein Chart-Hit von Rozalla (1991).",
       "fun_fact_es": "Un éxito de Rozalla (1991).",
       "fun_fact_fr": "Un tube de Rozalla (1991).",
-      "fun_fact_nl": "Een chart-hit van Rozalla (1991)."
+      "fun_fact_nl": "Een chart-hit van Rozalla (1991).",
+      "fun_fact_it": "Un successo in classifica di Rozalla (1991)."
     },
     {
       "artist": "Reel 2 Real",
@@ -2962,7 +2985,8 @@
       "fun_fact_de": "Ein Chart-Hit von Reel 2 Real (1993).",
       "fun_fact_es": "Un éxito de Reel 2 Real (1993).",
       "fun_fact_fr": "Un tube de Reel 2 Real (1993).",
-      "fun_fact_nl": "Een chart-hit van Reel 2 Real (1993)."
+      "fun_fact_nl": "Een chart-hit van Reel 2 Real (1993).",
+      "fun_fact_it": "Un successo in classifica di Reel 2 Real (1993)."
     },
     {
       "artist": "Scooter",
@@ -2987,7 +3011,8 @@
       "fun_fact_de": "Ein Chart-Hit von Scooter (1998).",
       "fun_fact_es": "Un éxito de Scooter (1998).",
       "fun_fact_fr": "Un tube de Scooter (1998).",
-      "fun_fact_nl": "Een chart-hit van Scooter (1998)."
+      "fun_fact_nl": "Een chart-hit van Scooter (1998).",
+      "fun_fact_it": "Un successo in classifica di Scooter (1998)."
     },
     {
       "artist": "Fettes Brot",
@@ -3012,7 +3037,8 @@
       "fun_fact_de": "Ein Chart-Hit von Fettes Brot (1996).",
       "fun_fact_es": "Un éxito de Fettes Brot (1996).",
       "fun_fact_fr": "Un tube de Fettes Brot (1996).",
-      "fun_fact_nl": "Een chart-hit van Fettes Brot (1996)."
+      "fun_fact_nl": "Een chart-hit van Fettes Brot (1996).",
+      "fun_fact_it": "Un successo in classifica di Fettes Brot (1996)."
     },
     {
       "artist": "The Bucketheads",
@@ -3037,7 +3063,8 @@
       "fun_fact_de": "Ein Chart-Hit von The Bucketheads (1994).",
       "fun_fact_es": "Un éxito de The Bucketheads (1994).",
       "fun_fact_fr": "Un tube de The Bucketheads (1994).",
-      "fun_fact_nl": "Een chart-hit van The Bucketheads (1994)."
+      "fun_fact_nl": "Een chart-hit van The Bucketheads (1994).",
+      "fun_fact_it": "Un successo in classifica di The Bucketheads (1994)."
     },
     {
       "artist": "Tokyo Ghetto Pussy",
@@ -3062,7 +3089,8 @@
       "fun_fact_de": "Ein Chart-Hit von Tokyo Ghetto Pussy (1995).",
       "fun_fact_es": "Un éxito de Tokyo Ghetto Pussy (1995).",
       "fun_fact_fr": "Un tube de Tokyo Ghetto Pussy (1995).",
-      "fun_fact_nl": "Een chart-hit van Tokyo Ghetto Pussy (1995)."
+      "fun_fact_nl": "Een chart-hit van Tokyo Ghetto Pussy (1995).",
+      "fun_fact_it": "Un successo in classifica di Tokyo Ghetto Pussy (1995)."
     },
     {
       "year": 1999,
@@ -3170,7 +3198,8 @@
       "fun_fact_de": "Ein Chart-Hit von Aswad (1994).",
       "fun_fact_es": "Un éxito de Aswad (1994).",
       "fun_fact_fr": "Un tube de Aswad (1994).",
-      "fun_fact_nl": "Een chart-hit van Aswad (1994)."
+      "fun_fact_nl": "Een chart-hit van Aswad (1994).",
+      "fun_fact_it": "Un successo in classifica di Aswad (1994)."
     },
     {
       "artist": "Crystal Waters",
@@ -3220,7 +3249,8 @@
       "fun_fact_de": "Ein Chart-Hit von Blur (1994).",
       "fun_fact_es": "Un éxito de Blur (1994).",
       "fun_fact_fr": "Un tube de Blur (1994).",
-      "fun_fact_nl": "Een chart-hit van Blur (1994)."
+      "fun_fact_nl": "Een chart-hit van Blur (1994).",
+      "fun_fact_it": "Un successo in classifica di Blur (1994)."
     },
     {
       "artist": "Spice Girls",
@@ -3245,7 +3275,8 @@
       "fun_fact_de": "Ein Chart-Hit von Spice Girls (1996).",
       "fun_fact_es": "Un éxito de Spice Girls (1996).",
       "fun_fact_fr": "Un tube de Spice Girls (1996).",
-      "fun_fact_nl": "Een chart-hit van Spice Girls (1996)."
+      "fun_fact_nl": "Een chart-hit van Spice Girls (1996).",
+      "fun_fact_it": "Un successo in classifica di Spice Girls (1996)."
     },
     {
       "artist": "Shaggy",
@@ -3270,7 +3301,8 @@
       "fun_fact_de": "Ein Chart-Hit von Shaggy (1993).",
       "fun_fact_es": "Un éxito de Shaggy (1993).",
       "fun_fact_fr": "Un tube de Shaggy (1993).",
-      "fun_fact_nl": "Een chart-hit van Shaggy (1993)."
+      "fun_fact_nl": "Een chart-hit van Shaggy (1993).",
+      "fun_fact_it": "Un successo in classifica di Shaggy (1993)."
     },
     {
       "artist": "Five",
@@ -3298,7 +3330,8 @@
       "fun_fact_de": "Ein Chart-Hit von Five (1999).",
       "fun_fact_es": "Un éxito de Five (1999).",
       "fun_fact_fr": "Un tube de Five (1999).",
-      "fun_fact_nl": "Een chart-hit van Five (1999)."
+      "fun_fact_nl": "Een chart-hit van Five (1999).",
+      "fun_fact_it": "Un successo in classifica di Five (1999)."
     },
     {
       "year": 1990,

--- a/custom_components/beatify/playlists/community/clasicos-disney-castellano.json
+++ b/custom_components/beatify/playlists/community/clasicos-disney-castellano.json
@@ -27,7 +27,8 @@
       "alt_artists": [
         "Mario A. González",
         "Sergio Zamora"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Aladdín» della Disney (1992)."
     },
     {
       "year": 1994,
@@ -43,7 +44,8 @@
       "alt_artists": [
         "Gema Castaño",
         "Josema Yuste"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (1994)."
     },
     {
       "year": 2003,
@@ -61,7 +63,8 @@
       "alt_artists": [
         "Anolita Domínguez",
         "Naima Barroso"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Tierra de Osos» della Disney (2003)."
     },
     {
       "year": 1999,
@@ -79,7 +82,8 @@
       "alt_artists": [
         "Geraldine Larrosa",
         "Marco Antonio Solís"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Tarzán» della Disney (1999)."
     },
     {
       "year": 1995,
@@ -97,7 +101,8 @@
       "alt_artists": [
         "Gisela",
         "Pablo Perea"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Pocahontas» della Disney (1995)."
     },
     {
       "year": 1998,
@@ -113,7 +118,8 @@
       "alt_artists": [
         "Lupita Pérez",
         "Miguel Ángel Jenner"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Mulán» della Disney (1998)."
     },
     {
       "year": 1998,
@@ -128,7 +134,8 @@
       "alt_artists": [
         "Gisela",
         "Sergio Zamora"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Mulán» della Disney (1998)."
     },
     {
       "year": 1997,
@@ -145,7 +152,8 @@
       "alt_artists": [
         "AD Santos",
         "Jordi Vila"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Hércules» della Disney (1997)."
     },
     {
       "year": 1967,
@@ -160,7 +168,8 @@
       "alt_artists": [
         "Chila Lynn",
         "Jim Sutherland"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «El Libro de la Selva» della Disney (1967)."
     },
     {
       "year": 1991,
@@ -178,7 +187,8 @@
       "alt_artists": [
         "Chila Lynn",
         "Flavio"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (1991)."
     },
     {
       "year": 1967,
@@ -196,7 +206,8 @@
       "alt_artists": [
         "Christina Aguilera",
         "Marco Antonio Solís"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «El Libro de la Selva» della Disney (1967)."
     },
     {
       "year": 2010,
@@ -212,7 +223,8 @@
       "alt_artists": [
         "Luis Ángel Gómez Jaramillo",
         "Lupita Pérez"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Enredados» della Disney (2010)."
     },
     {
       "year": 1997,
@@ -230,7 +242,8 @@
       "alt_artists": [
         "Christina Aguilera",
         "Pablo Perea"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Hércules» della Disney (1997)."
     },
     {
       "year": 1996,
@@ -245,7 +258,8 @@
       "alt_artists": [
         "Jim Sutherland",
         "Susan Martín"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «El Jorobado de Notre Dame» della Disney (1996)."
     },
     {
       "year": 1994,
@@ -261,7 +275,8 @@
       "alt_artists": [
         "Gema Castaño",
         "Malú"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (1994)."
     },
     {
       "year": 1996,
@@ -276,7 +291,8 @@
       "alt_artists": [
         "Jim Sutherland",
         "Pablo Perea"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «El Jorobado de Notre Dame» della Disney (1996)."
     },
     {
       "year": 2013,
@@ -292,7 +308,8 @@
       "alt_artists": [
         "María Parrado",
         "Pablo Perea"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Frozen» della Disney (2013)."
     },
     {
       "year": 1953,
@@ -309,7 +326,8 @@
       "alt_artists": [
         "Anolita Domínguez",
         "Sleeping Beauty"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Peter Pan» della Disney (1953)."
     },
     {
       "year": 2003,
@@ -327,7 +345,8 @@
       "alt_artists": [
         "Jim Sutherland",
         "Pablo Perea"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Tierra de Osos» della Disney (2003)."
     },
     {
       "year": 1959,
@@ -342,7 +361,8 @@
       "alt_artists": [
         "Malú",
         "Sleeping Beauty"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella Durmiente» della Disney (1959)."
     },
     {
       "year": 1995,
@@ -360,7 +380,8 @@
       "alt_artists": [
         "Malú",
         "Marc Pociello"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Pocahontas» della Disney (1995)."
     },
     {
       "year": 2016,
@@ -378,7 +399,8 @@
       "alt_artists": [
         "Carmen López",
         "Miguel Ángel Jenner"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Vaiana» della Disney (2016)."
     },
     {
       "year": 2009,
@@ -396,7 +418,8 @@
       "alt_artists": [
         "Alex Ubago",
         "Sleeping Beauty"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Tiana y el Sapo» della Disney (2009)."
     },
     {
       "year": 1998,
@@ -411,7 +434,8 @@
       "alt_artists": [
         "Carmen López",
         "Jon Secada"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Mulán» della Disney (1998)."
     },
     {
       "year": 1994,
@@ -427,7 +451,8 @@
       "alt_artists": [
         "Anolita Domínguez",
         "Chila Lynn"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (1994)."
     },
     {
       "year": 2010,
@@ -445,7 +470,8 @@
       "alt_artists": [
         "Jon Secada",
         "Susan Martín"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Enredados» della Disney (2010)."
     },
     {
       "year": 2012,
@@ -461,7 +487,8 @@
       "alt_artists": [
         "Ferran Gonzalez",
         "Naima Barroso"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Indomable» della Disney (2012)."
     },
     {
       "year": 2012,
@@ -477,7 +504,8 @@
       "alt_artists": [
         "Luis Ángel Gómez Jaramillo",
         "Marta Martorell"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Indomable» della Disney (2012)."
     },
     {
       "year": 1937,
@@ -494,7 +522,8 @@
       "alt_artists": [
         "Alex Ubago",
         "Susan Martín"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Blancanieves» della Disney (1937)."
     },
     {
       "year": 2009,
@@ -510,7 +539,8 @@
       "alt_artists": [
         "Gipsy Kings",
         "Gisela"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Tiana y el Sapo» della Disney (2009)."
     },
     {
       "year": 2006,
@@ -527,7 +557,8 @@
       "alt_artists": [
         "María Caneda",
         "Naima Barroso"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Hermano Oso 2» della Disney (2006)."
     },
     {
       "year": 1994,
@@ -545,7 +576,8 @@
       "alt_artists": [
         "Armando Pita",
         "Pablo Perea"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (1994)."
     },
     {
       "year": 2016,
@@ -563,7 +595,8 @@
       "alt_artists": [
         "Gisela",
         "Sol Pilas"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Vaiana» della Disney (2016)."
     },
     {
       "year": 1970,
@@ -579,7 +612,8 @@
       "alt_artists": [
         "AD Santos",
         "Gema Castaño"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Los Aristogatos» della Disney (1970)."
     },
     {
       "year": 2002,
@@ -597,7 +631,8 @@
       "alt_artists": [
         "Chila Lynn",
         "Gipsy Kings"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «El Planeta del Tesoro» della Disney (2002)."
     },
     {
       "year": 1959,
@@ -612,7 +647,8 @@
       "alt_artists": [
         "Jon Secada",
         "Phil Collins"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella Durmiente» della Disney (1959)."
     },
     {
       "year": 2010,
@@ -628,7 +664,8 @@
       "alt_artists": [
         "Beatriz Luengo",
         "Ferran Gonzalez"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Toy Story 3» della Disney (2010)."
     },
     {
       "year": 2016,
@@ -644,7 +681,8 @@
       "alt_artists": [
         "Alex Ubago",
         "Sol Pilas"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Vaiana» della Disney (2016)."
     },
     {
       "year": 1940,
@@ -660,7 +698,8 @@
       "alt_artists": [
         "Gisela",
         "Luis Ángel Gómez Jaramillo"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Pinocho» della Disney (1940)."
     },
     {
       "year": 1959,
@@ -675,7 +714,8 @@
       "alt_artists": [
         "Gipsy Kings",
         "Jesús Aguirre"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella Durmiente» della Disney (1959)."
     },
     {
       "year": 2016,
@@ -693,7 +733,8 @@
       "alt_artists": [
         "Angélica Valle",
         "Beatriz Luengo"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Vaiana» della Disney (2016)."
     },
     {
       "year": 1998,
@@ -709,7 +750,8 @@
       "alt_artists": [
         "Carmen López",
         "Marco Antonio Solís"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Mulán» della Disney (1998)."
     },
     {
       "year": 1937,
@@ -726,7 +768,8 @@
       "alt_artists": [
         "Jon Secada",
         "Marco Antonio Solís"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Blancanieves» della Disney (1937)."
     },
     {
       "year": 1997,
@@ -743,7 +786,8 @@
       "alt_artists": [
         "Josema Yuste",
         "Pablo Perea"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Hércules» della Disney (1997)."
     },
     {
       "year": 2013,
@@ -761,7 +805,8 @@
       "alt_artists": [
         "Jesús Aguirre",
         "María Parrado"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Frozen» della Disney (2013)."
     },
     {
       "year": 2017,
@@ -779,7 +824,8 @@
       "alt_artists": [
         "AD Santos",
         "Yolanda de las Heras"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Coco» della Disney (2017)."
     },
     {
       "year": 2017,
@@ -795,7 +841,8 @@
       "alt_artists": [
         "Beatriz Luengo",
         "Flavio"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Coco» della Disney (2017)."
     },
     {
       "year": 2017,
@@ -813,7 +860,8 @@
       "alt_artists": [
         "Carmen López",
         "Flavio"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Coco» della Disney (2017)."
     },
     {
       "year": 2017,
@@ -831,7 +879,8 @@
       "alt_artists": [
         "Geraldine Larrosa",
         "Yolanda de las Heras"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Coco» della Disney (2017)."
     },
     {
       "year": 1997,
@@ -848,7 +897,8 @@
       "alt_artists": [
         "Marta Martorell",
         "Sleeping Beauty"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Hércules» della Disney (1997)."
     },
     {
       "year": 1998,
@@ -866,7 +916,8 @@
       "alt_artists": [
         "Armando Pita",
         "Susan Martín"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Mulán» della Disney (1998)."
     },
     {
       "year": 1999,
@@ -884,7 +935,8 @@
       "alt_artists": [
         "Flavio",
         "Lupita Pérez"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Tarzán» della Disney (1999)."
     },
     {
       "year": 1953,
@@ -901,7 +953,8 @@
       "alt_artists": [
         "Jordi Doncos",
         "Sleeping Beauty"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Peter Pan» della Disney (1953)."
     },
     {
       "year": 1996,
@@ -919,7 +972,8 @@
       "alt_artists": [
         "Alex Ubago",
         "Chila Lynn"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «El Jorobado de Notre Dame» della Disney (1996)."
     },
     {
       "year": 2003,
@@ -934,7 +988,8 @@
       "alt_artists": [
         "Geraldine Larrosa",
         "Lupita Pérez"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Tierra de Osos» della Disney (2003)."
     },
     {
       "year": 1937,
@@ -949,7 +1004,8 @@
       "alt_artists": [
         "Josema Yuste",
         "Miguel Morant"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Blancanieves» della Disney (1937)."
     },
     {
       "year": 1995,
@@ -967,7 +1023,8 @@
       "alt_artists": [
         "Josema Yuste",
         "Susan Martín"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Pocahontas» della Disney (1995)."
     },
     {
       "year": 1996,
@@ -982,7 +1039,8 @@
       "alt_artists": [
         "Gipsy Kings",
         "Jim Sutherland"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «El Jorobado de Notre Dame» della Disney (1996)."
     },
     {
       "year": 1991,
@@ -998,7 +1056,8 @@
       "alt_artists": [
         "Josema Yuste",
         "Naima Barroso"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (1991)."
     },
     {
       "year": 1995,
@@ -1014,7 +1073,8 @@
       "alt_artists": [
         "Anolita Domínguez",
         "Jesús Aguirre"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Pocahontas» della Disney (1995)."
     },
     {
       "year": 1991,
@@ -1030,7 +1090,8 @@
       "alt_artists": [
         "AD Santos",
         "Josema Yuste"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (1991)."
     },
     {
       "year": 1992,
@@ -1048,7 +1109,8 @@
       "alt_artists": [
         "Jordi Doncos",
         "Ricky Martin"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Aladdín» della Disney (1992)."
     },
     {
       "year": 1992,
@@ -1066,7 +1128,8 @@
       "alt_artists": [
         "Malú",
         "Sol Pilas"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Aladdín» della Disney (1992)."
     },
     {
       "year": 1991,
@@ -1084,7 +1147,8 @@
       "alt_artists": [
         "Angélica Valle",
         "Malú"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (1991)."
     }
   ]
 }

--- a/custom_components/beatify/playlists/community/deutschpop-klassiker.json
+++ b/custom_components/beatify/playlists/community/deutschpop-klassiker.json
@@ -3824,7 +3824,8 @@
       "fun_fact_de": "Ein Chart-Hit von EAV (Erste Allgemeine Verunsicherung) (1990).",
       "fun_fact_es": "Un éxito de EAV (Erste Allgemeine Verunsicherung) (1990).",
       "fun_fact_fr": "Un tube de EAV (Erste Allgemeine Verunsicherung) (1990).",
-      "fun_fact_nl": "Een chart-hit van EAV (Erste Allgemeine Verunsicherung) (1990)."
+      "fun_fact_nl": "Een chart-hit van EAV (Erste Allgemeine Verunsicherung) (1990).",
+      "fun_fact_it": "Un successo in classifica di EAV (Erste Allgemeine Verunsicherung) (1990)."
     },
     {
       "artist": "Die Orsons",

--- a/custom_components/beatify/playlists/community/disney-latino.json
+++ b/custom_components/beatify/playlists/community/disney-latino.json
@@ -27,7 +27,8 @@
       "alt_artists": [
         "Mateo Ramírez Velasco",
         "Tata Vega"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Coco» della Disney (2017)."
     },
     {
       "year": 1994,
@@ -45,7 +46,8 @@
       "alt_artists": [
         "Ana Torroja",
         "Natalia Lafourcade"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (1994)."
     },
     {
       "year": 2019,
@@ -63,7 +65,8 @@
       "alt_artists": [
         "Marco Antonio Solís",
         "Sofia Carson"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Frozen II» della Disney (2019)."
     },
     {
       "year": 2010,
@@ -79,7 +82,8 @@
       "alt_artists": [
         "Elenco de Soy Luna",
         "Héctor Ortiz"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Toy Story 3» della Disney (2010)."
     },
     {
       "year": 2026,
@@ -97,7 +101,8 @@
       "alt_artists": [
         "David Bisbal",
         "Mijares"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Soy Luna: Volver a rodar» della Disney (2026)."
     },
     {
       "year": 1991,
@@ -115,7 +120,8 @@
       "alt_artists": [
         "Esteman",
         "Héctor Ortiz"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (1991)."
     },
     {
       "year": 2021,
@@ -133,7 +139,8 @@
       "alt_artists": [
         "Natalia Lafourcade",
         "Norma Herrera"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Encanto» della Disney (2021)."
     },
     {
       "year": 2019,
@@ -149,7 +156,8 @@
       "alt_artists": [
         "Frozen",
         "ZAYN"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (2019)."
     },
     {
       "year": 2021,
@@ -167,7 +175,8 @@
       "alt_artists": [
         "Beto Castillo",
         "Christina Aguilera"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Encanto» della Disney (2021)."
     },
     {
       "year": 2017,
@@ -185,7 +194,8 @@
       "alt_artists": [
         "Mendez",
         "Sebastian Yatra"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Coco» della Disney (2017)."
     },
     {
       "year": 2020,
@@ -203,7 +213,8 @@
       "alt_artists": [
         "Chayanne",
         "Claudia Pizá"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Mulan» della Disney (2020)."
     },
     {
       "year": 2021,
@@ -221,7 +232,8 @@
       "alt_artists": [
         "Mateo Ramírez Velasco",
         "TINI"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Encanto» della Disney (2021)."
     },
     {
       "year": 2017,
@@ -237,7 +249,8 @@
       "alt_artists": [
         "Carlos Vives",
         "Luis Fonsi"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (2017)."
     },
     {
       "year": 2020,
@@ -255,7 +268,8 @@
       "alt_artists": [
         "Ana Torroja",
         "Gipsy Kings"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Mulan» della Disney (2020)."
     },
     {
       "year": 1995,
@@ -273,7 +287,8 @@
       "alt_artists": [
         "Luis Fonsi",
         "Renato Lopez"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Pocahontas» della Disney (1995)."
     },
     {
       "year": 1991,
@@ -289,7 +304,8 @@
       "alt_artists": [
         "Ana Torroja",
         "ZAYN"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (1991)."
     },
     {
       "year": 1994,
@@ -305,7 +321,8 @@
       "alt_artists": [
         "Christina Aguilera",
         "Sofia Carson"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (1994)."
     },
     {
       "year": 1991,
@@ -321,7 +338,8 @@
       "alt_artists": [
         "Gipsy Kings",
         "Mateo Ramírez Velasco"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (1991)."
     },
     {
       "year": 2013,
@@ -339,7 +357,8 @@
       "alt_artists": [
         "Martina Stoessel",
         "Meli G"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Frozen» della Disney (2013)."
     },
     {
       "year": 1991,
@@ -355,7 +374,8 @@
       "alt_artists": [
         "Ana Torroja",
         "Luis Fonsi"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (1991)."
     },
     {
       "year": 1994,
@@ -373,7 +393,8 @@
       "alt_artists": [
         "Chayanne",
         "Eros Ramazzotti"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (1994)."
     },
     {
       "year": 2016,
@@ -389,7 +410,8 @@
       "alt_artists": [
         "Marco Antonio Solís",
         "Sofia Carson"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Moana» della Disney (2016)."
     },
     {
       "year": 2010,
@@ -407,7 +429,8 @@
       "alt_artists": [
         "Chayanne",
         "Eros Ramazzotti"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Enredados» della Disney (2010)."
     },
     {
       "year": 1991,
@@ -423,7 +446,8 @@
       "alt_artists": [
         "Irasema Terrazas",
         "TINI"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (1991)."
     },
     {
       "year": 2017,
@@ -439,7 +463,8 @@
       "alt_artists": [
         "Gonzo",
         "Tata Vega"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Coco» della Disney (2017)."
     },
     {
       "year": 2019,
@@ -457,7 +482,8 @@
       "alt_artists": [
         "Irasema Terrazas",
         "Marco Antonio Solís"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (2019)."
     },
     {
       "year": 2019,
@@ -473,7 +499,8 @@
       "alt_artists": [
         "Danna Paola",
         "Sebastian Yatra"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Aladdin» della Disney (2019)."
     },
     {
       "year": 2021,
@@ -491,7 +518,8 @@
       "alt_artists": [
         "Armando Gama",
         "Chayanne"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Encanto» della Disney (2021)."
     },
     {
       "year": 2011,
@@ -507,7 +535,8 @@
       "alt_artists": [
         "Analy",
         "Chayanne"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Los Muppets» della Disney (2011)."
     },
     {
       "year": 1989,
@@ -525,7 +554,8 @@
       "alt_artists": [
         "Luis Ángel Gómez Jaramillo",
         "Sugey Torres"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «La Sirenita» della Disney (1989)."
     },
     {
       "year": 1994,
@@ -543,7 +573,8 @@
       "alt_artists": [
         "Kalimba Marichal",
         "Tata Vega"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (1994)."
     },
     {
       "year": 1991,
@@ -561,7 +592,8 @@
       "alt_artists": [
         "Gonzo",
         "Mendez"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (1991)."
     },
     {
       "year": 2010,
@@ -579,7 +611,8 @@
       "alt_artists": [
         "Sugey Torres",
         "Tata Vega"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Enredados» della Disney (2010)."
     },
     {
       "year": 2016,
@@ -595,7 +628,8 @@
       "alt_artists": [
         "Marco Antonio Solís",
         "Olga Lucía Vives"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Tini: El gran cambio de Violetta» della Disney (2016)."
     },
     {
       "year": 2019,
@@ -611,7 +645,8 @@
       "alt_artists": [
         "Elenco de Soy Luna",
         "Sara Paula Gómez Arias"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (2019)."
     },
     {
       "year": 2013,
@@ -629,7 +664,8 @@
       "alt_artists": [
         "Analy",
         "Meli G"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Frozen» della Disney (2013)."
     },
     {
       "year": 2013,
@@ -647,7 +683,8 @@
       "alt_artists": [
         "Esteman",
         "Kalimba Marichal"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Frozen» della Disney (2013)."
     },
     {
       "year": 2016,
@@ -665,7 +702,8 @@
       "alt_artists": [
         "Romina Marroquín Payró",
         "Sebastian Yatra"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Moana» della Disney (2016)."
     },
     {
       "year": 1970,
@@ -683,7 +721,8 @@
       "alt_artists": [
         "Marco Antonio Solís",
         "ZAYN"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Los Aristogatos» della Disney (1970)."
     },
     {
       "year": 2017,
@@ -699,7 +738,8 @@
       "alt_artists": [
         "David Bisbal",
         "ZAYN"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (2017)."
     },
     {
       "year": 2013,
@@ -717,7 +757,8 @@
       "alt_artists": [
         "Carlos Vives",
         "Eduardo Tejedo"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Frozen» della Disney (2013)."
     },
     {
       "year": 1994,
@@ -733,7 +774,8 @@
       "alt_artists": [
         "Christina Aguilera",
         "TINI"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (1994)."
     },
     {
       "year": 2017,
@@ -751,7 +793,8 @@
       "alt_artists": [
         "Armando Gama",
         "Esteman"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Coco» della Disney (2017)."
     },
     {
       "year": 2017,
@@ -769,7 +812,8 @@
       "alt_artists": [
         "Carlos Rivera",
         "Meli G"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Coco» della Disney (2017)."
     },
     {
       "year": 1997,
@@ -787,7 +831,8 @@
       "alt_artists": [
         "Carlos Rivera",
         "Tata Vega"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Hércules» della Disney (1997)."
     },
     {
       "year": 1999,
@@ -805,7 +850,8 @@
       "alt_artists": [
         "Gipsy Kings",
         "Rubén Albarrán"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Toy Story 2» della Disney (1999)."
     },
     {
       "year": 2017,
@@ -823,7 +869,8 @@
       "alt_artists": [
         "Eros Ramazzotti",
         "Romina Marroquín Payró"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Coco» della Disney (2017)."
     },
     {
       "year": 2013,
@@ -841,7 +888,8 @@
       "alt_artists": [
         "Eduardo Tejedo",
         "Mendez"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Frozen» della Disney (2013)."
     },
     {
       "year": 1994,
@@ -859,7 +907,8 @@
       "alt_artists": [
         "Carlos Vives",
         "Eduardo Tejedo"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (1994)."
     },
     {
       "year": 2016,
@@ -875,7 +924,8 @@
       "alt_artists": [
         "Bronco",
         "Luis Ángel Gómez Jaramillo"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Moana» della Disney (2016)."
     },
     {
       "year": 2019,
@@ -893,7 +943,8 @@
       "alt_artists": [
         "Analy",
         "Sara Paula Gómez Arias"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Toy Story 4» della Disney (2019)."
     },
     {
       "year": 1999,
@@ -911,7 +962,8 @@
       "alt_artists": [
         "Jessi Corti",
         "Renato Lopez"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Tarzán» della Disney (1999)."
     },
     {
       "year": 2013,
@@ -929,7 +981,8 @@
       "alt_artists": [
         "Luis Ángel Gómez Jaramillo",
         "Renato Lopez"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «Frozen» della Disney (2013)."
     },
     {
       "year": 1994,
@@ -947,7 +1000,8 @@
       "alt_artists": [
         "Armando Gama",
         "TINI"
-      ]
+      ],
+      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (1994)."
     }
   ]
 }

--- a/custom_components/beatify/playlists/community/salsa-y-merengue.json
+++ b/custom_components/beatify/playlists/community/salsa-y-merengue.json
@@ -28,7 +28,8 @@
       "fun_fact_nl": "\"Ché Ché Colé\" van Willie Colón, Héctor Lavoe, voor het eerst uitgebracht in 1969.",
       "uri_deezer": "deezer://track/686077012",
       "uri_apple_music": "applemusic://track/1508050955",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=XgId1N1UbLs"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XgId1N1UbLs",
+      "fun_fact_it": "«Ché Ché Colé» di Willie Colón, Héctor Lavoe, pubblicata per la prima volta nel 1969."
     },
     {
       "year": 1970,
@@ -43,7 +44,8 @@
       "fun_fact_nl": "\"La Murga\" van Héctor Lavoe, Willie Colón, voor het eerst uitgebracht in 1970 op het album \"Asalto Navideño: Vol. 1 & 2\".",
       "uri_deezer": "deezer://track/686087482",
       "uri_apple_music": "applemusic://track/1464288858",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=XKCD99urScc"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XKCD99urScc",
+      "fun_fact_it": "«La Murga» di Héctor Lavoe, Willie Colón, pubblicata per la prima volta nel 1970 nell'album «Asalto Navideño: Vol. 1 & 2»."
     },
     {
       "year": 1969,
@@ -58,7 +60,8 @@
       "fun_fact_nl": "\"Periodico De Ayer\" van Héctor Lavoe, voor het eerst uitgebracht in 1969 op het album \"A Man And His Music: La Voz\".",
       "uri_deezer": "deezer://track/688751902",
       "uri_apple_music": "applemusic://track/1766860330",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=kwCV6OZI5GM"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=kwCV6OZI5GM",
+      "fun_fact_it": "«Periodico De Ayer» di Héctor Lavoe, pubblicata per la prima volta nel 1969 nell'album «A Man And His Music: La Voz»."
     },
     {
       "year": 1969,
@@ -73,7 +76,8 @@
       "fun_fact_nl": "\"El Cantante\" van Héctor Lavoe, voor het eerst uitgebracht in 1969 op het album \"Comedia\".",
       "uri_deezer": "deezer://track/689033892",
       "uri_apple_music": "applemusic://track/1701025846",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=BNo0vkEYWRc"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BNo0vkEYWRc",
+      "fun_fact_it": "«El Cantante» di Héctor Lavoe, pubblicata per la prima volta nel 1969 nell'album «Comedia»."
     },
     {
       "year": 2006,
@@ -87,7 +91,8 @@
       "fun_fact_fr": "« El Dia De Suerte » de Héctor Lavoe, parue pour la première fois en 2006 sur l'album « Salsa Navideña ».",
       "fun_fact_nl": "\"El Dia De Suerte\" van Héctor Lavoe, voor het eerst uitgebracht in 2006 op het album \"Salsa Navideña\".",
       "uri_deezer": "deezer://track/1182194142",
-      "uri_apple_music": "applemusic://track/1464272393"
+      "uri_apple_music": "applemusic://track/1464272393",
+      "fun_fact_it": "«El Dia De Suerte» di Héctor Lavoe, pubblicata per la prima volta nel 2006 nell'album «Salsa Navideña»."
     },
     {
       "year": 1982,
@@ -102,7 +107,8 @@
       "fun_fact_nl": "\"Triste Y Vacía\" van Héctor Lavoe, Willie Colón, voor het eerst uitgebracht in 1982.",
       "uri_deezer": "deezer://track/687772602",
       "uri_apple_music": "applemusic://track/1466317245",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=nShuNc2XkJI"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nShuNc2XkJI",
+      "fun_fact_it": "«Triste Y Vacía» di Héctor Lavoe, Willie Colón, pubblicata per la prima volta nel 1982."
     },
     {
       "year": 1969,
@@ -117,7 +123,8 @@
       "fun_fact_nl": "\"Calle Luna Calle Sol\" van Willie Colón, Héctor Lavoe, voor het eerst uitgebracht in 1969 op het album \"Lo Mato\".",
       "uri_deezer": "deezer://track/686101012",
       "uri_apple_music": "applemusic://track/1464272281",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=Z7fYCZtaJwo"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Z7fYCZtaJwo",
+      "fun_fact_it": "«Calle Luna Calle Sol» di Willie Colón, Héctor Lavoe, pubblicata per la prima volta nel 1969 nell'album «Lo Mato»."
     },
     {
       "year": 1973,
@@ -131,7 +138,8 @@
       "fun_fact_fr": "« Todo Tiene Su Final » de Héctor Lavoe, parue pour la première fois en 1973 sur l'album « Lo Mato ».",
       "fun_fact_nl": "\"Todo Tiene Su Final\" van Héctor Lavoe, voor het eerst uitgebracht in 1973 op het album \"Lo Mato\".",
       "uri_deezer": "deezer://track/686100982",
-      "uri_apple_music": "applemusic://track/1464271788"
+      "uri_apple_music": "applemusic://track/1464271788",
+      "fun_fact_it": "«Todo Tiene Su Final» di Héctor Lavoe, pubblicata per la prima volta nel 1973 nell'album «Lo Mato»."
     },
     {
       "year": 1975,
@@ -145,7 +153,8 @@
       "fun_fact_fr": "« El Todopoderoso » de Héctor Lavoe, parue pour la première fois en 1975 sur l'album « Masterworks: La Voz ».",
       "fun_fact_nl": "\"El Todopoderoso\" van Héctor Lavoe, voor het eerst uitgebracht in 1975 op het album \"Masterworks: La Voz\".",
       "uri_deezer": "deezer://track/689030762",
-      "uri_apple_music": "applemusic://track/1466318093"
+      "uri_apple_music": "applemusic://track/1466318093",
+      "fun_fact_it": "«El Todopoderoso» di Héctor Lavoe, pubblicata per la prima volta nel 1975 nell'album «Masterworks: La Voz»."
     },
     {
       "year": 1969,
@@ -159,7 +168,8 @@
       "fun_fact_fr": "« La Fama » de Héctor Lavoe, parue pour la première fois en 1969 sur l'album « Hector Lavoe Feria Del Hogar, Vol. 1 (En Vivo) ».",
       "fun_fact_nl": "\"La Fama\" van Héctor Lavoe, voor het eerst uitgebracht in 1969 op het album \"Hector Lavoe Feria Del Hogar, Vol. 1 (En Vivo)\".",
       "uri_deezer": "deezer://track/3207114351",
-      "uri_apple_music": "applemusic://track/1464288946"
+      "uri_apple_music": "applemusic://track/1464288946",
+      "fun_fact_it": "«La Fama» di Héctor Lavoe, pubblicata per la prima volta nel 1969 nell'album «Hector Lavoe Feria Del Hogar, Vol. 1 (En Vivo)»."
     },
     {
       "year": 1995,
@@ -173,7 +183,8 @@
       "fun_fact_fr": "« Talento De Televisión » de Willie Colón, parue pour la première fois en 1995 sur l'album « Mis Favoritas ».",
       "fun_fact_nl": "\"Talento De Televisión\" van Willie Colón, voor het eerst uitgebracht in 1995 op het album \"Mis Favoritas\".",
       "uri_deezer": "deezer://track/6237257",
-      "uri_apple_music": "applemusic://track/374542178"
+      "uri_apple_music": "applemusic://track/374542178",
+      "fun_fact_it": "«Talento De Televisión» di Willie Colón, pubblicata per la prima volta nel 1995 nell'album «Mis Favoritas»."
     },
     {
       "year": 1993,
@@ -187,7 +198,8 @@
       "fun_fact_fr": "« Idilio » de Willie Colón, parue pour la première fois en 1993 sur l'album « Mis Favoritas ».",
       "fun_fact_nl": "\"Idilio\" van Willie Colón, voor het eerst uitgebracht in 1993 op het album \"Mis Favoritas\".",
       "uri_deezer": "deezer://track/6237251",
-      "uri_apple_music": "applemusic://track/374542161"
+      "uri_apple_music": "applemusic://track/374542161",
+      "fun_fact_it": "«Idilio» di Willie Colón, pubblicata per la prima volta nel 1993 nell'album «Mis Favoritas»."
     },
     {
       "year": 1986,
@@ -201,7 +213,8 @@
       "fun_fact_fr": "« El Gran Varon » de Willie Colón, parue pour la première fois en 1986.",
       "fun_fact_nl": "\"El Gran Varon\" van Willie Colón, voor het eerst uitgebracht in 1986.",
       "uri_deezer": "deezer://track/686077162",
-      "uri_apple_music": "applemusic://track/1436559567"
+      "uri_apple_music": "applemusic://track/1436559567",
+      "fun_fact_it": "«El Gran Varon» di Willie Colón, pubblicata per la prima volta nel 1986."
     },
     {
       "year": 1969,
@@ -215,7 +228,8 @@
       "fun_fact_fr": "« Juanito Alimana » de Willie Colón, Héctor Lavoe, parue pour la première fois en 1969 sur l'album « Vigilante ».",
       "fun_fact_nl": "\"Juanito Alimana\" van Willie Colón, Héctor Lavoe, voor het eerst uitgebracht in 1969 op het album \"Vigilante\".",
       "uri_deezer": "deezer://track/689030362",
-      "uri_apple_music": "applemusic://track/1466317423"
+      "uri_apple_music": "applemusic://track/1466317423",
+      "fun_fact_it": "«Juanito Alimana» di Willie Colón, Héctor Lavoe, pubblicata per la prima volta nel 1969 nell'album «Vigilante»."
     },
     {
       "year": 1979,
@@ -229,7 +243,8 @@
       "fun_fact_fr": "« Sin Poderte Hablar » de Willie Colón, parue pour la première fois en 1979 sur l'album « Fania Records: The 70's, Vol. Six ».",
       "fun_fact_nl": "\"Sin Poderte Hablar\" van Willie Colón, voor het eerst uitgebracht in 1979 op het album \"Fania Records: The 70's, Vol. Six\".",
       "uri_deezer": "deezer://track/689130162",
-      "uri_apple_music": "applemusic://track/1435556999"
+      "uri_apple_music": "applemusic://track/1435556999",
+      "fun_fact_it": "«Sin Poderte Hablar» di Willie Colón, pubblicata per la prima volta nel 1979 nell'album «Fania Records: The 70's, Vol. Six»."
     },
     {
       "year": 1993,
@@ -243,7 +258,8 @@
       "fun_fact_fr": "« Cueste Lo Que Cueste » de Willie Colón, parue pour la première fois en 1993 sur l'album « Mis Favoritas ».",
       "fun_fact_nl": "\"Cueste Lo Que Cueste\" van Willie Colón, voor het eerst uitgebracht in 1993 op het album \"Mis Favoritas\".",
       "uri_deezer": "deezer://track/6237249",
-      "uri_apple_music": "applemusic://track/1308743244"
+      "uri_apple_music": "applemusic://track/1308743244",
+      "fun_fact_it": "«Cueste Lo Que Cueste» di Willie Colón, pubblicata per la prima volta nel 1993 nell'album «Mis Favoritas»."
     },
     {
       "year": 2004,
@@ -256,7 +272,8 @@
       "fun_fact_es": "\"Oh Que Será\" de Willie Colón, Rubén Blades, publicada por primera vez en 2004 en el álbum \"Live in the Netherlands\".",
       "fun_fact_fr": "« Oh Que Será » de Willie Colón, Rubén Blades, parue pour la première fois en 2004 sur l'album « Live in the Netherlands ».",
       "fun_fact_nl": "\"Oh Que Será\" van Willie Colón, Rubén Blades, voor het eerst uitgebracht in 2004 op het album \"Live in the Netherlands\".",
-      "uri_deezer": "deezer://track/14190980"
+      "uri_deezer": "deezer://track/14190980",
+      "fun_fact_it": "«Oh Que Será» di Willie Colón, Rubén Blades, pubblicata per la prima volta nel 2004 nell'album «Live in the Netherlands»."
     },
     {
       "year": 1978,
@@ -271,7 +288,8 @@
       "fun_fact_nl": "\"Pedro Navaja\" van Willie Colón, Rubén Blades, voor het eerst uitgebracht in 1978 op het album \"Siembra\".",
       "uri_deezer": "deezer://track/686098802",
       "uri_apple_music": "applemusic://track/1464957419",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=0hcoNykaI3k"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0hcoNykaI3k",
+      "fun_fact_it": "«Pedro Navaja» di Willie Colón, Rubén Blades, pubblicata per la prima volta nel 1978 nell'album «Siembra»."
     },
     {
       "year": 1978,
@@ -285,7 +303,8 @@
       "fun_fact_fr": "« Buscando Guayaba » de Rubén Blades, parue pour la première fois en 1978 sur l'album « Oliver And Company Original Soundtrack (English Version) ».",
       "fun_fact_nl": "\"Buscando Guayaba\" van Rubén Blades, voor het eerst uitgebracht in 1978 op het album \"Oliver And Company Original Soundtrack (English Version)\".",
       "uri_deezer": "deezer://track/3203474",
-      "uri_apple_music": "applemusic://track/1781312254"
+      "uri_apple_music": "applemusic://track/1781312254",
+      "fun_fact_it": "«Buscando Guayaba» di Rubén Blades, pubblicata per la prima volta nel 1978 nell'album «Oliver And Company Original Soundtrack (English Version)»."
     },
     {
       "year": 1974,
@@ -300,7 +319,8 @@
       "fun_fact_nl": "\"Lloraras\" van Oscar D'León, La Dimensión Latina, voor het eerst uitgebracht in 1974 op het album \"Oscar D'León En México\".",
       "uri_deezer": "deezer://track/861158912",
       "uri_apple_music": "applemusic://track/1495520388",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=Y9xD2rd2ukI"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Y9xD2rd2ukI",
+      "fun_fact_it": "«Lloraras» di Oscar D'León, La Dimensión Latina, pubblicata per la prima volta nel 1974 nell'album «Oscar D'León En México»."
     },
     {
       "year": 1991,
@@ -314,7 +334,8 @@
       "fun_fact_fr": "« Que Bueno Baila Usted » de Oscar D'León, parue pour la première fois en 1991 sur l'album « Oscar D'León En New York ».",
       "fun_fact_nl": "\"Que Bueno Baila Usted\" van Oscar D'León, voor het eerst uitgebracht in 1991 op het album \"Oscar D'León En New York\".",
       "uri_deezer": "deezer://track/861307112",
-      "uri_apple_music": "applemusic://track/1615524871"
+      "uri_apple_music": "applemusic://track/1615524871",
+      "fun_fact_it": "«Que Bueno Baila Usted» di Oscar D'León, pubblicata per la prima volta nel 1991 nell'album «Oscar D'León En New York»."
     },
     {
       "year": 1990,
@@ -328,7 +349,8 @@
       "fun_fact_fr": "« Detalles » de Oscar D'León, parue pour la première fois en 1990 sur l'album « Detalles ».",
       "fun_fact_nl": "\"Detalles\" van Oscar D'León, voor het eerst uitgebracht in 1990 op het album \"Detalles\".",
       "uri_deezer": "deezer://track/861264892",
-      "uri_apple_music": "applemusic://track/1495496931"
+      "uri_apple_music": "applemusic://track/1495496931",
+      "fun_fact_it": "«Detalles» di Oscar D'León, pubblicata per la prima volta nel 1990 nell'album «Detalles»."
     },
     {
       "year": 1990,
@@ -342,7 +364,8 @@
       "fun_fact_fr": "« Ven Morena » de Oscar D'León, parue pour la première fois en 1990.",
       "fun_fact_nl": "\"Ven Morena\" van Oscar D'León, voor het eerst uitgebracht in 1990.",
       "uri_deezer": "deezer://track/861420982",
-      "uri_apple_music": "applemusic://track/6798819275"
+      "uri_apple_music": "applemusic://track/6798819275",
+      "fun_fact_it": "«Ven Morena» di Oscar D'León, pubblicata per la prima volta nel 1990."
     },
     {
       "year": 1983,
@@ -356,7 +379,8 @@
       "fun_fact_fr": "« Sigue Tu Camino » de Oscar D'León, parue pour la première fois en 1983 sur l'album « En La Feria del Hogar (En vivo) ».",
       "fun_fact_nl": "\"Sigue Tu Camino\" van Oscar D'León, voor het eerst uitgebracht in 1983 op het album \"En La Feria del Hogar (En vivo)\".",
       "uri_deezer": "deezer://track/4184939582",
-      "uri_apple_music": "applemusic://track/6795978007"
+      "uri_apple_music": "applemusic://track/6795978007",
+      "fun_fact_it": "«Sigue Tu Camino» di Oscar D'León, pubblicata per la prima volta nel 1983 nell'album «En La Feria del Hogar (En vivo)»."
     },
     {
       "year": 1974,
@@ -370,7 +394,8 @@
       "fun_fact_fr": "« Me Voy Pa'Cali » de Oscar D'León, parue pour la première fois en 1974 sur l'album « Salsa ».",
       "fun_fact_nl": "\"Me Voy Pa'Cali\" van Oscar D'León, voor het eerst uitgebracht in 1974 op het album \"Salsa\".",
       "uri_deezer": "deezer://track/1167152",
-      "uri_apple_music": "applemusic://track/1443836245"
+      "uri_apple_music": "applemusic://track/1443836245",
+      "fun_fact_it": "«Me Voy Pa'Cali» di Oscar D'León, pubblicata per la prima volta nel 1974 nell'album «Salsa»."
     },
     {
       "year": 1983,
@@ -384,7 +409,8 @@
       "fun_fact_fr": "« Calculadora » de Oscar D'León, parue pour la première fois en 1983.",
       "fun_fact_nl": "\"Calculadora\" van Oscar D'León, voor het eerst uitgebracht in 1983.",
       "uri_deezer": "deezer://track/861269262",
-      "uri_apple_music": "applemusic://track/1495421330"
+      "uri_apple_music": "applemusic://track/1495421330",
+      "fun_fact_it": "«Calculadora» di Oscar D'León, pubblicata per la prima volta nel 1983."
     },
     {
       "year": 2007,
@@ -398,7 +424,8 @@
       "fun_fact_fr": "« Conteo Regresivo - Salsa Version » de Gilberto Santa Rosa, parue pour la première fois en 2007 sur l'album « Latin 101 ».",
       "fun_fact_nl": "\"Conteo Regresivo - Salsa Version\" van Gilberto Santa Rosa, voor het eerst uitgebracht in 2007 op het album \"Latin 101\".",
       "uri_deezer": "deezer://track/5404643",
-      "uri_apple_music": "applemusic://track/267953290"
+      "uri_apple_music": "applemusic://track/267953290",
+      "fun_fact_it": "«Conteo Regresivo - Salsa Version» di Gilberto Santa Rosa, pubblicata per la prima volta nel 2007 nell'album «Latin 101»."
     },
     {
       "year": 1991,
@@ -413,7 +440,8 @@
       "fun_fact_nl": "\"Conciencia\" van Gilberto Santa Rosa, voor het eerst uitgebracht in 1991 op het album \"Mis Favoritas\".",
       "uri_deezer": "deezer://track/6720628",
       "uri_apple_music": "applemusic://track/170115102",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=7kbjKCj-rMQ"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7kbjKCj-rMQ",
+      "fun_fact_it": "«Conciencia» di Gilberto Santa Rosa, pubblicata per la prima volta nel 1991 nell'album «Mis Favoritas»."
     },
     {
       "year": 1999,
@@ -427,7 +455,8 @@
       "fun_fact_fr": "« Que Alguien Me Diga » de Gilberto Santa Rosa, parue pour la première fois en 1999 sur l'album « El Caballero De La Salsa - La Historia Tropical ».",
       "fun_fact_nl": "\"Que Alguien Me Diga\" van Gilberto Santa Rosa, voor het eerst uitgebracht in 1999 op het album \"El Caballero De La Salsa - La Historia Tropical\".",
       "uri_deezer": "deezer://track/13204938",
-      "uri_apple_music": "applemusic://track/171830031"
+      "uri_apple_music": "applemusic://track/171830031",
+      "fun_fact_it": "«Que Alguien Me Diga» di Gilberto Santa Rosa, pubblicata per la prima volta nel 1999 nell'album «El Caballero De La Salsa - La Historia Tropical»."
     },
     {
       "year": 1998,
@@ -442,7 +471,8 @@
       "fun_fact_nl": "\"Un Montón de Estrellas\" van Gilberto Santa Rosa, voor het eerst uitgebracht in 1998 op het album \"El Caballero De La Salsa - La Historia Tropical\".",
       "uri_deezer": "deezer://track/13204940",
       "uri_apple_music": "applemusic://track/303411300",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=H5qWtG7cziE"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=H5qWtG7cziE",
+      "fun_fact_it": "«Un Montón de Estrellas» di Gilberto Santa Rosa, pubblicata per la prima volta nel 1998 nell'album «El Caballero De La Salsa - La Historia Tropical»."
     },
     {
       "year": 2001,
@@ -456,7 +486,8 @@
       "fun_fact_fr": "« La Agarro Bajando » de Gilberto Santa Rosa, parue pour la première fois en 2001 sur l'album « El Caballero De La Salsa - La Historia Tropical ».",
       "fun_fact_nl": "\"La Agarro Bajando\" van Gilberto Santa Rosa, voor het eerst uitgebracht in 2001 op het album \"El Caballero De La Salsa - La Historia Tropical\".",
       "uri_deezer": "deezer://track/13204939",
-      "uri_apple_music": "applemusic://track/170544677"
+      "uri_apple_music": "applemusic://track/170544677",
+      "fun_fact_it": "«La Agarro Bajando» di Gilberto Santa Rosa, pubblicata per la prima volta nel 2001 nell'album «El Caballero De La Salsa - La Historia Tropical»."
     },
     {
       "year": 1993,
@@ -470,7 +501,8 @@
       "fun_fact_fr": "« Qué Manera de Quererte » de Gilberto Santa Rosa, parue pour la première fois en 1993 sur l'album « 40... y Contando (En Vivo Desde Puerto Rico) ».",
       "fun_fact_nl": "\"Qué Manera de Quererte\" van Gilberto Santa Rosa, voor het eerst uitgebracht in 1993 op het album \"40... y Contando (En Vivo Desde Puerto Rico)\".",
       "uri_deezer": "deezer://track/681403142",
-      "uri_apple_music": "applemusic://track/303411269"
+      "uri_apple_music": "applemusic://track/303411269",
+      "fun_fact_it": "«Qué Manera de Quererte» di Gilberto Santa Rosa, pubblicata per la prima volta nel 1993 nell'album «40... y Contando (En Vivo Desde Puerto Rico)»."
     },
     {
       "year": 1993,
@@ -484,7 +516,8 @@
       "fun_fact_fr": "« Sin Voluntad » de Gilberto Santa Rosa, parue pour la première fois en 1993 sur l'album « El Caballero De La Salsa - La Historia Tropical ».",
       "fun_fact_nl": "\"Sin Voluntad\" van Gilberto Santa Rosa, voor het eerst uitgebracht in 1993 op het album \"El Caballero De La Salsa - La Historia Tropical\".",
       "uri_deezer": "deezer://track/13204933",
-      "uri_apple_music": "applemusic://track/303411268"
+      "uri_apple_music": "applemusic://track/303411268",
+      "fun_fact_it": "«Sin Voluntad» di Gilberto Santa Rosa, pubblicata per la prima volta nel 1993 nell'album «El Caballero De La Salsa - La Historia Tropical»."
     },
     {
       "year": 1990,
@@ -498,7 +531,8 @@
       "fun_fact_fr": "« Perdóname » de Gilberto Santa Rosa, parue pour la première fois en 1990 sur l'album « En Vivo Desde El Carnegie Hall ».",
       "fun_fact_nl": "\"Perdóname\" van Gilberto Santa Rosa, voor het eerst uitgebracht in 1990 op het album \"En Vivo Desde El Carnegie Hall\".",
       "uri_deezer": "deezer://track/62351524",
-      "uri_apple_music": "applemusic://track/170114432"
+      "uri_apple_music": "applemusic://track/170114432",
+      "fun_fact_it": "«Perdóname» di Gilberto Santa Rosa, pubblicata per la prima volta nel 1990 nell'album «En Vivo Desde El Carnegie Hall»."
     },
     {
       "year": 1990,
@@ -512,7 +546,8 @@
       "fun_fact_fr": "« Vivir Sin Ella » de Gilberto Santa Rosa, parue pour la première fois en 1990 sur l'album « El Caballero De La Salsa - La Historia Tropical ».",
       "fun_fact_nl": "\"Vivir Sin Ella\" van Gilberto Santa Rosa, voor het eerst uitgebracht in 1990 op het album \"El Caballero De La Salsa - La Historia Tropical\".",
       "uri_deezer": "deezer://track/13204930",
-      "uri_apple_music": "applemusic://track/303411265"
+      "uri_apple_music": "applemusic://track/303411265",
+      "fun_fact_it": "«Vivir Sin Ella» di Gilberto Santa Rosa, pubblicata per la prima volta nel 1990 nell'album «El Caballero De La Salsa - La Historia Tropical»."
     },
     {
       "year": 1989,
@@ -526,7 +561,8 @@
       "fun_fact_fr": "« Me Volvieron A Hablar De Ella » de Gilberto Santa Rosa, parue pour la première fois en 1989 sur l'album « Mis Favoritas ».",
       "fun_fact_nl": "\"Me Volvieron A Hablar De Ella\" van Gilberto Santa Rosa, voor het eerst uitgebracht in 1989 op het album \"Mis Favoritas\".",
       "uri_deezer": "deezer://track/6720634",
-      "uri_apple_music": "applemusic://track/271435280"
+      "uri_apple_music": "applemusic://track/271435280",
+      "fun_fact_it": "«Me Volvieron A Hablar De Ella» di Gilberto Santa Rosa, pubblicata per la prima volta nel 1989 nell'album «Mis Favoritas»."
     },
     {
       "year": 1994,
@@ -541,7 +577,8 @@
       "fun_fact_nl": "\"Te Propongo\" van Gilberto Santa Rosa, voor het eerst uitgebracht in 1994 op het album \"De Cara Al Viento\".",
       "uri_deezer": "deezer://track/13264588",
       "uri_apple_music": "applemusic://track/163345163",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=wh21tFCmzV0"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wh21tFCmzV0",
+      "fun_fact_it": "«Te Propongo» di Gilberto Santa Rosa, pubblicata per la prima volta nel 1994 nell'album «De Cara Al Viento»."
     },
     {
       "year": 2001,
@@ -555,7 +592,8 @@
       "fun_fact_fr": "« Tengo Ganas » de Víctor Manuelle, parue pour la première fois en 2001 sur l'album « Leyendas: Salsa Romántica ».",
       "fun_fact_nl": "\"Tengo Ganas\" van Víctor Manuelle, voor het eerst uitgebracht in 2001 op het album \"Leyendas: Salsa Romántica\".",
       "uri_deezer": "deezer://track/88877241",
-      "uri_apple_music": "applemusic://track/163349486"
+      "uri_apple_music": "applemusic://track/163349486",
+      "fun_fact_it": "«Tengo Ganas» di Víctor Manuelle, pubblicata per la prima volta nel 2001 nell'album «Leyendas: Salsa Romántica»."
     },
     {
       "year": 1993,
@@ -569,7 +607,8 @@
       "fun_fact_fr": "« He Tratado » de Víctor Manuelle, parue pour la première fois en 1993 sur l'album « Oro Salsero ».",
       "fun_fact_nl": "\"He Tratado\" van Víctor Manuelle, voor het eerst uitgebracht in 1993 op het album \"Oro Salsero\".",
       "uri_deezer": "deezer://track/13243134",
-      "uri_apple_music": "applemusic://track/161699108"
+      "uri_apple_music": "applemusic://track/161699108",
+      "fun_fact_it": "«He Tratado» di Víctor Manuelle, pubblicata per la prima volta nel 1993 nell'album «Oro Salsero»."
     },
     {
       "year": 1993,
@@ -583,7 +622,8 @@
       "fun_fact_fr": "« Así Es la Mujer » de Víctor Manuelle, parue pour la première fois en 1993 sur l'album « Oro Salsero ».",
       "fun_fact_nl": "\"Así Es la Mujer\" van Víctor Manuelle, voor het eerst uitgebracht in 1993 op het album \"Oro Salsero\".",
       "uri_deezer": "deezer://track/13243130",
-      "uri_apple_music": "applemusic://track/161698791"
+      "uri_apple_music": "applemusic://track/161698791",
+      "fun_fact_it": "«Así Es la Mujer» di Víctor Manuelle, pubblicata per la prima volta nel 1993 nell'album «Oro Salsero»."
     },
     {
       "year": 1996,
@@ -597,7 +637,8 @@
       "fun_fact_fr": "« Como una Estrella » de Víctor Manuelle, parue pour la première fois en 1996 sur l'album « Leyendas: Salsa Romántica ».",
       "fun_fact_nl": "\"Como una Estrella\" van Víctor Manuelle, voor het eerst uitgebracht in 1996 op het album \"Leyendas: Salsa Romántica\".",
       "uri_deezer": "deezer://track/88877229",
-      "uri_apple_music": "applemusic://track/163292982"
+      "uri_apple_music": "applemusic://track/163292982",
+      "fun_fact_it": "«Como una Estrella» di Víctor Manuelle, pubblicata per la prima volta nel 1996 nell'album «Leyendas: Salsa Romántica»."
     },
     {
       "year": 1996,
@@ -611,7 +652,8 @@
       "fun_fact_fr": "« Por Ella » de Víctor Manuelle, parue pour la première fois en 1996 sur l'album « Sólo para Mujeres ».",
       "fun_fact_nl": "\"Por Ella\" van Víctor Manuelle, voor het eerst uitgebracht in 1996 op het album \"Sólo para Mujeres\".",
       "uri_deezer": "deezer://track/81827772",
-      "uri_apple_music": "applemusic://track/378827887"
+      "uri_apple_music": "applemusic://track/378827887",
+      "fun_fact_it": "«Por Ella» di Víctor Manuelle, pubblicata per la prima volta nel 1996 nell'album «Sólo para Mujeres»."
     },
     {
       "year": 1995,
@@ -625,7 +667,8 @@
       "fun_fact_fr": "« Hay Que Poner el Alma » de Víctor Manuelle, parue pour la première fois en 1995 sur l'album « Mis Favoritas ».",
       "fun_fact_nl": "\"Hay Que Poner el Alma\" van Víctor Manuelle, voor het eerst uitgebracht in 1995 op het album \"Mis Favoritas\".",
       "uri_deezer": "deezer://track/6237237",
-      "uri_apple_music": "applemusic://track/163292265"
+      "uri_apple_music": "applemusic://track/163292265",
+      "fun_fact_it": "«Hay Que Poner el Alma» di Víctor Manuelle, pubblicata per la prima volta nel 1995 nell'album «Mis Favoritas»."
     },
     {
       "year": 1999,
@@ -639,7 +682,8 @@
       "fun_fact_fr": "« Si la Ves - Salsa Version » de Víctor Manuelle, parue pour la première fois en 1999.",
       "fun_fact_nl": "\"Si la Ves - Salsa Version\" van Víctor Manuelle, voor het eerst uitgebracht in 1999.",
       "uri_apple_music": "applemusic://track/1140336688",
-      "uri_deezer": "deezer://track/13230013"
+      "uri_deezer": "deezer://track/13230013",
+      "fun_fact_it": "«Si la Ves - Salsa Version» di Víctor Manuelle, pubblicata per la prima volta nel 1999."
     },
     {
       "year": 1997,
@@ -653,7 +697,8 @@
       "fun_fact_fr": "« Dile a Ella » de Víctor Manuelle, parue pour la première fois en 1997 sur l'album « A Pesar De Todo ».",
       "fun_fact_nl": "\"Dile a Ella\" van Víctor Manuelle, voor het eerst uitgebracht in 1997 op het album \"A Pesar De Todo\".",
       "uri_deezer": "deezer://track/13243155",
-      "uri_apple_music": "applemusic://track/161698940"
+      "uri_apple_music": "applemusic://track/161698940",
+      "fun_fact_it": "«Dile a Ella» di Víctor Manuelle, pubblicata per la prima volta nel 1997 nell'album «A Pesar De Todo»."
     },
     {
       "year": 1998,
@@ -667,7 +712,8 @@
       "fun_fact_fr": "« Qué Habría Sido de Mí - Radio Version » de Víctor Manuelle, parue pour la première fois en 1998.",
       "fun_fact_nl": "\"Qué Habría Sido de Mí - Radio Version\" van Víctor Manuelle, voor het eerst uitgebracht in 1998.",
       "uri_apple_music": "applemusic://track/161699762",
-      "uri_deezer": "deezer://track/130010946"
+      "uri_deezer": "deezer://track/130010946",
+      "fun_fact_it": "«Qué Habría Sido de Mí - Radio Version» di Víctor Manuelle, pubblicata per la prima volta nel 1998."
     },
     {
       "year": 1998,
@@ -681,7 +727,8 @@
       "fun_fact_fr": "« Se Me Rompe el Alma » de Víctor Manuelle, parue pour la première fois en 1998 sur l'album « Sólo para Mujeres ».",
       "fun_fact_nl": "\"Se Me Rompe el Alma\" van Víctor Manuelle, voor het eerst uitgebracht in 1998 op het album \"Sólo para Mujeres\".",
       "uri_deezer": "deezer://track/81827792",
-      "uri_apple_music": "applemusic://track/161699705"
+      "uri_apple_music": "applemusic://track/161699705",
+      "fun_fact_it": "«Se Me Rompe el Alma» di Víctor Manuelle, pubblicata per la prima volta nel 1998 nell'album «Sólo para Mujeres»."
     },
     {
       "year": 1996,
@@ -695,7 +742,8 @@
       "fun_fact_fr": "« La Razón de Mi Vida » de Víctor Manuelle, parue pour la première fois en 1996 sur l'album « Dos Clásicos ».",
       "fun_fact_nl": "\"La Razón de Mi Vida\" van Víctor Manuelle, voor het eerst uitgebracht in 1996 op het album \"Dos Clásicos\".",
       "uri_deezer": "deezer://track/10066268",
-      "uri_apple_music": "applemusic://track/163348126"
+      "uri_apple_music": "applemusic://track/163348126",
+      "fun_fact_it": "«La Razón de Mi Vida» di Víctor Manuelle, pubblicata per la prima volta nel 1996 nell'album «Dos Clásicos»."
     },
     {
       "year": 2000,
@@ -709,7 +757,8 @@
       "fun_fact_fr": "« Lloré Lloré » de Víctor Manuelle, parue pour la première fois en 2000 sur l'album « Victor Manuelle Desde El Carnegie Hall ».",
       "fun_fact_nl": "\"Lloré Lloré\" van Víctor Manuelle, voor het eerst uitgebracht in 2000 op het album \"Victor Manuelle Desde El Carnegie Hall\".",
       "uri_deezer": "deezer://track/13269840",
-      "uri_apple_music": "applemusic://track/163349441"
+      "uri_apple_music": "applemusic://track/163349441",
+      "fun_fact_it": "«Lloré Lloré» di Víctor Manuelle, pubblicata per la prima volta nel 2000 nell'album «Victor Manuelle Desde El Carnegie Hall»."
     },
     {
       "year": 1998,
@@ -723,7 +772,8 @@
       "fun_fact_fr": "« La Dueña de Mis Amores » de Víctor Manuelle, parue pour la première fois en 1998 sur l'album « Oro Salsero ».",
       "fun_fact_nl": "\"La Dueña de Mis Amores\" van Víctor Manuelle, voor het eerst uitgebracht in 1998 op het album \"Oro Salsero\".",
       "uri_deezer": "deezer://track/13243144",
-      "uri_apple_music": "applemusic://track/903158334"
+      "uri_apple_music": "applemusic://track/903158334",
+      "fun_fact_it": "«La Dueña de Mis Amores» di Víctor Manuelle, pubblicata per la prima volta nel 1998 nell'album «Oro Salsero»."
     },
     {
       "year": 1993,
@@ -737,7 +787,8 @@
       "fun_fact_fr": "« No Hace Falta Nada » de Víctor Manuelle, parue pour la première fois en 1993 sur l'album « Sólo para Mujeres ».",
       "fun_fact_nl": "\"No Hace Falta Nada\" van Víctor Manuelle, voor het eerst uitgebracht in 1993 op het album \"Sólo para Mujeres\".",
       "uri_deezer": "deezer://track/81827804",
-      "uri_apple_music": "applemusic://track/163347834"
+      "uri_apple_music": "applemusic://track/163347834",
+      "fun_fact_it": "«No Hace Falta Nada» di Víctor Manuelle, pubblicata per la prima volta nel 1993 nell'album «Sólo para Mujeres»."
     },
     {
       "year": 2004,
@@ -751,7 +802,8 @@
       "fun_fact_fr": "« Fabricando Fantasías » de Tito Nieves, parue pour la première fois en 2004 sur l'album « Noches Latinas 3 ».",
       "fun_fact_nl": "\"Fabricando Fantasías\" van Tito Nieves, voor het eerst uitgebracht in 2004 op het album \"Noches Latinas 3\".",
       "uri_deezer": "deezer://track/1255471942",
-      "uri_apple_music": "applemusic://track/1444166379"
+      "uri_apple_music": "applemusic://track/1444166379",
+      "fun_fact_it": "«Fabricando Fantasías» di Tito Nieves, pubblicata per la prima volta nel 2004 nell'album «Noches Latinas 3»."
     },
     {
       "year": 2004,
@@ -765,7 +817,8 @@
       "fun_fact_fr": "« Ya no Queda Nada » de Tito Nieves, parue pour la première fois en 2004 sur l'album « Imprescindibles de la Salsa ».",
       "fun_fact_nl": "\"Ya no Queda Nada\" van Tito Nieves, voor het eerst uitgebracht in 2004 op het album \"Imprescindibles de la Salsa\".",
       "uri_deezer": "deezer://track/1028496972",
-      "uri_apple_music": "applemusic://track/1444166556"
+      "uri_apple_music": "applemusic://track/1444166556",
+      "fun_fact_it": "«Ya no Queda Nada» di Tito Nieves, pubblicata per la prima volta nel 2004 nell'album «Imprescindibles de la Salsa»."
     },
     {
       "year": 2002,
@@ -779,7 +832,8 @@
       "fun_fact_fr": "« La Salsa Vive » de Tito Nieves, parue pour la première fois en 2002 sur l'album « Muy Agradecido ».",
       "fun_fact_nl": "\"La Salsa Vive\" van Tito Nieves, voor het eerst uitgebracht in 2002 op het album \"Muy Agradecido\".",
       "uri_deezer": "deezer://track/3867322",
-      "uri_apple_music": "applemusic://track/42234488"
+      "uri_apple_music": "applemusic://track/42234488",
+      "fun_fact_it": "«La Salsa Vive» di Tito Nieves, pubblicata per la prima volta nel 2002 nell'album «Muy Agradecido»."
     },
     {
       "year": 2006,
@@ -793,7 +847,8 @@
       "fun_fact_fr": "« Mas Que Tu Amigo » de Tito Nieves, parue pour la première fois en 2006 sur l'album « La Mejor Pareja ».",
       "fun_fact_nl": "\"Mas Que Tu Amigo\" van Tito Nieves, voor het eerst uitgebracht in 2006 op het album \"La Mejor Pareja\".",
       "uri_deezer": "deezer://track/127675263",
-      "uri_apple_music": "applemusic://track/1443532721"
+      "uri_apple_music": "applemusic://track/1443532721",
+      "fun_fact_it": "«Mas Que Tu Amigo» di Tito Nieves, pubblicata per la prima volta nel 2006 nell'album «La Mejor Pareja»."
     },
     {
       "year": 1990,
@@ -807,7 +862,8 @@
       "fun_fact_fr": "« De Mí Enamórate » de Tito Nieves, parue pour la première fois en 1990 sur l'album « Pura Salsa ».",
       "fun_fact_nl": "\"De Mí Enamórate\" van Tito Nieves, voor het eerst uitgebracht in 1990 op het album \"Pura Salsa\".",
       "uri_deezer": "deezer://track/16670365",
-      "uri_apple_music": "applemusic://track/1443898355"
+      "uri_apple_music": "applemusic://track/1443898355",
+      "fun_fact_it": "«De Mí Enamórate» di Tito Nieves, pubblicata per la prima volta nel 1990 nell'album «Pura Salsa»."
     },
     {
       "year": 1991,
@@ -821,7 +877,8 @@
       "fun_fact_fr": "« Sonámbulo » de Tito Nieves, parue pour la première fois en 1991 sur l'album « Salsa ».",
       "fun_fact_nl": "\"Sonámbulo\" van Tito Nieves, voor het eerst uitgebracht in 1991 op het album \"Salsa\".",
       "uri_deezer": "deezer://track/1167157",
-      "uri_apple_music": "applemusic://track/1825451969"
+      "uri_apple_music": "applemusic://track/1825451969",
+      "fun_fact_it": "«Sonámbulo» di Tito Nieves, pubblicata per la prima volta nel 1991 nell'album «Salsa»."
     },
     {
       "year": 1984,
@@ -835,7 +892,8 @@
       "fun_fact_fr": "« La Cura » de Frankie Ruiz, parue pour la première fois en 1984 sur l'album « Serie Platino: Frankie Ruíz ».",
       "fun_fact_nl": "\"La Cura\" van Frankie Ruiz, voor het eerst uitgebracht in 1984 op het album \"Serie Platino: Frankie Ruíz\".",
       "uri_deezer": "deezer://track/528330321",
-      "uri_apple_music": "applemusic://track/1445571965"
+      "uri_apple_music": "applemusic://track/1445571965",
+      "fun_fact_it": "«La Cura» di Frankie Ruiz, pubblicata per la prima volta nel 1984 nell'album «Serie Platino: Frankie Ruíz»."
     },
     {
       "year": 1984,
@@ -849,7 +907,8 @@
       "fun_fact_fr": "« Desnúdate Mujer » de Frankie Ruiz, parue pour la première fois en 1984 sur l'album « Tú Me Vuelves Loco (Baile Total) ».",
       "fun_fact_nl": "\"Desnúdate Mujer\" van Frankie Ruiz, voor het eerst uitgebracht in 1984 op het album \"Tú Me Vuelves Loco (Baile Total)\".",
       "uri_deezer": "deezer://track/429987872",
-      "uri_apple_music": "applemusic://track/1443820787"
+      "uri_apple_music": "applemusic://track/1443820787",
+      "fun_fact_it": "«Desnúdate Mujer» di Frankie Ruiz, pubblicata per la prima volta nel 1984 nell'album «Tú Me Vuelves Loco (Baile Total)»."
     },
     {
       "year": 1979,
@@ -864,7 +923,8 @@
       "fun_fact_nl": "\"La Rueda\" van Frankie Ruiz, voor het eerst uitgebracht in 1979 op het album \"Tú Me Vuelves Loco (Baile Total)\".",
       "uri_deezer": "deezer://track/429987902",
       "uri_apple_music": "applemusic://track/1478922776",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=pEEa4wl_BZM"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=pEEa4wl_BZM",
+      "fun_fact_it": "«La Rueda» di Frankie Ruiz, pubblicata per la prima volta nel 1979 nell'album «Tú Me Vuelves Loco (Baile Total)»."
     },
     {
       "year": 1985,
@@ -878,7 +938,8 @@
       "fun_fact_fr": "« Tú Con Él » de Frankie Ruiz, parue pour la première fois en 1985 sur l'album « Tú Me Vuelves Loco (Baile Total) ».",
       "fun_fact_nl": "\"Tú Con Él\" van Frankie Ruiz, voor het eerst uitgebracht in 1985 op het album \"Tú Me Vuelves Loco (Baile Total)\".",
       "uri_deezer": "deezer://track/429987882",
-      "uri_apple_music": "applemusic://track/1445571967"
+      "uri_apple_music": "applemusic://track/1445571967",
+      "fun_fact_it": "«Tú Con Él» di Frankie Ruiz, pubblicata per la prima volta nel 1985 nell'album «Tú Me Vuelves Loco (Baile Total)»."
     },
     {
       "year": 1993,
@@ -892,7 +953,8 @@
       "fun_fact_fr": "« Tú Me Vuelves Loco » de Frankie Ruiz, parue pour la première fois en 1993 sur l'album « Salsa Legends (Los Románticos Vol.2) ».",
       "fun_fact_nl": "\"Tú Me Vuelves Loco\" van Frankie Ruiz, voor het eerst uitgebracht in 1993 op het album \"Salsa Legends (Los Románticos Vol.2)\".",
       "uri_deezer": "deezer://track/129635806",
-      "uri_apple_music": "applemusic://track/1443820805"
+      "uri_apple_music": "applemusic://track/1443820805",
+      "fun_fact_it": "«Tú Me Vuelves Loco» di Frankie Ruiz, pubblicata per la prima volta nel 1993 nell'album «Salsa Legends (Los Románticos Vol.2)»."
     },
     {
       "year": 1992,
@@ -906,7 +968,8 @@
       "fun_fact_fr": "« Bailando » de Frankie Ruiz, parue pour la première fois en 1992 sur l'album « El Papá De La Salsa ».",
       "fun_fact_nl": "\"Bailando\" van Frankie Ruiz, voor het eerst uitgebracht in 1992 op het album \"El Papá De La Salsa\".",
       "uri_deezer": "deezer://track/750116052",
-      "uri_apple_music": "applemusic://track/1478922477"
+      "uri_apple_music": "applemusic://track/1478922477",
+      "fun_fact_it": "«Bailando» di Frankie Ruiz, pubblicata per la prima volta nel 1992 nell'album «El Papá De La Salsa»."
     },
     {
       "year": 1987,
@@ -920,7 +983,8 @@
       "fun_fact_fr": "« Quiero Llenarte » de Frankie Ruiz, parue pour la première fois en 1987 sur l'album « Show ».",
       "fun_fact_nl": "\"Quiero Llenarte\" van Frankie Ruiz, voor het eerst uitgebracht in 1987 op het album \"Show\".",
       "uri_deezer": "deezer://track/769774552",
-      "uri_apple_music": "applemusic://track/1612351889"
+      "uri_apple_music": "applemusic://track/1612351889",
+      "fun_fact_it": "«Quiero Llenarte» di Frankie Ruiz, pubblicata per la prima volta nel 1987 nell'album «Show»."
     },
     {
       "year": 1989,
@@ -934,7 +998,8 @@
       "fun_fact_fr": "« Deseándote » de Frankie Ruiz, parue pour la première fois en 1989 sur l'album « Show ».",
       "fun_fact_nl": "\"Deseándote\" van Frankie Ruiz, voor het eerst uitgebracht in 1989 op het album \"Show\".",
       "uri_deezer": "deezer://track/769774502",
-      "uri_apple_music": "applemusic://track/1443758872"
+      "uri_apple_music": "applemusic://track/1443758872",
+      "fun_fact_it": "«Deseándote» di Frankie Ruiz, pubblicata per la prima volta nel 1989 nell'album «Show»."
     },
     {
       "year": 1992,
@@ -948,7 +1013,8 @@
       "fun_fact_fr": "« Mi Libertad » de Frankie Ruiz, parue pour la première fois en 1992 sur l'album « Tú Me Vuelves Loco (Baile Total) ».",
       "fun_fact_nl": "\"Mi Libertad\" van Frankie Ruiz, voor het eerst uitgebracht in 1992 op het album \"Tú Me Vuelves Loco (Baile Total)\".",
       "uri_deezer": "deezer://track/429987912",
-      "uri_apple_music": "applemusic://track/1443821176"
+      "uri_apple_music": "applemusic://track/1443821176",
+      "fun_fact_it": "«Mi Libertad» di Frankie Ruiz, pubblicata per la prima volta nel 1992 nell'album «Tú Me Vuelves Loco (Baile Total)»."
     },
     {
       "year": 1996,
@@ -962,7 +1028,8 @@
       "fun_fact_fr": "« Ironía » de Frankie Ruiz, parue pour la première fois en 1996 sur l'album « Ironia ».",
       "fun_fact_nl": "\"Ironía\" van Frankie Ruiz, voor het eerst uitgebracht in 1996 op het album \"Ironia\".",
       "uri_deezer": "deezer://track/1976240437",
-      "uri_apple_music": "applemusic://track/1443867601"
+      "uri_apple_music": "applemusic://track/1443867601",
+      "fun_fact_it": "«Ironía» di Frankie Ruiz, pubblicata per la prima volta nel 1996 nell'album «Ironia»."
     },
     {
       "year": 2005,
@@ -976,7 +1043,8 @@
       "fun_fact_fr": "« Devorame Otra Vez » de Eddie Santiago, parue pour la première fois en 2005 sur l'album « Salsa Hits, Vol.1 ».",
       "fun_fact_nl": "\"Devorame Otra Vez\" van Eddie Santiago, voor het eerst uitgebracht in 2005 op het album \"Salsa Hits, Vol.1\".",
       "uri_deezer": "deezer://track/481584672",
-      "uri_apple_music": "applemusic://track/1445663988"
+      "uri_apple_music": "applemusic://track/1445663988",
+      "fun_fact_it": "«Devorame Otra Vez» di Eddie Santiago, pubblicata per la prima volta nel 2005 nell'album «Salsa Hits, Vol.1»."
     },
     {
       "year": 1986,
@@ -990,7 +1058,8 @@
       "fun_fact_fr": "« Tu Me Quemas » de Eddie Santiago, parue pour la première fois en 1986 sur l'album « Lluvia (Baile Total) ».",
       "fun_fact_nl": "\"Tu Me Quemas\" van Eddie Santiago, voor het eerst uitgebracht in 1986 op het album \"Lluvia (Baile Total)\".",
       "uri_deezer": "deezer://track/429989542",
-      "uri_apple_music": "applemusic://track/1443749129"
+      "uri_apple_music": "applemusic://track/1443749129",
+      "fun_fact_it": "«Tu Me Quemas» di Eddie Santiago, pubblicata per la prima volta nel 1986 nell'album «Lluvia (Baile Total)»."
     },
     {
       "year": 1993,
@@ -1004,7 +1073,8 @@
       "fun_fact_fr": "« Jamás » de Eddie Santiago, parue pour la première fois en 1993.",
       "fun_fact_nl": "\"Jamás\" van Eddie Santiago, voor het eerst uitgebracht in 1993.",
       "uri_deezer": "deezer://track/4164346",
-      "uri_apple_music": "applemusic://track/714791244"
+      "uri_apple_music": "applemusic://track/714791244",
+      "fun_fact_it": "«Jamás» di Eddie Santiago, pubblicata per la prima volta nel 1993."
     },
     {
       "year": 1987,
@@ -1018,7 +1088,8 @@
       "fun_fact_fr": "« Lluvia » de Eddie Santiago, parue pour la première fois en 1987 sur l'album « Lluvia (Baile Total) ».",
       "fun_fact_nl": "\"Lluvia\" van Eddie Santiago, voor het eerst uitgebracht in 1987 op het album \"Lluvia (Baile Total)\".",
       "uri_deezer": "deezer://track/429989512",
-      "uri_apple_music": "applemusic://track/1622431614"
+      "uri_apple_music": "applemusic://track/1622431614",
+      "fun_fact_it": "«Lluvia» di Eddie Santiago, pubblicata per la prima volta nel 1987 nell'album «Lluvia (Baile Total)»."
     },
     {
       "year": 1999,
@@ -1032,7 +1103,8 @@
       "fun_fact_fr": "« Te Va a Doler » de Maelo Ruiz, parue pour la première fois en 1999 sur l'album « En Tiempo De Amor ».",
       "fun_fact_nl": "\"Te Va a Doler\" van Maelo Ruiz, voor het eerst uitgebracht in 1999 op het album \"En Tiempo De Amor\".",
       "uri_deezer": "deezer://track/11108508",
-      "uri_apple_music": "applemusic://track/1714488734"
+      "uri_apple_music": "applemusic://track/1714488734",
+      "fun_fact_it": "«Te Va a Doler» di Maelo Ruiz, pubblicata per la prima volta nel 1999 nell'album «En Tiempo De Amor»."
     },
     {
       "year": 1990,
@@ -1046,7 +1118,8 @@
       "fun_fact_fr": "« Siempre Seré » de Tito Rojas, parue pour la première fois en 1990.",
       "fun_fact_nl": "\"Siempre Seré\" van Tito Rojas, voor het eerst uitgebracht in 1990.",
       "uri_deezer": "deezer://track/10973080",
-      "uri_apple_music": "applemusic://track/264123077"
+      "uri_apple_music": "applemusic://track/264123077",
+      "fun_fact_it": "«Siempre Seré» di Tito Rojas, pubblicata per la prima volta nel 1990."
     },
     {
       "year": 1990,
@@ -1060,7 +1133,8 @@
       "fun_fact_fr": "« Ella se Hizo Deseo » de Tito Rojas, parue pour la première fois en 1990.",
       "fun_fact_nl": "\"Ella se Hizo Deseo\" van Tito Rojas, voor het eerst uitgebracht in 1990.",
       "uri_deezer": "deezer://track/10973082",
-      "uri_apple_music": "applemusic://track/264123170"
+      "uri_apple_music": "applemusic://track/264123170",
+      "fun_fact_it": "«Ella se Hizo Deseo» di Tito Rojas, pubblicata per la prima volta nel 1990."
     },
     {
       "year": 1993,
@@ -1074,7 +1148,8 @@
       "fun_fact_fr": "« Señora De Madrugada » de Tito Rojas, parue pour la première fois en 1993 sur l'album « Vida ».",
       "fun_fact_nl": "\"Señora De Madrugada\" van Tito Rojas, voor het eerst uitgebracht in 1993 op het album \"Vida\".",
       "uri_deezer": "deezer://track/11507265",
-      "uri_apple_music": "applemusic://track/304149129"
+      "uri_apple_music": "applemusic://track/304149129",
+      "fun_fact_it": "«Señora De Madrugada» di Tito Rojas, pubblicata per la prima volta nel 1993 nell'album «Vida»."
     },
     {
       "year": 1995,
@@ -1088,7 +1163,8 @@
       "fun_fact_fr": "« Usted » de Tito Rojas, parue pour la première fois en 1995 sur l'album « Vida ».",
       "fun_fact_nl": "\"Usted\" van Tito Rojas, voor het eerst uitgebracht in 1995 op het album \"Vida\".",
       "uri_deezer": "deezer://track/11507270",
-      "uri_apple_music": "applemusic://track/345305954"
+      "uri_apple_music": "applemusic://track/345305954",
+      "fun_fact_it": "«Usted» di Tito Rojas, pubblicata per la prima volta nel 1995 nell'album «Vida»."
     },
     {
       "year": 1992,
@@ -1102,7 +1178,8 @@
       "fun_fact_fr": "« Porque Este Amor » de Tito Rojas, parue pour la première fois en 1992 sur l'album « Live - Auténticamente En Vivo ».",
       "fun_fact_nl": "\"Porque Este Amor\" van Tito Rojas, voor het eerst uitgebracht in 1992 op het album \"Live - Auténticamente En Vivo\".",
       "uri_deezer": "deezer://track/12018475",
-      "uri_apple_music": "applemusic://track/304157653"
+      "uri_apple_music": "applemusic://track/304157653",
+      "fun_fact_it": "«Porque Este Amor» di Tito Rojas, pubblicata per la prima volta nel 1992 nell'album «Live - Auténticamente En Vivo»."
     },
     {
       "year": 1992,
@@ -1116,7 +1193,8 @@
       "fun_fact_fr": "« Condename A Tu Amor » de Tito Rojas, parue pour la première fois en 1992 sur l'album « Condename ».",
       "fun_fact_nl": "\"Condename A Tu Amor\" van Tito Rojas, voor het eerst uitgebracht in 1992 op het album \"Condename\".",
       "uri_deezer": "deezer://track/64118615",
-      "uri_apple_music": "applemusic://track/304157693"
+      "uri_apple_music": "applemusic://track/304157693",
+      "fun_fact_it": "«Condename A Tu Amor» di Tito Rojas, pubblicata per la prima volta nel 1992 nell'album «Condename»."
     },
     {
       "year": 1992,
@@ -1130,7 +1208,8 @@
       "fun_fact_fr": "« A Ti Volvere » de Tito Rojas, parue pour la première fois en 1992 sur l'album « Condename ».",
       "fun_fact_nl": "\"A Ti Volvere\" van Tito Rojas, voor het eerst uitgebracht in 1992 op het album \"Condename\".",
       "uri_deezer": "deezer://track/64118618",
-      "uri_apple_music": "applemusic://track/304157700"
+      "uri_apple_music": "applemusic://track/304157700",
+      "fun_fact_it": "«A Ti Volvere» di Tito Rojas, pubblicata per la prima volta nel 1992 nell'album «Condename»."
     },
     {
       "year": 1993,
@@ -1144,7 +1223,8 @@
       "fun_fact_fr": "« Lo Que Te Queda » de Tito Rojas, parue pour la première fois en 1993 sur l'album « Me Tienes Que Recordar ».",
       "fun_fact_nl": "\"Lo Que Te Queda\" van Tito Rojas, voor het eerst uitgebracht in 1993 op het album \"Me Tienes Que Recordar\".",
       "uri_deezer": "deezer://track/2017810637",
-      "uri_apple_music": "applemusic://track/304149149"
+      "uri_apple_music": "applemusic://track/304149149",
+      "fun_fact_it": "«Lo Que Te Queda» di Tito Rojas, pubblicata per la prima volta nel 1993 nell'album «Me Tienes Que Recordar»."
     },
     {
       "year": 1992,
@@ -1158,7 +1238,8 @@
       "fun_fact_fr": "« Aparentemente » de Tony Vega, parue pour la première fois en 1992 sur l'album « Pura Salsa ».",
       "fun_fact_nl": "\"Aparentemente\" van Tony Vega, voor het eerst uitgebracht in 1992 op het album \"Pura Salsa\".",
       "uri_deezer": "deezer://track/15493895",
-      "uri_apple_music": "applemusic://track/1443808820"
+      "uri_apple_music": "applemusic://track/1443808820",
+      "fun_fact_it": "«Aparentemente» di Tony Vega, pubblicata per la prima volta nel 1992 nell'album «Pura Salsa»."
     },
     {
       "year": 1993,
@@ -1172,7 +1253,8 @@
       "fun_fact_fr": "« No Vale La Pena » de Johnny Rivera, Ray Sepulveda, parue pour la première fois en 1993.",
       "fun_fact_nl": "\"No Vale La Pena\" van Johnny Rivera, Ray Sepulveda, voor het eerst uitgebracht in 1993.",
       "uri_deezer": "deezer://track/67666100",
-      "uri_apple_music": "applemusic://track/1705328227"
+      "uri_apple_music": "applemusic://track/1705328227",
+      "fun_fact_it": "«No Vale La Pena» di Johnny Rivera, Ray Sepulveda, pubblicata per la prima volta nel 1993."
     },
     {
       "year": 1992,
@@ -1186,7 +1268,8 @@
       "fun_fact_fr": "« Amores Como el Nuestro » de Jerry Rivera, parue pour la première fois en 1992 sur l'album « Sólo para Mujeres ».",
       "fun_fact_nl": "\"Amores Como el Nuestro\" van Jerry Rivera, voor het eerst uitgebracht in 1992 op het album \"Sólo para Mujeres\".",
       "uri_deezer": "deezer://track/81827848",
-      "uri_apple_music": "applemusic://track/192784400"
+      "uri_apple_music": "applemusic://track/192784400",
+      "fun_fact_it": "«Amores Como el Nuestro» di Jerry Rivera, pubblicata per la prima volta nel 1992 nell'album «Sólo para Mujeres»."
     },
     {
       "year": 1993,
@@ -1200,7 +1283,8 @@
       "fun_fact_fr": "« Qué Hay de Malo » de Jerry Rivera, parue pour la première fois en 1993 sur l'album « Cara De Niño ».",
       "fun_fact_nl": "\"Qué Hay de Malo\" van Jerry Rivera, voor het eerst uitgebracht in 1993 op het album \"Cara De Niño\".",
       "uri_deezer": "deezer://track/1031403",
-      "uri_apple_music": "applemusic://track/209434825"
+      "uri_apple_music": "applemusic://track/209434825",
+      "fun_fact_it": "«Qué Hay de Malo» di Jerry Rivera, pubblicata per la prima volta nel 1993 nell'album «Cara De Niño»."
     },
     {
       "year": 1992,
@@ -1214,7 +1298,8 @@
       "fun_fact_fr": "« Ese » de Jerry Rivera, parue pour la première fois en 1992.",
       "fun_fact_nl": "\"Ese\" van Jerry Rivera, voor het eerst uitgebracht in 1992.",
       "uri_deezer": "deezer://track/13213223",
-      "uri_apple_music": "applemusic://track/170127562"
+      "uri_apple_music": "applemusic://track/170127562",
+      "fun_fact_it": "«Ese» di Jerry Rivera, pubblicata per la prima volta nel 1992."
     },
     {
       "year": 1992,
@@ -1228,7 +1313,8 @@
       "fun_fact_fr": "« Casi un Hechizo » de Jerry Rivera, parue pour la première fois en 1992.",
       "fun_fact_nl": "\"Casi un Hechizo\" van Jerry Rivera, voor het eerst uitgebracht in 1992.",
       "uri_deezer": "deezer://track/13213219",
-      "uri_apple_music": "applemusic://track/192784381"
+      "uri_apple_music": "applemusic://track/192784381",
+      "fun_fact_it": "«Casi un Hechizo» di Jerry Rivera, pubblicata per la prima volta nel 1992."
     },
     {
       "year": 1993,
@@ -1242,7 +1328,8 @@
       "fun_fact_fr": "« Cara de Niño » de Jerry Rivera, parue pour la première fois en 1993 sur l'album « Leyendas: Salsa Romántica ».",
       "fun_fact_nl": "\"Cara de Niño\" van Jerry Rivera, voor het eerst uitgebracht in 1993 op het album \"Leyendas: Salsa Romántica\".",
       "uri_deezer": "deezer://track/88877239",
-      "uri_apple_music": "applemusic://track/217767192"
+      "uri_apple_music": "applemusic://track/217767192",
+      "fun_fact_it": "«Cara de Niño» di Jerry Rivera, pubblicata per la prima volta nel 1993 nell'album «Leyendas: Salsa Romántica»."
     },
     {
       "year": 2002,
@@ -1256,7 +1343,8 @@
       "fun_fact_fr": "« Vuela Muy Alto » de Jerry Rivera, parue pour la première fois en 2002 sur l'album « Vuela Muy Alto ».",
       "fun_fact_nl": "\"Vuela Muy Alto\" van Jerry Rivera, voor het eerst uitgebracht in 2002 op het album \"Vuela Muy Alto\".",
       "uri_deezer": "deezer://track/13271522",
-      "uri_apple_music": "applemusic://track/253648767"
+      "uri_apple_music": "applemusic://track/253648767",
+      "fun_fact_it": "«Vuela Muy Alto» di Jerry Rivera, pubblicata per la prima volta nel 2002 nell'album «Vuela Muy Alto»."
     },
     {
       "year": 1992,
@@ -1270,7 +1358,8 @@
       "fun_fact_fr": "« Cuenta Conmigo » de Jerry Rivera, parue pour la première fois en 1992 sur l'album « Leyendas: Salsa Romántica ».",
       "fun_fact_nl": "\"Cuenta Conmigo\" van Jerry Rivera, voor het eerst uitgebracht in 1992 op het album \"Leyendas: Salsa Romántica\".",
       "uri_deezer": "deezer://track/88877221",
-      "uri_apple_music": "applemusic://track/192784793"
+      "uri_apple_music": "applemusic://track/192784793",
+      "fun_fact_it": "«Cuenta Conmigo» di Jerry Rivera, pubblicata per la prima volta nel 1992 nell'album «Leyendas: Salsa Romántica»."
     },
     {
       "year": 1993,
@@ -1284,7 +1373,8 @@
       "fun_fact_fr": "« Mi Media Mitad » de Rey Ruiz, parue pour la première fois en 1993 sur l'album « Mis Favoritas ».",
       "fun_fact_nl": "\"Mi Media Mitad\" van Rey Ruiz, voor het eerst uitgebracht in 1993 op het album \"Mis Favoritas\".",
       "uri_deezer": "deezer://track/13099828",
-      "uri_apple_music": "applemusic://track/170979101"
+      "uri_apple_music": "applemusic://track/170979101",
+      "fun_fact_it": "«Mi Media Mitad» di Rey Ruiz, pubblicata per la prima volta nel 1993 nell'album «Mis Favoritas»."
     },
     {
       "year": 1992,
@@ -1298,7 +1388,8 @@
       "fun_fact_fr": "« No Me Acostumbro » de Rey Ruiz, parue pour la première fois en 1992 sur l'album « Mis Favoritas ».",
       "fun_fact_nl": "\"No Me Acostumbro\" van Rey Ruiz, voor het eerst uitgebracht in 1992 op het album \"Mis Favoritas\".",
       "uri_deezer": "deezer://track/13099822",
-      "uri_apple_music": "applemusic://track/170979317"
+      "uri_apple_music": "applemusic://track/170979317",
+      "fun_fact_it": "«No Me Acostumbro» di Rey Ruiz, pubblicata per la prima volta nel 1992 nell'album «Mis Favoritas»."
     },
     {
       "year": 1992,
@@ -1312,7 +1403,8 @@
       "fun_fact_fr": "« Luna Negra » de Rey Ruiz, parue pour la première fois en 1992 sur l'album « Lo Esencial ».",
       "fun_fact_nl": "\"Luna Negra\" van Rey Ruiz, voor het eerst uitgebracht in 1992 op het album \"Lo Esencial\".",
       "uri_deezer": "deezer://track/13354600",
-      "uri_apple_music": "applemusic://track/170980459"
+      "uri_apple_music": "applemusic://track/170980459",
+      "fun_fact_it": "«Luna Negra» di Rey Ruiz, pubblicata per la prima volta nel 1992 nell'album «Lo Esencial»."
     },
     {
       "year": 1992,
@@ -1326,7 +1418,8 @@
       "fun_fact_fr": "« Amiga » de Rey Ruiz, parue pour la première fois en 1992 sur l'album « Dos Clásicos ».",
       "fun_fact_nl": "\"Amiga\" van Rey Ruiz, voor het eerst uitgebracht in 1992 op het album \"Dos Clásicos\".",
       "uri_deezer": "deezer://track/10066309",
-      "uri_apple_music": "applemusic://track/170980947"
+      "uri_apple_music": "applemusic://track/170980947",
+      "fun_fact_it": "«Amiga» di Rey Ruiz, pubblicata per la prima volta nel 1992 nell'album «Dos Clásicos»."
     },
     {
       "year": 1999,
@@ -1340,7 +1433,8 @@
       "fun_fact_fr": "« Creo en el Amor » de Rey Ruiz, parue pour la première fois en 1999 sur l'album « Lo Esencial ».",
       "fun_fact_nl": "\"Creo en el Amor\" van Rey Ruiz, voor het eerst uitgebracht in 1999 op het album \"Lo Esencial\".",
       "uri_deezer": "deezer://track/13250633",
-      "uri_apple_music": "applemusic://track/192687759"
+      "uri_apple_music": "applemusic://track/192687759",
+      "fun_fact_it": "«Creo en el Amor» di Rey Ruiz, pubblicata per la prima volta nel 1999 nell'album «Lo Esencial»."
     },
     {
       "year": 1992,
@@ -1354,7 +1448,8 @@
       "fun_fact_fr": "« Si Te Preguntan » de Rey Ruiz, parue pour la première fois en 1992 sur l'album « Dos Clásicos ».",
       "fun_fact_nl": "\"Si Te Preguntan\" van Rey Ruiz, voor het eerst uitgebracht in 1992 op het album \"Dos Clásicos\".",
       "uri_deezer": "deezer://track/10066318",
-      "uri_apple_music": "applemusic://track/170980312"
+      "uri_apple_music": "applemusic://track/170980312",
+      "fun_fact_it": "«Si Te Preguntan» di Rey Ruiz, pubblicata per la prima volta nel 1992 nell'album «Dos Clásicos»."
     },
     {
       "year": 1992,
@@ -1368,7 +1463,8 @@
       "fun_fact_fr": "« Estamos Solos » de Rey Ruiz, parue pour la première fois en 1992 sur l'album « Lo Esencial ».",
       "fun_fact_nl": "\"Estamos Solos\" van Rey Ruiz, voor het eerst uitgebracht in 1992 op het album \"Lo Esencial\".",
       "uri_deezer": "deezer://track/13354602",
-      "uri_apple_music": "applemusic://track/455673011"
+      "uri_apple_music": "applemusic://track/455673011",
+      "fun_fact_it": "«Estamos Solos» di Rey Ruiz, pubblicata per la prima volta nel 1992 nell'album «Lo Esencial»."
     },
     {
       "year": 1984,
@@ -1382,7 +1478,8 @@
       "fun_fact_fr": "« Cali Pachanguero » de Grupo Niche, parue pour la première fois en 1984 sur l'album « No Hay Quinto Malo ».",
       "fun_fact_nl": "\"Cali Pachanguero\" van Grupo Niche, voor het eerst uitgebracht in 1984 op het album \"No Hay Quinto Malo\".",
       "uri_deezer": "deezer://track/87231893",
-      "uri_apple_music": "applemusic://track/1750353645"
+      "uri_apple_music": "applemusic://track/1750353645",
+      "fun_fact_it": "«Cali Pachanguero» di Grupo Niche, pubblicata per la prima volta nel 1984 nell'album «No Hay Quinto Malo»."
     },
     {
       "year": 1987,
@@ -1396,7 +1493,8 @@
       "fun_fact_fr": "« Una Aventura » de Grupo Niche, parue pour la première fois en 1987 sur l'album « Mis Favoritas ».",
       "fun_fact_nl": "\"Una Aventura\" van Grupo Niche, voor het eerst uitgebracht in 1987 op het album \"Mis Favoritas\".",
       "uri_deezer": "deezer://track/6720639",
-      "uri_apple_music": "applemusic://track/321443361"
+      "uri_apple_music": "applemusic://track/321443361",
+      "fun_fact_it": "«Una Aventura» di Grupo Niche, pubblicata per la prima volta nel 1987 nell'album «Mis Favoritas»."
     },
     {
       "year": 1990,
@@ -1410,7 +1508,8 @@
       "fun_fact_fr": "« Sin Sentimientos » de Grupo Niche, parue pour la première fois en 1990 sur l'album « The Best ».",
       "fun_fact_nl": "\"Sin Sentimientos\" van Grupo Niche, voor het eerst uitgebracht in 1990 op het album \"The Best\".",
       "uri_deezer": "deezer://track/13211932",
-      "uri_apple_music": "applemusic://track/321443791"
+      "uri_apple_music": "applemusic://track/321443791",
+      "fun_fact_it": "«Sin Sentimientos» di Grupo Niche, pubblicata per la prima volta nel 1990 nell'album «The Best»."
     },
     {
       "year": 1995,
@@ -1424,7 +1523,8 @@
       "fun_fact_fr": "« Gotas De Lluvia » de Grupo Niche, parue pour la première fois en 1995 sur l'album « Mis Favoritas ».",
       "fun_fact_nl": "\"Gotas De Lluvia\" van Grupo Niche, voor het eerst uitgebracht in 1995 op het album \"Mis Favoritas\".",
       "uri_deezer": "deezer://track/6720644",
-      "uri_apple_music": "applemusic://track/321435846"
+      "uri_apple_music": "applemusic://track/321435846",
+      "fun_fact_it": "«Gotas De Lluvia» di Grupo Niche, pubblicata per la prima volta nel 1995 nell'album «Mis Favoritas»."
     },
     {
       "year": 1991,
@@ -1438,7 +1538,8 @@
       "fun_fact_fr": "« Hagamos Lo Que Diga El Corazón » de Grupo Niche, parue pour la première fois en 1991 sur l'album « Mis Favoritas ».",
       "fun_fact_nl": "\"Hagamos Lo Que Diga El Corazón\" van Grupo Niche, voor het eerst uitgebracht in 1991 op het album \"Mis Favoritas\".",
       "uri_deezer": "deezer://track/6720641",
-      "uri_apple_music": "applemusic://track/321443353"
+      "uri_apple_music": "applemusic://track/321443353",
+      "fun_fact_it": "«Hagamos Lo Que Diga El Corazón» di Grupo Niche, pubblicata per la prima volta nel 1991 nell'album «Mis Favoritas»."
     },
     {
       "year": 1988,
@@ -1452,7 +1553,8 @@
       "fun_fact_fr": "« Se Pareció Tanto a Ti - Radio Version » de Grupo Niche, parue pour la première fois en 1988.",
       "fun_fact_nl": "\"Se Pareció Tanto a Ti - Radio Version\" van Grupo Niche, voor het eerst uitgebracht in 1988.",
       "uri_apple_music": "applemusic://track/321443761",
-      "uri_deezer": "deezer://track/13211925"
+      "uri_deezer": "deezer://track/13211925",
+      "fun_fact_it": "«Se Pareció Tanto a Ti - Radio Version» di Grupo Niche, pubblicata per la prima volta nel 1988."
     },
     {
       "year": 1990,
@@ -1466,7 +1568,8 @@
       "fun_fact_fr": "« Busca Por Dentro » de Grupo Niche, parue pour la première fois en 1990 sur l'album « The Best ».",
       "fun_fact_nl": "\"Busca Por Dentro\" van Grupo Niche, voor het eerst uitgebracht in 1990 op het album \"The Best\".",
       "uri_deezer": "deezer://track/13211933",
-      "uri_apple_music": "applemusic://track/321443858"
+      "uri_apple_music": "applemusic://track/321443858",
+      "fun_fact_it": "«Busca Por Dentro» di Grupo Niche, pubblicata per la prima volta nel 1990 nell'album «The Best»."
     },
     {
       "year": 1988,
@@ -1480,7 +1583,8 @@
       "fun_fact_fr": "« Nuestro Sueño » de Grupo Niche, parue pour la première fois en 1988 sur l'album « Mis Favoritas ».",
       "fun_fact_nl": "\"Nuestro Sueño\" van Grupo Niche, voor het eerst uitgebracht in 1988 op het album \"Mis Favoritas\".",
       "uri_deezer": "deezer://track/6720646",
-      "uri_apple_music": "applemusic://track/321443778"
+      "uri_apple_music": "applemusic://track/321443778",
+      "fun_fact_it": "«Nuestro Sueño» di Grupo Niche, pubblicata per la prima volta nel 1988 nell'album «Mis Favoritas»."
     },
     {
       "year": 1996,
@@ -1494,7 +1598,8 @@
       "fun_fact_fr": "« La Magia De Tus Besos » de Grupo Niche, parue pour la première fois en 1996 sur l'album « Siempre Una Aventura ».",
       "fun_fact_nl": "\"La Magia De Tus Besos\" van Grupo Niche, voor het eerst uitgebracht in 1996 op het album \"Siempre Una Aventura\".",
       "uri_deezer": "deezer://track/13234888",
-      "uri_apple_music": "applemusic://track/260756820"
+      "uri_apple_music": "applemusic://track/260756820",
+      "fun_fact_it": "«La Magia De Tus Besos» di Grupo Niche, pubblicata per la prima volta nel 1996 nell'album «Siempre Una Aventura»."
     },
     {
       "year": 1993,
@@ -1508,7 +1613,8 @@
       "fun_fact_fr": "« Duele Más » de Grupo Niche, parue pour la première fois en 1993 sur l'album « Mis Favoritas ».",
       "fun_fact_nl": "\"Duele Más\" van Grupo Niche, voor het eerst uitgebracht in 1993 op het album \"Mis Favoritas\".",
       "uri_deezer": "deezer://track/6720643",
-      "uri_apple_music": "applemusic://track/321443348"
+      "uri_apple_music": "applemusic://track/321443348",
+      "fun_fact_it": "«Duele Más» di Grupo Niche, pubblicata per la prima volta nel 1993 nell'album «Mis Favoritas»."
     },
     {
       "year": 1989,
@@ -1522,7 +1628,8 @@
       "fun_fact_fr": "« Como Podre Disimular » de Grupo Niche, parue pour la première fois en 1989 sur l'album « 12 Años ».",
       "fun_fact_nl": "\"Como Podre Disimular\" van Grupo Niche, voor het eerst uitgebracht in 1989 op het album \"12 Años\".",
       "uri_deezer": "deezer://track/3729415212",
-      "uri_apple_music": "applemusic://track/1862946402"
+      "uri_apple_music": "applemusic://track/1862946402",
+      "fun_fact_it": "«Como Podre Disimular» di Grupo Niche, pubblicata per la prima volta nel 1989 nell'album «12 Años»."
     },
     {
       "year": 1988,
@@ -1536,7 +1643,8 @@
       "fun_fact_fr": "« La Noche » de Joe Arroyo, La Verdad, parue pour la première fois en 1988 sur l'album « La Salsa: Identidad de un Pueblo, Vol. 4 Expresión de Inspiración ».",
       "fun_fact_nl": "\"La Noche\" van Joe Arroyo, La Verdad, voor het eerst uitgebracht in 1988 op het album \"La Salsa: Identidad de un Pueblo, Vol. 4 Expresión de Inspiración\".",
       "uri_deezer": "deezer://track/132108910",
-      "uri_apple_music": "applemusic://track/455561898"
+      "uri_apple_music": "applemusic://track/455561898",
+      "fun_fact_it": "«La Noche» di Joe Arroyo, La Verdad, pubblicata per la prima volta nel 1988 nell'album «La Salsa: Identidad de un Pueblo, Vol. 4 Expresión de Inspiración»."
     },
     {
       "year": 1981,
@@ -1550,7 +1658,8 @@
       "fun_fact_fr": "« En Barranquilla Me Quedo » de Joe Arroyo, La Verdad, parue pour la première fois en 1981.",
       "fun_fact_nl": "\"En Barranquilla Me Quedo\" van Joe Arroyo, La Verdad, voor het eerst uitgebracht in 1981.",
       "uri_deezer": "deezer://track/112972818",
-      "uri_apple_music": "applemusic://track/455561901"
+      "uri_apple_music": "applemusic://track/455561901",
+      "fun_fact_it": "«En Barranquilla Me Quedo» di Joe Arroyo, La Verdad, pubblicata per la prima volta nel 1981."
     },
     {
       "year": 1995,
@@ -1564,7 +1673,8 @@
       "fun_fact_fr": "« Tal Para Cual - de la serie Medusa, de Netflix » de Joe Arroyo, parue pour la première fois en 1995 sur l'album « Afro Latin Hitz ».",
       "fun_fact_nl": "\"Tal Para Cual - de la serie Medusa, de Netflix\" van Joe Arroyo, voor het eerst uitgebracht in 1995 op het album \"Afro Latin Hitz\".",
       "uri_deezer": "deezer://track/9437190",
-      "uri_apple_music": "applemusic://track/1784765370"
+      "uri_apple_music": "applemusic://track/1784765370",
+      "fun_fact_it": "«Tal Para Cual - de la serie Medusa, de Netflix» di Joe Arroyo, pubblicata per la prima volta nel 1995 nell'album «Afro Latin Hitz»."
     },
     {
       "year": 1990,
@@ -1578,7 +1688,8 @@
       "fun_fact_fr": "« Noche de Arreboles » de Joe Arroyo, parue pour la première fois en 1990.",
       "fun_fact_nl": "\"Noche de Arreboles\" van Joe Arroyo, voor het eerst uitgebracht in 1990.",
       "uri_deezer": "deezer://track/16403981",
-      "uri_apple_music": "applemusic://track/542053584"
+      "uri_apple_music": "applemusic://track/542053584",
+      "fun_fact_it": "«Noche de Arreboles» di Joe Arroyo, pubblicata per la prima volta nel 1990."
     },
     {
       "year": 1972,
@@ -1592,7 +1703,8 @@
       "fun_fact_fr": "« El Ausente » de Fruko Y Sus Tesos, Joe Arroyo, parue pour la première fois en 1972 sur l'album « Fruko el Bueno \"ayunando\" ».",
       "fun_fact_nl": "\"El Ausente\" van Fruko Y Sus Tesos, Joe Arroyo, voor het eerst uitgebracht in 1972 op het album \"Fruko el Bueno \"ayunando\"\".",
       "uri_deezer": "deezer://track/447088172",
-      "uri_apple_music": "applemusic://track/455561917"
+      "uri_apple_music": "applemusic://track/455561917",
+      "fun_fact_it": "«El Ausente» di Fruko Y Sus Tesos, Joe Arroyo, pubblicata per la prima volta nel 1972 nell'album «Fruko el Bueno \"ayunando\"»."
     },
     {
       "year": 2009,
@@ -1605,7 +1717,8 @@
       "fun_fact_es": "\"El Preso\" de Verschiedene Interpreten, publicada por primera vez en 2009 en el álbum \"Lo Mejor de Mexico\".",
       "fun_fact_fr": "« El Preso » de Verschiedene Interpreten, parue pour la première fois en 2009 sur l'album « Lo Mejor de Mexico ».",
       "fun_fact_nl": "\"El Preso\" van Verschiedene Interpreten, voor het eerst uitgebracht in 2009 op het album \"Lo Mejor de Mexico\".",
-      "uri_deezer": "deezer://track/5925704"
+      "uri_deezer": "deezer://track/5925704",
+      "fun_fact_it": "«El Preso» di Verschiedene Interpreten, pubblicata per la prima volta nel 2009 nell'album «Lo Mejor de Mexico»."
     },
     {
       "year": 1973,
@@ -1619,7 +1732,8 @@
       "fun_fact_fr": "« El Caminante » de Fruko Y Sus Tesos, Joe Arroyo, parue pour la première fois en 1973 sur l'album « El Caminante ».",
       "fun_fact_nl": "\"El Caminante\" van Fruko Y Sus Tesos, Joe Arroyo, voor het eerst uitgebracht in 1973 op het album \"El Caminante\".",
       "uri_deezer": "deezer://track/1352281272",
-      "uri_apple_music": "applemusic://track/455561913"
+      "uri_apple_music": "applemusic://track/455561913",
+      "fun_fact_it": "«El Caminante» di Fruko Y Sus Tesos, Joe Arroyo, pubblicata per la prima volta nel 1973 nell'album «El Caminante»."
     },
     {
       "year": 1988,
@@ -1633,7 +1747,8 @@
       "fun_fact_fr": "« Barranquillero Arrebatao » de Fruko Y Sus Tesos, Wilson \"Saoko\" Manyoma, parue pour la première fois en 1988 sur l'album « Música Tropical de Colombia, Vol. 8 ».",
       "fun_fact_nl": "\"Barranquillero Arrebatao\" van Fruko Y Sus Tesos, Wilson \"Saoko\" Manyoma, voor het eerst uitgebracht in 1988 op het album \"Música Tropical de Colombia, Vol. 8\".",
       "uri_deezer": "deezer://track/113035242",
-      "uri_apple_music": "applemusic://track/1016581600"
+      "uri_apple_music": "applemusic://track/1016581600",
+      "fun_fact_it": "«Barranquillero Arrebatao» di Fruko Y Sus Tesos, Wilson \"Saoko\" Manyoma, pubblicata per la prima volta nel 1988 nell'album «Música Tropical de Colombia, Vol. 8»."
     },
     {
       "year": 1974,
@@ -1647,7 +1762,8 @@
       "fun_fact_fr": "« Tania » de Fruko Y Sus Tesos, Joe Arroyo, parue pour la première fois en 1974 sur l'album « El Caminante ».",
       "fun_fact_nl": "\"Tania\" van Fruko Y Sus Tesos, Joe Arroyo, voor het eerst uitgebracht in 1974 op het album \"El Caminante\".",
       "uri_deezer": "deezer://track/1352281242",
-      "uri_apple_music": "applemusic://track/455561914"
+      "uri_apple_music": "applemusic://track/455561914",
+      "fun_fact_it": "«Tania» di Fruko Y Sus Tesos, Joe Arroyo, pubblicata per la prima volta nel 1974 nell'album «El Caminante»."
     },
     {
       "year": 2000,
@@ -1661,7 +1777,8 @@
       "fun_fact_fr": "« Cali de Rumba » de Fruko Y Sus Tesos, parue pour la première fois en 2000 sur l'album « Cali de Rumba Con Sabor a Salsa ».",
       "fun_fact_nl": "\"Cali de Rumba\" van Fruko Y Sus Tesos, voor het eerst uitgebracht in 2000 op het album \"Cali de Rumba Con Sabor a Salsa\".",
       "uri_deezer": "deezer://track/131108996",
-      "uri_apple_music": "applemusic://track/278850902"
+      "uri_apple_music": "applemusic://track/278850902",
+      "fun_fact_it": "«Cali de Rumba» di Fruko Y Sus Tesos, pubblicata per la prima volta nel 2000 nell'album «Cali de Rumba Con Sabor a Salsa»."
     },
     {
       "year": 1987,
@@ -1675,7 +1792,8 @@
       "fun_fact_fr": "« Charanga Campesina » de Fruko Y Sus Tesos, parue pour la première fois en 1987 sur l'album « Música Tropical de Colombia, Vol. 9 ».",
       "fun_fact_nl": "\"Charanga Campesina\" van Fruko Y Sus Tesos, voor het eerst uitgebracht in 1987 op het album \"Música Tropical de Colombia, Vol. 9\".",
       "uri_deezer": "deezer://track/113029380",
-      "uri_apple_music": "applemusic://track/1884031865"
+      "uri_apple_music": "applemusic://track/1884031865",
+      "fun_fact_it": "«Charanga Campesina» di Fruko Y Sus Tesos, pubblicata per la prima volta nel 1987 nell'album «Música Tropical de Colombia, Vol. 9»."
     },
     {
       "year": 1975,
@@ -1689,7 +1807,8 @@
       "fun_fact_fr": "« Las Caleñas Son Como Las Flores » de The Latin Brothers, parue pour la première fois en 1975 sur l'album « Narcos, Vol. 2 (More Music from the Netflix Original Series) ».",
       "fun_fact_nl": "\"Las Caleñas Son Como Las Flores\" van The Latin Brothers, voor het eerst uitgebracht in 1975 op het album \"Narcos, Vol. 2 (More Music from the Netflix Original Series)\".",
       "uri_deezer": "deezer://track/130871026",
-      "uri_apple_music": "applemusic://track/203977513"
+      "uri_apple_music": "applemusic://track/203977513",
+      "fun_fact_it": "«Las Caleñas Son Como Las Flores» di The Latin Brothers, pubblicata per la prima volta nel 1975 nell'album «Narcos, Vol. 2 (More Music from the Netflix Original Series)»."
     },
     {
       "year": 1978,
@@ -1703,7 +1822,8 @@
       "fun_fact_fr": "« Sobre Las Olas » de The Latin Brothers, parue pour la première fois en 1978 sur l'album « The Latin Brothers (2025 Remasterizado) ».",
       "fun_fact_nl": "\"Sobre Las Olas\" van The Latin Brothers, voor het eerst uitgebracht in 1978 op het album \"The Latin Brothers (2025 Remasterizado)\".",
       "uri_deezer": "deezer://track/3262851311",
-      "uri_apple_music": "applemusic://track/14948214"
+      "uri_apple_music": "applemusic://track/14948214",
+      "fun_fact_it": "«Sobre Las Olas» di The Latin Brothers, pubblicata per la prima volta nel 1978 nell'album «The Latin Brothers (2025 Remasterizado)»."
     },
     {
       "year": 1965,
@@ -1717,7 +1837,8 @@
       "fun_fact_fr": "« Dime Que Paso » de The Latin Brothers, parue pour la première fois en 1965 sur l'album « La Salsa: Identidad de un Pueblo, Vol. 5 Expresión Rumbera ».",
       "fun_fact_nl": "\"Dime Que Paso\" van The Latin Brothers, voor het eerst uitgebracht in 1965 op het album \"La Salsa: Identidad de un Pueblo, Vol. 5 Expresión Rumbera\".",
       "uri_deezer": "deezer://track/132093100",
-      "uri_apple_music": "applemusic://track/14948217"
+      "uri_apple_music": "applemusic://track/14948217",
+      "fun_fact_it": "«Dime Que Paso» di The Latin Brothers, pubblicata per la prima volta nel 1965 nell'album «La Salsa: Identidad de un Pueblo, Vol. 5 Expresión Rumbera»."
     },
     {
       "year": 1972,
@@ -1731,7 +1852,8 @@
       "fun_fact_fr": "« Buscandote » de The Latin Brothers, parue pour la première fois en 1972.",
       "fun_fact_nl": "\"Buscandote\" van The Latin Brothers, voor het eerst uitgebracht in 1972.",
       "uri_deezer": "deezer://track/389147781",
-      "uri_apple_music": "applemusic://track/1784527855"
+      "uri_apple_music": "applemusic://track/1784527855",
+      "fun_fact_it": "«Buscandote» di The Latin Brothers, pubblicata per la prima volta nel 1972."
     },
     {
       "year": 1981,
@@ -1745,7 +1867,8 @@
       "fun_fact_fr": "« Micaela » de Sonora Carruseles, Luis Florez, parue pour la première fois en 1981.",
       "fun_fact_nl": "\"Micaela\" van Sonora Carruseles, Luis Florez, voor het eerst uitgebracht in 1981.",
       "uri_deezer": "deezer://track/129506550",
-      "uri_apple_music": "applemusic://track/1052291318"
+      "uri_apple_music": "applemusic://track/1052291318",
+      "fun_fact_it": "«Micaela» di Sonora Carruseles, Luis Florez, pubblicata per la prima volta nel 1981."
     },
     {
       "year": 1998,
@@ -1759,7 +1882,8 @@
       "fun_fact_fr": "« La Comay » de Sonora Carruseles, parue pour la première fois en 1998 sur l'album « Al Son de los Cueros ».",
       "fun_fact_nl": "\"La Comay\" van Sonora Carruseles, voor het eerst uitgebracht in 1998 op het album \"Al Son de los Cueros\".",
       "uri_deezer": "deezer://track/113014916",
-      "uri_apple_music": "applemusic://track/218874432"
+      "uri_apple_music": "applemusic://track/218874432",
+      "fun_fact_it": "«La Comay» di Sonora Carruseles, pubblicata per la prima volta nel 1998 nell'album «Al Son de los Cueros»."
     },
     {
       "year": 2006,
@@ -1773,7 +1897,8 @@
       "fun_fact_fr": "« La Negra Baila Sabroso » de Sonora Carruseles, parue pour la première fois en 2006 sur l'album « Latino 55 - Salsa Bachata Merengue Reggaeton (Latin Hits) ».",
       "fun_fact_nl": "\"La Negra Baila Sabroso\" van Sonora Carruseles, voor het eerst uitgebracht in 2006 op het album \"Latino 55 - Salsa Bachata Merengue Reggaeton (Latin Hits)\".",
       "uri_deezer": "deezer://track/828361142",
-      "uri_apple_music": "applemusic://track/1052291817"
+      "uri_apple_music": "applemusic://track/1052291817",
+      "fun_fact_it": "«La Negra Baila Sabroso» di Sonora Carruseles, pubblicata per la prima volta nel 2006 nell'album «Latino 55 - Salsa Bachata Merengue Reggaeton (Latin Hits)»."
     },
     {
       "year": 2000,
@@ -1787,7 +1912,8 @@
       "fun_fact_fr": "« Mala Vida » de Yuri Buenaventura, parue pour la première fois en 2000 sur l'album « Yo Soy ».",
       "fun_fact_nl": "\"Mala Vida\" van Yuri Buenaventura, voor het eerst uitgebracht in 2000 op het album \"Yo Soy\".",
       "uri_deezer": "deezer://track/2533869",
-      "uri_apple_music": "applemusic://track/1444026581"
+      "uri_apple_music": "applemusic://track/1444026581",
+      "fun_fact_it": "«Mala Vida» di Yuri Buenaventura, pubblicata per la prima volta nel 2000 nell'album «Yo Soy»."
     },
     {
       "year": 2000,
@@ -1801,7 +1927,8 @@
       "fun_fact_fr": "« La Negra Tiene Tumbao » de Celia Cruz, parue pour la première fois en 2000 sur l'album « La Reina Y Sus Amigos ».",
       "fun_fact_nl": "\"La Negra Tiene Tumbao\" van Celia Cruz, voor het eerst uitgebracht in 2000 op het album \"La Reina Y Sus Amigos\".",
       "uri_deezer": "deezer://track/4762499",
-      "uri_apple_music": "applemusic://track/338891891"
+      "uri_apple_music": "applemusic://track/338891891",
+      "fun_fact_it": "«La Negra Tiene Tumbao» di Celia Cruz, pubblicata per la prima volta nel 2000 nell'album «La Reina Y Sus Amigos»."
     },
     {
       "year": 1964,
@@ -1815,7 +1942,8 @@
       "fun_fact_fr": "« Quizas, Quizas, Quizas, » de Celia Cruz, parue pour la première fois en 1964 sur l'album « Boleros ».",
       "fun_fact_nl": "\"Quizas, Quizas, Quizas,\" van Celia Cruz, voor het eerst uitgebracht in 1964 op het album \"Boleros\".",
       "uri_deezer": "deezer://track/687131292",
-      "uri_apple_music": "applemusic://track/1465817304"
+      "uri_apple_music": "applemusic://track/1465817304",
+      "fun_fact_it": "«Quizas, Quizas, Quizas,» di Celia Cruz, pubblicata per la prima volta nel 1964 nell'album «Boleros»."
     },
     {
       "year": 2003,
@@ -1829,7 +1957,8 @@
       "fun_fact_fr": "« Rie y Llora » de Celia Cruz, parue pour la première fois en 2003 sur l'album « Soy Mujer ».",
       "fun_fact_nl": "\"Rie y Llora\" van Celia Cruz, voor het eerst uitgebracht in 2003 op het album \"Soy Mujer\".",
       "uri_deezer": "deezer://track/88877135",
-      "uri_apple_music": "applemusic://track/168404788"
+      "uri_apple_music": "applemusic://track/168404788",
+      "fun_fact_it": "«Rie y Llora» di Celia Cruz, pubblicata per la prima volta nel 2003 nell'album «Soy Mujer»."
     },
     {
       "year": 1965,
@@ -1843,7 +1972,8 @@
       "fun_fact_fr": "« Guantanamera » de Celia Cruz, parue pour la première fois en 1965.",
       "fun_fact_nl": "\"Guantanamera\" van Celia Cruz, voor het eerst uitgebracht in 1965.",
       "uri_deezer": "deezer://track/98373878",
-      "uri_apple_music": "applemusic://track/1467841714"
+      "uri_apple_music": "applemusic://track/1467841714",
+      "fun_fact_it": "«Guantanamera» di Celia Cruz, pubblicata per la prima volta nel 1965."
     },
     {
       "year": 1972,
@@ -1857,7 +1987,8 @@
       "fun_fact_fr": "« Salsa Y Sabor » de Tito Puente, parue pour la première fois en 1972 sur l'album « Para los Rumberos ».",
       "fun_fact_nl": "\"Salsa Y Sabor\" van Tito Puente, voor het eerst uitgebracht in 1972 op het album \"Para los Rumberos\".",
       "uri_deezer": "deezer://track/688275892",
-      "uri_apple_music": "applemusic://track/1678886676"
+      "uri_apple_music": "applemusic://track/1678886676",
+      "fun_fact_it": "«Salsa Y Sabor» di Tito Puente, pubblicata per la prima volta nel 1972 nell'album «Para los Rumberos»."
     },
     {
       "year": 1964,
@@ -1871,7 +2002,8 @@
       "fun_fact_fr": "« Ran Kan Kan » de Tito Puente, parue pour la première fois en 1964 sur l'album « Mambo & Salsa Hits ».",
       "fun_fact_nl": "\"Ran Kan Kan\" van Tito Puente, voor het eerst uitgebracht in 1964 op het album \"Mambo & Salsa Hits\".",
       "uri_deezer": "deezer://track/1456124472",
-      "uri_apple_music": "applemusic://track/1464267065"
+      "uri_apple_music": "applemusic://track/1464267065",
+      "fun_fact_it": "«Ran Kan Kan» di Tito Puente, pubblicata per la prima volta nel 1964 nell'album «Mambo & Salsa Hits»."
     },
     {
       "year": 1957,
@@ -1885,7 +2017,8 @@
       "fun_fact_fr": "« Mambo Gozon » de Tito Puente, parue pour la première fois en 1957 sur l'album « Dance Mania (Legacy Edition) ».",
       "fun_fact_nl": "\"Mambo Gozon\" van Tito Puente, voor het eerst uitgebracht in 1957 op het album \"Dance Mania (Legacy Edition)\".",
       "uri_deezer": "deezer://track/3571275",
-      "uri_apple_music": "applemusic://track/570825684"
+      "uri_apple_music": "applemusic://track/570825684",
+      "fun_fact_it": "«Mambo Gozon» di Tito Puente, pubblicata per la prima volta nel 1957 nell'album «Dance Mania (Legacy Edition)»."
     },
     {
       "year": 1971,
@@ -1899,7 +2032,8 @@
       "fun_fact_fr": "« Anacaona » de Cheo Feliciano, parue pour la première fois en 1971.",
       "fun_fact_nl": "\"Anacaona\" van Cheo Feliciano, voor het eerst uitgebracht in 1971.",
       "uri_deezer": "deezer://track/2511634171",
-      "uri_apple_music": "applemusic://track/1847697427"
+      "uri_apple_music": "applemusic://track/1847697427",
+      "fun_fact_it": "«Anacaona» di Cheo Feliciano, pubblicata per la prima volta nel 1971."
     },
     {
       "year": 1980,
@@ -1913,7 +2047,8 @@
       "fun_fact_fr": "« Amada Mia » de Cheo Feliciano, parue pour la première fois en 1980 sur l'album « Romántico ».",
       "fun_fact_nl": "\"Amada Mia\" van Cheo Feliciano, voor het eerst uitgebracht in 1980 op het album \"Romántico\".",
       "uri_deezer": "deezer://track/686074322",
-      "uri_apple_music": "applemusic://track/1464284237"
+      "uri_apple_music": "applemusic://track/1464284237",
+      "fun_fact_it": "«Amada Mia» di Cheo Feliciano, pubblicata per la prima volta nel 1980 nell'album «Romántico»."
     },
     {
       "year": 1975,
@@ -1927,7 +2062,8 @@
       "fun_fact_fr": "« Cachondea » de Cheo Feliciano, parue pour la première fois en 1975 sur l'album « La Salsa, Identidad de un Pueblo - Vol. 3 Expresión del Bailador ».",
       "fun_fact_nl": "\"Cachondea\" van Cheo Feliciano, voor het eerst uitgebracht in 1975 op het album \"La Salsa, Identidad de un Pueblo - Vol. 3 Expresión del Bailador\".",
       "uri_deezer": "deezer://track/131107392",
-      "uri_apple_music": "applemusic://track/1465972653"
+      "uri_apple_music": "applemusic://track/1465972653",
+      "fun_fact_it": "«Cachondea» di Cheo Feliciano, pubblicata per la prima volta nel 1975 nell'album «La Salsa, Identidad de un Pueblo - Vol. 3 Expresión del Bailador»."
     },
     {
       "year": 2004,
@@ -1941,7 +2077,8 @@
       "fun_fact_fr": "« Tu Cariñito » de Luisito Ayala Y La Puerto Rican Power, parue pour la première fois en 2004 sur l'album « Men in Salsa ».",
       "fun_fact_nl": "\"Tu Cariñito\" van Luisito Ayala Y La Puerto Rican Power, voor het eerst uitgebracht in 2004 op het album \"Men in Salsa\".",
       "uri_deezer": "deezer://track/10963411",
-      "uri_apple_music": "applemusic://track/1791778078"
+      "uri_apple_music": "applemusic://track/1791778078",
+      "fun_fact_it": "«Tu Cariñito» di Luisito Ayala Y La Puerto Rican Power, pubblicata per la prima volta nel 2004 nell'album «Men in Salsa»."
     },
     {
       "year": 2008,
@@ -1955,7 +2092,8 @@
       "fun_fact_fr": "« Juguete De Nadie » de Luisito Ayala Y La Puerto Rican Power, parue pour la première fois en 2008.",
       "fun_fact_nl": "\"Juguete De Nadie\" van Luisito Ayala Y La Puerto Rican Power, voor het eerst uitgebracht in 2008.",
       "uri_deezer": "deezer://track/14219823",
-      "uri_apple_music": "applemusic://track/1791778082"
+      "uri_apple_music": "applemusic://track/1791778082",
+      "fun_fact_it": "«Juguete De Nadie» di Luisito Ayala Y La Puerto Rican Power, pubblicata per la prima volta nel 2008."
     },
     {
       "year": 1998,
@@ -1969,7 +2107,8 @@
       "fun_fact_fr": "« A Donde Iras » de Luisito Ayala Y La Puerto Rican Power, parue pour la première fois en 1998.",
       "fun_fact_nl": "\"A Donde Iras\" van Luisito Ayala Y La Puerto Rican Power, voor het eerst uitgebracht in 1998.",
       "uri_deezer": "deezer://track/61025739",
-      "uri_apple_music": "applemusic://track/1791778073"
+      "uri_apple_music": "applemusic://track/1791778073",
+      "fun_fact_it": "«A Donde Iras» di Luisito Ayala Y La Puerto Rican Power, pubblicata per la prima volta nel 1998."
     },
     {
       "year": 2004,
@@ -1983,7 +2122,8 @@
       "fun_fact_fr": "« Me Tiene Loco » de Luisito Ayala Y La Puerto Rican Power, parue pour la première fois en 2004.",
       "fun_fact_nl": "\"Me Tiene Loco\" van Luisito Ayala Y La Puerto Rican Power, voor het eerst uitgebracht in 2004.",
       "uri_deezer": "deezer://track/61025736",
-      "uri_apple_music": "applemusic://track/22048041"
+      "uri_apple_music": "applemusic://track/22048041",
+      "fun_fact_it": "«Me Tiene Loco» di Luisito Ayala Y La Puerto Rican Power, pubblicata per la prima volta nel 2004."
     },
     {
       "year": 2008,
@@ -1997,7 +2137,8 @@
       "fun_fact_fr": "« Pena De Amor » de Luisito Ayala Y La Puerto Rican Power, parue pour la première fois en 2008.",
       "fun_fact_nl": "\"Pena De Amor\" van Luisito Ayala Y La Puerto Rican Power, voor het eerst uitgebracht in 2008.",
       "uri_deezer": "deezer://track/14219831",
-      "uri_apple_music": "applemusic://track/22048038"
+      "uri_apple_music": "applemusic://track/22048038",
+      "fun_fact_it": "«Pena De Amor» di Luisito Ayala Y La Puerto Rican Power, pubblicata per la prima volta nel 2008."
     },
     {
       "year": 2006,
@@ -2011,7 +2152,8 @@
       "fun_fact_fr": "« Solo Con Un Beso » de Luisito Ayala Y La Puerto Rican Power, Tito Rojas, parue pour la première fois en 2006 sur l'album « Canta Tito Rojas ».",
       "fun_fact_nl": "\"Solo Con Un Beso\" van Luisito Ayala Y La Puerto Rican Power, Tito Rojas, voor het eerst uitgebracht in 2006 op het album \"Canta Tito Rojas\".",
       "uri_deezer": "deezer://track/64118622",
-      "uri_apple_music": "applemusic://track/498336880"
+      "uri_apple_music": "applemusic://track/498336880",
+      "fun_fact_it": "«Solo Con Un Beso» di Luisito Ayala Y La Puerto Rican Power, Tito Rojas, pubblicata per la prima volta nel 2006 nell'album «Canta Tito Rojas»."
     },
     {
       "year": 1990,
@@ -2025,7 +2167,8 @@
       "fun_fact_fr": "« Porque Te Amo » de Nino Segarra, parue pour la première fois en 1990.",
       "fun_fact_nl": "\"Porque Te Amo\" van Nino Segarra, voor het eerst uitgebracht in 1990.",
       "uri_deezer": "deezer://track/12018038",
-      "uri_apple_music": "applemusic://track/19923863"
+      "uri_apple_music": "applemusic://track/19923863",
+      "fun_fact_it": "«Porque Te Amo» di Nino Segarra, pubblicata per la prima volta nel 1990."
     },
     {
       "year": 2007,
@@ -2039,7 +2182,8 @@
       "fun_fact_fr": "« Nuestro Sueño » de Tito Gomez, parue pour la première fois en 2007 sur l'album « Un Legado Musical - Lo Nuevo y Lo Mejor ».",
       "fun_fact_nl": "\"Nuestro Sueño\" van Tito Gomez, voor het eerst uitgebracht in 2007 op het album \"Un Legado Musical - Lo Nuevo y Lo Mejor\".",
       "uri_deezer": "deezer://track/11146570",
-      "uri_apple_music": "applemusic://track/1711899359"
+      "uri_apple_music": "applemusic://track/1711899359",
+      "fun_fact_it": "«Nuestro Sueño» di Tito Gomez, pubblicata per la prima volta nel 2007 nell'album «Un Legado Musical - Lo Nuevo y Lo Mejor»."
     },
     {
       "year": 1988,
@@ -2053,7 +2197,8 @@
       "fun_fact_fr": "« Casi Te Envidio » de Andy Montañez, parue pour la première fois en 1988 sur l'album « Rumbo al Caribe, La Llegada de la Salsa Romántica ».",
       "fun_fact_nl": "\"Casi Te Envidio\" van Andy Montañez, voor het eerst uitgebracht in 1988 op het album \"Rumbo al Caribe, La Llegada de la Salsa Romántica\".",
       "uri_deezer": "deezer://track/123362694",
-      "uri_apple_music": "applemusic://track/1444011481"
+      "uri_apple_music": "applemusic://track/1444011481",
+      "fun_fact_it": "«Casi Te Envidio» di Andy Montañez, pubblicata per la prima volta nel 1988 nell'album «Rumbo al Caribe, La Llegada de la Salsa Romántica»."
     },
     {
       "year": 1985,
@@ -2067,7 +2212,8 @@
       "fun_fact_fr": "« Payaso » de Andy Montañez, parue pour la première fois en 1985 sur l'album « Payaso (Baile Total) ».",
       "fun_fact_nl": "\"Payaso\" van Andy Montañez, voor het eerst uitgebracht in 1985 op het album \"Payaso (Baile Total)\".",
       "uri_deezer": "deezer://track/429985712",
-      "uri_apple_music": "applemusic://track/1444011478"
+      "uri_apple_music": "applemusic://track/1444011478",
+      "fun_fact_it": "«Payaso» di Andy Montañez, pubblicata per la prima volta nel 1985 nell'album «Payaso (Baile Total)»."
     },
     {
       "year": 1997,
@@ -2081,7 +2227,8 @@
       "fun_fact_fr": "« Que Locura Enamorarme De Ti (feat. Eddie Santiago) » de Huey Dunbar, Eddie Santiago, parue pour la première fois en 1997 sur l'album « Mis Favoritas ».",
       "fun_fact_nl": "\"Que Locura Enamorarme De Ti (feat. Eddie Santiago)\" van Huey Dunbar, Eddie Santiago, voor het eerst uitgebracht in 1997 op het album \"Mis Favoritas\".",
       "uri_deezer": "deezer://track/6720615",
-      "uri_apple_music": "applemusic://track/384175510"
+      "uri_apple_music": "applemusic://track/384175510",
+      "fun_fact_it": "«Que Locura Enamorarme De Ti (feat. Eddie Santiago)» di Huey Dunbar, Eddie Santiago, pubblicata per la prima volta nel 1997 nell'album «Mis Favoritas»."
     },
     {
       "year": 1992,
@@ -2095,7 +2242,8 @@
       "fun_fact_fr": "« Ay Amor Cuando Hablan Las Miradas » de Guayacán Orquesta, parue pour la première fois en 1992.",
       "fun_fact_nl": "\"Ay Amor Cuando Hablan Las Miradas\" van Guayacán Orquesta, voor het eerst uitgebracht in 1992.",
       "uri_deezer": "deezer://track/633458082",
-      "uri_apple_music": "applemusic://track/1453085412"
+      "uri_apple_music": "applemusic://track/1453085412",
+      "fun_fact_it": "«Ay Amor Cuando Hablan Las Miradas» di Guayacán Orquesta, pubblicata per la prima volta nel 1992."
     },
     {
       "year": 1990,
@@ -2109,7 +2257,8 @@
       "fun_fact_fr": "« Invierno En Primavera » de Guayacán Orquesta, parue pour la première fois en 1990 sur l'album « 30 Años de Gala ».",
       "fun_fact_nl": "\"Invierno En Primavera\" van Guayacán Orquesta, voor het eerst uitgebracht in 1990 op het album \"30 Años de Gala\".",
       "uri_deezer": "deezer://track/2683393092",
-      "uri_apple_music": "applemusic://track/1444164161"
+      "uri_apple_music": "applemusic://track/1444164161",
+      "fun_fact_it": "«Invierno En Primavera» di Guayacán Orquesta, pubblicata per la prima volta nel 1990 nell'album «30 Años de Gala»."
     },
     {
       "year": 1990,
@@ -2123,7 +2272,8 @@
       "fun_fact_fr": "« Te Amo Te Extrano » de Guayacán Orquesta, parue pour la première fois en 1990 sur l'album « Sentimental de Punta a Punta ».",
       "fun_fact_nl": "\"Te Amo Te Extrano\" van Guayacán Orquesta, voor het eerst uitgebracht in 1990 op het album \"Sentimental de Punta a Punta\".",
       "uri_deezer": "deezer://track/2702846432",
-      "uri_apple_music": "applemusic://track/1735849205"
+      "uri_apple_music": "applemusic://track/1735849205",
+      "fun_fact_it": "«Te Amo Te Extrano» di Guayacán Orquesta, pubblicata per la prima volta nel 1990 nell'album «Sentimental de Punta a Punta»."
     },
     {
       "year": 1985,
@@ -2137,7 +2287,8 @@
       "fun_fact_fr": "« Maria Teresa y Danilo » de Hansel Y Raul, parue pour la première fois en 1985.",
       "fun_fact_nl": "\"Maria Teresa y Danilo\" van Hansel Y Raul, voor het eerst uitgebracht in 1985.",
       "uri_deezer": "deezer://track/13244918",
-      "uri_apple_music": "applemusic://track/321384223"
+      "uri_apple_music": "applemusic://track/321384223",
+      "fun_fact_it": "«Maria Teresa y Danilo» di Hansel Y Raul, pubblicata per la prima volta nel 1985."
     },
     {
       "year": 1980,
@@ -2151,7 +2302,8 @@
       "fun_fact_fr": "« Sobredosis » de Los Titanes, parue pour la première fois en 1980 sur l'album « Sobredosis de Amor - Salsa ».",
       "fun_fact_nl": "\"Sobredosis\" van Los Titanes, voor het eerst uitgebracht in 1980 op het album \"Sobredosis de Amor - Salsa\".",
       "uri_deezer": "deezer://track/4022316331",
-      "uri_apple_music": "applemusic://track/33912024"
+      "uri_apple_music": "applemusic://track/33912024",
+      "fun_fact_it": "«Sobredosis» di Los Titanes, pubblicata per la prima volta nel 1980 nell'album «Sobredosis de Amor - Salsa»."
     },
     {
       "year": 1988,
@@ -2165,7 +2317,8 @@
       "fun_fact_fr": "« Zodiaco » de Los Titanes, parue pour la première fois en 1988.",
       "fun_fact_nl": "\"Zodiaco\" van Los Titanes, voor het eerst uitgebracht in 1988.",
       "uri_deezer": "deezer://track/112972816",
-      "uri_apple_music": "applemusic://track/33911944"
+      "uri_apple_music": "applemusic://track/33911944",
+      "fun_fact_it": "«Zodiaco» di Los Titanes, pubblicata per la prima volta nel 1988."
     },
     {
       "year": 2013,
@@ -2179,7 +2332,8 @@
       "fun_fact_fr": "« Vivir Mi Vida » de Marc Anthony, parue pour la première fois en 2013 sur l'album « 3.0 ».",
       "fun_fact_nl": "\"Vivir Mi Vida\" van Marc Anthony, voor het eerst uitgebracht in 2013 op het album \"3.0\".",
       "uri_deezer": "deezer://track/68771815",
-      "uri_apple_music": "applemusic://track/668743167"
+      "uri_apple_music": "applemusic://track/668743167",
+      "fun_fact_it": "«Vivir Mi Vida» di Marc Anthony, pubblicata per la prima volta nel 2013 nell'album «3.0»."
     },
     {
       "year": 2004,
@@ -2193,7 +2347,8 @@
       "fun_fact_fr": "« Valió la Pena - Salsa Version » de Marc Anthony, parue pour la première fois en 2004 sur l'album « Valio La Pena ».",
       "fun_fact_nl": "\"Valió la Pena - Salsa Version\" van Marc Anthony, voor het eerst uitgebracht in 2004 op het album \"Valio La Pena\".",
       "uri_deezer": "deezer://track/15050441",
-      "uri_apple_music": "applemusic://track/201265571"
+      "uri_apple_music": "applemusic://track/201265571",
+      "fun_fact_it": "«Valió la Pena - Salsa Version» di Marc Anthony, pubblicata per la prima volta nel 2004 nell'album «Valio La Pena»."
     },
     {
       "year": 2004,
@@ -2207,7 +2362,8 @@
       "fun_fact_fr": "« Ahora Quien - Salsa Version » de Marc Anthony, parue pour la première fois en 2004 sur l'album « Valio La Pena ».",
       "fun_fact_nl": "\"Ahora Quien - Salsa Version\" van Marc Anthony, voor het eerst uitgebracht in 2004 op het album \"Valio La Pena\".",
       "uri_deezer": "deezer://track/15050443",
-      "uri_apple_music": "applemusic://track/1756636591"
+      "uri_apple_music": "applemusic://track/1756636591",
+      "fun_fact_it": "«Ahora Quien - Salsa Version» di Marc Anthony, pubblicata per la prima volta nel 2004 nell'album «Valio La Pena»."
     },
     {
       "year": 2013,
@@ -2221,7 +2377,8 @@
       "fun_fact_fr": "« Cambio de Piel » de Marc Anthony, parue pour la première fois en 2013 sur l'album « 3.0 ».",
       "fun_fact_nl": "\"Cambio de Piel\" van Marc Anthony, voor het eerst uitgebracht in 2013 op het album \"3.0\".",
       "uri_deezer": "deezer://track/68771818",
-      "uri_apple_music": "applemusic://track/668743492"
+      "uri_apple_music": "applemusic://track/668743492",
+      "fun_fact_it": "«Cambio de Piel» di Marc Anthony, pubblicata per la prima volta nel 2013 nell'album «3.0»."
     },
     {
       "year": 2004,
@@ -2235,7 +2392,8 @@
       "fun_fact_fr": "« Tu Amor Me Hace Bien - Salsa Version » de Marc Anthony, parue pour la première fois en 2004 sur l'album « Valio La Pena ».",
       "fun_fact_nl": "\"Tu Amor Me Hace Bien - Salsa Version\" van Marc Anthony, voor het eerst uitgebracht in 2004 op het album \"Valio La Pena\".",
       "uri_deezer": "deezer://track/15050444",
-      "uri_apple_music": "applemusic://track/163291336"
+      "uri_apple_music": "applemusic://track/163291336",
+      "fun_fact_it": "«Tu Amor Me Hace Bien - Salsa Version» di Marc Anthony, pubblicata per la prima volta nel 2004 nell'album «Valio La Pena»."
     },
     {
       "year": 1997,
@@ -2249,7 +2407,8 @@
       "fun_fact_fr": "« Aguanile » de Marc Anthony, parue pour la première fois en 1997 sur l'album « Lo Mejor de la Salsa ».",
       "fun_fact_nl": "\"Aguanile\" van Marc Anthony, voor het eerst uitgebracht in 1997 op het album \"Lo Mejor de la Salsa\".",
       "uri_deezer": "deezer://track/4036808551",
-      "uri_apple_music": "applemusic://track/653548602"
+      "uri_apple_music": "applemusic://track/653548602",
+      "fun_fact_it": "«Aguanile» di Marc Anthony, pubblicata per la prima volta nel 1997 nell'album «Lo Mejor de la Salsa»."
     },
     {
       "year": 1999,
@@ -2263,7 +2422,8 @@
       "fun_fact_fr": "« Dímelo » de Marc Anthony, parue pour la première fois en 1999 sur l'album « Sigo Siendo Yo ».",
       "fun_fact_nl": "\"Dímelo\" van Marc Anthony, voor het eerst uitgebracht in 1999 op het album \"Sigo Siendo Yo\".",
       "uri_deezer": "deezer://track/547749",
-      "uri_apple_music": "applemusic://track/191009795"
+      "uri_apple_music": "applemusic://track/191009795",
+      "fun_fact_it": "«Dímelo» di Marc Anthony, pubblicata per la prima volta nel 1999 nell'album «Sigo Siendo Yo»."
     },
     {
       "year": 1999,
@@ -2277,7 +2437,8 @@
       "fun_fact_fr": "« Como Ella Me Quiere A Mí (She's Been Good to Me) » de Marc Anthony, parue pour la première fois en 1999 sur l'album « Marc Anthony ».",
       "fun_fact_nl": "\"Como Ella Me Quiere A Mí (She's Been Good to Me)\" van Marc Anthony, voor het eerst uitgebracht in 1999 op het album \"Marc Anthony\".",
       "uri_deezer": "deezer://track/623500",
-      "uri_apple_music": "applemusic://track/191009814"
+      "uri_apple_music": "applemusic://track/191009814",
+      "fun_fact_it": "«Como Ella Me Quiere A Mí (She's Been Good to Me)» di Marc Anthony, pubblicata per la prima volta nel 1999 nell'album «Marc Anthony»."
     },
     {
       "year": 1999,
@@ -2291,7 +2452,8 @@
       "fun_fact_fr": "« Da La Vuelta » de Marc Anthony, parue pour la première fois en 1999 sur l'album « Marc Anthony ».",
       "fun_fact_nl": "\"Da La Vuelta\" van Marc Anthony, voor het eerst uitgebracht in 1999 op het album \"Marc Anthony\".",
       "uri_deezer": "deezer://track/624593",
-      "uri_apple_music": "applemusic://track/191009893"
+      "uri_apple_music": "applemusic://track/191009893",
+      "fun_fact_it": "«Da La Vuelta» di Marc Anthony, pubblicata per la prima volta nel 1999 nell'album «Marc Anthony»."
     },
     {
       "year": 2001,
@@ -2305,7 +2467,8 @@
       "fun_fact_fr": "« Celos » de Marc Anthony, parue pour la première fois en 2001 sur l'album « Sigo Siendo Yo ».",
       "fun_fact_nl": "\"Celos\" van Marc Anthony, voor het eerst uitgebracht in 2001 op het album \"Sigo Siendo Yo\".",
       "uri_deezer": "deezer://track/547753",
-      "uri_apple_music": "applemusic://track/192785611"
+      "uri_apple_music": "applemusic://track/192785611",
+      "fun_fact_it": "«Celos» di Marc Anthony, pubblicata per la prima volta nel 2001 nell'album «Sigo Siendo Yo»."
     },
     {
       "year": 2001,
@@ -2319,7 +2482,8 @@
       "fun_fact_fr": "« Barco a la Deriva » de Marc Anthony, parue pour la première fois en 2001 sur l'album « Sigo Siendo Yo ».",
       "fun_fact_nl": "\"Barco a la Deriva\" van Marc Anthony, voor het eerst uitgebracht in 2001 op het album \"Sigo Siendo Yo\".",
       "uri_deezer": "deezer://track/547755",
-      "uri_apple_music": "applemusic://track/192785720"
+      "uri_apple_music": "applemusic://track/192785720",
+      "fun_fact_it": "«Barco a la Deriva» di Marc Anthony, pubblicata per la prima volta nel 2001 nell'album «Sigo Siendo Yo»."
     },
     {
       "year": 2001,
@@ -2333,7 +2497,8 @@
       "fun_fact_fr": "« Tragedia » de Marc Anthony, parue pour la première fois en 2001 sur l'album « Sigo Siendo Yo ».",
       "fun_fact_nl": "\"Tragedia\" van Marc Anthony, voor het eerst uitgebracht in 2001 op het album \"Sigo Siendo Yo\".",
       "uri_deezer": "deezer://track/547754",
-      "uri_apple_music": "applemusic://track/163291210"
+      "uri_apple_music": "applemusic://track/163291210",
+      "fun_fact_it": "«Tragedia» di Marc Anthony, pubblicata per la prima volta nel 2001 nell'album «Sigo Siendo Yo»."
     },
     {
       "year": 2002,
@@ -2347,7 +2512,8 @@
       "fun_fact_fr": "« Me Haces Falta » de Marc Anthony, parue pour la première fois en 2002 sur l'album « Mended ».",
       "fun_fact_nl": "\"Me Haces Falta\" van Marc Anthony, voor het eerst uitgebracht in 2002 op het album \"Mended\".",
       "uri_deezer": "deezer://track/627945",
-      "uri_apple_music": "applemusic://track/217551342"
+      "uri_apple_music": "applemusic://track/217551342",
+      "fun_fact_it": "«Me Haces Falta» di Marc Anthony, pubblicata per la prima volta nel 2002 nell'album «Mended»."
     },
     {
       "year": 2010,
@@ -2361,7 +2527,8 @@
       "fun_fact_fr": "« Cuando Me Enamoro » de Enrique Iglesias, Juan Luis Guerra 4.40, parue pour la première fois en 2010 sur l'album « Euphoria (Intl 14 track version) ».",
       "fun_fact_nl": "\"Cuando Me Enamoro\" van Enrique Iglesias, Juan Luis Guerra 4.40, voor het eerst uitgebracht in 2010 op het album \"Euphoria (Intl 14 track version)\".",
       "uri_deezer": "deezer://track/6558033",
-      "uri_apple_music": "applemusic://track/1440722442"
+      "uri_apple_music": "applemusic://track/1440722442",
+      "fun_fact_it": "«Cuando Me Enamoro» di Enrique Iglesias, Juan Luis Guerra 4.40, pubblicata per la prima volta nel 2010 nell'album «Euphoria (Intl 14 track version)»."
     },
     {
       "year": 1990,
@@ -2375,7 +2542,8 @@
       "fun_fact_fr": "« La Bilirrubina - En Vivo Estadio Olímpico De República Dominicana/2012 » de Juan Luis Guerra 4.40, parue pour la première fois en 1990 sur l'album « Asondeguerra Tour (En Vivo Estadio Olímpico De República Dominicana/2012) ».",
       "fun_fact_nl": "\"La Bilirrubina - En Vivo Estadio Olímpico De República Dominicana/2012\" van Juan Luis Guerra 4.40, voor het eerst uitgebracht in 1990 op het album \"Asondeguerra Tour (En Vivo Estadio Olímpico De República Dominicana/2012)\".",
       "uri_deezer": "deezer://track/66674553",
-      "uri_apple_music": "applemusic://track/1613803375"
+      "uri_apple_music": "applemusic://track/1613803375",
+      "fun_fact_it": "«La Bilirrubina - En Vivo Estadio Olímpico De República Dominicana/2012» di Juan Luis Guerra 4.40, pubblicata per la prima volta nel 1990 nell'album «Asondeguerra Tour (En Vivo Estadio Olímpico De República Dominicana/2012)»."
     },
     {
       "year": 2004,
@@ -2389,7 +2557,8 @@
       "fun_fact_fr": "« Las Avispas » de Juan Luis Guerra 4.40, parue pour la première fois en 2004.",
       "fun_fact_nl": "\"Las Avispas\" van Juan Luis Guerra 4.40, voor het eerst uitgebracht in 2004.",
       "uri_deezer": "deezer://track/705003522",
-      "uri_apple_music": "applemusic://track/1470329883"
+      "uri_apple_music": "applemusic://track/1470329883",
+      "fun_fact_it": "«Las Avispas» di Juan Luis Guerra 4.40, pubblicata per la prima volta nel 2004."
     },
     {
       "year": 1989,
@@ -2403,7 +2572,8 @@
       "fun_fact_fr": "« Ojala Que Llueva Café » de Juan Luis Guerra 4.40, parue pour la première fois en 1989 sur l'album « Ojalá Que Llueva Café ».",
       "fun_fact_nl": "\"Ojala Que Llueva Café\" van Juan Luis Guerra 4.40, voor het eerst uitgebracht in 1989 op het album \"Ojalá Que Llueva Café\".",
       "uri_deezer": "deezer://track/1857134427",
-      "uri_apple_music": "applemusic://track/19468935"
+      "uri_apple_music": "applemusic://track/19468935",
+      "fun_fact_it": "«Ojala Que Llueva Café» di Juan Luis Guerra 4.40, pubblicata per la prima volta nel 1989 nell'album «Ojalá Que Llueva Café»."
     },
     {
       "year": 2013,
@@ -2417,7 +2587,8 @@
       "fun_fact_fr": "« Visa Para Un Sueño - Live - Estadio Olímpico De República Dominicana/2012 » de Juan Luis Guerra 4.40, parue pour la première fois en 2013 sur l'album « Asondeguerra Tour (En Vivo Estadio Olímpico De República Dominicana/2012) ».",
       "fun_fact_nl": "\"Visa Para Un Sueño - Live - Estadio Olímpico De República Dominicana/2012\" van Juan Luis Guerra 4.40, voor het eerst uitgebracht in 2013 op het album \"Asondeguerra Tour (En Vivo Estadio Olímpico De República Dominicana/2012)\".",
       "uri_deezer": "deezer://track/66674559",
-      "uri_apple_music": "applemusic://track/1831094444"
+      "uri_apple_music": "applemusic://track/1831094444",
+      "fun_fact_it": "«Visa Para Un Sueño - Live - Estadio Olímpico De República Dominicana/2012» di Juan Luis Guerra 4.40, pubblicata per la prima volta nel 2013 nell'album «Asondeguerra Tour (En Vivo Estadio Olímpico De República Dominicana/2012)»."
     },
     {
       "year": 1998,
@@ -2431,7 +2602,8 @@
       "fun_fact_fr": "« Tu Sonrisa » de Elvis Crespo, parue pour la première fois en 1998 sur l'album « Pintame ».",
       "fun_fact_nl": "\"Tu Sonrisa\" van Elvis Crespo, voor het eerst uitgebracht in 1998 op het album \"Pintame\".",
       "uri_deezer": "deezer://track/557092",
-      "uri_apple_music": "applemusic://track/187429849"
+      "uri_apple_music": "applemusic://track/187429849",
+      "fun_fact_it": "«Tu Sonrisa» di Elvis Crespo, pubblicata per la prima volta nel 1998 nell'album «Pintame»."
     },
     {
       "year": 1995,
@@ -2445,7 +2617,8 @@
       "fun_fact_fr": "« Píntame » de Elvis Crespo, parue pour la première fois en 1995 sur l'album « Pintame ».",
       "fun_fact_nl": "\"Píntame\" van Elvis Crespo, voor het eerst uitgebracht in 1995 op het album \"Pintame\".",
       "uri_deezer": "deezer://track/557079",
-      "uri_apple_music": "applemusic://track/321313238"
+      "uri_apple_music": "applemusic://track/321313238",
+      "fun_fact_it": "«Píntame» di Elvis Crespo, pubblicata per la prima volta nel 1995 nell'album «Pintame»."
     },
     {
       "year": 1998,
@@ -2459,7 +2632,8 @@
       "fun_fact_fr": "« Princesita » de Elvis Crespo, parue pour la première fois en 1998 sur l'album « Dos Clásicos ».",
       "fun_fact_nl": "\"Princesita\" van Elvis Crespo, voor het eerst uitgebracht in 1998 op het album \"Dos Clásicos\".",
       "uri_deezer": "deezer://track/10066285",
-      "uri_apple_music": "applemusic://track/187429781"
+      "uri_apple_music": "applemusic://track/187429781",
+      "fun_fact_it": "«Princesita» di Elvis Crespo, pubblicata per la prima volta nel 1998 nell'album «Dos Clásicos»."
     },
     {
       "year": 1998,
@@ -2473,7 +2647,8 @@
       "fun_fact_fr": "« Luna Llena » de Elvis Crespo, parue pour la première fois en 1998 sur l'album « Suavemente ».",
       "fun_fact_nl": "\"Luna Llena\" van Elvis Crespo, voor het eerst uitgebracht in 1998 op het album \"Suavemente\".",
       "uri_deezer": "deezer://track/13208886",
-      "uri_apple_music": "applemusic://track/187429723"
+      "uri_apple_music": "applemusic://track/187429723",
+      "fun_fact_it": "«Luna Llena» di Elvis Crespo, pubblicata per la prima volta nel 1998 nell'album «Suavemente»."
     },
     {
       "year": 1998,
@@ -2487,7 +2662,8 @@
       "fun_fact_fr": "« Suavemente » de Elvis Crespo, parue pour la première fois en 1998 sur l'album « Pintame ».",
       "fun_fact_nl": "\"Suavemente\" van Elvis Crespo, voor het eerst uitgebracht in 1998 op het album \"Pintame\".",
       "uri_deezer": "deezer://track/557093",
-      "uri_apple_music": "applemusic://track/187429633"
+      "uri_apple_music": "applemusic://track/187429633",
+      "fun_fact_it": "«Suavemente» di Elvis Crespo, pubblicata per la prima volta nel 1998 nell'album «Pintame»."
     },
     {
       "year": 1997,
@@ -2501,7 +2677,8 @@
       "fun_fact_fr": "« Procura » de ChiChi Peralta, parue pour la première fois en 1997 sur l'album « Pa' Otro La 'O ».",
       "fun_fact_nl": "\"Procura\" van ChiChi Peralta, voor het eerst uitgebracht in 1997 op het album \"Pa' Otro La 'O\".",
       "uri_deezer": "deezer://track/833443452",
-      "uri_apple_music": "applemusic://track/1389774337"
+      "uri_apple_music": "applemusic://track/1389774337",
+      "fun_fact_it": "«Procura» di ChiChi Peralta, pubblicata per la prima volta nel 1997 nell'album «Pa' Otro La 'O»."
     },
     {
       "year": 1997,
@@ -2515,7 +2692,8 @@
       "fun_fact_fr": "« Amor Narcótico » de ChiChi Peralta, parue pour la première fois en 1997 sur l'album « Pa' Otro La 'O ».",
       "fun_fact_nl": "\"Amor Narcótico\" van ChiChi Peralta, voor het eerst uitgebracht in 1997 op het album \"Pa' Otro La 'O\".",
       "uri_deezer": "deezer://track/833443392",
-      "uri_apple_music": "applemusic://track/1389774000"
+      "uri_apple_music": "applemusic://track/1389774000",
+      "fun_fact_it": "«Amor Narcótico» di ChiChi Peralta, pubblicata per la prima volta nel 1997 nell'album «Pa' Otro La 'O»."
     },
     {
       "year": 1997,
@@ -2529,7 +2707,8 @@
       "fun_fact_fr": "« La Ciguapa » de ChiChi Peralta, parue pour la première fois en 1997 sur l'album « Pa' Otro La 'O ».",
       "fun_fact_nl": "\"La Ciguapa\" van ChiChi Peralta, voor het eerst uitgebracht in 1997 op het album \"Pa' Otro La 'O\".",
       "uri_deezer": "deezer://track/833443402",
-      "uri_apple_music": "applemusic://track/1389774004"
+      "uri_apple_music": "applemusic://track/1389774004",
+      "fun_fact_it": "«La Ciguapa» di ChiChi Peralta, pubblicata per la prima volta nel 1997 nell'album «Pa' Otro La 'O»."
     },
     {
       "year": 1997,
@@ -2543,7 +2722,8 @@
       "fun_fact_fr": "« Me Enamoré » de ChiChi Peralta, parue pour la première fois en 1997 sur l'album « Pa' Otro La 'O ».",
       "fun_fact_nl": "\"Me Enamoré\" van ChiChi Peralta, voor het eerst uitgebracht in 1997 op het album \"Pa' Otro La 'O\".",
       "uri_deezer": "deezer://track/833443472",
-      "uri_apple_music": "applemusic://track/1389774345"
+      "uri_apple_music": "applemusic://track/1389774345",
+      "fun_fact_it": "«Me Enamoré» di ChiChi Peralta, pubblicata per la prima volta nel 1997 nell'album «Pa' Otro La 'O»."
     },
     {
       "year": 1997,
@@ -2557,7 +2737,8 @@
       "fun_fact_fr": "« Limón Con Sal » de ChiChi Peralta, parue pour la première fois en 1997 sur l'album « Pa' Otro La 'O ».",
       "fun_fact_nl": "\"Limón Con Sal\" van ChiChi Peralta, voor het eerst uitgebracht in 1997 op het album \"Pa' Otro La 'O\".",
       "uri_deezer": "deezer://track/833443482",
-      "uri_apple_music": "applemusic://track/1389774355"
+      "uri_apple_music": "applemusic://track/1389774355",
+      "fun_fact_it": "«Limón Con Sal» di ChiChi Peralta, pubblicata per la prima volta nel 1997 nell'album «Pa' Otro La 'O»."
     },
     {
       "year": 1999,
@@ -2571,7 +2752,8 @@
       "fun_fact_fr": "« A Puro Dolor » de Son By Four, parue pour la première fois en 1999 sur l'album « Son By 4 ».",
       "fun_fact_nl": "\"A Puro Dolor\" van Son By Four, voor het eerst uitgebracht in 1999 op het album \"Son By 4\".",
       "uri_deezer": "deezer://track/13248020",
-      "uri_apple_music": "applemusic://track/259567852"
+      "uri_apple_music": "applemusic://track/259567852",
+      "fun_fact_it": "«A Puro Dolor» di Son By Four, pubblicata per la prima volta nel 1999 nell'album «Son By 4»."
     },
     {
       "year": 2000,
@@ -2585,7 +2767,8 @@
       "fun_fact_fr": "« Pegame Tu Vicio » de Eddy Herrera, parue pour la première fois en 2000 sur l'album « Pegame Tu Vicio ».",
       "fun_fact_nl": "\"Pegame Tu Vicio\" van Eddy Herrera, voor het eerst uitgebracht in 2000 op het album \"Pegame Tu Vicio\".",
       "uri_deezer": "deezer://track/70970558",
-      "uri_apple_music": "applemusic://track/20842031"
+      "uri_apple_music": "applemusic://track/20842031",
+      "fun_fact_it": "«Pegame Tu Vicio» di Eddy Herrera, pubblicata per la prima volta nel 2000 nell'album «Pegame Tu Vicio»."
     },
     {
       "year": 2000,
@@ -2599,7 +2782,8 @@
       "fun_fact_fr": "« Tu Eres Ajena » de Eddy Herrera, parue pour la première fois en 2000.",
       "fun_fact_nl": "\"Tu Eres Ajena\" van Eddy Herrera, voor het eerst uitgebracht in 2000.",
       "uri_deezer": "deezer://track/11125329",
-      "uri_apple_music": "applemusic://track/988533917"
+      "uri_apple_music": "applemusic://track/988533917",
+      "fun_fact_it": "«Tu Eres Ajena» di Eddy Herrera, pubblicata per la prima volta nel 2000."
     },
     {
       "year": 2009,
@@ -2613,7 +2797,8 @@
       "fun_fact_fr": "« A Dormir Juntitos - Liz featuring Eddy Herrera » de Eddy Herrera, parue pour la première fois en 2009 sur l'album « Aqui Esperandote (2022 Remastered) ».",
       "fun_fact_nl": "\"A Dormir Juntitos - Liz featuring Eddy Herrera\" van Eddy Herrera, voor het eerst uitgebracht in 2009 op het album \"Aqui Esperandote (2022 Remastered)\".",
       "uri_deezer": "deezer://track/2261594037",
-      "uri_apple_music": "applemusic://track/1685522015"
+      "uri_apple_music": "applemusic://track/1685522015",
+      "fun_fact_it": "«A Dormir Juntitos - Liz featuring Eddy Herrera» di Eddy Herrera, pubblicata per la prima volta nel 2009 nell'album «Aqui Esperandote (2022 Remastered)»."
     },
     {
       "year": 2002,
@@ -2627,7 +2812,8 @@
       "fun_fact_fr": "« Un Idiota » de Eddy Herrera, parue pour la première fois en 2002 sur l'album « Para Siempre ».",
       "fun_fact_nl": "\"Un Idiota\" van Eddy Herrera, voor het eerst uitgebracht in 2002 op het album \"Para Siempre\".",
       "uri_deezer": "deezer://track/10963842",
-      "uri_apple_music": "applemusic://track/472096761"
+      "uri_apple_music": "applemusic://track/472096761",
+      "fun_fact_it": "«Un Idiota» di Eddy Herrera, pubblicata per la prima volta nel 2002 nell'album «Para Siempre»."
     },
     {
       "year": 2001,
@@ -2641,7 +2827,8 @@
       "fun_fact_fr": "« Como Llora Mi Alma » de Eddy Herrera, parue pour la première fois en 2001 sur l'album « Pégame Tu Vicio ».",
       "fun_fact_nl": "\"Como Llora Mi Alma\" van Eddy Herrera, voor het eerst uitgebracht in 2001 op het album \"Pégame Tu Vicio\".",
       "uri_deezer": "deezer://track/741113902",
-      "uri_apple_music": "applemusic://track/1478012744"
+      "uri_apple_music": "applemusic://track/1478012744",
+      "fun_fact_it": "«Como Llora Mi Alma» di Eddy Herrera, pubblicata per la prima volta nel 2001 nell'album «Pégame Tu Vicio»."
     },
     {
       "year": 2005,
@@ -2655,7 +2842,8 @@
       "fun_fact_fr": "« Como Hago » de Eddy Herrera, parue pour la première fois en 2005 sur l'album « Pégame Tu Vicio ».",
       "fun_fact_nl": "\"Como Hago\" van Eddy Herrera, voor het eerst uitgebracht in 2005 op het album \"Pégame Tu Vicio\".",
       "uri_deezer": "deezer://track/741113882",
-      "uri_apple_music": "applemusic://track/121473101"
+      "uri_apple_music": "applemusic://track/121473101",
+      "fun_fact_it": "«Como Hago» di Eddy Herrera, pubblicata per la prima volta nel 2005 nell'album «Pégame Tu Vicio»."
     },
     {
       "year": 1990,
@@ -2669,7 +2857,8 @@
       "fun_fact_fr": "« La Ventanita » de Sergio Vargas, parue pour la première fois en 1990.",
       "fun_fact_nl": "\"La Ventanita\" van Sergio Vargas, voor het eerst uitgebracht in 1990.",
       "uri_deezer": "deezer://track/13271089",
-      "uri_apple_music": "applemusic://track/304774828"
+      "uri_apple_music": "applemusic://track/304774828",
+      "fun_fact_it": "«La Ventanita» di Sergio Vargas, pubblicata per la prima volta nel 1990."
     },
     {
       "year": 1996,
@@ -2683,7 +2872,8 @@
       "fun_fact_fr": "« La Quiero A Morir/ Si Algun Dia La Vez/ Madre » de Sergio Vargas, parue pour la première fois en 1996 sur l'album « El Hombre Y Su Merengue ».",
       "fun_fact_nl": "\"La Quiero A Morir/ Si Algun Dia La Vez/ Madre\" van Sergio Vargas, voor het eerst uitgebracht in 1996 op het album \"El Hombre Y Su Merengue\".",
       "uri_deezer": "deezer://track/95527846",
-      "uri_apple_music": "applemusic://track/1521266026"
+      "uri_apple_music": "applemusic://track/1521266026",
+      "fun_fact_it": "«La Quiero A Morir/ Si Algun Dia La Vez/ Madre» di Sergio Vargas, pubblicata per la prima volta nel 1996 nell'album «El Hombre Y Su Merengue»."
     },
     {
       "year": 1993,
@@ -2697,7 +2887,8 @@
       "fun_fact_fr": "« La Pastilla » de Sergio Vargas, parue pour la première fois en 1993.",
       "fun_fact_nl": "\"La Pastilla\" van Sergio Vargas, voor het eerst uitgebracht in 1993.",
       "uri_deezer": "deezer://track/13254157",
-      "uri_apple_music": "applemusic://track/285788866"
+      "uri_apple_music": "applemusic://track/285788866",
+      "fun_fact_it": "«La Pastilla» di Sergio Vargas, pubblicata per la prima volta nel 1993."
     },
     {
       "year": 1989,
@@ -2711,7 +2902,8 @@
       "fun_fact_fr": "« Lastima de tanto amor » de Sergio Vargas, parue pour la première fois en 1989 sur l'album « Sergio Vargas en Vivo (En vivo) ».",
       "fun_fact_nl": "\"Lastima de tanto amor\" van Sergio Vargas, voor het eerst uitgebracht in 1989 op het album \"Sergio Vargas en Vivo (En vivo)\".",
       "uri_deezer": "deezer://track/2587502862",
-      "uri_apple_music": "applemusic://track/1666329413"
+      "uri_apple_music": "applemusic://track/1666329413",
+      "fun_fact_it": "«Lastima de tanto amor» di Sergio Vargas, pubblicata per la prima volta nel 1989 nell'album «Sergio Vargas en Vivo (En vivo)»."
     },
     {
       "year": 1992,
@@ -2725,7 +2917,8 @@
       "fun_fact_fr": "« Ni tu ni yo » de Sergio Vargas, parue pour la première fois en 1992.",
       "fun_fact_nl": "\"Ni tu ni yo\" van Sergio Vargas, voor het eerst uitgebracht in 1992.",
       "uri_deezer": "deezer://track/13271090",
-      "uri_apple_music": "applemusic://track/304774830"
+      "uri_apple_music": "applemusic://track/304774830",
+      "fun_fact_it": "«Ni tu ni yo» di Sergio Vargas, pubblicata per la prima volta nel 1992."
     },
     {
       "year": 1995,
@@ -2739,7 +2932,8 @@
       "fun_fact_fr": "« La Dueña del Swing » de Los Hermanos Rosario, parue pour la première fois en 1995 sur l'album « Los Dueños del Swing ».",
       "fun_fact_nl": "\"La Dueña del Swing\" van Los Hermanos Rosario, voor het eerst uitgebracht in 1995 op het album \"Los Dueños del Swing\".",
       "uri_deezer": "deezer://track/1857103157",
-      "uri_apple_music": "applemusic://track/1635180756"
+      "uri_apple_music": "applemusic://track/1635180756",
+      "fun_fact_it": "«La Dueña del Swing» di Los Hermanos Rosario, pubblicata per la prima volta nel 1995 nell'album «Los Dueños del Swing»."
     },
     {
       "year": 1990,
@@ -2753,7 +2947,8 @@
       "fun_fact_fr": "« Pecadora » de Los Hermanos Rosario, parue pour la première fois en 1990 sur l'album « El Dísco de Oro de los Hermanos Rosario ».",
       "fun_fact_nl": "\"Pecadora\" van Los Hermanos Rosario, voor het eerst uitgebracht in 1990 op het album \"El Dísco de Oro de los Hermanos Rosario\".",
       "uri_deezer": "deezer://track/136465746",
-      "uri_apple_music": "applemusic://track/1178369746"
+      "uri_apple_music": "applemusic://track/1178369746",
+      "fun_fact_it": "«Pecadora» di Los Hermanos Rosario, pubblicata per la prima volta nel 1990 nell'album «El Dísco de Oro de los Hermanos Rosario»."
     },
     {
       "year": 1985,
@@ -2767,7 +2962,8 @@
       "fun_fact_fr": "« El Baile del Perrito » de Wilfrido Vargas, parue pour la première fois en 1985 sur l'album « Itinerario ».",
       "fun_fact_nl": "\"El Baile del Perrito\" van Wilfrido Vargas, voor het eerst uitgebracht in 1985 op het album \"Itinerario\".",
       "uri_deezer": "deezer://track/599807222",
-      "uri_apple_music": "applemusic://track/1445571397"
+      "uri_apple_music": "applemusic://track/1445571397",
+      "fun_fact_it": "«El Baile del Perrito» di Wilfrido Vargas, pubblicata per la prima volta nel 1985 nell'album «Itinerario»."
     },
     {
       "year": 1980,
@@ -2781,7 +2977,8 @@
       "fun_fact_fr": "« Abusadora » de Wilfrido Vargas, parue pour la première fois en 1980 sur l'album « Abusadora…! ».",
       "fun_fact_nl": "\"Abusadora\" van Wilfrido Vargas, voor het eerst uitgebracht in 1980 op het album \"Abusadora…!\".",
       "uri_deezer": "deezer://track/1857091827",
-      "uri_apple_music": "applemusic://track/304776748"
+      "uri_apple_music": "applemusic://track/304776748",
+      "fun_fact_it": "«Abusadora» di Wilfrido Vargas, pubblicata per la prima volta nel 1980 nell'album «Abusadora…!»."
     },
     {
       "year": 1983,
@@ -2795,7 +2992,8 @@
       "fun_fact_fr": "« El Africano » de Wilfrido Vargas, parue pour la première fois en 1983 sur l'album « Juntos ».",
       "fun_fact_nl": "\"El Africano\" van Wilfrido Vargas, voor het eerst uitgebracht in 1983 op het album \"Juntos\".",
       "uri_deezer": "deezer://track/13248477",
-      "uri_apple_music": "applemusic://track/304776750"
+      "uri_apple_music": "applemusic://track/304776750",
+      "fun_fact_it": "«El Africano» di Wilfrido Vargas, pubblicata per la prima volta nel 1983 nell'album «Juntos»."
     },
     {
       "year": 1987,
@@ -2809,7 +3007,8 @@
       "fun_fact_fr": "« A Mover la Colita » de Wilfrido Vargas, parue pour la première fois en 1987 sur l'album « Wilfrido Vargas y Sus Consentidas ».",
       "fun_fact_nl": "\"A Mover la Colita\" van Wilfrido Vargas, voor het eerst uitgebracht in 1987 op het album \"Wilfrido Vargas y Sus Consentidas\".",
       "uri_deezer": "deezer://track/611640762",
-      "uri_apple_music": "applemusic://track/1447684181"
+      "uri_apple_music": "applemusic://track/1447684181",
+      "fun_fact_it": "«A Mover la Colita» di Wilfrido Vargas, pubblicata per la prima volta nel 1987 nell'album «Wilfrido Vargas y Sus Consentidas»."
     },
     {
       "year": 1980,
@@ -2823,7 +3022,8 @@
       "fun_fact_fr": "« Volveré » de Wilfrido Vargas, parue pour la première fois en 1980.",
       "fun_fact_nl": "\"Volveré\" van Wilfrido Vargas, voor het eerst uitgebracht in 1980.",
       "uri_deezer": "deezer://track/13270389",
-      "uri_apple_music": "applemusic://track/304776751"
+      "uri_apple_music": "applemusic://track/304776751",
+      "fun_fact_it": "«Volveré» di Wilfrido Vargas, pubblicata per la prima volta nel 1980."
     },
     {
       "year": 1980,
@@ -2837,7 +3037,8 @@
       "fun_fact_fr": "« El Hombre Divertido » de Wilfrido Vargas, parue pour la première fois en 1980.",
       "fun_fact_nl": "\"El Hombre Divertido\" van Wilfrido Vargas, voor het eerst uitgebracht in 1980.",
       "uri_deezer": "deezer://track/13270383",
-      "uri_apple_music": "applemusic://track/1526575215"
+      "uri_apple_music": "applemusic://track/1526575215",
+      "fun_fact_it": "«El Hombre Divertido» di Wilfrido Vargas, pubblicata per la prima volta nel 1980."
     },
     {
       "year": 2000,
@@ -2851,7 +3052,8 @@
       "fun_fact_fr": "« Ella es Tan Bella » de Rikarena, parue pour la première fois en 2000 sur l'album « Con Arena Nueva ».",
       "fun_fact_nl": "\"Ella es Tan Bella\" van Rikarena, voor het eerst uitgebracht in 2000 op het album \"Con Arena Nueva\".",
       "uri_deezer": "deezer://track/11139454",
-      "uri_apple_music": "applemusic://track/284800794"
+      "uri_apple_music": "applemusic://track/284800794",
+      "fun_fact_it": "«Ella es Tan Bella» di Rikarena, pubblicata per la prima volta nel 2000 nell'album «Con Arena Nueva»."
     },
     {
       "year": 1997,
@@ -2865,7 +3067,8 @@
       "fun_fact_fr": "« Era Mentira » de Rikarena, parue pour la première fois en 1997 sur l'album « Sin Medir Distancia ».",
       "fun_fact_nl": "\"Era Mentira\" van Rikarena, voor het eerst uitgebracht in 1997 op het album \"Sin Medir Distancia\".",
       "uri_deezer": "deezer://track/11532593",
-      "uri_apple_music": "applemusic://track/20845235"
+      "uri_apple_music": "applemusic://track/20845235",
+      "fun_fact_it": "«Era Mentira» di Rikarena, pubblicata per la prima volta nel 1997 nell'album «Sin Medir Distancia»."
     },
     {
       "year": 1997,
@@ -2879,7 +3082,8 @@
       "fun_fact_fr": "« No Puedo Olvidarla » de Rikarena, parue pour la première fois en 1997.",
       "fun_fact_nl": "\"No Puedo Olvidarla\" van Rikarena, voor het eerst uitgebracht in 1997.",
       "uri_deezer": "deezer://track/10963132",
-      "uri_apple_music": "applemusic://track/284800669"
+      "uri_apple_music": "applemusic://track/284800669",
+      "fun_fact_it": "«No Puedo Olvidarla» di Rikarena, pubblicata per la prima volta nel 1997."
     },
     {
       "year": 1995,
@@ -2893,7 +3097,8 @@
       "fun_fact_fr": "« Te Voy Hacer Falta » de Rikarena, parue pour la première fois en 1995.",
       "fun_fact_nl": "\"Te Voy Hacer Falta\" van Rikarena, voor het eerst uitgebracht in 1995.",
       "uri_deezer": "deezer://track/10963138",
-      "uri_apple_music": "applemusic://track/284800693"
+      "uri_apple_music": "applemusic://track/284800693",
+      "fun_fact_it": "«Te Voy Hacer Falta» di Rikarena, pubblicata per la prima volta nel 1995."
     },
     {
       "year": 2000,
@@ -2907,7 +3112,8 @@
       "fun_fact_fr": "« Cuando El Amor Se Daña » de Rikarena, parue pour la première fois en 2000.",
       "fun_fact_nl": "\"Cuando El Amor Se Daña\" van Rikarena, voor het eerst uitgebracht in 2000.",
       "uri_deezer": "deezer://track/10963135",
-      "uri_apple_music": "applemusic://track/284800767"
+      "uri_apple_music": "applemusic://track/284800767",
+      "fun_fact_it": "«Cuando El Amor Se Daña» di Rikarena, pubblicata per la prima volta nel 2000."
     },
     {
       "year": 1994,
@@ -2921,7 +3127,8 @@
       "fun_fact_fr": "« Ay! » de Rikarena, parue pour la première fois en 1994.",
       "fun_fact_nl": "\"Ay!\" van Rikarena, voor het eerst uitgebracht in 1994.",
       "uri_deezer": "deezer://track/10963130",
-      "uri_apple_music": "applemusic://track/21274571"
+      "uri_apple_music": "applemusic://track/21274571",
+      "fun_fact_it": "«Ay!» di Rikarena, pubblicata per la prima volta nel 1994."
     },
     {
       "year": 1997,
@@ -2934,7 +3141,8 @@
       "fun_fact_es": "\"El Gorila\" de Rikarena, publicada por primera vez en 1997 en el álbum \"Sin Medir Distancia\".",
       "fun_fact_fr": "« El Gorila » de Rikarena, parue pour la première fois en 1997 sur l'album « Sin Medir Distancia ».",
       "fun_fact_nl": "\"El Gorila\" van Rikarena, voor het eerst uitgebracht in 1997 op het album \"Sin Medir Distancia\".",
-      "uri_deezer": "deezer://track/11532596"
+      "uri_deezer": "deezer://track/11532596",
+      "fun_fact_it": "«El Gorila» di Rikarena, pubblicata per la prima volta nel 1997 nell'album «Sin Medir Distancia»."
     },
     {
       "year": 2015,
@@ -2948,7 +3156,8 @@
       "fun_fact_fr": "« Beautiful Lady » de Proyecto Uno, parue pour la première fois en 2015 sur l'album « Beautiful Lady ».",
       "fun_fact_nl": "\"Beautiful Lady\" van Proyecto Uno, voor het eerst uitgebracht in 2015 op het album \"Beautiful Lady\".",
       "uri_deezer": "deezer://track/104374848",
-      "uri_apple_music": "applemusic://track/1020827881"
+      "uri_apple_music": "applemusic://track/1020827881",
+      "fun_fact_it": "«Beautiful Lady» di Proyecto Uno, pubblicata per la prima volta nel 2015 nell'album «Beautiful Lady»."
     },
     {
       "year": 1996,
@@ -2962,7 +3171,8 @@
       "fun_fact_fr": "« Latinos » de Proyecto Uno, parue pour la première fois en 1996 sur l'album « Latinos ».",
       "fun_fact_nl": "\"Latinos\" van Proyecto Uno, voor het eerst uitgebracht in 1996 op het album \"Latinos\".",
       "uri_deezer": "deezer://track/11513249",
-      "uri_apple_music": "applemusic://track/276705636"
+      "uri_apple_music": "applemusic://track/276705636",
+      "fun_fact_it": "«Latinos» di Proyecto Uno, pubblicata per la prima volta nel 1996 nell'album «Latinos»."
     },
     {
       "year": 1993,
@@ -2976,7 +3186,8 @@
       "fun_fact_fr": "« Esta Pegao » de Proyecto Uno, parue pour la première fois en 1993 sur l'album « In Da House ».",
       "fun_fact_nl": "\"Esta Pegao\" van Proyecto Uno, voor het eerst uitgebracht in 1993 op het album \"In Da House\".",
       "uri_deezer": "deezer://track/60991517",
-      "uri_apple_music": "applemusic://track/525133203"
+      "uri_apple_music": "applemusic://track/525133203",
+      "fun_fact_it": "«Esta Pegao» di Proyecto Uno, pubblicata per la prima volta nel 1993 nell'album «In Da House»."
     },
     {
       "year": 1999,
@@ -2990,7 +3201,8 @@
       "fun_fact_fr": "« 25 Horas » de Proyecto Uno, parue pour la première fois en 1999 sur l'album « 25 Horas ».",
       "fun_fact_nl": "\"25 Horas\" van Proyecto Uno, voor het eerst uitgebracht in 1999 op het album \"25 Horas\".",
       "uri_deezer": "deezer://track/79125923",
-      "uri_apple_music": "applemusic://track/885035099"
+      "uri_apple_music": "applemusic://track/885035099",
+      "fun_fact_it": "«25 Horas» di Proyecto Uno, pubblicata per la prima volta nel 1999 nell'album «25 Horas»."
     },
     {
       "year": 1993,
@@ -3004,7 +3216,8 @@
       "fun_fact_fr": "« Another Night » de Proyecto Uno, parue pour la première fois en 1993.",
       "fun_fact_nl": "\"Another Night\" van Proyecto Uno, voor het eerst uitgebracht in 1993.",
       "uri_deezer": "deezer://track/11135906",
-      "uri_apple_music": "applemusic://track/20845962"
+      "uri_apple_music": "applemusic://track/20845962",
+      "fun_fact_it": "«Another Night» di Proyecto Uno, pubblicata per la prima volta nel 1993."
     },
     {
       "year": 1996,
@@ -3018,7 +3231,8 @@
       "fun_fact_fr": "« Pumpin' » de Proyecto Uno, parue pour la première fois en 1996 sur l'album « New Era ».",
       "fun_fact_nl": "\"Pumpin'\" van Proyecto Uno, voor het eerst uitgebracht in 1996 op het album \"New Era\".",
       "uri_deezer": "deezer://track/10984119",
-      "uri_apple_music": "applemusic://track/276705367"
+      "uri_apple_music": "applemusic://track/276705367",
+      "fun_fact_it": "«Pumpin'» di Proyecto Uno, pubblicata per la prima volta nel 1996 nell'album «New Era»."
     },
     {
       "year": 1996,
@@ -3032,7 +3246,8 @@
       "fun_fact_fr": "« El Grillero » de Proyecto Uno, parue pour la première fois en 1996 sur l'album « New Era ».",
       "fun_fact_nl": "\"El Grillero\" van Proyecto Uno, voor het eerst uitgebracht in 1996 op het album \"New Era\".",
       "uri_deezer": "deezer://track/10984125",
-      "uri_apple_music": "applemusic://track/276705709"
+      "uri_apple_music": "applemusic://track/276705709",
+      "fun_fact_it": "«El Grillero» di Proyecto Uno, pubblicata per la prima volta nel 1996 nell'album «New Era»."
     },
     {
       "year": 1991,
@@ -3046,7 +3261,8 @@
       "fun_fact_fr": "« Brinca » de Proyecto Uno, parue pour la première fois en 1991.",
       "fun_fact_nl": "\"Brinca\" van Proyecto Uno, voor het eerst uitgebracht in 1991.",
       "uri_deezer": "deezer://track/120138458",
-      "uri_apple_music": "applemusic://track/451881068"
+      "uri_apple_music": "applemusic://track/451881068",
+      "fun_fact_it": "«Brinca» di Proyecto Uno, pubblicata per la prima volta nel 1991."
     },
     {
       "year": 1996,
@@ -3060,7 +3276,8 @@
       "fun_fact_fr": "« Cuarto De Hotel » de Proyecto Uno, parue pour la première fois en 1996 sur l'album « New Era ».",
       "fun_fact_nl": "\"Cuarto De Hotel\" van Proyecto Uno, voor het eerst uitgebracht in 1996 op het album \"New Era\".",
       "uri_deezer": "deezer://track/10984126",
-      "uri_apple_music": "applemusic://track/276705736"
+      "uri_apple_music": "applemusic://track/276705736",
+      "fun_fact_it": "«Cuarto De Hotel» di Proyecto Uno, pubblicata per la prima volta nel 1996 nell'album «New Era»."
     },
     {
       "year": 1993,
@@ -3074,7 +3291,8 @@
       "fun_fact_fr": "« Tiburon » de Proyecto Uno, parue pour la première fois en 1993 sur l'album « El Poder de la Música ».",
       "fun_fact_nl": "\"Tiburon\" van Proyecto Uno, voor het eerst uitgebracht in 1993 op het album \"El Poder de la Música\".",
       "uri_deezer": "deezer://track/11126567",
-      "uri_apple_music": "applemusic://track/451881067"
+      "uri_apple_music": "applemusic://track/451881067",
+      "fun_fact_it": "«Tiburon» di Proyecto Uno, pubblicata per la prima volta nel 1993 nell'album «El Poder de la Música»."
     },
     {
       "year": 1999,
@@ -3088,7 +3306,8 @@
       "fun_fact_fr": "« No me Digas Que No » de La Makina, parue pour la première fois en 1999.",
       "fun_fact_nl": "\"No me Digas Que No\" van La Makina, voor het eerst uitgebracht in 1999.",
       "uri_deezer": "deezer://track/10963920",
-      "uri_apple_music": "applemusic://track/48698608"
+      "uri_apple_music": "applemusic://track/48698608",
+      "fun_fact_it": "«No me Digas Que No» di La Makina, pubblicata per la prima volta nel 1999."
     },
     {
       "year": 1997,
@@ -3102,7 +3321,8 @@
       "fun_fact_fr": "« Nadie Se Muere » de La Makina, parue pour la première fois en 1997.",
       "fun_fact_nl": "\"Nadie Se Muere\" van La Makina, voor het eerst uitgebracht in 1997.",
       "uri_deezer": "deezer://track/10963918",
-      "uri_apple_music": "applemusic://track/27064166"
+      "uri_apple_music": "applemusic://track/27064166",
+      "fun_fact_it": "«Nadie Se Muere» di La Makina, pubblicata per la prima volta nel 1997."
     },
     {
       "year": 1996,
@@ -3116,7 +3336,8 @@
       "fun_fact_fr": "« Mi Reina » de La Makina, parue pour la première fois en 1996 sur l'album « Uniquehits ».",
       "fun_fact_nl": "\"Mi Reina\" van La Makina, voor het eerst uitgebracht in 1996 op het album \"Uniquehits\".",
       "uri_deezer": "deezer://track/90471541",
-      "uri_apple_music": "applemusic://track/20845916"
+      "uri_apple_music": "applemusic://track/20845916",
+      "fun_fact_it": "«Mi Reina» di La Makina, pubblicata per la prima volta nel 1996 nell'album «Uniquehits»."
     },
     {
       "year": 2001,
@@ -3130,7 +3351,8 @@
       "fun_fact_fr": "« Me rompio El Corazon » de La Makina, parue pour la première fois en 2001.",
       "fun_fact_nl": "\"Me rompio El Corazon\" van La Makina, voor het eerst uitgebracht in 2001.",
       "uri_deezer": "deezer://track/11485709",
-      "uri_apple_music": "applemusic://track/27064239"
+      "uri_apple_music": "applemusic://track/27064239",
+      "fun_fact_it": "«Me rompio El Corazon» di La Makina, pubblicata per la prima volta nel 2001."
     },
     {
       "year": 1996,
@@ -3144,7 +3366,8 @@
       "fun_fact_fr": "« Tu Muere Aqui » de La Banda Gorda, parue pour la première fois en 1996 sur l'album « Tu Muere Aqui ».",
       "fun_fact_nl": "\"Tu Muere Aqui\" van La Banda Gorda, voor het eerst uitgebracht in 1996 op het album \"Tu Muere Aqui\".",
       "uri_deezer": "deezer://track/63627119",
-      "uri_apple_music": "applemusic://track/64822788"
+      "uri_apple_music": "applemusic://track/64822788",
+      "fun_fact_it": "«Tu Muere Aqui» di La Banda Gorda, pubblicata per la prima volta nel 1996 nell'album «Tu Muere Aqui»."
     },
     {
       "year": 1995,
@@ -3158,7 +3381,8 @@
       "fun_fact_fr": "« Candela Pura » de La Banda Gorda, parue pour la première fois en 1995 sur l'album « Candela Pura ».",
       "fun_fact_nl": "\"Candela Pura\" van La Banda Gorda, voor het eerst uitgebracht in 1995 op het album \"Candela Pura\".",
       "uri_deezer": "deezer://track/12018080",
-      "uri_apple_music": "applemusic://track/1232763357"
+      "uri_apple_music": "applemusic://track/1232763357",
+      "fun_fact_it": "«Candela Pura» di La Banda Gorda, pubblicata per la prima volta nel 1995 nell'album «Candela Pura»."
     },
     {
       "year": 1996,
@@ -3172,7 +3396,8 @@
       "fun_fact_fr": "« El Rey Del Mambo » de La Banda Gorda, parue pour la première fois en 1996 sur l'album « Tu Muere Aqui ».",
       "fun_fact_nl": "\"El Rey Del Mambo\" van La Banda Gorda, voor het eerst uitgebracht in 1996 op het album \"Tu Muere Aqui\".",
       "uri_deezer": "deezer://track/63627118",
-      "uri_apple_music": "applemusic://track/288157925"
+      "uri_apple_music": "applemusic://track/288157925",
+      "fun_fact_it": "«El Rey Del Mambo» di La Banda Gorda, pubblicata per la prima volta nel 1996 nell'album «Tu Muere Aqui»."
     },
     {
       "year": 1997,
@@ -3186,7 +3411,8 @@
       "fun_fact_fr": "« Me Miras y Te Miro » de Grupo Mania, parue pour la première fois en 1997 sur l'album « 20th Anniversary ».",
       "fun_fact_nl": "\"Me Miras y Te Miro\" van Grupo Mania, voor het eerst uitgebracht in 1997 op het album \"20th Anniversary\".",
       "uri_deezer": "deezer://track/13258242",
-      "uri_apple_music": "applemusic://track/1443201379"
+      "uri_apple_music": "applemusic://track/1443201379",
+      "fun_fact_it": "«Me Miras y Te Miro» di Grupo Mania, pubblicata per la prima volta nel 1997 nell'album «20th Anniversary»."
     },
     {
       "year": 1996,
@@ -3200,7 +3426,8 @@
       "fun_fact_fr": "« Linda Eh » de Grupo Mania, parue pour la première fois en 1996.",
       "fun_fact_nl": "\"Linda Eh\" van Grupo Mania, voor het eerst uitgebracht in 1996.",
       "uri_deezer": "deezer://track/13211607",
-      "uri_apple_music": "applemusic://track/251534643"
+      "uri_apple_music": "applemusic://track/251534643",
+      "fun_fact_it": "«Linda Eh» di Grupo Mania, pubblicata per la prima volta nel 1996."
     },
     {
       "year": 1992,
@@ -3214,7 +3441,8 @@
       "fun_fact_fr": "« Hacer El Amor Con Otro » de Las Chicas Del Can, parue pour la première fois en 1992 sur l'album « Explosivo ».",
       "fun_fact_nl": "\"Hacer El Amor Con Otro\" van Las Chicas Del Can, voor het eerst uitgebracht in 1992 op het album \"Explosivo\".",
       "uri_deezer": "deezer://track/89965263",
-      "uri_apple_music": "applemusic://track/939120994"
+      "uri_apple_music": "applemusic://track/939120994",
+      "fun_fact_it": "«Hacer El Amor Con Otro» di Las Chicas Del Can, pubblicata per la prima volta nel 1992 nell'album «Explosivo»."
     },
     {
       "year": 1997,
@@ -3228,7 +3456,8 @@
       "fun_fact_fr": "« El Cepillo » de Fulanito, parue pour la première fois en 1997.",
       "fun_fact_nl": "\"El Cepillo\" van Fulanito, voor het eerst uitgebracht in 1997.",
       "uri_deezer": "deezer://track/11873532",
-      "uri_apple_music": "applemusic://track/276693211"
+      "uri_apple_music": "applemusic://track/276693211",
+      "fun_fact_it": "«El Cepillo» di Fulanito, pubblicata per la prima volta nel 1997."
     },
     {
       "year": 1997,
@@ -3242,7 +3471,8 @@
       "fun_fact_fr": "« Guallando » de Fulanito, parue pour la première fois en 1997 sur l'album « El Hombre Mas Famoso De La Tierra ».",
       "fun_fact_nl": "\"Guallando\" van Fulanito, voor het eerst uitgebracht in 1997 op het album \"El Hombre Mas Famoso De La Tierra\".",
       "uri_deezer": "deezer://track/11671201",
-      "uri_apple_music": "applemusic://track/4312096"
+      "uri_apple_music": "applemusic://track/4312096",
+      "fun_fact_it": "«Guallando» di Fulanito, pubblicata per la prima volta nel 1997 nell'album «El Hombre Mas Famoso De La Tierra»."
     },
     {
       "year": 2008,
@@ -3256,7 +3486,8 @@
       "fun_fact_fr": "« Pena Por Ti (La Novela) » de Fulanito, parue pour la première fois en 2008.",
       "fun_fact_nl": "\"Pena Por Ti (La Novela)\" van Fulanito, voor het eerst uitgebracht in 2008.",
       "uri_deezer": "deezer://track/11873533",
-      "uri_apple_music": "applemusic://track/276693212"
+      "uri_apple_music": "applemusic://track/276693212",
+      "fun_fact_it": "«Pena Por Ti (La Novela)» di Fulanito, pubblicata per la prima volta nel 2008."
     },
     {
       "year": 2001,
@@ -3270,7 +3501,8 @@
       "fun_fact_fr": "« Callate » de Fulanito, parue pour la première fois en 2001.",
       "fun_fact_nl": "\"Callate\" van Fulanito, voor het eerst uitgebracht in 2001.",
       "uri_deezer": "deezer://track/11873538",
-      "uri_apple_music": "applemusic://track/276693244"
+      "uri_apple_music": "applemusic://track/276693244",
+      "fun_fact_it": "«Callate» di Fulanito, pubblicata per la prima volta nel 2001."
     },
     {
       "year": 2001,
@@ -3284,7 +3516,8 @@
       "fun_fact_fr": "« Pecho a Pechuga » de Fulanito, parue pour la première fois en 2001 sur l'album « Americanizao ».",
       "fun_fact_nl": "\"Pecho a Pechuga\" van Fulanito, voor het eerst uitgebracht in 2001 op het album \"Americanizao\".",
       "uri_deezer": "deezer://track/11671256",
-      "uri_apple_music": "applemusic://track/276693240"
+      "uri_apple_music": "applemusic://track/276693240",
+      "fun_fact_it": "«Pecho a Pechuga» di Fulanito, pubblicata per la prima volta nel 2001 nell'album «Americanizao»."
     },
     {
       "year": 1999,
@@ -3298,7 +3531,8 @@
       "fun_fact_fr": "« Quien Es Fulanito » de Fulanito, parue pour la première fois en 1999.",
       "fun_fact_nl": "\"Quien Es Fulanito\" van Fulanito, voor het eerst uitgebracht in 1999.",
       "uri_deezer": "deezer://track/11873535",
-      "uri_apple_music": "applemusic://track/41978675"
+      "uri_apple_music": "applemusic://track/41978675",
+      "fun_fact_it": "«Quien Es Fulanito» di Fulanito, pubblicata per la prima volta nel 1999."
     },
     {
       "year": 1999,
@@ -3312,7 +3546,8 @@
       "fun_fact_fr": "« La Vaca » de Mala Fe, parue pour la première fois en 1999 sur l'album « Con Su Loquera ».",
       "fun_fact_nl": "\"La Vaca\" van Mala Fe, voor het eerst uitgebracht in 1999 op het album \"Con Su Loquera\".",
       "uri_deezer": "deezer://track/10848438",
-      "uri_apple_music": "applemusic://track/21483663"
+      "uri_apple_music": "applemusic://track/21483663",
+      "fun_fact_it": "«La Vaca» di Mala Fe, pubblicata per la prima volta nel 1999 nell'album «Con Su Loquera»."
     },
     {
       "year": 2001,
@@ -3326,7 +3561,8 @@
       "fun_fact_fr": "« Tra Tra » de Mala Fe, parue pour la première fois en 2001 sur l'album « La Vaca ».",
       "fun_fact_nl": "\"Tra Tra\" van Mala Fe, voor het eerst uitgebracht in 2001 op het album \"La Vaca\".",
       "uri_deezer": "deezer://track/700897472",
-      "uri_apple_music": "applemusic://track/450201025"
+      "uri_apple_music": "applemusic://track/450201025",
+      "fun_fact_it": "«Tra Tra» di Mala Fe, pubblicata per la prima volta nel 2001 nell'album «La Vaca»."
     },
     {
       "year": 1999,
@@ -3340,7 +3576,8 @@
       "fun_fact_fr": "« Me Recoje Tu Maleta » de Mala Fe, parue pour la première fois en 1999 sur l'album « La Vaca ».",
       "fun_fact_nl": "\"Me Recoje Tu Maleta\" van Mala Fe, voor het eerst uitgebracht in 1999 op het album \"La Vaca\".",
       "uri_deezer": "deezer://track/700897562",
-      "uri_apple_music": "applemusic://track/21483716"
+      "uri_apple_music": "applemusic://track/21483716",
+      "fun_fact_it": "«Me Recoje Tu Maleta» di Mala Fe, pubblicata per la prima volta nel 1999 nell'album «La Vaca»."
     },
     {
       "year": 1994,
@@ -3354,7 +3591,8 @@
       "fun_fact_fr": "« Mueve Mueve - I Like to Move It » de Sandy & Papo, parue pour la première fois en 1994 sur l'album « Sandy & Papo MC ».",
       "fun_fact_nl": "\"Mueve Mueve - I Like to Move It\" van Sandy & Papo, voor het eerst uitgebracht in 1994 op het album \"Sandy & Papo MC\".",
       "uri_deezer": "deezer://track/7878493",
-      "uri_apple_music": "applemusic://track/20384907"
+      "uri_apple_music": "applemusic://track/20384907",
+      "fun_fact_it": "«Mueve Mueve - I Like to Move It» di Sandy & Papo, pubblicata per la prima volta nel 1994 nell'album «Sandy & Papo MC»."
     },
     {
       "year": 1995,
@@ -3368,7 +3606,8 @@
       "fun_fact_fr": "« La Hora De Bailar » de Sandy & Papo, parue pour la première fois en 1995 sur l'album « Sandy & Papo MC ».",
       "fun_fact_nl": "\"La Hora De Bailar\" van Sandy & Papo, voor het eerst uitgebracht in 1995 op het album \"Sandy & Papo MC\".",
       "uri_deezer": "deezer://track/7878496",
-      "uri_apple_music": "applemusic://track/1517909588"
+      "uri_apple_music": "applemusic://track/1517909588",
+      "fun_fact_it": "«La Hora De Bailar» di Sandy & Papo, pubblicata per la prima volta nel 1995 nell'album «Sandy & Papo MC»."
     },
     {
       "year": 1995,
@@ -3382,7 +3621,8 @@
       "fun_fact_fr": "« Bueno Pa' Goza » de Sandy & Papo, parue pour la première fois en 1995 sur l'album « Sandy & Papo MC ».",
       "fun_fact_nl": "\"Bueno Pa' Goza\" van Sandy & Papo, voor het eerst uitgebracht in 1995 op het album \"Sandy & Papo MC\".",
       "uri_deezer": "deezer://track/7878498",
-      "uri_apple_music": "applemusic://track/1517909107"
+      "uri_apple_music": "applemusic://track/1517909107",
+      "fun_fact_it": "«Bueno Pa' Goza» di Sandy & Papo, pubblicata per la prima volta nel 1995 nell'album «Sandy & Papo MC»."
     },
     {
       "year": 1995,
@@ -3396,7 +3636,8 @@
       "fun_fact_fr": "« El Alacrán » de Sandy & Papo, parue pour la première fois en 1995 sur l'album « Otra Vez ».",
       "fun_fact_nl": "\"El Alacrán\" van Sandy & Papo, voor het eerst uitgebracht in 1995 op het album \"Otra Vez\".",
       "uri_deezer": "deezer://track/7878391",
-      "uri_apple_music": "applemusic://track/1539193700"
+      "uri_apple_music": "applemusic://track/1539193700",
+      "fun_fact_it": "«El Alacrán» di Sandy & Papo, pubblicata per la prima volta nel 1995 nell'album «Otra Vez»."
     },
     {
       "year": 1995,
@@ -3410,7 +3651,8 @@
       "fun_fact_fr": "« La Chica Sexy » de Sandy & Papo, parue pour la première fois en 1995 sur l'album « Sandy & Papo MC ».",
       "fun_fact_nl": "\"La Chica Sexy\" van Sandy & Papo, voor het eerst uitgebracht in 1995 op het album \"Sandy & Papo MC\".",
       "uri_deezer": "deezer://track/7878494",
-      "uri_apple_music": "applemusic://track/1539193931"
+      "uri_apple_music": "applemusic://track/1539193931",
+      "fun_fact_it": "«La Chica Sexy» di Sandy & Papo, pubblicata per la prima volta nel 1995 nell'album «Sandy & Papo MC»."
     },
     {
       "year": 1997,
@@ -3424,7 +3666,8 @@
       "fun_fact_fr": "« Huelepega » de Sandy & Papo, parue pour la première fois en 1997 sur l'album « Otra Vez ».",
       "fun_fact_nl": "\"Huelepega\" van Sandy & Papo, voor het eerst uitgebracht in 1997 op het album \"Otra Vez\".",
       "uri_deezer": "deezer://track/7878396",
-      "uri_apple_music": "applemusic://track/20714622"
+      "uri_apple_music": "applemusic://track/20714622",
+      "fun_fact_it": "«Huelepega» di Sandy & Papo, pubblicata per la prima volta nel 1997 nell'album «Otra Vez»."
     },
     {
       "year": 1995,
@@ -3438,7 +3681,8 @@
       "fun_fact_fr": "« Candela » de Sandy & Papo, parue pour la première fois en 1995 sur l'album « Sandy & Papo MC ».",
       "fun_fact_nl": "\"Candela\" van Sandy & Papo, voor het eerst uitgebracht in 1995 op het album \"Sandy & Papo MC\".",
       "uri_deezer": "deezer://track/7878495",
-      "uri_apple_music": "applemusic://track/20384914"
+      "uri_apple_music": "applemusic://track/20384914",
+      "fun_fact_it": "«Candela» di Sandy & Papo, pubblicata per la prima volta nel 1995 nell'album «Sandy & Papo MC»."
     },
     {
       "year": 1997,
@@ -3452,7 +3696,8 @@
       "fun_fact_fr": "« La Fiesta » de Sandy & Papo, parue pour la première fois en 1997 sur l'album « Otra Vez ».",
       "fun_fact_nl": "\"La Fiesta\" van Sandy & Papo, voor het eerst uitgebracht in 1997 op het album \"Otra Vez\".",
       "uri_deezer": "deezer://track/7878390",
-      "uri_apple_music": "applemusic://track/20714585"
+      "uri_apple_music": "applemusic://track/20714585",
+      "fun_fact_it": "«La Fiesta» di Sandy & Papo, pubblicata per la prima volta nel 1997 nell'album «Otra Vez»."
     },
     {
       "year": 2013,
@@ -3466,7 +3711,8 @@
       "fun_fact_fr": "« Chucuchá » de Ilegales, parue pour la première fois en 2013 sur l'album « Chucuchá ».",
       "fun_fact_nl": "\"Chucuchá\" van Ilegales, voor het eerst uitgebracht in 2013 op het album \"Chucuchá\".",
       "uri_deezer": "deezer://track/77096658",
-      "uri_apple_music": "applemusic://track/853045193"
+      "uri_apple_music": "applemusic://track/853045193",
+      "fun_fact_it": "«Chucuchá» di Ilegales, pubblicata per la prima volta nel 2013 nell'album «Chucuchá»."
     },
     {
       "year": 1997,
@@ -3480,7 +3726,8 @@
       "fun_fact_fr": "« Como Un Trueno » de Ilegales, parue pour la première fois en 1997 sur l'album « Rebotando ».",
       "fun_fact_nl": "\"Como Un Trueno\" van Ilegales, voor het eerst uitgebracht in 1997 op het album \"Rebotando\".",
       "uri_deezer": "deezer://track/13239356",
-      "uri_apple_music": "applemusic://track/298515055"
+      "uri_apple_music": "applemusic://track/298515055",
+      "fun_fact_it": "«Como Un Trueno» di Ilegales, pubblicata per la prima volta nel 1997 nell'album «Rebotando»."
     },
     {
       "year": 2001,
@@ -3494,7 +3741,8 @@
       "fun_fact_fr": "« Tu Recuerdo » de Ilegales, parue pour la première fois en 2001 sur l'album « On Time ».",
       "fun_fact_nl": "\"Tu Recuerdo\" van Ilegales, voor het eerst uitgebracht in 2001 op het album \"On Time\".",
       "uri_deezer": "deezer://track/13243473",
-      "uri_apple_music": "applemusic://track/254425721"
+      "uri_apple_music": "applemusic://track/254425721",
+      "fun_fact_it": "«Tu Recuerdo» di Ilegales, pubblicata per la prima volta nel 2001 nell'album «On Time»."
     },
     {
       "year": 1990,
@@ -3508,7 +3756,8 @@
       "fun_fact_fr": "« La Morena » de Ilegales, parue pour la première fois en 1990 sur l'album « Hits ».",
       "fun_fact_nl": "\"La Morena\" van Ilegales, voor het eerst uitgebracht in 1990 op het album \"Hits\".",
       "uri_deezer": "deezer://track/966378",
-      "uri_apple_music": "applemusic://track/268460488"
+      "uri_apple_music": "applemusic://track/268460488",
+      "fun_fact_it": "«La Morena» di Ilegales, pubblicata per la prima volta nel 1990 nell'album «Hits»."
     },
     {
       "year": 1995,
@@ -3522,7 +3771,8 @@
       "fun_fact_fr": "« Fiesta Caliente » de Ilegales, parue pour la première fois en 1995 sur l'album « Mis Favoritas ».",
       "fun_fact_nl": "\"Fiesta Caliente\" van Ilegales, voor het eerst uitgebracht in 1995 op het album \"Mis Favoritas\".",
       "uri_deezer": "deezer://track/6237279",
-      "uri_apple_music": "applemusic://track/298515073"
+      "uri_apple_music": "applemusic://track/298515073",
+      "fun_fact_it": "«Fiesta Caliente» di Ilegales, pubblicata per la prima volta nel 1995 nell'album «Mis Favoritas»."
     },
     {
       "year": 1998,
@@ -3536,7 +3786,8 @@
       "fun_fact_fr": "« La Bomba » de Azul Azul, parue pour la première fois en 1998 sur l'album « La Bomba ».",
       "fun_fact_nl": "\"La Bomba\" van Azul Azul, voor het eerst uitgebracht in 1998 op het album \"La Bomba\".",
       "uri_deezer": "deezer://track/15839179",
-      "uri_apple_music": "applemusic://track/574008989"
+      "uri_apple_music": "applemusic://track/574008989",
+      "fun_fact_it": "«La Bomba» di Azul Azul, pubblicata per la prima volta nel 1998 nell'album «La Bomba»."
     },
     {
       "year": 1994,
@@ -3550,7 +3801,8 @@
       "fun_fact_fr": "« Rica y Apretadita (feat. Anayka) » de El General, Anayka, parue pour la première fois en 1994 sur l'album « Originales ».",
       "fun_fact_nl": "\"Rica y Apretadita (feat. Anayka)\" van El General, Anayka, voor het eerst uitgebracht in 1994 op het album \"Originales\".",
       "uri_deezer": "deezer://track/13247121",
-      "uri_apple_music": "applemusic://track/1460608788"
+      "uri_apple_music": "applemusic://track/1460608788",
+      "fun_fact_it": "«Rica y Apretadita (feat. Anayka)» di El General, Anayka, pubblicata per la prima volta nel 1994 nell'album «Originales»."
     },
     {
       "year": 1991,
@@ -3563,7 +3815,8 @@
       "fun_fact_es": "\"Tu Pun Pun\" de El General, publicada por primera vez en 1991 en el álbum \"Estas Buena\".",
       "fun_fact_fr": "\"Tu Pun Pun\" de El General, sortie pour la première fois en 1991 sur l'album \"Estas Buena\".",
       "fun_fact_nl": "\"Tu Pun Pun\" van El General, voor het eerst uitgebracht in 1991 op het album \"Estas Buena\".",
-      "uri_deezer": "deezer://track/11897729"
+      "uri_deezer": "deezer://track/11897729",
+      "fun_fact_it": "«Tu Pun Pun» di El General, pubblicata per la prima volta nel 1991 nell'album «Estas Buena»."
     },
     {
       "year": 1991,
@@ -3577,7 +3830,8 @@
       "fun_fact_fr": "« Muévelo » de El General, parue pour la première fois en 1991 sur l'album « Originales ».",
       "fun_fact_nl": "\"Muévelo\" van El General, voor het eerst uitgebracht in 1991 op het album \"Originales\".",
       "uri_deezer": "deezer://track/13247122",
-      "uri_apple_music": "applemusic://track/254577710"
+      "uri_apple_music": "applemusic://track/254577710",
+      "fun_fact_it": "«Muévelo» di El General, pubblicata per la prima volta nel 1991 nell'album «Originales»."
     },
     {
       "year": 1996,
@@ -3591,7 +3845,8 @@
       "fun_fact_fr": "« Mis Ojos Lloran Por Ti » de Big Boy, Angel Lopez, parue pour la première fois en 1996 sur l'album « Mis Ojos Lloran Por Ti ».",
       "fun_fact_nl": "\"Mis Ojos Lloran Por Ti\" van Big Boy, Angel Lopez, voor het eerst uitgebracht in 1996 op het album \"Mis Ojos Lloran Por Ti\".",
       "uri_deezer": "deezer://track/12018109",
-      "uri_apple_music": "applemusic://track/1371029820"
+      "uri_apple_music": "applemusic://track/1371029820",
+      "fun_fact_it": "«Mis Ojos Lloran Por Ti» di Big Boy, Angel Lopez, pubblicata per la prima volta nel 1996 nell'album «Mis Ojos Lloran Por Ti»."
     },
     {
       "year": 1996,
@@ -3605,7 +3860,8 @@
       "fun_fact_fr": "« Voz Sensual » de Big Boy, parue pour la première fois en 1996 sur l'album « Mis Ojos Lloran Por Ti ».",
       "fun_fact_nl": "\"Voz Sensual\" van Big Boy, voor het eerst uitgebracht in 1996 op het album \"Mis Ojos Lloran Por Ti\".",
       "uri_deezer": "deezer://track/12018103",
-      "uri_apple_music": "applemusic://track/346026420"
+      "uri_apple_music": "applemusic://track/346026420",
+      "fun_fact_it": "«Voz Sensual» di Big Boy, pubblicata per la prima volta nel 1996 nell'album «Mis Ojos Lloran Por Ti»."
     },
     {
       "year": 1994,
@@ -3619,7 +3875,8 @@
       "fun_fact_fr": "« Ese Hombre » de LA INDIA, parue pour la première fois en 1994 sur l'album « Ese Hombre (Baile Total) ».",
       "fun_fact_nl": "\"Ese Hombre\" van LA INDIA, voor het eerst uitgebracht in 1994 op het album \"Ese Hombre (Baile Total)\".",
       "uri_deezer": "deezer://track/429988082",
-      "uri_apple_music": "applemusic://track/1443757013"
+      "uri_apple_music": "applemusic://track/1443757013",
+      "fun_fact_it": "«Ese Hombre» di LA INDIA, pubblicata per la prima volta nel 1994 nell'album «Ese Hombre (Baile Total)»."
     },
     {
       "year": 2000,
@@ -3633,7 +3890,8 @@
       "fun_fact_fr": "« Celia's Oye Cómo Va (Oye Cómo Va) » de Celia Cruz, LA INDIA, parue pour la première fois en 2000 sur l'album « La Reina Y Sus Amigos ».",
       "fun_fact_nl": "\"Celia's Oye Cómo Va (Oye Cómo Va)\" van Celia Cruz, LA INDIA, voor het eerst uitgebracht in 2000 op het album \"La Reina Y Sus Amigos\".",
       "uri_deezer": "deezer://track/4762493",
-      "uri_apple_music": "applemusic://track/338891804"
+      "uri_apple_music": "applemusic://track/338891804",
+      "fun_fact_it": "«Celia's Oye Cómo Va (Oye Cómo Va)» di Celia Cruz, LA INDIA, pubblicata per la prima volta nel 2000 nell'album «La Reina Y Sus Amigos»."
     },
     {
       "year": 1994,
@@ -3647,7 +3905,8 @@
       "fun_fact_fr": "« Nunca Voy A Olvidarte » de LA INDIA, parue pour la première fois en 1994 sur l'album « Pura Salsa ».",
       "fun_fact_nl": "\"Nunca Voy A Olvidarte\" van LA INDIA, voor het eerst uitgebracht in 1994 op het album \"Pura Salsa\".",
       "uri_deezer": "deezer://track/15508091",
-      "uri_apple_music": "applemusic://track/1444083248"
+      "uri_apple_music": "applemusic://track/1444083248",
+      "fun_fact_it": "«Nunca Voy A Olvidarte» di LA INDIA, pubblicata per la prima volta nel 1994 nell'album «Pura Salsa»."
     },
     {
       "year": 1993,
@@ -3661,7 +3920,8 @@
       "fun_fact_fr": "« Vivir Lo Nuestro » de LA INDIA, Marc Anthony, parue pour la première fois en 1993 sur l'album « Ese Hombre (Baile Total) ».",
       "fun_fact_nl": "\"Vivir Lo Nuestro\" van LA INDIA, Marc Anthony, voor het eerst uitgebracht in 1993 op het album \"Ese Hombre (Baile Total)\".",
       "uri_deezer": "deezer://track/429988092",
-      "uri_apple_music": "applemusic://track/1444083786"
+      "uri_apple_music": "applemusic://track/1444083786",
+      "fun_fact_it": "«Vivir Lo Nuestro» di LA INDIA, Marc Anthony, pubblicata per la prima volta nel 1993 nell'album «Ese Hombre (Baile Total)»."
     },
     {
       "year": 2011,
@@ -3675,7 +3935,8 @@
       "fun_fact_fr": "« Si Entendieras » de Alex Matos, parue pour la première fois en 2011 sur l'album « El Salsero De Ahora ».",
       "fun_fact_nl": "\"Si Entendieras\" van Alex Matos, voor het eerst uitgebracht in 2011 op het album \"El Salsero De Ahora\".",
       "uri_deezer": "deezer://track/63509504",
-      "uri_apple_music": "applemusic://track/511981638"
+      "uri_apple_music": "applemusic://track/511981638",
+      "fun_fact_it": "«Si Entendieras» di Alex Matos, pubblicata per la prima volta nel 2011 nell'album «El Salsero De Ahora»."
     },
     {
       "year": 1997,
@@ -3689,7 +3950,8 @@
       "fun_fact_fr": "« La Quiero A Morir » de DLG, parue pour la première fois en 1997 sur l'album « Lo Esencial ».",
       "fun_fact_nl": "\"La Quiero A Morir\" van DLG, voor het eerst uitgebracht in 1997 op het album \"Lo Esencial\".",
       "uri_deezer": "deezer://track/13182317",
-      "uri_apple_music": "applemusic://track/159869333"
+      "uri_apple_music": "applemusic://track/159869333",
+      "fun_fact_it": "«La Quiero A Morir» di DLG, pubblicata per la prima volta nel 1997 nell'album «Lo Esencial»."
     },
     {
       "year": 1997,
@@ -3703,7 +3965,8 @@
       "fun_fact_fr": "« Juliana » de DLG, parue pour la première fois en 1997 sur l'album « Mis Favoritas ».",
       "fun_fact_nl": "\"Juliana\" van DLG, voor het eerst uitgebracht in 1997 op het album \"Mis Favoritas\".",
       "uri_deezer": "deezer://track/6720610",
-      "uri_apple_music": "applemusic://track/257766007"
+      "uri_apple_music": "applemusic://track/257766007",
+      "fun_fact_it": "«Juliana» di DLG, pubblicata per la prima volta nel 1997 nell'album «Mis Favoritas»."
     },
     {
       "year": 1995,
@@ -3717,7 +3980,8 @@
       "fun_fact_fr": "« No Morirá - No Matter What » de DLG, parue pour la première fois en 1995 sur l'album « Canciones De Amor... En Salsa ».",
       "fun_fact_nl": "\"No Morirá - No Matter What\" van DLG, voor het eerst uitgebracht in 1995 op het album \"Canciones De Amor... En Salsa\".",
       "uri_deezer": "deezer://track/63353119",
-      "uri_apple_music": "applemusic://track/384175504"
+      "uri_apple_music": "applemusic://track/384175504",
+      "fun_fact_it": "«No Morirá - No Matter What» di DLG, pubblicata per la prima volta nel 1995 nell'album «Canciones De Amor... En Salsa»."
     },
     {
       "year": 1999,
@@ -3731,7 +3995,8 @@
       "fun_fact_fr": "« Volvere » de DLG, parue pour la première fois en 1999 sur l'album « Lo Esencial ».",
       "fun_fact_nl": "\"Volvere\" van DLG, voor het eerst uitgebracht in 1999 op het album \"Lo Esencial\".",
       "uri_deezer": "deezer://track/13182318",
-      "uri_apple_music": "applemusic://track/321424453"
+      "uri_apple_music": "applemusic://track/321424453",
+      "fun_fact_it": "«Volvere» di DLG, pubblicata per la prima volta nel 1999 nell'album «Lo Esencial»."
     },
     {
       "year": 1999,
@@ -3745,7 +4010,8 @@
       "fun_fact_fr": "« Acuyuye » de DLG, parue pour la première fois en 1999 sur l'album « Lo Esencial ».",
       "fun_fact_nl": "\"Acuyuye\" van DLG, voor het eerst uitgebracht in 1999 op het album \"Lo Esencial\".",
       "uri_deezer": "deezer://track/13182322",
-      "uri_apple_music": "applemusic://track/321424567"
+      "uri_apple_music": "applemusic://track/321424567",
+      "fun_fact_it": "«Acuyuye» di DLG, pubblicata per la prima volta nel 1999 nell'album «Lo Esencial»."
     },
     {
       "year": 1997,
@@ -3759,7 +4025,8 @@
       "fun_fact_fr": "« Magdalena, Mi Amor (Quimbara) » de DLG, parue pour la première fois en 1997 sur l'album « Swing On ».",
       "fun_fact_nl": "\"Magdalena, Mi Amor (Quimbara)\" van DLG, voor het eerst uitgebracht in 1997 op het album \"Swing On\".",
       "uri_deezer": "deezer://track/72189846",
-      "uri_apple_music": "applemusic://track/159869477"
+      "uri_apple_music": "applemusic://track/159869477",
+      "fun_fact_it": "«Magdalena, Mi Amor (Quimbara)» di DLG, pubblicata per la prima volta nel 1997 nell'album «Swing On»."
     },
     {
       "year": 1996,
@@ -3773,7 +4040,8 @@
       "fun_fact_fr": "« Muevete » de DLG, parue pour la première fois en 1996 sur l'album « Lo Esencial ».",
       "fun_fact_nl": "\"Muevete\" van DLG, voor het eerst uitgebracht in 1996 op het album \"Lo Esencial\".",
       "uri_deezer": "deezer://track/13182325",
-      "uri_apple_music": "applemusic://track/159869373"
+      "uri_apple_music": "applemusic://track/159869373",
+      "fun_fact_it": "«Muevete» di DLG, pubblicata per la prima volta nel 1996 nell'album «Lo Esencial»."
     },
     {
       "year": 2011,
@@ -3787,7 +4055,8 @@
       "fun_fact_fr": "« Si Tú Me Besas » de Víctor Manuelle, parue pour la première fois en 2011 sur l'album « Si Tú Me Besas ».",
       "fun_fact_nl": "\"Si Tú Me Besas\" van Víctor Manuelle, voor het eerst uitgebracht in 2011 op het album \"Si Tú Me Besas\".",
       "uri_deezer": "deezer://track/14847589",
-      "uri_apple_music": "applemusic://track/486982721"
+      "uri_apple_music": "applemusic://track/486982721",
+      "fun_fact_it": "«Si Tú Me Besas» di Víctor Manuelle, pubblicata per la prima volta nel 2011 nell'album «Si Tú Me Besas»."
     },
     {
       "year": 2012,
@@ -3801,7 +4070,8 @@
       "fun_fact_fr": "« En El Cielo No Hay Hospital » de Juan Luis Guerra 4.40, parue pour la première fois en 2012.",
       "fun_fact_nl": "\"En El Cielo No Hay Hospital\" van Juan Luis Guerra 4.40, voor het eerst uitgebracht in 2012.",
       "uri_deezer": "deezer://track/705003542",
-      "uri_apple_music": "applemusic://track/1470329795"
+      "uri_apple_music": "applemusic://track/1470329795",
+      "fun_fact_it": "«En El Cielo No Hay Hospital» di Juan Luis Guerra 4.40, pubblicata per la prima volta nel 2012."
     },
     {
       "year": 1979,
@@ -3815,7 +4085,8 @@
       "fun_fact_fr": "« Brujeria » de El Gran Combo De Puerto Rico, parue pour la première fois en 1979 sur l'album « En Vivo Desde el Bronx Ny ».",
       "fun_fact_nl": "\"Brujeria\" van El Gran Combo De Puerto Rico, voor het eerst uitgebracht in 1979 op het album \"En Vivo Desde el Bronx Ny\".",
       "uri_deezer": "deezer://track/2365877045",
-      "uri_apple_music": "applemusic://track/280795362"
+      "uri_apple_music": "applemusic://track/280795362",
+      "fun_fact_it": "«Brujeria» di El Gran Combo De Puerto Rico, pubblicata per la prima volta nel 1979 nell'album «En Vivo Desde el Bronx Ny»."
     },
     {
       "year": 1982,
@@ -3829,7 +4100,8 @@
       "fun_fact_fr": "« La Muerte » de El Gran Combo De Puerto Rico, parue pour la première fois en 1982 sur l'album « 45 Years of Music- From the Beginning (1962-2007) ».",
       "fun_fact_nl": "\"La Muerte\" van El Gran Combo De Puerto Rico, voor het eerst uitgebracht in 1982 op het album \"45 Years of Music- From the Beginning (1962-2007)\".",
       "uri_deezer": "deezer://track/63361321",
-      "uri_apple_music": "applemusic://track/416808736"
+      "uri_apple_music": "applemusic://track/416808736",
+      "fun_fact_it": "«La Muerte» di El Gran Combo De Puerto Rico, pubblicata per la prima volta nel 1982 nell'album «45 Years of Music- From the Beginning (1962-2007)»."
     },
     {
       "year": 1974,
@@ -3843,7 +4115,8 @@
       "fun_fact_fr": "« Quimbara » de Celia Cruz, Johnny Pacheco, parue pour la première fois en 1974 sur l'album « Salsa Party, Vol. 2 ».",
       "fun_fact_nl": "\"Quimbara\" van Celia Cruz, Johnny Pacheco, voor het eerst uitgebracht in 1974 op het album \"Salsa Party, Vol. 2\".",
       "uri_deezer": "deezer://track/686082732",
-      "uri_apple_music": "applemusic://track/1769530331"
+      "uri_apple_music": "applemusic://track/1769530331",
+      "fun_fact_it": "«Quimbara» di Celia Cruz, Johnny Pacheco, pubblicata per la prima volta nel 1974 nell'album «Salsa Party, Vol. 2»."
     },
     {
       "year": 1999,
@@ -3857,7 +4130,8 @@
       "fun_fact_fr": "« Estás Enamorada » de Limi-T 21, parue pour la première fois en 1999 sur l'album « Limi-T 21 Para Siempre Live! ».",
       "fun_fact_nl": "\"Estás Enamorada\" van Limi-T 21, voor het eerst uitgebracht in 1999 op het album \"Limi-T 21 Para Siempre Live!\".",
       "uri_deezer": "deezer://track/2702317022",
-      "uri_apple_music": "applemusic://track/1443856072"
+      "uri_apple_music": "applemusic://track/1443856072",
+      "fun_fact_it": "«Estás Enamorada» di Limi-T 21, pubblicata per la prima volta nel 1999 nell'album «Limi-T 21 Para Siempre Live!»."
     },
     {
       "year": 2012,
@@ -3871,7 +4145,8 @@
       "fun_fact_fr": "« Ella Lo Que Quiere Es Salsa (feat. Voltio & Jowell y Randy) » de Víctor Manuelle, Voltio, Jowell & Randy, parue pour la première fois en 2012 sur l'album « Ella Lo Que Quiere Es Salsa (feat. Voltio & Jowell y Randy) ».",
       "fun_fact_nl": "\"Ella Lo Que Quiere Es Salsa (feat. Voltio & Jowell y Randy)\" van Víctor Manuelle, Voltio, Jowell & Randy, voor het eerst uitgebracht in 2012 op het album \"Ella Lo Que Quiere Es Salsa (feat. Voltio & Jowell y Randy)\".",
       "uri_deezer": "deezer://track/17479944",
-      "uri_apple_music": "applemusic://track/486982724"
+      "uri_apple_music": "applemusic://track/486982724",
+      "fun_fact_it": "«Ella Lo Que Quiere Es Salsa (feat. Voltio & Jowell y Randy)» di Víctor Manuelle, Voltio, Jowell & Randy, pubblicata per la prima volta nel 2012 nell'album «Ella Lo Que Quiere Es Salsa (feat. Voltio & Jowell y Randy)»."
     },
     {
       "year": 1998,
@@ -3885,7 +4160,8 @@
       "fun_fact_fr": "« La Vida Es Un Carnaval » de Celia Cruz, parue pour la première fois en 1998 sur l'album « La Vida Es Un Carnaval (Baile Total) ».",
       "fun_fact_nl": "\"La Vida Es Un Carnaval\" van Celia Cruz, voor het eerst uitgebracht in 1998 op het album \"La Vida Es Un Carnaval (Baile Total)\".",
       "uri_deezer": "deezer://track/429989292",
-      "uri_apple_music": "applemusic://track/1445663595"
+      "uri_apple_music": "applemusic://track/1445663595",
+      "fun_fact_it": "«La Vida Es Un Carnaval» di Celia Cruz, pubblicata per la prima volta nel 1998 nell'album «La Vida Es Un Carnaval (Baile Total)»."
     },
     {
       "year": 2008,
@@ -3899,7 +4175,8 @@
       "fun_fact_fr": "« Ella Menea » de NG2, parue pour la première fois en 2008.",
       "fun_fact_nl": "\"Ella Menea\" van NG2, voor het eerst uitgebracht in 2008.",
       "uri_deezer": "deezer://track/5104565",
-      "uri_apple_music": "applemusic://track/1599153720"
+      "uri_apple_music": "applemusic://track/1599153720",
+      "fun_fact_it": "«Ella Menea» di NG2, pubblicata per la prima volta nel 2008."
     },
     {
       "year": 2007,
@@ -3913,7 +4190,8 @@
       "fun_fact_fr": "« La Travesia » de Juan Luis Guerra 4.40, parue pour la première fois en 2007 sur l'album « La Llave De Mi Corazon ».",
       "fun_fact_nl": "\"La Travesia\" van Juan Luis Guerra 4.40, voor het eerst uitgebracht in 2007 op het album \"La Llave De Mi Corazon\".",
       "uri_deezer": "deezer://track/3355948",
-      "uri_apple_music": "applemusic://track/714621812"
+      "uri_apple_music": "applemusic://track/714621812",
+      "fun_fact_it": "«La Travesia» di Juan Luis Guerra 4.40, pubblicata per la prima volta nel 2007 nell'album «La Llave De Mi Corazon»."
     },
     {
       "year": 2015,
@@ -3927,7 +4205,8 @@
       "fun_fact_fr": "« Desde el Día en Que te Fuiste (Version Salsa) (feat. Gilberto Santa Rosa) » de ChocQuibTown, Gilberto Santa Rosa, parue pour la première fois en 2015 sur l'album « Desde el Día en Que te Fuiste (Version Salsa) (feat. Gilberto Santa Rosa) ».",
       "fun_fact_nl": "\"Desde el Día en Que te Fuiste (Version Salsa) (feat. Gilberto Santa Rosa)\" van ChocQuibTown, Gilberto Santa Rosa, voor het eerst uitgebracht in 2015 op het album \"Desde el Día en Que te Fuiste (Version Salsa) (feat. Gilberto Santa Rosa)\".",
       "uri_deezer": "deezer://track/113949062",
-      "uri_apple_music": "applemusic://track/1062009029"
+      "uri_apple_music": "applemusic://track/1062009029",
+      "fun_fact_it": "«Desde el Día en Que te Fuiste (Version Salsa) (feat. Gilberto Santa Rosa)» di ChocQuibTown, Gilberto Santa Rosa, pubblicata per la prima volta nel 2015 nell'album «Desde el Día en Que te Fuiste (Version Salsa) (feat. Gilberto Santa Rosa)»."
     },
     {
       "year": 1997,
@@ -3941,7 +4220,8 @@
       "fun_fact_fr": "« Ella Y Tu » de Joe Arroyo, parue pour la première fois en 1997.",
       "fun_fact_nl": "\"Ella Y Tu\" van Joe Arroyo, voor het eerst uitgebracht in 1997.",
       "uri_deezer": "deezer://track/16403976",
-      "uri_apple_music": "applemusic://track/542053574"
+      "uri_apple_music": "applemusic://track/542053574",
+      "fun_fact_it": "«Ella Y Tu» di Joe Arroyo, pubblicata per la prima volta nel 1997."
     },
     {
       "year": 1990,
@@ -3955,7 +4235,8 @@
       "fun_fact_fr": "« Ron Pa' Todo el Mundo (feat. Diomedes Díaz) » de Joe Arroyo, Diomedes Diaz, parue pour la première fois en 1990.",
       "fun_fact_nl": "\"Ron Pa' Todo el Mundo (feat. Diomedes Díaz)\" van Joe Arroyo, Diomedes Diaz, voor het eerst uitgebracht in 1990.",
       "uri_deezer": "deezer://track/13247341",
-      "uri_apple_music": "applemusic://track/405513030"
+      "uri_apple_music": "applemusic://track/405513030",
+      "fun_fact_it": "«Ron Pa' Todo el Mundo (feat. Diomedes Díaz)» di Joe Arroyo, Diomedes Diaz, pubblicata per la prima volta nel 1990."
     },
     {
       "year": 1975,
@@ -3969,7 +4250,8 @@
       "fun_fact_fr": "« Musica, Musica - Merengue » de Los Tupamaros, parue pour la première fois en 1975 sur l'album « Tropic Dance (Zouk, Soukouss, Salsa, Merengué, Compa) ».",
       "fun_fact_nl": "\"Musica, Musica - Merengue\" van Los Tupamaros, voor het eerst uitgebracht in 1975 op het album \"Tropic Dance (Zouk, Soukouss, Salsa, Merengué, Compa)\".",
       "uri_deezer": "deezer://track/78835672",
-      "uri_apple_music": "applemusic://track/882189522"
+      "uri_apple_music": "applemusic://track/882189522",
+      "fun_fact_it": "«Musica, Musica - Merengue» di Los Tupamaros, pubblicata per la prima volta nel 1975 nell'album «Tropic Dance (Zouk, Soukouss, Salsa, Merengué, Compa)»."
     },
     {
       "year": 1978,
@@ -3982,7 +4264,8 @@
       "fun_fact_es": "\"Los Amores de Petrona\" de Los Tupamaros, publicada por primera vez en 1978.",
       "fun_fact_fr": "« Los Amores de Petrona » de Los Tupamaros, parue pour la première fois en 1978.",
       "fun_fact_nl": "\"Los Amores de Petrona\" van Los Tupamaros, voor het eerst uitgebracht in 1978.",
-      "uri_apple_music": "applemusic://track/826926526"
+      "uri_apple_music": "applemusic://track/826926526",
+      "fun_fact_it": "«Los Amores de Petrona» di Los Tupamaros, pubblicata per la prima volta nel 1978."
     },
     {
       "year": 1973,
@@ -3995,7 +4278,8 @@
       "fun_fact_es": "\"Enamorao\" de Los Tupamaros, publicada por primera vez en 1973.",
       "fun_fact_fr": "« Enamorao » de Los Tupamaros, parue pour la première fois en 1973.",
       "fun_fact_nl": "\"Enamorao\" van Los Tupamaros, voor het eerst uitgebracht in 1973.",
-      "uri_apple_music": "applemusic://track/277169810"
+      "uri_apple_music": "applemusic://track/277169810",
+      "fun_fact_it": "«Enamorao» di Los Tupamaros, pubblicata per la prima volta nel 1973."
     },
     {
       "year": 2014,
@@ -4009,7 +4293,8 @@
       "fun_fact_fr": "« Algo Contigo (with Our Latin Thing) » de Vicentico, Our Latin Thing, parue pour la première fois en 2014 sur l'album « Último Acto ».",
       "fun_fact_nl": "\"Algo Contigo (with Our Latin Thing)\" van Vicentico, Our Latin Thing, voor het eerst uitgebracht in 2014 op het album \"Último Acto\".",
       "uri_deezer": "deezer://track/87957469",
-      "uri_apple_music": "applemusic://track/928681935"
+      "uri_apple_music": "applemusic://track/928681935",
+      "fun_fact_it": "«Algo Contigo (with Our Latin Thing)» di Vicentico, Our Latin Thing, pubblicata per la prima volta nel 2014 nell'album «Último Acto»."
     },
     {
       "year": 2007,
@@ -4023,7 +4308,8 @@
       "fun_fact_fr": "« El Amor de Mi Vida \"Se Fue\" » de Grupo Galé, parue pour la première fois en 2007 sur l'album « Dos Decadas de Oro ».",
       "fun_fact_nl": "\"El Amor de Mi Vida \"Se Fue\"\" van Grupo Galé, voor het eerst uitgebracht in 2007 op het album \"Dos Decadas de Oro\".",
       "uri_deezer": "deezer://track/73000889",
-      "uri_apple_music": "applemusic://track/1712787347"
+      "uri_apple_music": "applemusic://track/1712787347",
+      "fun_fact_it": "«El Amor de Mi Vida \"Se Fue\"» di Grupo Galé, pubblicata per la prima volta nel 2007 nell'album «Dos Decadas de Oro»."
     },
     {
       "year": 1999,
@@ -4037,7 +4323,8 @@
       "fun_fact_fr": "« Lo Que Yo Más Quiero » de Son By Four, parue pour la première fois en 1999 sur l'album « Lo Esencial ».",
       "fun_fact_nl": "\"Lo Que Yo Más Quiero\" van Son By Four, voor het eerst uitgebracht in 1999 op het album \"Lo Esencial\".",
       "uri_deezer": "deezer://track/13252404",
-      "uri_apple_music": "applemusic://track/259568007"
+      "uri_apple_music": "applemusic://track/259568007",
+      "fun_fact_it": "«Lo Que Yo Más Quiero» di Son By Four, pubblicata per la prima volta nel 1999 nell'album «Lo Esencial»."
     },
     {
       "year": 1997,
@@ -4051,7 +4338,8 @@
       "fun_fact_fr": "« Abusadora » de Oro Solido, parue pour la première fois en 1997 sur l'album « El Poder de New York ».",
       "fun_fact_nl": "\"Abusadora\" van Oro Solido, voor het eerst uitgebracht in 1997 op het album \"El Poder de New York\".",
       "uri_deezer": "deezer://track/1955198807",
-      "uri_apple_music": "applemusic://track/1648739205"
+      "uri_apple_music": "applemusic://track/1648739205",
+      "fun_fact_it": "«Abusadora» di Oro Solido, pubblicata per la prima volta nel 1997 nell'album «El Poder de New York»."
     },
     {
       "year": 2015,
@@ -4064,7 +4352,8 @@
       "fun_fact_es": "\"Yo Te Recuerdo - Version Salsa\" de Juan Gabriel, Marc Anthony, publicada por primera vez en 2015.",
       "fun_fact_fr": "« Yo Te Recuerdo - Version Salsa » de Juan Gabriel, Marc Anthony, parue pour la première fois en 2015.",
       "fun_fact_nl": "\"Yo Te Recuerdo - Version Salsa\" van Juan Gabriel, Marc Anthony, voor het eerst uitgebracht in 2015.",
-      "uri_apple_music": "applemusic://track/1571588937"
+      "uri_apple_music": "applemusic://track/1571588937",
+      "fun_fact_it": "«Yo Te Recuerdo - Version Salsa» di Juan Gabriel, Marc Anthony, pubblicata per la prima volta nel 2015."
     },
     {
       "year": 2010,
@@ -4078,7 +4367,8 @@
       "fun_fact_fr": "« Bachata En Fukuoka » de Juan Luis Guerra 4.40, parue pour la première fois en 2010 sur l'album « Bachata En Fukuoka ».",
       "fun_fact_nl": "\"Bachata En Fukuoka\" van Juan Luis Guerra 4.40, voor het eerst uitgebracht in 2010 op het album \"Bachata En Fukuoka\".",
       "uri_deezer": "deezer://track/5645452",
-      "uri_apple_music": "applemusic://track/715793668"
+      "uri_apple_music": "applemusic://track/715793668",
+      "fun_fact_it": "«Bachata En Fukuoka» di Juan Luis Guerra 4.40, pubblicata per la prima volta nel 2010 nell'album «Bachata En Fukuoka»."
     },
     {
       "year": 2006,
@@ -4091,7 +4381,8 @@
       "fun_fact_es": "\"Todo el Mundo Necesita un Beso\" de Los Tupamaros, publicada por primera vez en 2006.",
       "fun_fact_fr": "« Todo el Mundo Necesita un Beso » de Los Tupamaros, parue pour la première fois en 2006.",
       "fun_fact_nl": "\"Todo el Mundo Necesita un Beso\" van Los Tupamaros, voor het eerst uitgebracht in 2006.",
-      "uri_apple_music": "applemusic://track/194645592"
+      "uri_apple_music": "applemusic://track/194645592",
+      "fun_fact_it": "«Todo el Mundo Necesita un Beso» di Los Tupamaros, pubblicata per la prima volta nel 2006."
     },
     {
       "year": 2015,
@@ -4105,7 +4396,8 @@
       "fun_fact_fr": "« Con la Copa Arriba » de Wilfrido Vargas, parue pour la première fois en 2015 sur l'album « Con la Copa Arriba ».",
       "fun_fact_nl": "\"Con la Copa Arriba\" van Wilfrido Vargas, voor het eerst uitgebracht in 2015 op het album \"Con la Copa Arriba\".",
       "uri_deezer": "deezer://track/108632476",
-      "uri_apple_music": "applemusic://track/1044533288"
+      "uri_apple_music": "applemusic://track/1044533288",
+      "fun_fact_it": "«Con la Copa Arriba» di Wilfrido Vargas, pubblicata per la prima volta nel 2015 nell'album «Con la Copa Arriba»."
     },
     {
       "year": 2009,
@@ -4119,7 +4411,8 @@
       "fun_fact_fr": "« Yo No Se Manana - Salsa Version » de Luis Enrique, parue pour la première fois en 2009 sur l'album « Latin Hits Club Edition 2013 (Kuduro, Salsa, Bachata, Merengue, Reggaeton, Fitness, Mambo, Timba, Cubaton, Dembow, Cumbia) ».",
       "fun_fact_nl": "\"Yo No Se Manana - Salsa Version\" van Luis Enrique, voor het eerst uitgebracht in 2009 op het album \"Latin Hits Club Edition 2013 (Kuduro, Salsa, Bachata, Merengue, Reggaeton, Fitness, Mambo, Timba, Cubaton, Dembow, Cumbia)\".",
       "uri_deezer": "deezer://track/69898701",
-      "uri_apple_music": "applemusic://track/1781051966"
+      "uri_apple_music": "applemusic://track/1781051966",
+      "fun_fact_it": "«Yo No Se Manana - Salsa Version» di Luis Enrique, pubblicata per la prima volta nel 2009 nell'album «Latin Hits Club Edition 2013 (Kuduro, Salsa, Bachata, Merengue, Reggaeton, Fitness, Mambo, Timba, Cubaton, Dembow, Cumbia)»."
     },
     {
       "year": 2005,
@@ -4133,7 +4426,8 @@
       "fun_fact_fr": "« Regálame una Noche » de Maelo Ruiz, parue pour la première fois en 2005 sur l'album « Regálame Una Noche ».",
       "fun_fact_nl": "\"Regálame una Noche\" van Maelo Ruiz, voor het eerst uitgebracht in 2005 op het album \"Regálame Una Noche\".",
       "uri_deezer": "deezer://track/11108492",
-      "uri_apple_music": "applemusic://track/1714511567"
+      "uri_apple_music": "applemusic://track/1714511567",
+      "fun_fact_it": "«Regálame una Noche» di Maelo Ruiz, pubblicata per la prima volta nel 2005 nell'album «Regálame Una Noche»."
     },
     {
       "year": 1992,
@@ -4147,7 +4441,8 @@
       "fun_fact_fr": "« Pequeñas Cosas » de Willie Gonzalez, parue pour la première fois en 1992.",
       "fun_fact_nl": "\"Pequeñas Cosas\" van Willie Gonzalez, voor het eerst uitgebracht in 1992.",
       "uri_deezer": "deezer://track/63804912",
-      "uri_apple_music": "applemusic://track/18848447"
+      "uri_apple_music": "applemusic://track/18848447",
+      "fun_fact_it": "«Pequeñas Cosas» di Willie Gonzalez, pubblicata per la prima volta nel 1992."
     },
     {
       "year": 1988,
@@ -4161,7 +4456,8 @@
       "fun_fact_fr": "« Quiero Morir En Tu Piel » de Willie Gonzalez, parue pour la première fois en 1988.",
       "fun_fact_nl": "\"Quiero Morir En Tu Piel\" van Willie Gonzalez, voor het eerst uitgebracht in 1988.",
       "uri_deezer": "deezer://track/63804916",
-      "uri_apple_music": "applemusic://track/18848455"
+      "uri_apple_music": "applemusic://track/18848455",
+      "fun_fact_it": "«Quiero Morir En Tu Piel» di Willie Gonzalez, pubblicata per la prima volta nel 1988."
     },
     {
       "year": 2016,
@@ -4175,7 +4471,8 @@
       "fun_fact_fr": "« Deje de Amar » de Felipe Muñiz, Marc Anthony, parue pour la première fois en 2016 sur l'album « Deje de Amar ».",
       "fun_fact_nl": "\"Deje de Amar\" van Felipe Muñiz, Marc Anthony, voor het eerst uitgebracht in 2016 op het album \"Deje de Amar\".",
       "uri_deezer": "deezer://track/132316824",
-      "uri_apple_music": "applemusic://track/1155763623"
+      "uri_apple_music": "applemusic://track/1155763623",
+      "fun_fact_it": "«Deje de Amar» di Felipe Muñiz, Marc Anthony, pubblicata per la prima volta nel 2016 nell'album «Deje de Amar»."
     },
     {
       "year": 2007,
@@ -4187,7 +4484,8 @@
       "fun_fact_de": "„Busco una novia salsera\" von Salsa Kids, erstmals 2007 erschienen.",
       "fun_fact_es": "\"Busco una novia salsera\" de Salsa Kids, publicada por primera vez en 2007.",
       "fun_fact_fr": "« Busco una novia salsera » de Salsa Kids, parue pour la première fois en 2007.",
-      "fun_fact_nl": "\"Busco una novia salsera\" van Salsa Kids, voor het eerst uitgebracht in 2007."
+      "fun_fact_nl": "\"Busco una novia salsera\" van Salsa Kids, voor het eerst uitgebracht in 2007.",
+      "fun_fact_it": "«Busco una novia salsera» di Salsa Kids, pubblicata per la prima volta nel 2007."
     },
     {
       "year": 2014,
@@ -4201,7 +4499,8 @@
       "fun_fact_fr": "« Yo También (feat. Marc Anthony) » de Romeo Santos, Marc Anthony, parue pour la première fois en 2014 sur l'album « Fórmula, Vol. 2 (Deluxe Edition) ».",
       "fun_fact_nl": "\"Yo También (feat. Marc Anthony)\" van Romeo Santos, Marc Anthony, voor het eerst uitgebracht in 2014 op het album \"Fórmula, Vol. 2 (Deluxe Edition)\".",
       "uri_deezer": "deezer://track/75212173",
-      "uri_apple_music": "applemusic://track/804145422"
+      "uri_apple_music": "applemusic://track/804145422",
+      "fun_fact_it": "«Yo También (feat. Marc Anthony)» di Romeo Santos, Marc Anthony, pubblicata per la prima volta nel 2014 nell'album «Fórmula, Vol. 2 (Deluxe Edition)»."
     },
     {
       "year": 1996,
@@ -4215,7 +4514,8 @@
       "fun_fact_fr": "« Anoche Hablamos De Amor » de Sergio Vargas, parue pour la première fois en 1996 sur l'album « Concierto Desde el Teatro Nacional de Cuba (En Concierto) ».",
       "fun_fact_nl": "\"Anoche Hablamos De Amor\" van Sergio Vargas, voor het eerst uitgebracht in 1996 op het album \"Concierto Desde el Teatro Nacional de Cuba (En Concierto)\".",
       "uri_deezer": "deezer://track/1131908142",
-      "uri_apple_music": "applemusic://track/1538767208"
+      "uri_apple_music": "applemusic://track/1538767208",
+      "fun_fact_it": "«Anoche Hablamos De Amor» di Sergio Vargas, pubblicata per la prima volta nel 1996 nell'album «Concierto Desde el Teatro Nacional de Cuba (En Concierto)»."
     },
     {
       "year": 1996,
@@ -4229,7 +4529,8 @@
       "fun_fact_fr": "« Aquel Lugar » de Adolescent's Orquesta, parue pour la première fois en 1996.",
       "fun_fact_nl": "\"Aquel Lugar\" van Adolescent's Orquesta, voor het eerst uitgebracht in 1996.",
       "uri_deezer": "deezer://track/1385723032",
-      "uri_apple_music": "applemusic://track/1569057082"
+      "uri_apple_music": "applemusic://track/1569057082",
+      "fun_fact_it": "«Aquel Lugar» di Adolescent's Orquesta, pubblicata per la prima volta nel 1996."
     },
     {
       "year": 1996,
@@ -4243,7 +4544,8 @@
       "fun_fact_fr": "« Me Tengo Que Ir » de Adolescent's Orquesta, parue pour la première fois en 1996 sur l'album « Persona Ideal ».",
       "fun_fact_nl": "\"Me Tengo Que Ir\" van Adolescent's Orquesta, voor het eerst uitgebracht in 1996 op het album \"Persona Ideal\".",
       "uri_deezer": "deezer://track/1385725502",
-      "uri_apple_music": "applemusic://track/1569677757"
+      "uri_apple_music": "applemusic://track/1569677757",
+      "fun_fact_it": "«Me Tengo Que Ir» di Adolescent's Orquesta, pubblicata per la prima volta nel 1996 nell'album «Persona Ideal»."
     },
     {
       "year": 2000,
@@ -4257,7 +4559,8 @@
       "fun_fact_fr": "« Cachondea » de Fruko Y Sus Tesos, parue pour la première fois en 2000 sur l'album « Staying Fit with the #1 Dance Workout ».",
       "fun_fact_nl": "\"Cachondea\" van Fruko Y Sus Tesos, voor het eerst uitgebracht in 2000 op het album \"Staying Fit with the #1 Dance Workout\".",
       "uri_deezer": "deezer://track/125448656",
-      "uri_apple_music": "applemusic://track/26879230"
+      "uri_apple_music": "applemusic://track/26879230",
+      "fun_fact_it": "«Cachondea» di Fruko Y Sus Tesos, pubblicata per la prima volta nel 2000 nell'album «Staying Fit with the #1 Dance Workout»."
     },
     {
       "year": 1975,
@@ -4271,7 +4574,8 @@
       "fun_fact_fr": "« Si Supieras » de Los Niches, parue pour la première fois en 1975 sur l'album « La Salsa, Identidad de un Pueblo - Vol. 3 Expresión del Bailador ».",
       "fun_fact_nl": "\"Si Supieras\" van Los Niches, voor het eerst uitgebracht in 1975 op het album \"La Salsa, Identidad de un Pueblo - Vol. 3 Expresión del Bailador\".",
       "uri_deezer": "deezer://track/131107396",
-      "uri_apple_music": "applemusic://track/203977549"
+      "uri_apple_music": "applemusic://track/203977549",
+      "fun_fact_it": "«Si Supieras» di Los Niches, pubblicata per la prima volta nel 1975 nell'album «La Salsa, Identidad de un Pueblo - Vol. 3 Expresión del Bailador»."
     },
     {
       "year": 2006,
@@ -4285,7 +4589,8 @@
       "fun_fact_fr": "« Qué Precio Tiene el Cielo - Salsa Version » de Marc Anthony, parue pour la première fois en 2006.",
       "fun_fact_nl": "\"Qué Precio Tiene el Cielo - Salsa Version\" van Marc Anthony, voor het eerst uitgebracht in 2006.",
       "uri_apple_music": "applemusic://track/163291459",
-      "uri_deezer": "deezer://track/549343"
+      "uri_deezer": "deezer://track/549343",
+      "fun_fact_it": "«Qué Precio Tiene el Cielo - Salsa Version» di Marc Anthony, pubblicata per la prima volta nel 2006."
     },
     {
       "year": 1978,
@@ -4299,7 +4604,8 @@
       "fun_fact_fr": "« Pedro Navaja » de Rubén Blades, Willie Colon Y Ruben Blades, parue pour la première fois en 1978 sur l'album « El Poliedro de Caracas Tembló ».",
       "fun_fact_nl": "\"Pedro Navaja\" van Rubén Blades, Willie Colon Y Ruben Blades, voor het eerst uitgebracht in 1978 op het album \"El Poliedro de Caracas Tembló\".",
       "uri_deezer": "deezer://track/600766432",
-      "uri_apple_music": "applemusic://track/1464957419"
+      "uri_apple_music": "applemusic://track/1464957419",
+      "fun_fact_it": "«Pedro Navaja» di Rubén Blades, Willie Colon Y Ruben Blades, pubblicata per la prima volta nel 1978 nell'album «El Poliedro de Caracas Tembló»."
     },
     {
       "year": 1994,
@@ -4313,7 +4619,8 @@
       "fun_fact_fr": "« Apiádate de Mi » de Víctor Manuelle, parue pour la première fois en 1994 sur l'album « Mis Favoritas ».",
       "fun_fact_nl": "\"Apiádate de Mi\" van Víctor Manuelle, voor het eerst uitgebracht in 1994 op het album \"Mis Favoritas\".",
       "uri_deezer": "deezer://track/6237240",
-      "uri_apple_music": "applemusic://track/158633934"
+      "uri_apple_music": "applemusic://track/158633934",
+      "fun_fact_it": "«Apiádate de Mi» di Víctor Manuelle, pubblicata per la prima volta nel 1994 nell'album «Mis Favoritas»."
     },
     {
       "year": 1997,
@@ -4327,7 +4634,8 @@
       "fun_fact_fr": "« Mi Mayor Venganza » de LA INDIA, parue pour la première fois en 1997 sur l'album « Pura Salsa ».",
       "fun_fact_nl": "\"Mi Mayor Venganza\" van LA INDIA, voor het eerst uitgebracht in 1997 op het album \"Pura Salsa\".",
       "uri_deezer": "deezer://track/15508102",
-      "uri_apple_music": "applemusic://track/1443909822"
+      "uri_apple_music": "applemusic://track/1443909822",
+      "fun_fact_it": "«Mi Mayor Venganza» di LA INDIA, pubblicata per la prima volta nel 1997 nell'album «Pura Salsa»."
     },
     {
       "year": 2013,
@@ -4341,7 +4649,8 @@
       "fun_fact_fr": "« Flor Pálida » de Marc Anthony, parue pour la première fois en 2013 sur l'album « 3.0 ».",
       "fun_fact_nl": "\"Flor Pálida\" van Marc Anthony, voor het eerst uitgebracht in 2013 op het album \"3.0\".",
       "uri_deezer": "deezer://track/68771817",
-      "uri_apple_music": "applemusic://track/668743491"
+      "uri_apple_music": "applemusic://track/668743491",
+      "fun_fact_it": "«Flor Pálida» di Marc Anthony, pubblicata per la prima volta nel 2013 nell'album «3.0»."
     },
     {
       "year": 1988,
@@ -4355,7 +4664,8 @@
       "fun_fact_fr": "« Mía » de Eddie Santiago, parue pour la première fois en 1988 sur l'album « Lluvia (Baile Total) ».",
       "fun_fact_nl": "\"Mía\" van Eddie Santiago, voor het eerst uitgebracht in 1988 op het album \"Lluvia (Baile Total)\".",
       "uri_deezer": "deezer://track/429989502",
-      "uri_apple_music": "applemusic://track/1445663831"
+      "uri_apple_music": "applemusic://track/1445663831",
+      "fun_fact_it": "«Mía» di Eddie Santiago, pubblicata per la prima volta nel 1988 nell'album «Lluvia (Baile Total)»."
     },
     {
       "year": 1989,
@@ -4369,7 +4679,8 @@
       "fun_fact_fr": "« Aquél Viejo Motel » de David Pabon, parue pour la première fois en 1989 sur l'album « 12 Favoritas ».",
       "fun_fact_nl": "\"Aquél Viejo Motel\" van David Pabon, voor het eerst uitgebracht in 1989 op het album \"12 Favoritas\".",
       "uri_deezer": "deezer://track/79275725",
-      "uri_apple_music": "applemusic://track/1443736368"
+      "uri_apple_music": "applemusic://track/1443736368",
+      "fun_fact_it": "«Aquél Viejo Motel» di David Pabon, pubblicata per la prima volta nel 1989 nell'album «12 Favoritas»."
     },
     {
       "year": 1992,
@@ -4383,7 +4694,8 @@
       "fun_fact_fr": "« Hasta El Sol De Hoy » de Edgar Joel, parue pour la première fois en 1992 sur l'album « Hasta El Sol De Hoy ».",
       "fun_fact_nl": "\"Hasta El Sol De Hoy\" van Edgar Joel, voor het eerst uitgebracht in 1992 op het album \"Hasta El Sol De Hoy\".",
       "uri_deezer": "deezer://track/3506551341",
-      "uri_apple_music": "applemusic://track/6786046333"
+      "uri_apple_music": "applemusic://track/6786046333",
+      "fun_fact_it": "«Hasta El Sol De Hoy» di Edgar Joel, pubblicata per la prima volta nel 1992 nell'album «Hasta El Sol De Hoy»."
     },
     {
       "year": 1972,
@@ -4397,7 +4709,8 @@
       "fun_fact_fr": "« Cinco Noches » de Paquito Guzman, parue pour la première fois en 1972 sur l'album « Historia ».",
       "fun_fact_nl": "\"Cinco Noches\" van Paquito Guzman, voor het eerst uitgebracht in 1972 op het album \"Historia\".",
       "uri_deezer": "deezer://track/1442205772",
-      "uri_apple_music": "applemusic://track/1677841690"
+      "uri_apple_music": "applemusic://track/1677841690",
+      "fun_fact_it": "«Cinco Noches» di Paquito Guzman, pubblicata per la prima volta nel 1972 nell'album «Historia»."
     },
     {
       "year": 1981,
@@ -4411,7 +4724,8 @@
       "fun_fact_fr": "« Rebelión » de Joe Arroyo, La Verdad, parue pour la première fois en 1981 sur l'album « Discos Fuentes Salsa Sampler ».",
       "fun_fact_nl": "\"Rebelión\" van Joe Arroyo, La Verdad, voor het eerst uitgebracht in 1981 op het album \"Discos Fuentes Salsa Sampler\".",
       "uri_deezer": "deezer://track/112896870",
-      "uri_apple_music": "applemusic://track/203977425"
+      "uri_apple_music": "applemusic://track/203977425",
+      "fun_fact_it": "«Rebelión» di Joe Arroyo, La Verdad, pubblicata per la prima volta nel 1981 nell'album «Discos Fuentes Salsa Sampler»."
     },
     {
       "year": 1992,
@@ -4425,7 +4739,8 @@
       "fun_fact_fr": "« Extraño Tu Amor » de Guayacán Orquesta, parue pour la première fois en 1992.",
       "fun_fact_nl": "\"Extraño Tu Amor\" van Guayacán Orquesta, voor het eerst uitgebracht in 1992.",
       "uri_deezer": "deezer://track/633458012",
-      "uri_apple_music": "applemusic://track/1787876838"
+      "uri_apple_music": "applemusic://track/1787876838",
+      "fun_fact_it": "«Extraño Tu Amor» di Guayacán Orquesta, pubblicata per la prima volta nel 1992."
     },
     {
       "year": 2011,
@@ -4439,7 +4754,8 @@
       "fun_fact_fr": "« Viene Y Se Va » de Mauro Castillo, parue pour la première fois en 2011 sur l'album « Baila Salsa ».",
       "fun_fact_nl": "\"Viene Y Se Va\" van Mauro Castillo, voor het eerst uitgebracht in 2011 op het album \"Baila Salsa\".",
       "uri_deezer": "deezer://track/2724883591",
-      "uri_apple_music": "applemusic://track/1779541347"
+      "uri_apple_music": "applemusic://track/1779541347",
+      "fun_fact_it": "«Viene Y Se Va» di Mauro Castillo, pubblicata per la prima volta nel 2011 nell'album «Baila Salsa»."
     },
     {
       "year": 1992,
@@ -4453,7 +4769,8 @@
       "fun_fact_fr": "« Carro de Fuego » de Guayacán Orquesta, parue pour la première fois en 1992.",
       "fun_fact_nl": "\"Carro de Fuego\" van Guayacán Orquesta, voor het eerst uitgebracht in 1992.",
       "uri_deezer": "deezer://track/633458042",
-      "uri_apple_music": "applemusic://track/1787876836"
+      "uri_apple_music": "applemusic://track/1787876836",
+      "fun_fact_it": "«Carro de Fuego» di Guayacán Orquesta, pubblicata per la prima volta nel 1992."
     },
     {
       "year": 2010,
@@ -4467,7 +4784,8 @@
       "fun_fact_fr": "« Ya No Queda Nada - Ángeles Version » de Angeles, parue pour la première fois en 2010 sur l'album « Venimos del Cielo (Bonus Track Version) ».",
       "fun_fact_nl": "\"Ya No Queda Nada - Ángeles Version\" van Angeles, voor het eerst uitgebracht in 2010 op het album \"Venimos del Cielo (Bonus Track Version)\".",
       "uri_deezer": "deezer://track/1255526522",
-      "uri_apple_music": "applemusic://track/447628138"
+      "uri_apple_music": "applemusic://track/447628138",
+      "fun_fact_it": "«Ya No Queda Nada - Ángeles Version» di Angeles, pubblicata per la prima volta nel 2010 nell'album «Venimos del Cielo (Bonus Track Version)»."
     },
     {
       "year": 1975,
@@ -4481,7 +4799,8 @@
       "fun_fact_fr": "« Que Haré Sin Ti » de Grupo Caneo, parue pour la première fois en 1975 sur l'album « Grupo Caneo (En Vivo) ».",
       "fun_fact_nl": "\"Que Haré Sin Ti\" van Grupo Caneo, voor het eerst uitgebracht in 1975 op het album \"Grupo Caneo (En Vivo)\".",
       "uri_deezer": "deezer://track/139519049",
-      "uri_apple_music": "applemusic://track/1719964281"
+      "uri_apple_music": "applemusic://track/1719964281",
+      "fun_fact_it": "«Que Haré Sin Ti» di Grupo Caneo, pubblicata per la prima volta nel 1975 nell'album «Grupo Caneo (En Vivo)»."
     },
     {
       "year": 1993,
@@ -4495,7 +4814,8 @@
       "fun_fact_fr": "« Quien Piensa en Ti » de Grupo Caneo, parue pour la première fois en 1993.",
       "fun_fact_nl": "\"Quien Piensa en Ti\" van Grupo Caneo, voor het eerst uitgebracht in 1993.",
       "uri_deezer": "deezer://track/2573869562",
-      "uri_apple_music": "applemusic://track/251726204"
+      "uri_apple_music": "applemusic://track/251726204",
+      "fun_fact_it": "«Quien Piensa en Ti» di Grupo Caneo, pubblicata per la prima volta nel 1993."
     },
     {
       "year": 1997,
@@ -4509,7 +4829,8 @@
       "fun_fact_fr": "« Me Niegas Tanto Amor » de Pedro Conga, parue pour la première fois en 1997.",
       "fun_fact_nl": "\"Me Niegas Tanto Amor\" van Pedro Conga, voor het eerst uitgebracht in 1997.",
       "uri_deezer": "deezer://track/63739432",
-      "uri_apple_music": "applemusic://track/287472593"
+      "uri_apple_music": "applemusic://track/287472593",
+      "fun_fact_it": "«Me Niegas Tanto Amor» di Pedro Conga, pubblicata per la prima volta nel 1997."
     },
     {
       "year": 1999,
@@ -4523,7 +4844,8 @@
       "fun_fact_fr": "« Vicio » de Pedro Conga, Maelo Ruiz, parue pour la première fois en 1999 sur l'album « Pedro Conga Y Su Orquesta Internacional ».",
       "fun_fact_nl": "\"Vicio\" van Pedro Conga, Maelo Ruiz, voor het eerst uitgebracht in 1999 op het album \"Pedro Conga Y Su Orquesta Internacional\".",
       "uri_deezer": "deezer://track/64248239",
-      "uri_apple_music": "applemusic://track/1357652898"
+      "uri_apple_music": "applemusic://track/1357652898",
+      "fun_fact_it": "«Vicio» di Pedro Conga, Maelo Ruiz, pubblicata per la prima volta nel 1999 nell'album «Pedro Conga Y Su Orquesta Internacional»."
     },
     {
       "year": 2001,
@@ -4537,7 +4859,8 @@
       "fun_fact_fr": "« Ni Siquiera » de Antonio Cartagena, parue pour la première fois en 2001 sur l'album « Mi Historia Musical, Vol. 3 ».",
       "fun_fact_nl": "\"Ni Siquiera\" van Antonio Cartagena, voor het eerst uitgebracht in 2001 op het album \"Mi Historia Musical, Vol. 3\".",
       "uri_deezer": "deezer://track/393925252",
-      "uri_apple_music": "applemusic://track/1270877791"
+      "uri_apple_music": "applemusic://track/1270877791",
+      "fun_fact_it": "«Ni Siquiera» di Antonio Cartagena, pubblicata per la prima volta nel 2001 nell'album «Mi Historia Musical, Vol. 3»."
     },
     {
       "year": 2010,
@@ -4551,7 +4874,8 @@
       "fun_fact_fr": "« Mejor Sin Ti » de Aguanile, parue pour la première fois en 2010 sur l'album « Esta Es Tu Salsa ».",
       "fun_fact_nl": "\"Mejor Sin Ti\" van Aguanile, voor het eerst uitgebracht in 2010 op het album \"Esta Es Tu Salsa\".",
       "uri_deezer": "deezer://track/11108078",
-      "uri_apple_music": "applemusic://track/1711675709"
+      "uri_apple_music": "applemusic://track/1711675709",
+      "fun_fact_it": "«Mejor Sin Ti» di Aguanile, pubblicata per la prima volta nel 2010 nell'album «Esta Es Tu Salsa»."
     },
     {
       "year": 2000,
@@ -4565,7 +4889,8 @@
       "fun_fact_fr": "« Esa Mujer » de Mariano Civico, parue pour la première fois en 2000 sur l'album « Te Voy a Hacer Feliz ».",
       "fun_fact_nl": "\"Esa Mujer\" van Mariano Civico, voor het eerst uitgebracht in 2000 op het album \"Te Voy a Hacer Feliz\".",
       "uri_deezer": "deezer://track/2702772282",
-      "uri_apple_music": "applemusic://track/1735824980"
+      "uri_apple_music": "applemusic://track/1735824980",
+      "fun_fact_it": "«Esa Mujer» di Mariano Civico, pubblicata per la prima volta nel 2000 nell'album «Te Voy a Hacer Feliz»."
     },
     {
       "year": 1991,
@@ -4579,7 +4904,8 @@
       "fun_fact_fr": "« Entre La Espada y La Pared » de Nino Segarra, parue pour la première fois en 1991 sur l'album « Vida ».",
       "fun_fact_nl": "\"Entre La Espada y La Pared\" van Nino Segarra, voor het eerst uitgebracht in 1991 op het album \"Vida\".",
       "uri_deezer": "deezer://track/11507278",
-      "uri_apple_music": "applemusic://track/377784675"
+      "uri_apple_music": "applemusic://track/377784675",
+      "fun_fact_it": "«Entre La Espada y La Pared» di Nino Segarra, pubblicata per la prima volta nel 1991 nell'album «Vida»."
     },
     {
       "year": 2001,
@@ -4593,7 +4919,8 @@
       "fun_fact_fr": "« Caradura » de David Pabon, parue pour la première fois en 2001 sur l'album « Mejor Que Ayer ».",
       "fun_fact_nl": "\"Caradura\" van David Pabon, voor het eerst uitgebracht in 2001 op het album \"Mejor Que Ayer\".",
       "uri_deezer": "deezer://track/11134484",
-      "uri_apple_music": "applemusic://track/1712395447"
+      "uri_apple_music": "applemusic://track/1712395447",
+      "fun_fact_it": "«Caradura» di David Pabon, pubblicata per la prima volta nel 2001 nell'album «Mejor Que Ayer»."
     },
     {
       "year": 1993,
@@ -4607,7 +4934,8 @@
       "fun_fact_fr": "« Si Me Ves Llorar » de David Pabon, parue pour la première fois en 1993 sur l'album « Mejor Que Ayer ».",
       "fun_fact_nl": "\"Si Me Ves Llorar\" van David Pabon, voor het eerst uitgebracht in 1993 op het album \"Mejor Que Ayer\".",
       "uri_deezer": "deezer://track/11134491",
-      "uri_apple_music": "applemusic://track/1712392771"
+      "uri_apple_music": "applemusic://track/1712392771",
+      "fun_fact_it": "«Si Me Ves Llorar» di David Pabon, pubblicata per la prima volta nel 1993 nell'album «Mejor Que Ayer»."
     },
     {
       "year": 1990,
@@ -4621,7 +4949,8 @@
       "fun_fact_fr": "« Y Nos Amamos » de David Pabon, parue pour la première fois en 1990 sur l'album « Salsas Románticas Vol.2 ».",
       "fun_fact_nl": "\"Y Nos Amamos\" van David Pabon, voor het eerst uitgebracht in 1990 op het album \"Salsas Románticas Vol.2\".",
       "uri_deezer": "deezer://track/1356779532",
-      "uri_apple_music": "applemusic://track/1443537647"
+      "uri_apple_music": "applemusic://track/1443537647",
+      "fun_fact_it": "«Y Nos Amamos» di David Pabon, pubblicata per la prima volta nel 1990 nell'album «Salsas Románticas Vol.2»."
     },
     {
       "year": 1997,
@@ -4635,7 +4964,8 @@
       "fun_fact_fr": "« Herida » de Brenda K. Starr, parue pour la première fois en 1997 sur l'album « Te Sigo Esperando ».",
       "fun_fact_nl": "\"Herida\" van Brenda K. Starr, voor het eerst uitgebracht in 1997 op het album \"Te Sigo Esperando\".",
       "uri_deezer": "deezer://track/7878508",
-      "uri_apple_music": "applemusic://track/199145303"
+      "uri_apple_music": "applemusic://track/199145303",
+      "fun_fact_it": "«Herida» di Brenda K. Starr, pubblicata per la prima volta nel 1997 nell'album «Te Sigo Esperando»."
     },
     {
       "year": 2002,
@@ -4649,7 +4979,8 @@
       "fun_fact_fr": "« Sedúceme - Salsa Version » de LA INDIA, parue pour la première fois en 2002.",
       "fun_fact_nl": "\"Sedúceme - Salsa Version\" van LA INDIA, voor het eerst uitgebracht in 2002.",
       "uri_apple_music": "applemusic://track/251562387",
-      "uri_deezer": "deezer://track/571707"
+      "uri_deezer": "deezer://track/571707",
+      "fun_fact_it": "«Sedúceme - Salsa Version» di LA INDIA, pubblicata per la prima volta nel 2002."
     },
     {
       "year": 2021,
@@ -4662,7 +4993,8 @@
       "fun_fact_es": "\"No Renunciare\" de Eukaris \"La Nena Sexy De La Salsa\", publicada por primera vez en 2021 en el álbum \"Dulcemente Atrevida\".",
       "fun_fact_fr": "« No Renunciare » de Eukaris \"La Nena Sexy De La Salsa\", parue pour la première fois en 2021 sur l'album « Dulcemente Atrevida ».",
       "fun_fact_nl": "\"No Renunciare\" van Eukaris \"La Nena Sexy De La Salsa\", voor het eerst uitgebracht in 2021 op het album \"Dulcemente Atrevida\".",
-      "uri_deezer": "deezer://track/1648806632"
+      "uri_deezer": "deezer://track/1648806632",
+      "fun_fact_it": "«No Renunciare» di Eukaris \"La Nena Sexy De La Salsa\", pubblicata per la prima volta nel 2021 nell'album «Dulcemente Atrevida»."
     },
     {
       "year": 1993,
@@ -4676,7 +5008,8 @@
       "fun_fact_fr": "« La Puerta De Alcala » de La Grande De Madrid, parue pour la première fois en 1993 sur l'album « Para Puerto Rico y El Mundo ».",
       "fun_fact_nl": "\"La Puerta De Alcala\" van La Grande De Madrid, voor het eerst uitgebracht in 1993 op het album \"Para Puerto Rico y El Mundo\".",
       "uri_deezer": "deezer://track/2780045081",
-      "uri_apple_music": "applemusic://track/1799788443"
+      "uri_apple_music": "applemusic://track/1799788443",
+      "fun_fact_it": "«La Puerta De Alcala» di La Grande De Madrid, pubblicata per la prima volta nel 1993 nell'album «Para Puerto Rico y El Mundo»."
     },
     {
       "year": 1992,
@@ -4690,7 +5023,8 @@
       "fun_fact_fr": "« La Cita » de Galy Galiano, parue pour la première fois en 1992.",
       "fun_fact_nl": "\"La Cita\" van Galy Galiano, voor het eerst uitgebracht in 1992.",
       "uri_deezer": "deezer://track/2758471701",
-      "uri_apple_music": "applemusic://track/1684882289"
+      "uri_apple_music": "applemusic://track/1684882289",
+      "fun_fact_it": "«La Cita» di Galy Galiano, pubblicata per la prima volta nel 1992."
     },
     {
       "year": 2000,
@@ -4704,7 +5038,8 @@
       "fun_fact_fr": "« Un Monton De Estrellas » de Polo Montañez, parue pour la première fois en 2000 sur l'album « Memoria ».",
       "fun_fact_nl": "\"Un Monton De Estrellas\" van Polo Montañez, voor het eerst uitgebracht in 2000 op het album \"Memoria\".",
       "uri_deezer": "deezer://track/135341772",
-      "uri_apple_music": "applemusic://track/473696146"
+      "uri_apple_music": "applemusic://track/473696146",
+      "fun_fact_it": "«Un Monton De Estrellas» di Polo Montañez, pubblicata per la prima volta nel 2000 nell'album «Memoria»."
     },
     {
       "year": 2000,
@@ -4718,7 +5053,8 @@
       "fun_fact_fr": "« Si Se Enamora De Mi » de Polo Montañez, parue pour la première fois en 2000 sur l'album « Guajiro Natural ».",
       "fun_fact_nl": "\"Si Se Enamora De Mi\" van Polo Montañez, voor het eerst uitgebracht in 2000 op het album \"Guajiro Natural\".",
       "uri_deezer": "deezer://track/14272965",
-      "uri_apple_music": "applemusic://track/473697036"
+      "uri_apple_music": "applemusic://track/473697036",
+      "fun_fact_it": "«Si Se Enamora De Mi» di Polo Montañez, pubblicata per la prima volta nel 2000 nell'album «Guajiro Natural»."
     },
     {
       "year": 1974,
@@ -4732,7 +5068,8 @@
       "fun_fact_fr": "« Bacalao con Pan » de Irakere, parue pour la première fois en 1974 sur l'album « Irakere 30 Años (Remasterizado) ».",
       "fun_fact_nl": "\"Bacalao con Pan\" van Irakere, voor het eerst uitgebracht in 1974 op het album \"Irakere 30 Años (Remasterizado)\".",
       "uri_deezer": "deezer://track/407700092",
-      "uri_apple_music": "applemusic://track/1712042130"
+      "uri_apple_music": "applemusic://track/1712042130",
+      "fun_fact_it": "«Bacalao con Pan» di Irakere, pubblicata per la prima volta nel 1974 nell'album «Irakere 30 Años (Remasterizado)»."
     },
     {
       "year": 2003,
@@ -4746,7 +5083,8 @@
       "fun_fact_fr": "« El Sol de la Noche » de Salsa Celtica, parue pour la première fois en 2003 sur l'album « El Agua de la Vida ».",
       "fun_fact_nl": "\"El Sol de la Noche\" van Salsa Celtica, voor het eerst uitgebracht in 2003 op het album \"El Agua de la Vida\".",
       "uri_deezer": "deezer://track/61189854",
-      "uri_apple_music": "applemusic://track/569047447"
+      "uri_apple_music": "applemusic://track/569047447",
+      "fun_fact_it": "«El Sol de la Noche» di Salsa Celtica, pubblicata per la prima volta nel 2003 nell'album «El Agua de la Vida»."
     },
     {
       "year": 2000,
@@ -4760,7 +5098,8 @@
       "fun_fact_fr": "« Volare » de Son Boricua, parue pour la première fois en 2000 sur l'album « Musical A Cortijo - Rivera ».",
       "fun_fact_nl": "\"Volare\" van Son Boricua, voor het eerst uitgebracht in 2000 op het album \"Musical A Cortijo - Rivera\".",
       "uri_deezer": "deezer://track/144593862",
-      "uri_apple_music": "applemusic://track/133628177"
+      "uri_apple_music": "applemusic://track/133628177",
+      "fun_fact_it": "«Volare» di Son Boricua, pubblicata per la prima volta nel 2000 nell'album «Musical A Cortijo - Rivera»."
     },
     {
       "year": 2000,
@@ -4772,7 +5111,8 @@
       "fun_fact_de": "„Calambre\" von Conjunto Barbacoa, erstmals 2000 auf dem Album „Händel: Serse - The Sony Opera House\" erschienen.",
       "fun_fact_es": "\"Calambre\" de Conjunto Barbacoa, publicada por primera vez en 2000 en el álbum \"Händel: Serse - The Sony Opera House\".",
       "fun_fact_fr": "« Calambre » de Conjunto Barbacoa, parue pour la première fois en 2000 sur l'album « Händel: Serse - The Sony Opera House ».",
-      "fun_fact_nl": "\"Calambre\" van Conjunto Barbacoa, voor het eerst uitgebracht in 2000 op het album \"Händel: Serse - The Sony Opera House\"."
+      "fun_fact_nl": "\"Calambre\" van Conjunto Barbacoa, voor het eerst uitgebracht in 2000 op het album \"Händel: Serse - The Sony Opera House\".",
+      "fun_fact_it": "«Calambre» di Conjunto Barbacoa, pubblicata per la prima volta nel 2000 nell'album «Händel: Serse - The Sony Opera House»."
     },
     {
       "year": 1993,
@@ -4786,7 +5126,8 @@
       "fun_fact_fr": "« Noches de Media Luna » de Diveana, parue pour la première fois en 1993.",
       "fun_fact_nl": "\"Noches de Media Luna\" van Diveana, voor het eerst uitgebracht in 1993.",
       "uri_deezer": "deezer://track/12205230",
-      "uri_apple_music": "applemusic://track/1445774026"
+      "uri_apple_music": "applemusic://track/1445774026",
+      "fun_fact_it": "«Noches de Media Luna» di Diveana, pubblicata per la prima volta nel 1993."
     },
     {
       "year": 1993,
@@ -4800,7 +5141,8 @@
       "fun_fact_fr": "« Te Compro Tu Novia » de Ramón Orlando, parue pour la première fois en 1993 sur l'album « América Sin Queja ».",
       "fun_fact_nl": "\"Te Compro Tu Novia\" van Ramón Orlando, voor het eerst uitgebracht in 1993 op het album \"América Sin Queja\".",
       "uri_deezer": "deezer://track/1856991837",
-      "uri_apple_music": "applemusic://track/1526508102"
+      "uri_apple_music": "applemusic://track/1526508102",
+      "fun_fact_it": "«Te Compro Tu Novia» di Ramón Orlando, pubblicata per la prima volta nel 1993 nell'album «América Sin Queja»."
     },
     {
       "year": 1991,
@@ -4814,7 +5156,8 @@
       "fun_fact_fr": "« Gotas De Pena » de Ramón Orlando, parue pour la première fois en 1991.",
       "fun_fact_nl": "\"Gotas De Pena\" van Ramón Orlando, voor het eerst uitgebracht in 1991.",
       "uri_deezer": "deezer://track/10963118",
-      "uri_apple_music": "applemusic://track/292580380"
+      "uri_apple_music": "applemusic://track/292580380",
+      "fun_fact_it": "«Gotas De Pena» di Ramón Orlando, pubblicata per la prima volta nel 1991."
     },
     {
       "year": 1991,
@@ -4828,7 +5171,8 @@
       "fun_fact_fr": "« Mas » de Ramón Orlando, parue pour la première fois en 1991.",
       "fun_fact_nl": "\"Mas\" van Ramón Orlando, voor het eerst uitgebracht in 1991.",
       "uri_deezer": "deezer://track/10963119",
-      "uri_apple_music": "applemusic://track/330822016"
+      "uri_apple_music": "applemusic://track/330822016",
+      "fun_fact_it": "«Mas» di Ramón Orlando, pubblicata per la prima volta nel 1991."
     },
     {
       "year": 2015,
@@ -4842,7 +5186,8 @@
       "fun_fact_fr": "« Lágrimas Negras » de Buena Vista Social Club, Omara Portuondo, parue pour la première fois en 2015 sur l'album « Lost and Found ».",
       "fun_fact_nl": "\"Lágrimas Negras\" van Buena Vista Social Club, Omara Portuondo, voor het eerst uitgebracht in 2015 op het album \"Lost and Found\".",
       "uri_deezer": "deezer://track/3761250002",
-      "uri_apple_music": "applemusic://track/1471007163"
+      "uri_apple_music": "applemusic://track/1471007163",
+      "fun_fact_it": "«Lágrimas Negras» di Buena Vista Social Club, Omara Portuondo, pubblicata per la prima volta nel 2015 nell'album «Lost and Found»."
     },
     {
       "year": 1983,
@@ -4856,7 +5201,8 @@
       "fun_fact_fr": "« Y No Hago Mas Na' » de El Gran Combo De Puerto Rico, parue pour la première fois en 1983 sur l'album « 25th Anniversary ».",
       "fun_fact_nl": "\"Y No Hago Mas Na'\" van El Gran Combo De Puerto Rico, voor het eerst uitgebracht in 1983 op het album \"25th Anniversary\".",
       "uri_deezer": "deezer://track/12700701",
-      "uri_apple_music": "applemusic://track/278804902"
+      "uri_apple_music": "applemusic://track/278804902",
+      "fun_fact_it": "«Y No Hago Mas Na'» di El Gran Combo De Puerto Rico, pubblicata per la prima volta nel 1983 nell'album «25th Anniversary»."
     },
     {
       "year": 1996,
@@ -4870,7 +5216,8 @@
       "fun_fact_fr": "« Vete Y Dile » de Sergio Vargas, parue pour la première fois en 1996 sur l'album « Vete y Dile ».",
       "fun_fact_nl": "\"Vete Y Dile\" van Sergio Vargas, voor het eerst uitgebracht in 1996 op het album \"Vete y Dile\".",
       "uri_deezer": "deezer://track/1364347132",
-      "uri_apple_music": "applemusic://track/1586058297"
+      "uri_apple_music": "applemusic://track/1586058297",
+      "fun_fact_it": "«Vete Y Dile» di Sergio Vargas, pubblicata per la prima volta nel 1996 nell'album «Vete y Dile»."
     },
     {
       "year": 1970,
@@ -4884,7 +5231,8 @@
       "fun_fact_fr": "« Aires De Navidad » de Willie Colón, Héctor Lavoe, parue pour la première fois en 1970 sur l'album « Asalto Navideño: Vol. 1 & 2 ».",
       "fun_fact_nl": "\"Aires De Navidad\" van Willie Colón, Héctor Lavoe, voor het eerst uitgebracht in 1970 op het album \"Asalto Navideño: Vol. 1 & 2\".",
       "uri_deezer": "deezer://track/686087472",
-      "uri_apple_music": "applemusic://track/1838532465"
+      "uri_apple_music": "applemusic://track/1838532465",
+      "fun_fact_it": "«Aires De Navidad» di Willie Colón, Héctor Lavoe, pubblicata per la prima volta nel 1970 nell'album «Asalto Navideño: Vol. 1 & 2»."
     },
     {
       "year": 2018,
@@ -4898,7 +5246,8 @@
       "fun_fact_fr": "« Mi Forma de Ser (feat. Ala Jaza) - Mambo Version » de Farruko, Ala Jaza, parue pour la première fois en 2018 sur l'album « Mi Forma de Ser (feat. Ala Jaza) (Mambo Version) ».",
       "fun_fact_nl": "\"Mi Forma de Ser (feat. Ala Jaza) - Mambo Version\" van Farruko, Ala Jaza, voor het eerst uitgebracht in 2018 op het album \"Mi Forma de Ser (feat. Ala Jaza) (Mambo Version)\".",
       "uri_deezer": "deezer://track/529810281",
-      "uri_apple_music": "applemusic://track/1413852639"
+      "uri_apple_music": "applemusic://track/1413852639",
+      "fun_fact_it": "«Mi Forma de Ser (feat. Ala Jaza) - Mambo Version» di Farruko, Ala Jaza, pubblicata per la prima volta nel 2018 nell'album «Mi Forma de Ser (feat. Ala Jaza) (Mambo Version)»."
     },
     {
       "year": 2023,
@@ -4911,7 +5260,8 @@
       "fun_fact_es": "\"Confesiones\" de Adolescent's Orquesta, publicada por primera vez en 2023 en el álbum \"Mi Confesión\".",
       "fun_fact_fr": "« Confesiones » de Adolescent's Orquesta, parue pour la première fois en 2023 sur l'album « Mi Confesión ».",
       "fun_fact_nl": "\"Confesiones\" van Adolescent's Orquesta, voor het eerst uitgebracht in 2023 op het album \"Mi Confesión\".",
-      "uri_deezer": "deezer://track/2360920485"
+      "uri_deezer": "deezer://track/2360920485",
+      "fun_fact_it": "«Confesiones» di Adolescent's Orquesta, pubblicata per la prima volta nel 2023 nell'album «Mi Confesión»."
     },
     {
       "year": 1991,
@@ -4925,7 +5275,8 @@
       "fun_fact_fr": "« Esa Mujer » de Tony Vega, parue pour la première fois en 1991 sur l'album « Pura Salsa ».",
       "fun_fact_nl": "\"Esa Mujer\" van Tony Vega, voor het eerst uitgebracht in 1991 op het album \"Pura Salsa\".",
       "uri_deezer": "deezer://track/15493903",
-      "uri_apple_music": "applemusic://track/1443896843"
+      "uri_apple_music": "applemusic://track/1443896843",
+      "fun_fact_it": "«Esa Mujer» di Tony Vega, pubblicata per la prima volta nel 1991 nell'album «Pura Salsa»."
     },
     {
       "year": 2015,
@@ -4939,7 +5290,8 @@
       "fun_fact_fr": "« Con la Misma Moneda » de Josimar y Su Yambú, parue pour la première fois en 2015 sur l'album « Por Culpa de Alguien ».",
       "fun_fact_nl": "\"Con la Misma Moneda\" van Josimar y Su Yambú, voor het eerst uitgebracht in 2015 op het album \"Por Culpa de Alguien\".",
       "uri_deezer": "deezer://track/640220502",
-      "uri_apple_music": "applemusic://track/1454454183"
+      "uri_apple_music": "applemusic://track/1454454183",
+      "fun_fact_it": "«Con la Misma Moneda» di Josimar y Su Yambú, pubblicata per la prima volta nel 2015 nell'album «Por Culpa de Alguien»."
     },
     {
       "year": 2018,
@@ -4953,7 +5305,8 @@
       "fun_fact_fr": "« Como Mirarte » de Josimar y Su Yambú, parue pour la première fois en 2018 sur l'album « Como Mirarte ».",
       "fun_fact_nl": "\"Como Mirarte\" van Josimar y Su Yambú, voor het eerst uitgebracht in 2018 op het album \"Como Mirarte\".",
       "uri_deezer": "deezer://track/640205132",
-      "uri_apple_music": "applemusic://track/1460069155"
+      "uri_apple_music": "applemusic://track/1460069155",
+      "fun_fact_it": "«Como Mirarte» di Josimar y Su Yambú, pubblicata per la prima volta nel 2018 nell'album «Como Mirarte»."
     },
     {
       "year": 2018,
@@ -4967,7 +5320,8 @@
       "fun_fact_fr": "« Porque un Hombre No Llora » de Josimar y Su Yambú, parue pour la première fois en 2018 sur l'album « Porque un Hombre No Llora ».",
       "fun_fact_nl": "\"Porque un Hombre No Llora\" van Josimar y Su Yambú, voor het eerst uitgebracht in 2018 op het album \"Porque un Hombre No Llora\".",
       "uri_deezer": "deezer://track/640205112",
-      "uri_apple_music": "applemusic://track/1454457541"
+      "uri_apple_music": "applemusic://track/1454457541",
+      "fun_fact_it": "«Porque un Hombre No Llora» di Josimar y Su Yambú, pubblicata per la prima volta nel 2018 nell'album «Porque un Hombre No Llora»."
     },
     {
       "year": 1997,
@@ -4981,7 +5335,8 @@
       "fun_fact_fr": "« El Baile del Sua Sua » de Kinito Mendez, parue pour la première fois en 1997 sur l'album « Vida ».",
       "fun_fact_nl": "\"El Baile del Sua Sua\" van Kinito Mendez, voor het eerst uitgebracht in 1997 op het album \"Vida\".",
       "uri_deezer": "deezer://track/11100199",
-      "uri_apple_music": "applemusic://track/1311675983"
+      "uri_apple_music": "applemusic://track/1311675983",
+      "fun_fact_it": "«El Baile del Sua Sua» di Kinito Mendez, pubblicata per la prima volta nel 1997 nell'album «Vida»."
     },
     {
       "year": 1995,
@@ -4995,7 +5350,8 @@
       "fun_fact_fr": "« Cachamba » de Kinito Mendez, parue pour la première fois en 1995 sur l'album « El Hombre Merengue ».",
       "fun_fact_nl": "\"Cachamba\" van Kinito Mendez, voor het eerst uitgebracht in 1995 op het album \"El Hombre Merengue\".",
       "uri_deezer": "deezer://track/10992820",
-      "uri_apple_music": "applemusic://track/21219731"
+      "uri_apple_music": "applemusic://track/21219731",
+      "fun_fact_it": "«Cachamba» di Kinito Mendez, pubblicata per la prima volta nel 1995 nell'album «El Hombre Merengue»."
     },
     {
       "year": 1996,
@@ -5009,7 +5365,8 @@
       "fun_fact_fr": "« Entre Tu Cuerpo y el Mio » de Milly Quezada, Los Vecinos, parue pour la première fois en 1996 sur l'album « Mis Favoritas ».",
       "fun_fact_nl": "\"Entre Tu Cuerpo y el Mio\" van Milly Quezada, Los Vecinos, voor het eerst uitgebracht in 1996 op het album \"Mis Favoritas\".",
       "uri_deezer": "deezer://track/7812557",
-      "uri_apple_music": "applemusic://track/405512770"
+      "uri_apple_music": "applemusic://track/405512770",
+      "fun_fact_it": "«Entre Tu Cuerpo y el Mio» di Milly Quezada, Los Vecinos, pubblicata per la prima volta nel 1996 nell'album «Mis Favoritas»."
     },
     {
       "year": 1966,
@@ -5023,7 +5380,8 @@
       "fun_fact_fr": "« I Like It Like That » de Pete Rodriguez, parue pour la première fois en 1966 sur l'album « I Like It Like That ».",
       "fun_fact_nl": "\"I Like It Like That\" van Pete Rodriguez, voor het eerst uitgebracht in 1966 op het album \"I Like It Like That\".",
       "uri_deezer": "deezer://track/686070052",
-      "uri_apple_music": "applemusic://track/1465799115"
+      "uri_apple_music": "applemusic://track/1465799115",
+      "fun_fact_it": "«I Like It Like That» di Pete Rodriguez, pubblicata per la prima volta nel 1966 nell'album «I Like It Like That»."
     },
     {
       "year": 1972,
@@ -5037,7 +5395,8 @@
       "fun_fact_fr": "« Sofrito » de Mongo Santamaria, parue pour la première fois en 1972 sur l'album « Cocktail Music ».",
       "fun_fact_nl": "\"Sofrito\" van Mongo Santamaria, voor het eerst uitgebracht in 1972 op het album \"Cocktail Music\".",
       "uri_deezer": "deezer://track/893750902",
-      "uri_apple_music": "applemusic://track/1464278447"
+      "uri_apple_music": "applemusic://track/1464278447",
+      "fun_fact_it": "«Sofrito» di Mongo Santamaria, pubblicata per la prima volta nel 1972 nell'album «Cocktail Music»."
     },
     {
       "year": 1996,
@@ -5051,7 +5410,8 @@
       "fun_fact_fr": "« Salsa » de Yuri Buenaventura, parue pour la première fois en 1996 sur l'album « Yo Soy ».",
       "fun_fact_nl": "\"Salsa\" van Yuri Buenaventura, voor het eerst uitgebracht in 1996 op het album \"Yo Soy\".",
       "uri_deezer": "deezer://track/2533865",
-      "uri_apple_music": "applemusic://track/1444026291"
+      "uri_apple_music": "applemusic://track/1444026291",
+      "fun_fact_it": "«Salsa» di Yuri Buenaventura, pubblicata per la prima volta nel 1996 nell'album «Yo Soy»."
     },
     {
       "year": 1994,
@@ -5065,7 +5425,8 @@
       "fun_fact_fr": "« Disco Azúcar » de Juan Formell y Los Van Van, parue pour la première fois en 1994 sur l'album « Azúcar ».",
       "fun_fact_nl": "\"Disco Azúcar\" van Juan Formell y Los Van Van, voor het eerst uitgebracht in 1994 op het album \"Azúcar\".",
       "uri_deezer": "deezer://track/90782047",
-      "uri_apple_music": "applemusic://track/281166052"
+      "uri_apple_music": "applemusic://track/281166052",
+      "fun_fact_it": "«Disco Azúcar» di Juan Formell y Los Van Van, pubblicata per la prima volta nel 1994 nell'album «Azúcar»."
     },
     {
       "year": 1986,
@@ -5079,7 +5440,8 @@
       "fun_fact_fr": "« Lo Que Pasó Entre Tú y Yo Pasó » de Luis Enrique, parue pour la première fois en 1986 sur l'album « Leyendas: Salsa Romántica ».",
       "fun_fact_nl": "\"Lo Que Pasó Entre Tú y Yo Pasó\" van Luis Enrique, voor het eerst uitgebracht in 1986 op het album \"Leyendas: Salsa Romántica\".",
       "uri_deezer": "deezer://track/88877219",
-      "uri_apple_music": "applemusic://track/398419109"
+      "uri_apple_music": "applemusic://track/398419109",
+      "fun_fact_it": "«Lo Que Pasó Entre Tú y Yo Pasó» di Luis Enrique, pubblicata per la prima volta nel 1986 nell'album «Leyendas: Salsa Romántica»."
     },
     {
       "year": 2000,
@@ -5093,7 +5455,8 @@
       "fun_fact_fr": "« La Salsa la Traigo Yo » de Sonora Carruseles, parue pour la première fois en 2000 sur l'album « Al Son de los Cueros ».",
       "fun_fact_nl": "\"La Salsa la Traigo Yo\" van Sonora Carruseles, voor het eerst uitgebracht in 2000 op het album \"Al Son de los Cueros\".",
       "uri_deezer": "deezer://track/113014902",
-      "uri_apple_music": "applemusic://track/6562423"
+      "uri_apple_music": "applemusic://track/6562423",
+      "fun_fact_it": "«La Salsa la Traigo Yo» di Sonora Carruseles, pubblicata per la prima volta nel 2000 nell'album «Al Son de los Cueros»."
     },
     {
       "year": 1970,
@@ -5107,7 +5470,8 @@
       "fun_fact_fr": "« Que Se Sepa » de Roberto Roena, parue pour la première fois en 1970 sur l'album « Apollo Sound 5 ».",
       "fun_fact_nl": "\"Que Se Sepa\" van Roberto Roena, voor het eerst uitgebracht in 1970 op het album \"Apollo Sound 5\".",
       "uri_deezer": "deezer://track/686073702",
-      "uri_apple_music": "applemusic://track/1464277544"
+      "uri_apple_music": "applemusic://track/1464277544",
+      "fun_fact_it": "«Que Se Sepa» di Roberto Roena, pubblicata per la prima volta nel 1970 nell'album «Apollo Sound 5»."
     },
     {
       "year": 1989,
@@ -5121,7 +5485,8 @@
       "fun_fact_fr": "« Así Es la Vida » de Luis Enrique, parue pour la première fois en 1989 sur l'album « Mis Favoritas ».",
       "fun_fact_nl": "\"Así Es la Vida\" van Luis Enrique, voor het eerst uitgebracht in 1989 op het album \"Mis Favoritas\".",
       "uri_deezer": "deezer://track/6269960",
-      "uri_apple_music": "applemusic://track/1453126327"
+      "uri_apple_music": "applemusic://track/1453126327",
+      "fun_fact_it": "«Así Es la Vida» di Luis Enrique, pubblicata per la prima volta nel 1989 nell'album «Mis Favoritas»."
     },
     {
       "year": 1993,
@@ -5133,7 +5498,8 @@
       "fun_fact_de": "„Raquel\" von La Misma Gente, Grupo Niche, erstmals 1993 erschienen.",
       "fun_fact_es": "\"Raquel\" de La Misma Gente, Grupo Niche, publicada por primera vez en 1993.",
       "fun_fact_fr": "« Raquel » de La Misma Gente, Grupo Niche, parue pour la première fois en 1993.",
-      "fun_fact_nl": "\"Raquel\" van La Misma Gente, Grupo Niche, voor het eerst uitgebracht in 1993."
+      "fun_fact_nl": "\"Raquel\" van La Misma Gente, Grupo Niche, voor het eerst uitgebracht in 1993.",
+      "fun_fact_it": "«Raquel» di La Misma Gente, Grupo Niche, pubblicata per la prima volta nel 1993."
     },
     {
       "year": 2000,
@@ -5146,7 +5512,8 @@
       "fun_fact_es": "\"Castígala\" de Los Nemus Del Pacifico, publicada por primera vez en 2000.",
       "fun_fact_fr": "« Castígala » de Los Nemus Del Pacifico, parue pour la première fois en 2000.",
       "fun_fact_nl": "\"Castígala\" van Los Nemus Del Pacifico, voor het eerst uitgebracht in 2000.",
-      "uri_apple_music": "applemusic://track/26111813"
+      "uri_apple_music": "applemusic://track/26111813",
+      "fun_fact_it": "«Castígala» di Los Nemus Del Pacifico, pubblicata per la prima volta nel 2000."
     },
     {
       "year": 2001,
@@ -5160,7 +5527,8 @@
       "fun_fact_fr": "« I Love Salsa » de N'Klabe, parue pour la première fois en 2001 sur l'album « I Love Salsa (re-release) ».",
       "fun_fact_nl": "\"I Love Salsa\" van N'Klabe, voor het eerst uitgebracht in 2001 op het album \"I Love Salsa (re-release)\".",
       "uri_deezer": "deezer://track/13207217",
-      "uri_apple_music": "applemusic://track/321352677"
+      "uri_apple_music": "applemusic://track/321352677",
+      "fun_fact_it": "«I Love Salsa» di N'Klabe, pubblicata per la prima volta nel 2001 nell'album «I Love Salsa (re-release)»."
     },
     {
       "year": 2000,
@@ -5174,7 +5542,8 @@
       "fun_fact_fr": "« -Te Voy A Hacer Feliz » de Mariano Civico, parue pour la première fois en 2000 sur l'album « Costa Brava ».",
       "fun_fact_nl": "\"-Te Voy A Hacer Feliz\" van Mariano Civico, voor het eerst uitgebracht in 2000 op het album \"Costa Brava\".",
       "uri_deezer": "deezer://track/1104813912",
-      "uri_apple_music": "applemusic://track/1735824620"
+      "uri_apple_music": "applemusic://track/1735824620",
+      "fun_fact_it": "«-Te Voy A Hacer Feliz» di Mariano Civico, pubblicata per la prima volta nel 2000 nell'album «Costa Brava»."
     },
     {
       "year": 2006,
@@ -5188,7 +5557,8 @@
       "fun_fact_fr": "« Toro Mata » de Johnny Pacheco, Celia Cruz, parue pour la première fois en 2006 sur l'album « The 'Brillante' Best ».",
       "fun_fact_nl": "\"Toro Mata\" van Johnny Pacheco, Celia Cruz, voor het eerst uitgebracht in 2006 op het album \"The 'Brillante' Best\".",
       "uri_deezer": "deezer://track/686112862",
-      "uri_apple_music": "applemusic://track/1464284939"
+      "uri_apple_music": "applemusic://track/1464284939",
+      "fun_fact_it": "«Toro Mata» di Johnny Pacheco, Celia Cruz, pubblicata per la prima volta nel 2006 nell'album «The 'Brillante' Best»."
     },
     {
       "year": 2004,
@@ -5202,7 +5572,8 @@
       "fun_fact_fr": "« La Esencia Del Guaguancó » de Johnny Pacheco, Pete \"El Conde\" Rodriguez, parue pour la première fois en 2004.",
       "fun_fact_nl": "\"La Esencia Del Guaguancó\" van Johnny Pacheco, Pete \"El Conde\" Rodriguez, voor het eerst uitgebracht in 2004.",
       "uri_deezer": "deezer://track/686137662",
-      "uri_apple_music": "applemusic://track/1464963061"
+      "uri_apple_music": "applemusic://track/1464963061",
+      "fun_fact_it": "«La Esencia Del Guaguancó» di Johnny Pacheco, Pete \"El Conde\" Rodriguez, pubblicata per la prima volta nel 2004."
     },
     {
       "year": 1975,
@@ -5216,7 +5587,8 @@
       "fun_fact_fr": "« El Faisán » de Johnny Pacheco, parue pour la première fois en 1975 sur l'album « El Maestro ».",
       "fun_fact_nl": "\"El Faisán\" van Johnny Pacheco, voor het eerst uitgebracht in 1975 op het album \"El Maestro\".",
       "uri_deezer": "deezer://track/688271792",
-      "uri_apple_music": "applemusic://track/1466113040"
+      "uri_apple_music": "applemusic://track/1466113040",
+      "fun_fact_it": "«El Faisán» di Johnny Pacheco, pubblicata per la prima volta nel 1975 nell'album «El Maestro»."
     },
     {
       "year": 1979,
@@ -5230,7 +5602,8 @@
       "fun_fact_fr": "« Agua De Clavelito » de Johnny Pacheco, Hector Casanova, parue pour la première fois en 1979 sur l'album « Los Amigos ».",
       "fun_fact_nl": "\"Agua De Clavelito\" van Johnny Pacheco, Hector Casanova, voor het eerst uitgebracht in 1979 op het album \"Los Amigos\".",
       "uri_deezer": "deezer://track/695411602",
-      "uri_apple_music": "applemusic://track/1468172741"
+      "uri_apple_music": "applemusic://track/1468172741",
+      "fun_fact_it": "«Agua De Clavelito» di Johnny Pacheco, Hector Casanova, pubblicata per la prima volta nel 1979 nell'album «Los Amigos»."
     },
     {
       "year": 2021,
@@ -5244,7 +5617,8 @@
       "fun_fact_fr": "« Víctimas las Dos » de Víctor Manuelle, LA INDIA, parue pour la première fois en 2021 sur l'album « Víctimas las Dos ».",
       "fun_fact_nl": "\"Víctimas las Dos\" van Víctor Manuelle, LA INDIA, voor het eerst uitgebracht in 2021 op het album \"Víctimas las Dos\".",
       "uri_deezer": "deezer://track/1241247942",
-      "uri_apple_music": "applemusic://track/1553326681"
+      "uri_apple_music": "applemusic://track/1553326681",
+      "fun_fact_it": "«Víctimas las Dos» di Víctor Manuelle, LA INDIA, pubblicata per la prima volta nel 2021 nell'album «Víctimas las Dos»."
     },
     {
       "year": 1978,
@@ -5258,7 +5632,8 @@
       "fun_fact_fr": "« Guaguancó Del Adios » de Roberto Roena Y Su Apollo Sound, parue pour la première fois en 1978 sur l'album « El Progreso ».",
       "fun_fact_nl": "\"Guaguancó Del Adios\" van Roberto Roena Y Su Apollo Sound, voor het eerst uitgebracht in 1978 op het album \"El Progreso\".",
       "uri_deezer": "deezer://track/686156482",
-      "uri_apple_music": "applemusic://track/1464959738"
+      "uri_apple_music": "applemusic://track/1464959738",
+      "fun_fact_it": "«Guaguancó Del Adios» di Roberto Roena Y Su Apollo Sound, pubblicata per la prima volta nel 1978 nell'album «El Progreso»."
     },
     {
       "year": 1978,
@@ -5272,7 +5647,8 @@
       "fun_fact_fr": "« Plástico » de Willie Colón, Rubén Blades, parue pour la première fois en 1978 sur l'album « Siembra ».",
       "fun_fact_nl": "\"Plástico\" van Willie Colón, Rubén Blades, voor het eerst uitgebracht in 1978 op het album \"Siembra\".",
       "uri_deezer": "deezer://track/686098782",
-      "uri_apple_music": "applemusic://track/1464956799"
+      "uri_apple_music": "applemusic://track/1464956799",
+      "fun_fact_it": "«Plástico» di Willie Colón, Rubén Blades, pubblicata per la prima volta nel 1978 nell'album «Siembra»."
     },
     {
       "year": 1990,
@@ -5286,7 +5662,8 @@
       "fun_fact_fr": "« Ella Es » de Tony Vega, parue pour la première fois en 1990 sur l'album « Pura Salsa ».",
       "fun_fact_nl": "\"Ella Es\" van Tony Vega, voor het eerst uitgebracht in 1990 op het album \"Pura Salsa\".",
       "uri_deezer": "deezer://track/15493896",
-      "uri_apple_music": "applemusic://track/1443808823"
+      "uri_apple_music": "applemusic://track/1443808823",
+      "fun_fact_it": "«Ella Es» di Tony Vega, pubblicata per la prima volta nel 1990 nell'album «Pura Salsa»."
     },
     {
       "year": 2008,
@@ -5300,7 +5677,8 @@
       "fun_fact_fr": "« Lo Mio Es Amor - En Vivo » de Tony Vega, parue pour la première fois en 2008 sur l'album « En Concierto ».",
       "fun_fact_nl": "\"Lo Mio Es Amor - En Vivo\" van Tony Vega, voor het eerst uitgebracht in 2008 op het album \"En Concierto\".",
       "uri_deezer": "deezer://track/11108198",
-      "uri_apple_music": "applemusic://track/1739684719"
+      "uri_apple_music": "applemusic://track/1739684719",
+      "fun_fact_it": "«Lo Mio Es Amor - En Vivo» di Tony Vega, pubblicata per la prima volta nel 2008 nell'album «En Concierto»."
     },
     {
       "year": 1989,
@@ -5314,7 +5692,8 @@
       "fun_fact_fr": "« La noche más linda del mundo » de Adalberto Santiago, parue pour la première fois en 1989 sur l'album « Sex Symbol ».",
       "fun_fact_nl": "\"La noche más linda del mundo\" van Adalberto Santiago, voor het eerst uitgebracht in 1989 op het album \"Sex Symbol\".",
       "uri_deezer": "deezer://track/1746443747",
-      "uri_apple_music": "applemusic://track/1623359770"
+      "uri_apple_music": "applemusic://track/1623359770",
+      "fun_fact_it": "«La noche más linda del mundo» di Adalberto Santiago, pubblicata per la prima volta nel 1989 nell'album «Sex Symbol»."
     },
     {
       "year": 1983,
@@ -5328,7 +5707,8 @@
       "fun_fact_fr": "« Nadie Se Salva De La Rumba » de Ray Barretto, Adalberto Santiago, Celia Cruz, parue pour la première fois en 1983 sur l'album « Celia ».",
       "fun_fact_nl": "\"Nadie Se Salva De La Rumba\" van Ray Barretto, Adalberto Santiago, Celia Cruz, voor het eerst uitgebracht in 1983 op het album \"Celia\".",
       "uri_deezer": "deezer://track/686101152",
-      "uri_apple_music": "applemusic://track/1768182445"
+      "uri_apple_music": "applemusic://track/1768182445",
+      "fun_fact_it": "«Nadie Se Salva De La Rumba» di Ray Barretto, Adalberto Santiago, Celia Cruz, pubblicata per la prima volta nel 1983 nell'album «Celia»."
     },
     {
       "year": 1995,
@@ -5342,7 +5722,8 @@
       "fun_fact_fr": "« Y Qué Me Pasa - Salsa » de Mickey Taveras, parue pour la première fois en 1995 sur l'album « Lucharé ».",
       "fun_fact_nl": "\"Y Qué Me Pasa - Salsa\" van Mickey Taveras, voor het eerst uitgebracht in 1995 op het album \"Lucharé\".",
       "uri_deezer": "deezer://track/1857087807",
-      "uri_apple_music": "applemusic://track/1571773569"
+      "uri_apple_music": "applemusic://track/1571773569",
+      "fun_fact_it": "«Y Qué Me Pasa - Salsa» di Mickey Taveras, pubblicata per la prima volta nel 1995 nell'album «Lucharé»."
     },
     {
       "year": 1995,
@@ -5356,7 +5737,8 @@
       "fun_fact_fr": "« A Pesar del Tiempo » de Mickey Taveras, parue pour la première fois en 1995 sur l'album « Lucharé ».",
       "fun_fact_nl": "\"A Pesar del Tiempo\" van Mickey Taveras, voor het eerst uitgebracht in 1995 op het album \"Lucharé\".",
       "uri_deezer": "deezer://track/1857087797",
-      "uri_apple_music": "applemusic://track/1536630646"
+      "uri_apple_music": "applemusic://track/1536630646",
+      "fun_fact_it": "«A Pesar del Tiempo» di Mickey Taveras, pubblicata per la prima volta nel 1995 nell'album «Lucharé»."
     },
     {
       "year": 1995,
@@ -5370,7 +5752,8 @@
       "fun_fact_fr": "« Me Gustas » de Mickey Taveras, parue pour la première fois en 1995 sur l'album « Lucharé ».",
       "fun_fact_nl": "\"Me Gustas\" van Mickey Taveras, voor het eerst uitgebracht in 1995 op het album \"Lucharé\".",
       "uri_deezer": "deezer://track/1857087827",
-      "uri_apple_music": "applemusic://track/1571773587"
+      "uri_apple_music": "applemusic://track/1571773587",
+      "fun_fact_it": "«Me Gustas» di Mickey Taveras, pubblicata per la prima volta nel 1995 nell'album «Lucharé»."
     },
     {
       "year": 1999,
@@ -5384,7 +5767,8 @@
       "fun_fact_fr": "« Mi Historia Entre Tus Dedos » de Mickey Taveras, parue pour la première fois en 1999.",
       "fun_fact_nl": "\"Mi Historia Entre Tus Dedos\" van Mickey Taveras, voor het eerst uitgebracht in 1999.",
       "uri_deezer": "deezer://track/1878375587",
-      "uri_apple_music": "applemusic://track/1443852388"
+      "uri_apple_music": "applemusic://track/1443852388",
+      "fun_fact_it": "«Mi Historia Entre Tus Dedos» di Mickey Taveras, pubblicata per la prima volta nel 1999."
     },
     {
       "year": 1999,
@@ -5398,7 +5782,8 @@
       "fun_fact_fr": "« Cuando Acaba el Placer » de Mickey Taveras, parue pour la première fois en 1999 sur l'album « Más Romántico- Salsa en la Calle ».",
       "fun_fact_nl": "\"Cuando Acaba el Placer\" van Mickey Taveras, voor het eerst uitgebracht in 1999 op het album \"Más Romántico- Salsa en la Calle\".",
       "uri_deezer": "deezer://track/1856919357",
-      "uri_apple_music": "applemusic://track/1767350493"
+      "uri_apple_music": "applemusic://track/1767350493",
+      "fun_fact_it": "«Cuando Acaba el Placer» di Mickey Taveras, pubblicata per la prima volta nel 1999 nell'album «Más Romántico- Salsa en la Calle»."
     },
     {
       "year": 2006,
@@ -5412,7 +5797,8 @@
       "fun_fact_fr": "« Mi Mujer Me Gobierna » de La Banda Gorda, parue pour la première fois en 2006 sur l'album « En Vivo ».",
       "fun_fact_nl": "\"Mi Mujer Me Gobierna\" van La Banda Gorda, voor het eerst uitgebracht in 2006 op het album \"En Vivo\".",
       "uri_deezer": "deezer://track/798851062",
-      "uri_apple_music": "applemusic://track/1486695424"
+      "uri_apple_music": "applemusic://track/1486695424",
+      "fun_fact_it": "«Mi Mujer Me Gobierna» di La Banda Gorda, pubblicata per la prima volta nel 2006 nell'album «En Vivo»."
     },
     {
       "year": 1990,
@@ -5426,7 +5812,8 @@
       "fun_fact_fr": "« Date un Chance » de Luis Enrique, parue pour la première fois en 1990 sur l'album « Lo Que Pasó... La Historia Del Príncipe De La Salsa ».",
       "fun_fact_nl": "\"Date un Chance\" van Luis Enrique, voor het eerst uitgebracht in 1990 op het album \"Lo Que Pasó... La Historia Del Príncipe De La Salsa\".",
       "uri_deezer": "deezer://track/7436387",
-      "uri_apple_music": "applemusic://track/159868835"
+      "uri_apple_music": "applemusic://track/159868835",
+      "fun_fact_it": "«Date un Chance» di Luis Enrique, pubblicata per la prima volta nel 1990 nell'album «Lo Que Pasó... La Historia Del Príncipe De La Salsa»."
     },
     {
       "year": 2002,
@@ -5440,7 +5827,8 @@
       "fun_fact_fr": "« Bailamos Otra Vez » de José Alberto \"El Canario\", parue pour la première fois en 2002 sur l'album « Discúlpeme Señora (Baile Total) ».",
       "fun_fact_nl": "\"Bailamos Otra Vez\" van José Alberto \"El Canario\", voor het eerst uitgebracht in 2002 op het album \"Discúlpeme Señora (Baile Total)\".",
       "uri_deezer": "deezer://track/429985842",
-      "uri_apple_music": "applemusic://track/1878132970"
+      "uri_apple_music": "applemusic://track/1878132970",
+      "fun_fact_it": "«Bailamos Otra Vez» di José Alberto \"El Canario\", pubblicata per la prima volta nel 2002 nell'album «Discúlpeme Señora (Baile Total)»."
     },
     {
       "year": 1988,
@@ -5454,7 +5842,8 @@
       "fun_fact_fr": "« Mascarada » de Johnny Ray, parue pour la première fois en 1988 sur l'album « Imprescindibles de la Salsa ».",
       "fun_fact_nl": "\"Mascarada\" van Johnny Ray, voor het eerst uitgebracht in 1988 op het album \"Imprescindibles de la Salsa\".",
       "uri_deezer": "deezer://track/1028496912",
-      "uri_apple_music": "applemusic://track/1443620307"
+      "uri_apple_music": "applemusic://track/1443620307",
+      "fun_fact_it": "«Mascarada» di Johnny Ray, pubblicata per la prima volta nel 1988 nell'album «Imprescindibles de la Salsa»."
     },
     {
       "year": 1992,
@@ -5468,7 +5857,8 @@
       "fun_fact_fr": "« Amor Traicionero » de Guayacán Orquesta, parue pour la première fois en 1992 sur l'album « 30 Años de Gala ».",
       "fun_fact_nl": "\"Amor Traicionero\" van Guayacán Orquesta, voor het eerst uitgebracht in 1992 op het album \"30 Años de Gala\".",
       "uri_deezer": "deezer://track/2683393132",
-      "uri_apple_music": "applemusic://track/1444164681"
+      "uri_apple_music": "applemusic://track/1444164681",
+      "fun_fact_it": "«Amor Traicionero» di Guayacán Orquesta, pubblicata per la prima volta nel 1992 nell'album «30 Años de Gala»."
     },
     {
       "year": 1993,
@@ -5482,7 +5872,8 @@
       "fun_fact_fr": "« Pagina de Amor » de Tito Gomez, parue pour la première fois en 1993 sur l'album « El Sonero Errante (En Vivo) ».",
       "fun_fact_nl": "\"Pagina de Amor\" van Tito Gomez, voor het eerst uitgebracht in 1993 op het album \"El Sonero Errante (En Vivo)\".",
       "uri_deezer": "deezer://track/3289546741",
-      "uri_apple_music": "applemusic://track/18848299"
+      "uri_apple_music": "applemusic://track/18848299",
+      "fun_fact_it": "«Pagina de Amor» di Tito Gomez, pubblicata per la prima volta nel 1993 nell'album «El Sonero Errante (En Vivo)»."
     },
     {
       "year": 1991,
@@ -5496,7 +5887,8 @@
       "fun_fact_fr": "« Amor y Control » de Rubén Blades, parue pour la première fois en 1991 sur l'album « Salsero Original ».",
       "fun_fact_nl": "\"Amor y Control\" van Rubén Blades, voor het eerst uitgebracht in 1991 op het album \"Salsero Original\".",
       "uri_deezer": "deezer://track/130084030",
-      "uri_apple_music": "applemusic://track/315159629"
+      "uri_apple_music": "applemusic://track/315159629",
+      "fun_fact_it": "«Amor y Control» di Rubén Blades, pubblicata per la prima volta nel 1991 nell'album «Salsero Original»."
     },
     {
       "year": 1996,
@@ -5510,7 +5902,8 @@
       "fun_fact_fr": "« Quiero Hacerte El Amor » de Tito Rojas, parue pour la première fois en 1996 sur l'album « Vida ».",
       "fun_fact_nl": "\"Quiero Hacerte El Amor\" van Tito Rojas, voor het eerst uitgebracht in 1996 op het album \"Vida\".",
       "uri_deezer": "deezer://track/11507267",
-      "uri_apple_music": "applemusic://track/345599755"
+      "uri_apple_music": "applemusic://track/345599755",
+      "fun_fact_it": "«Quiero Hacerte El Amor» di Tito Rojas, pubblicata per la prima volta nel 1996 nell'album «Vida»."
     },
     {
       "year": 1992,
@@ -5524,7 +5917,8 @@
       "fun_fact_fr": "« Hechizo De Luna » de Anthony Colon, Edgar Joel, parue pour la première fois en 1992 sur l'album « EN EL TOPE ».",
       "fun_fact_nl": "\"Hechizo De Luna\" van Anthony Colon, Edgar Joel, voor het eerst uitgebracht in 1992 op het album \"EN EL TOPE\".",
       "uri_deezer": "deezer://track/4091947981",
-      "uri_apple_music": "applemusic://track/1486463072"
+      "uri_apple_music": "applemusic://track/1486463072",
+      "fun_fact_it": "«Hechizo De Luna» di Anthony Colon, Edgar Joel, pubblicata per la prima volta nel 1992 nell'album «EN EL TOPE»."
     },
     {
       "year": 1998,
@@ -5538,7 +5932,8 @@
       "fun_fact_fr": "« Huellas » de Adolescent's Orquesta, parue pour la première fois en 1998 sur l'album « Millenium Hits ».",
       "fun_fact_nl": "\"Huellas\" van Adolescent's Orquesta, voor het eerst uitgebracht in 1998 op het album \"Millenium Hits\".",
       "uri_deezer": "deezer://track/1385726482",
-      "uri_apple_music": "applemusic://track/1569805980"
+      "uri_apple_music": "applemusic://track/1569805980",
+      "fun_fact_it": "«Huellas» di Adolescent's Orquesta, pubblicata per la prima volta nel 1998 nell'album «Millenium Hits»."
     },
     {
       "year": 1995,
@@ -5552,7 +5947,8 @@
       "fun_fact_fr": "« Se Me Sigue Olvidando » de Marc Anthony, parue pour la première fois en 1995 sur l'album « Todo A Su Tiempo ».",
       "fun_fact_nl": "\"Se Me Sigue Olvidando\" van Marc Anthony, voor het eerst uitgebracht in 1995 op het album \"Todo A Su Tiempo\".",
       "uri_deezer": "deezer://track/2530313",
-      "uri_apple_music": "applemusic://track/1440793076"
+      "uri_apple_music": "applemusic://track/1440793076",
+      "fun_fact_it": "«Se Me Sigue Olvidando» di Marc Anthony, pubblicata per la prima volta nel 1995 nell'album «Todo A Su Tiempo»."
     },
     {
       "year": 1995,
@@ -5566,7 +5962,8 @@
       "fun_fact_fr": "« Te Conozco Bien » de Marc Anthony, parue pour la première fois en 1995 sur l'album « Todo A Su Tiempo ».",
       "fun_fact_nl": "\"Te Conozco Bien\" van Marc Anthony, voor het eerst uitgebracht in 1995 op het album \"Todo A Su Tiempo\".",
       "uri_deezer": "deezer://track/2530314",
-      "uri_apple_music": "applemusic://track/1440793079"
+      "uri_apple_music": "applemusic://track/1440793079",
+      "fun_fact_it": "«Te Conozco Bien» di Marc Anthony, pubblicata per la prima volta nel 1995 nell'album «Todo A Su Tiempo»."
     },
     {
       "year": 1995,
@@ -5580,7 +5977,8 @@
       "fun_fact_fr": "« Hasta Ayer » de Marc Anthony, parue pour la première fois en 1995 sur l'album « Todo A Su Tiempo ».",
       "fun_fact_nl": "\"Hasta Ayer\" van Marc Anthony, voor het eerst uitgebracht in 1995 op het album \"Todo A Su Tiempo\".",
       "uri_deezer": "deezer://track/2530315",
-      "uri_apple_music": "applemusic://track/1440793082"
+      "uri_apple_music": "applemusic://track/1440793082",
+      "fun_fact_it": "«Hasta Ayer» di Marc Anthony, pubblicata per la prima volta nel 1995 nell'album «Todo A Su Tiempo»."
     },
     {
       "year": 1995,
@@ -5594,7 +5992,8 @@
       "fun_fact_fr": "« Nadie Como Ella » de Marc Anthony, parue pour la première fois en 1995.",
       "fun_fact_nl": "\"Nadie Como Ella\" van Marc Anthony, voor het eerst uitgebracht in 1995.",
       "uri_deezer": "deezer://track/1008687952",
-      "uri_apple_music": "applemusic://track/1440793086"
+      "uri_apple_music": "applemusic://track/1440793086",
+      "fun_fact_it": "«Nadie Como Ella» di Marc Anthony, pubblicata per la prima volta nel 1995."
     },
     {
       "year": 1995,
@@ -5608,7 +6007,8 @@
       "fun_fact_fr": "« Te Amaré » de Marc Anthony, parue pour la première fois en 1995 sur l'album « Todo A Su Tiempo ».",
       "fun_fact_nl": "\"Te Amaré\" van Marc Anthony, voor het eerst uitgebracht in 1995 op het album \"Todo A Su Tiempo\".",
       "uri_deezer": "deezer://track/2530317",
-      "uri_apple_music": "applemusic://track/1445753458"
+      "uri_apple_music": "applemusic://track/1445753458",
+      "fun_fact_it": "«Te Amaré» di Marc Anthony, pubblicata per la prima volta nel 1995 nell'album «Todo A Su Tiempo»."
     },
     {
       "year": 1995,
@@ -5622,7 +6022,8 @@
       "fun_fact_fr": "« Llegaste A Mi » de Marc Anthony, parue pour la première fois en 1995 sur l'album « Todo A Su Tiempo ».",
       "fun_fact_nl": "\"Llegaste A Mi\" van Marc Anthony, voor het eerst uitgebracht in 1995 op het album \"Todo A Su Tiempo\".",
       "uri_deezer": "deezer://track/2530318",
-      "uri_apple_music": "applemusic://track/1440793310"
+      "uri_apple_music": "applemusic://track/1440793310",
+      "fun_fact_it": "«Llegaste A Mi» di Marc Anthony, pubblicata per la prima volta nel 1995 nell'album «Todo A Su Tiempo»."
     },
     {
       "year": 1995,
@@ -5636,7 +6037,8 @@
       "fun_fact_fr": "« Por Amar Se Da Todo » de Marc Anthony, parue pour la première fois en 1995 sur l'album « Imprescindibles de la Salsa ».",
       "fun_fact_nl": "\"Por Amar Se Da Todo\" van Marc Anthony, voor het eerst uitgebracht in 1995 op het album \"Imprescindibles de la Salsa\".",
       "uri_deezer": "deezer://track/1028496922",
-      "uri_apple_music": "applemusic://track/1440793315"
+      "uri_apple_music": "applemusic://track/1440793315",
+      "fun_fact_it": "«Por Amar Se Da Todo» di Marc Anthony, pubblicata per la prima volta nel 1995 nell'album «Imprescindibles de la Salsa»."
     },
     {
       "year": 1995,
@@ -5650,7 +6052,8 @@
       "fun_fact_fr": "« Vieja Mesa » de Marc Anthony, parue pour la première fois en 1995 sur l'album « Todo A Su Tiempo ».",
       "fun_fact_nl": "\"Vieja Mesa\" van Marc Anthony, voor het eerst uitgebracht in 1995 op het album \"Todo A Su Tiempo\".",
       "uri_deezer": "deezer://track/2530321",
-      "uri_apple_music": "applemusic://track/1440793318"
+      "uri_apple_music": "applemusic://track/1440793318",
+      "fun_fact_it": "«Vieja Mesa» di Marc Anthony, pubblicata per la prima volta nel 1995 nell'album «Todo A Su Tiempo»."
     },
     {
       "year": 1994,
@@ -5664,7 +6067,8 @@
       "fun_fact_fr": "« A Corazón Abierto » de Hector Tricoche, parue pour la première fois en 1994 sur l'album « 12 Favoritas ».",
       "fun_fact_nl": "\"A Corazón Abierto\" van Hector Tricoche, voor het eerst uitgebracht in 1994 op het album \"12 Favoritas\".",
       "uri_deezer": "deezer://track/79275609",
-      "uri_apple_music": "applemusic://track/1443714923"
+      "uri_apple_music": "applemusic://track/1443714923",
+      "fun_fact_it": "«A Corazón Abierto» di Hector Tricoche, pubblicata per la prima volta nel 1994 nell'album «12 Favoritas»."
     },
     {
       "year": 1994,
@@ -5678,7 +6082,8 @@
       "fun_fact_fr": "« O Ella O Yo » de LA INDIA, parue pour la première fois en 1994 sur l'album « Ese Hombre (Baile Total) ».",
       "fun_fact_nl": "\"O Ella O Yo\" van LA INDIA, voor het eerst uitgebracht in 1994 op het album \"Ese Hombre (Baile Total)\".",
       "uri_deezer": "deezer://track/429988132",
-      "uri_apple_music": "applemusic://track/1444038147"
+      "uri_apple_music": "applemusic://track/1444038147",
+      "fun_fact_it": "«O Ella O Yo» di LA INDIA, pubblicata per la prima volta nel 1994 nell'album «Ese Hombre (Baile Total)»."
     },
     {
       "year": 1992,
@@ -5692,7 +6097,8 @@
       "fun_fact_fr": "« Frío Frío » de Juan Luis Guerra 4.40, parue pour la première fois en 1992 sur l'album « Frío, Frío (En Vivo Estadio Olímpico De República Dominicana) ».",
       "fun_fact_nl": "\"Frío Frío\" van Juan Luis Guerra 4.40, voor het eerst uitgebracht in 1992 op het album \"Frío, Frío (En Vivo Estadio Olímpico De República Dominicana)\".",
       "uri_deezer": "deezer://track/65401110",
-      "uri_apple_music": "applemusic://track/167014580"
+      "uri_apple_music": "applemusic://track/167014580",
+      "fun_fact_it": "«Frío Frío» di Juan Luis Guerra 4.40, pubblicata per la prima volta nel 1992 nell'album «Frío, Frío (En Vivo Estadio Olímpico De República Dominicana)»."
     },
     {
       "year": 2022,
@@ -5705,7 +6111,8 @@
       "fun_fact_es": "\"Nada de Nada\" de Marc Anthony, publicada por primera vez en 2022 en el álbum \"Pa'lla Voy\".",
       "fun_fact_fr": "\"Nada de Nada\" de Marc Anthony, sortie pour la première fois en 2022 sur l'album \"Pa'lla Voy\".",
       "fun_fact_nl": "\"Nada de Nada\" van Marc Anthony, voor het eerst uitgebracht in 2022 op het album \"Pa'lla Voy\".",
-      "uri_deezer": "deezer://track/1658479112"
+      "uri_deezer": "deezer://track/1658479112",
+      "fun_fact_it": "«Nada de Nada» di Marc Anthony, pubblicata per la prima volta nel 2022 nell'album «Pa'lla Voy»."
     },
     {
       "year": 2021,
@@ -5719,7 +6126,8 @@
       "fun_fact_fr": "« Si Tú Me Dices Ven - Versión Salsa » de Luis Figueroa, parue pour la première fois en 2021 sur l'album « Canciones del Alma ».",
       "fun_fact_nl": "\"Si Tú Me Dices Ven - Versión Salsa\" van Luis Figueroa, voor het eerst uitgebracht in 2021 op het album \"Canciones del Alma\".",
       "uri_deezer": "deezer://track/1447668092",
-      "uri_apple_music": "applemusic://track/1578605705"
+      "uri_apple_music": "applemusic://track/1578605705",
+      "fun_fact_it": "«Si Tú Me Dices Ven - Versión Salsa» di Luis Figueroa, pubblicata per la prima volta nel 2021 nell'album «Canciones del Alma»."
     },
     {
       "year": 2022,
@@ -5733,7 +6141,8 @@
       "fun_fact_fr": "« Es por ti » de Stay Homas, Rubén Blades, parue pour la première fois en 2022 sur l'album « Here2Play ».",
       "fun_fact_nl": "\"Es por ti\" van Stay Homas, Rubén Blades, voor het eerst uitgebracht in 2022 op het album \"Here2Play\".",
       "uri_deezer": "deezer://track/3234556351",
-      "uri_apple_music": "applemusic://track/1626981568"
+      "uri_apple_music": "applemusic://track/1626981568",
+      "fun_fact_it": "«Es por ti» di Stay Homas, Rubén Blades, pubblicata per la prima volta nel 2022 nell'album «Here2Play»."
     },
     {
       "year": 2021,
@@ -5747,7 +6156,8 @@
       "fun_fact_fr": "« Mala » de Marc Anthony, parue pour la première fois en 2021 sur l'album « Mala ».",
       "fun_fact_nl": "\"Mala\" van Marc Anthony, voor het eerst uitgebracht in 2021 op het album \"Mala\".",
       "uri_deezer": "deezer://track/1544242362",
-      "uri_apple_music": "applemusic://track/1610820675"
+      "uri_apple_music": "applemusic://track/1610820675",
+      "fun_fact_it": "«Mala» di Marc Anthony, pubblicata per la prima volta nel 2021 nell'album «Mala»."
     },
     {
       "year": 1996,
@@ -5761,7 +6171,8 @@
       "fun_fact_fr": "« Arrepentida » de Adolescent's Orquesta, parue pour la première fois en 1996 sur l'album « Persona Ideal ».",
       "fun_fact_nl": "\"Arrepentida\" van Adolescent's Orquesta, voor het eerst uitgebracht in 1996 op het album \"Persona Ideal\".",
       "uri_deezer": "deezer://track/1385725512",
-      "uri_apple_music": "applemusic://track/1569677758"
+      "uri_apple_music": "applemusic://track/1569677758",
+      "fun_fact_it": "«Arrepentida» di Adolescent's Orquesta, pubblicata per la prima volta nel 1996 nell'album «Persona Ideal»."
     },
     {
       "year": 2001,
@@ -5775,7 +6186,8 @@
       "fun_fact_fr": "« Me Liberé » de El Gran Combo De Puerto Rico, parue pour la première fois en 2001 sur l'album « 45 Years of Music- From the Beginning (1962-2007) ».",
       "fun_fact_nl": "\"Me Liberé\" van El Gran Combo De Puerto Rico, voor het eerst uitgebracht in 2001 op het album \"45 Years of Music- From the Beginning (1962-2007)\".",
       "uri_deezer": "deezer://track/63361366",
-      "uri_apple_music": "applemusic://track/336093816"
+      "uri_apple_music": "applemusic://track/336093816",
+      "fun_fact_it": "«Me Liberé» di El Gran Combo De Puerto Rico, pubblicata per la prima volta nel 2001 nell'album «45 Years of Music- From the Beginning (1962-2007)»."
     },
     {
       "year": 2001,
@@ -5789,7 +6201,8 @@
       "fun_fact_fr": "« Yo Si Me Enamoré - Son Version » de Huey Dunbar, parue pour la première fois en 2001 sur l'album « Yo Si Me Enamoré ».",
       "fun_fact_nl": "\"Yo Si Me Enamoré - Son Version\" van Huey Dunbar, voor het eerst uitgebracht in 2001 op het album \"Yo Si Me Enamoré\".",
       "uri_deezer": "deezer://track/13254475",
-      "uri_apple_music": "applemusic://track/384175508"
+      "uri_apple_music": "applemusic://track/384175508",
+      "fun_fact_it": "«Yo Si Me Enamoré - Son Version» di Huey Dunbar, pubblicata per la prima volta nel 2001 nell'album «Yo Si Me Enamoré»."
     },
     {
       "year": 1990,
@@ -5803,7 +6216,8 @@
       "fun_fact_fr": "« Bachata Rosa » de Juan Luis Guerra 4.40, parue pour la première fois en 1990.",
       "fun_fact_nl": "\"Bachata Rosa\" van Juan Luis Guerra 4.40, voor het eerst uitgebracht in 1990.",
       "uri_deezer": "deezer://track/1857061987",
-      "uri_apple_music": "applemusic://track/19468970"
+      "uri_apple_music": "applemusic://track/19468970",
+      "fun_fact_it": "«Bachata Rosa» di Juan Luis Guerra 4.40, pubblicata per la prima volta nel 1990."
     },
     {
       "year": 1990,
@@ -5817,7 +6231,8 @@
       "fun_fact_fr": "« Burbujas de Amor » de Juan Luis Guerra 4.40, parue pour la première fois en 1990.",
       "fun_fact_nl": "\"Burbujas de Amor\" van Juan Luis Guerra 4.40, voor het eerst uitgebracht in 1990.",
       "uri_deezer": "deezer://track/1857061907",
-      "uri_apple_music": "applemusic://track/19468968"
+      "uri_apple_music": "applemusic://track/19468968",
+      "fun_fact_it": "«Burbujas de Amor» di Juan Luis Guerra 4.40, pubblicata per la prima volta nel 1990."
     },
     {
       "year": 2021,
@@ -5831,7 +6246,8 @@
       "fun_fact_fr": "« Me Hace Daño Verte » de Fresto Music, parue pour la première fois en 2021 sur l'album « Trovando El Son ».",
       "fun_fact_nl": "\"Me Hace Daño Verte\" van Fresto Music, voor het eerst uitgebracht in 2021 op het album \"Trovando El Son\".",
       "uri_deezer": "deezer://track/2008600457",
-      "uri_apple_music": "applemusic://track/1802279290"
+      "uri_apple_music": "applemusic://track/1802279290",
+      "fun_fact_it": "«Me Hace Daño Verte» di Fresto Music, pubblicata per la prima volta nel 2021 nell'album «Trovando El Son»."
     },
     {
       "year": 1998,
@@ -5845,7 +6261,8 @@
       "fun_fact_fr": "« Déjame Un Beso » de Salsa Kids, parue pour la première fois en 1998 sur l'album « En Nuestra Salsa ».",
       "fun_fact_nl": "\"Déjame Un Beso\" van Salsa Kids, voor het eerst uitgebracht in 1998 op het album \"En Nuestra Salsa\".",
       "uri_deezer": "deezer://track/1074717062",
-      "uri_apple_music": "applemusic://track/1444140229"
+      "uri_apple_music": "applemusic://track/1444140229",
+      "fun_fact_it": "«Déjame Un Beso» di Salsa Kids, pubblicata per la prima volta nel 1998 nell'album «En Nuestra Salsa»."
     },
     {
       "year": 2004,
@@ -5859,7 +6276,8 @@
       "fun_fact_fr": "« La-33 » de La-33, parue pour la première fois en 2004 sur l'album « La-33 ».",
       "fun_fact_nl": "\"La-33\" van La-33, voor het eerst uitgebracht in 2004 op het album \"La-33\".",
       "uri_deezer": "deezer://track/77343180",
-      "uri_apple_music": "applemusic://track/733395330"
+      "uri_apple_music": "applemusic://track/733395330",
+      "fun_fact_it": "«La-33» di La-33, pubblicata per la prima volta nel 2004 nell'album «La-33»."
     },
     {
       "year": 1990,
@@ -5873,7 +6291,8 @@
       "fun_fact_fr": "« Oiga, Mire, Vea » de Guayacán Orquesta, parue pour la première fois en 1990 sur l'album « Diez en Todo Salsero ».",
       "fun_fact_nl": "\"Oiga, Mire, Vea\" van Guayacán Orquesta, voor het eerst uitgebracht in 1990 op het album \"Diez en Todo Salsero\".",
       "uri_deezer": "deezer://track/2683338362",
-      "uri_apple_music": "applemusic://track/1735818962"
+      "uri_apple_music": "applemusic://track/1735818962",
+      "fun_fact_it": "«Oiga, Mire, Vea» di Guayacán Orquesta, pubblicata per la prima volta nel 1990 nell'album «Diez en Todo Salsero»."
     },
     {
       "year": 1986,
@@ -5887,7 +6306,8 @@
       "fun_fact_fr": "« Tú No Le Amas Le Temes » de Luis Enrique, parue pour la première fois en 1986 sur l'album « Lo Que Pasó... La Historia Del Príncipe De La Salsa ».",
       "fun_fact_nl": "\"Tú No Le Amas Le Temes\" van Luis Enrique, voor het eerst uitgebracht in 1986 op het album \"Lo Que Pasó... La Historia Del Príncipe De La Salsa\".",
       "uri_deezer": "deezer://track/7436382",
-      "uri_apple_music": "applemusic://track/170539278"
+      "uri_apple_music": "applemusic://track/170539278",
+      "fun_fact_it": "«Tú No Le Amas Le Temes» di Luis Enrique, pubblicata per la prima volta nel 1986 nell'album «Lo Que Pasó... La Historia Del Príncipe De La Salsa»."
     },
     {
       "year": 1998,
@@ -5901,7 +6321,8 @@
       "fun_fact_fr": "« El Niágara en Bicicleta » de Juan Luis Guerra 4.40, parue pour la première fois en 1998 sur l'album « Ni Es Lo Mismo Ni Es Igual ».",
       "fun_fact_nl": "\"El Niágara en Bicicleta\" van Juan Luis Guerra 4.40, voor het eerst uitgebracht in 1998 op het album \"Ni Es Lo Mismo Ni Es Igual\".",
       "uri_deezer": "deezer://track/1857077927",
-      "uri_apple_music": "applemusic://track/19469222"
+      "uri_apple_music": "applemusic://track/19469222",
+      "fun_fact_it": "«El Niágara en Bicicleta» di Juan Luis Guerra 4.40, pubblicata per la prima volta nel 1998 nell'album «Ni Es Lo Mismo Ni Es Igual»."
     },
     {
       "year": 1963,
@@ -5915,7 +6336,8 @@
       "fun_fact_fr": "« Yo Vine Pa' Ver » de Joe Cuba, parue pour la première fois en 1963 sur l'album « Steppin' Out ».",
       "fun_fact_nl": "\"Yo Vine Pa' Ver\" van Joe Cuba, voor het eerst uitgebracht in 1963 op het album \"Steppin' Out\".",
       "uri_deezer": "deezer://track/687128292",
-      "uri_apple_music": "applemusic://track/1465816974"
+      "uri_apple_music": "applemusic://track/1465816974",
+      "fun_fact_it": "«Yo Vine Pa' Ver» di Joe Cuba, pubblicata per la prima volta nel 1963 nell'album «Steppin' Out»."
     },
     {
       "year": 1997,
@@ -5929,7 +6351,8 @@
       "fun_fact_fr": "« Marieta » de Sierra Maestra, parue pour la première fois en 1997 sur l'album « Tibiri Tabara ».",
       "fun_fact_nl": "\"Marieta\" van Sierra Maestra, voor het eerst uitgebracht in 1997 op het album \"Tibiri Tabara\".",
       "uri_deezer": "deezer://track/3801783532",
-      "uri_apple_music": "applemusic://track/1619108739"
+      "uri_apple_music": "applemusic://track/1619108739",
+      "fun_fact_it": "«Marieta» di Sierra Maestra, pubblicata per la prima volta nel 1997 nell'album «Tibiri Tabara»."
     },
     {
       "year": 2017,
@@ -5943,7 +6366,8 @@
       "fun_fact_fr": "« Salsa en la Calle » de Sr Ortegon, Pana Black, parue pour la première fois en 2017 sur l'album « Reggaeton Generation ».",
       "fun_fact_nl": "\"Salsa en la Calle\" van Sr Ortegon, Pana Black, voor het eerst uitgebracht in 2017 op het album \"Reggaeton Generation\".",
       "uri_deezer": "deezer://track/145543694",
-      "uri_apple_music": "applemusic://track/1221925459"
+      "uri_apple_music": "applemusic://track/1221925459",
+      "fun_fact_it": "«Salsa en la Calle» di Sr Ortegon, Pana Black, pubblicata per la prima volta nel 2017 nell'album «Reggaeton Generation»."
     },
     {
       "year": 2023,
@@ -5957,7 +6381,8 @@
       "fun_fact_fr": "« El Merengue » de Marshmello, Manuel Turizo, parue pour la première fois en 2023 sur l'album « El Merengue ».",
       "fun_fact_nl": "\"El Merengue\" van Marshmello, Manuel Turizo, voor het eerst uitgebracht in 2023 op het album \"El Merengue\".",
       "uri_deezer": "deezer://track/2169294337",
-      "uri_apple_music": "applemusic://track/1673869624"
+      "uri_apple_music": "applemusic://track/1673869624",
+      "fun_fact_it": "«El Merengue» di Marshmello, Manuel Turizo, pubblicata per la prima volta nel 2023 nell'album «El Merengue»."
     },
     {
       "year": 2022,
@@ -5971,7 +6396,8 @@
       "fun_fact_fr": "« Después de la Playa » de Bad Bunny, parue pour la première fois en 2022 sur l'album « Un Verano Sin Ti ».",
       "fun_fact_nl": "\"Después de la Playa\" van Bad Bunny, voor het eerst uitgebracht in 2022 op het album \"Un Verano Sin Ti\".",
       "uri_deezer": "deezer://track/1741494297",
-      "uri_apple_music": "applemusic://track/1622045626"
+      "uri_apple_music": "applemusic://track/1622045626",
+      "fun_fact_it": "«Después de la Playa» di Bad Bunny, pubblicata per la prima volta nel 2022 nell'album «Un Verano Sin Ti»."
     },
     {
       "year": 2022,
@@ -5984,7 +6410,8 @@
       "fun_fact_es": "\"15,500 Noches\" de Romeo Santos, Toño Rosario, Rubby Pérez, Fernando Villalona, Ramón Orlando, publicada por primera vez en 2022.",
       "fun_fact_fr": "« 15,500 Noches » de Romeo Santos, Toño Rosario, Rubby Pérez, Fernando Villalona, Ramón Orlando, parue pour la première fois en 2022.",
       "fun_fact_nl": "\"15,500 Noches\" van Romeo Santos, Toño Rosario, Rubby Pérez, Fernando Villalona, Ramón Orlando, voor het eerst uitgebracht in 2022.",
-      "uri_apple_music": "applemusic://track/1640944607"
+      "uri_apple_music": "applemusic://track/1640944607",
+      "fun_fact_it": "«15,500 Noches» di Romeo Santos, Toño Rosario, Rubby Pérez, Fernando Villalona, Ramón Orlando, pubblicata per la prima volta nel 2022."
     },
     {
       "year": 2021,
@@ -5998,7 +6425,8 @@
       "fun_fact_fr": "« Pa'lla Voy » de Marc Anthony, parue pour la première fois en 2021 sur l'album « Pa'lla Voy ».",
       "fun_fact_nl": "\"Pa'lla Voy\" van Marc Anthony, voor het eerst uitgebracht in 2021 op het album \"Pa'lla Voy\".",
       "uri_deezer": "deezer://track/1466619062",
-      "uri_apple_music": "applemusic://track/1610820666"
+      "uri_apple_music": "applemusic://track/1610820666",
+      "fun_fact_it": "«Pa'lla Voy» di Marc Anthony, pubblicata per la prima volta nel 2021 nell'album «Pa'lla Voy»."
     },
     {
       "year": 2001,
@@ -6012,7 +6440,8 @@
       "fun_fact_fr": "« Ya No Regreso Contigo » de Roberto Blades, parue pour la première fois en 2001 sur l'album « Encore ».",
       "fun_fact_nl": "\"Ya No Regreso Contigo\" van Roberto Blades, voor het eerst uitgebracht in 2001 op het album \"Encore\".",
       "uri_deezer": "deezer://track/1499078502",
-      "uri_apple_music": "applemusic://track/1797925217"
+      "uri_apple_music": "applemusic://track/1797925217",
+      "fun_fact_it": "«Ya No Regreso Contigo» di Roberto Blades, pubblicata per la prima volta nel 2001 nell'album «Encore»."
     },
     {
       "year": 2008,
@@ -6025,7 +6454,8 @@
       "fun_fact_es": "\"Una Noche Más\" de Gabino Pampini, publicada por primera vez en 2008.",
       "fun_fact_fr": "« Una Noche Más » de Gabino Pampini, parue pour la première fois en 2008.",
       "fun_fact_nl": "\"Una Noche Más\" van Gabino Pampini, voor het eerst uitgebracht in 2008.",
-      "uri_apple_music": "applemusic://track/1483871962"
+      "uri_apple_music": "applemusic://track/1483871962",
+      "fun_fact_it": "«Una Noche Más» di Gabino Pampini, pubblicata per la prima volta nel 2008."
     },
     {
       "year": 1965,
@@ -6039,7 +6469,8 @@
       "fun_fact_fr": "« Trucutu » de Tommy Olivencia y Su Orquesta, Chamaco Ramírez, parue pour la première fois en 1965 sur l'album « Planté Bandera ».",
       "fun_fact_nl": "\"Trucutu\" van Tommy Olivencia y Su Orquesta, Chamaco Ramírez, voor het eerst uitgebracht in 1965 op het album \"Planté Bandera\".",
       "uri_deezer": "deezer://track/695411502",
-      "uri_apple_music": "applemusic://track/1468172950"
+      "uri_apple_music": "applemusic://track/1468172950",
+      "fun_fact_it": "«Trucutu» di Tommy Olivencia y Su Orquesta, Chamaco Ramírez, pubblicata per la prima volta nel 1965 nell'album «Planté Bandera»."
     },
     {
       "year": 2007,
@@ -6051,7 +6482,8 @@
       "fun_fact_de": "„Alo Alo\" von Wayne Gorbea, erstmals 2007 auf dem Album „Introducing Wayne Gorbea's Salsa Picante\" erschienen.",
       "fun_fact_es": "\"Alo Alo\" de Wayne Gorbea, publicada por primera vez en 2007 en el álbum \"Introducing Wayne Gorbea's Salsa Picante\".",
       "fun_fact_fr": "« Alo Alo » de Wayne Gorbea, parue pour la première fois en 2007 sur l'album « Introducing Wayne Gorbea's Salsa Picante ».",
-      "fun_fact_nl": "\"Alo Alo\" van Wayne Gorbea, voor het eerst uitgebracht in 2007 op het album \"Introducing Wayne Gorbea's Salsa Picante\"."
+      "fun_fact_nl": "\"Alo Alo\" van Wayne Gorbea, voor het eerst uitgebracht in 2007 op het album \"Introducing Wayne Gorbea's Salsa Picante\".",
+      "fun_fact_it": "«Alo Alo» di Wayne Gorbea, pubblicata per la prima volta nel 2007 nell'album «Introducing Wayne Gorbea's Salsa Picante»."
     },
     {
       "year": 1981,
@@ -6065,7 +6497,8 @@
       "fun_fact_fr": "« Buenaventura y Caney » de Grupo Niche, parue pour la première fois en 1981 sur l'album « Virtual Hits ».",
       "fun_fact_nl": "\"Buenaventura y Caney\" van Grupo Niche, voor het eerst uitgebracht in 1981 op het album \"Virtual Hits\".",
       "uri_deezer": "deezer://track/1713176",
-      "uri_apple_music": "applemusic://track/1712807138"
+      "uri_apple_music": "applemusic://track/1712807138",
+      "fun_fact_it": "«Buenaventura y Caney» di Grupo Niche, pubblicata per la prima volta nel 1981 nell'album «Virtual Hits»."
     },
     {
       "year": 1988,
@@ -6079,7 +6512,8 @@
       "fun_fact_fr": "« Ven Devórame Otra Vez » de Lalo Rodriguez, parue pour la première fois en 1988 sur l'album « Ven Devórame Otra Vez (Baile Total) ».",
       "fun_fact_nl": "\"Ven Devórame Otra Vez\" van Lalo Rodriguez, voor het eerst uitgebracht in 1988 op het album \"Ven Devórame Otra Vez (Baile Total)\".",
       "uri_deezer": "deezer://track/429987972",
-      "uri_apple_music": "applemusic://track/1445663988"
+      "uri_apple_music": "applemusic://track/1445663988",
+      "fun_fact_it": "«Ven Devórame Otra Vez» di Lalo Rodriguez, pubblicata per la prima volta nel 1988 nell'album «Ven Devórame Otra Vez (Baile Total)»."
     },
     {
       "year": 2021,
@@ -6093,7 +6527,8 @@
       "fun_fact_fr": "« Manos de Tijera » de Yiyo Sarante, parue pour la première fois en 2021 sur l'album « Manos de Tijera ».",
       "fun_fact_nl": "\"Manos de Tijera\" van Yiyo Sarante, voor het eerst uitgebracht in 2021 op het album \"Manos de Tijera\".",
       "uri_deezer": "deezer://track/2531767201",
-      "uri_apple_music": "applemusic://track/1715395336"
+      "uri_apple_music": "applemusic://track/1715395336",
+      "fun_fact_it": "«Manos de Tijera» di Yiyo Sarante, pubblicata per la prima volta nel 2021 nell'album «Manos de Tijera»."
     },
     {
       "year": 1961,
@@ -6107,7 +6542,8 @@
       "fun_fact_fr": "« Lluvia con Nieve » de Mon Rivera, parue pour la première fois en 1961 sur l'album « Que Gente Averiguá ».",
       "fun_fact_nl": "\"Lluvia con Nieve\" van Mon Rivera, voor het eerst uitgebracht in 1961 op het album \"Que Gente Averiguá\".",
       "uri_deezer": "deezer://track/686072402",
-      "uri_apple_music": "applemusic://track/1464959207"
+      "uri_apple_music": "applemusic://track/1464959207",
+      "fun_fact_it": "«Lluvia con Nieve» di Mon Rivera, pubblicata per la prima volta nel 1961 nell'album «Que Gente Averiguá»."
     },
     {
       "year": 2023,
@@ -6120,7 +6556,8 @@
       "fun_fact_es": "\"LA RONDA\" de Myke Towers, publicada por primera vez en 2023 en el álbum \"LVEU: VIVE LA TUYA...NO LA MIA\".",
       "fun_fact_fr": "\"LA RONDA\" de Myke Towers, sortie pour la première fois en 2023 sur l'album \"LVEU: VIVE LA TUYA...NO LA MIA\".",
       "fun_fact_nl": "\"LA RONDA\" van Myke Towers, voor het eerst uitgebracht in 2023 op het album \"LVEU: VIVE LA TUYA...NO LA MIA\".",
-      "uri_deezer": "deezer://track/2542594551"
+      "uri_deezer": "deezer://track/2542594551",
+      "fun_fact_it": "«LA RONDA» di Myke Towers, pubblicata per la prima volta nel 2023 nell'album «LVEU: VIVE LA TUYA...NO LA MIA»."
     },
     {
       "year": 2023,
@@ -6134,7 +6571,8 @@
       "fun_fact_fr": "« No Es Amor » de Gian Marco, Daniela Darcourt, parue pour la première fois en 2023 sur l'album « No Es Amor ».",
       "fun_fact_nl": "\"No Es Amor\" van Gian Marco, Daniela Darcourt, voor het eerst uitgebracht in 2023 op het album \"No Es Amor\".",
       "uri_deezer": "deezer://track/3262977231",
-      "uri_apple_music": "applemusic://track/1713683185"
+      "uri_apple_music": "applemusic://track/1713683185",
+      "fun_fact_it": "«No Es Amor» di Gian Marco, Daniela Darcourt, pubblicata per la prima volta nel 2023 nell'album «No Es Amor»."
     },
     {
       "year": 2023,
@@ -6148,7 +6586,8 @@
       "fun_fact_fr": "« Amantes Suicidas » de Mon Laferte, parue pour la première fois en 2023 sur l'album « Autopoiética ».",
       "fun_fact_nl": "\"Amantes Suicidas\" van Mon Laferte, voor het eerst uitgebracht in 2023 op het album \"Autopoiética\".",
       "uri_deezer": "deezer://track/2526335651",
-      "uri_apple_music": "applemusic://track/1712827329"
+      "uri_apple_music": "applemusic://track/1712827329",
+      "fun_fact_it": "«Amantes Suicidas» di Mon Laferte, pubblicata per la prima volta nel 2023 nell'album «Autopoiética»."
     },
     {
       "year": 2023,
@@ -6162,7 +6601,8 @@
       "fun_fact_fr": "« 18 » de Luis Vazquez, parue pour la première fois en 2023 sur l'album « 18 ».",
       "fun_fact_nl": "\"18\" van Luis Vazquez, voor het eerst uitgebracht in 2023 op het album \"18\".",
       "uri_deezer": "deezer://track/2567187282",
-      "uri_apple_music": "applemusic://track/1719380431"
+      "uri_apple_music": "applemusic://track/1719380431",
+      "fun_fact_it": "«18» di Luis Vazquez, pubblicata per la prima volta nel 2023 nell'album «18»."
     },
     {
       "year": 1986,
@@ -6176,7 +6616,8 @@
       "fun_fact_fr": "« Que Locura Enamorarme De Ti » de Eddie Santiago, parue pour la première fois en 1986 sur l'album « Lluvia (Baile Total) ».",
       "fun_fact_nl": "\"Que Locura Enamorarme De Ti\" van Eddie Santiago, voor het eerst uitgebracht in 1986 op het album \"Lluvia (Baile Total)\".",
       "uri_deezer": "deezer://track/429989492",
-      "uri_apple_music": "applemusic://track/1445663657"
+      "uri_apple_music": "applemusic://track/1445663657",
+      "fun_fact_it": "«Que Locura Enamorarme De Ti» di Eddie Santiago, pubblicata per la prima volta nel 1986 nell'album «Lluvia (Baile Total)»."
     },
     {
       "year": 1996,
@@ -6190,7 +6631,8 @@
       "fun_fact_fr": "« Como Te Hago Entender » de Roberto Roena Y Su Apollo Sound, parue pour la première fois en 1996 sur l'album « Mi Musica ».",
       "fun_fact_nl": "\"Como Te Hago Entender\" van Roberto Roena Y Su Apollo Sound, voor het eerst uitgebracht in 1996 op het album \"Mi Musica\".",
       "uri_deezer": "deezer://track/63619693",
-      "uri_apple_music": "applemusic://track/1590159569"
+      "uri_apple_music": "applemusic://track/1590159569",
+      "fun_fact_it": "«Como Te Hago Entender» di Roberto Roena Y Su Apollo Sound, pubblicata per la prima volta nel 1996 nell'album «Mi Musica»."
     },
     {
       "year": 2023,
@@ -6204,7 +6646,8 @@
       "fun_fact_fr": "« La Fórmula » de Maluma, Marc Anthony, parue pour la première fois en 2023 sur l'album « La Fórmula ».",
       "fun_fact_nl": "\"La Fórmula\" van Maluma, Marc Anthony, voor het eerst uitgebracht in 2023 op het album \"La Fórmula\".",
       "uri_deezer": "deezer://track/2124708237",
-      "uri_apple_music": "applemusic://track/1667595041"
+      "uri_apple_music": "applemusic://track/1667595041",
+      "fun_fact_it": "«La Fórmula» di Maluma, Marc Anthony, pubblicata per la prima volta nel 2023 nell'album «La Fórmula»."
     },
     {
       "year": 1993,
@@ -6218,7 +6661,8 @@
       "fun_fact_fr": "« Uno Se Cura » de Raulin Rosendo, parue pour la première fois en 1993 sur l'album « El Sonero Quel El Pueblo Prefiere ».",
       "fun_fact_nl": "\"Uno Se Cura\" van Raulin Rosendo, voor het eerst uitgebracht in 1993 op het album \"El Sonero Quel El Pueblo Prefiere\".",
       "uri_deezer": "deezer://track/11766901",
-      "uri_apple_music": "applemusic://track/374401162"
+      "uri_apple_music": "applemusic://track/374401162",
+      "fun_fact_it": "«Uno Se Cura» di Raulin Rosendo, pubblicata per la prima volta nel 1993 nell'album «El Sonero Quel El Pueblo Prefiere»."
     },
     {
       "year": 2004,
@@ -6232,7 +6676,8 @@
       "fun_fact_fr": "« Con la Punta del Pie » de La Gloria Matancera, parue pour la première fois en 2004 sur l'album « Con Sabor Cubano, Vol. 2 ».",
       "fun_fact_nl": "\"Con la Punta del Pie\" van La Gloria Matancera, voor het eerst uitgebracht in 2004 op het album \"Con Sabor Cubano, Vol. 2\".",
       "uri_deezer": "deezer://track/113229668",
-      "uri_apple_music": "applemusic://track/1057531320"
+      "uri_apple_music": "applemusic://track/1057531320",
+      "fun_fact_it": "«Con la Punta del Pie» di La Gloria Matancera, pubblicata per la prima volta nel 2004 nell'album «Con Sabor Cubano, Vol. 2»."
     },
     {
       "year": 1972,
@@ -6246,7 +6691,8 @@
       "fun_fact_fr": "« Pa' Bravo Yo » de Justo Betancourt, parue pour la première fois en 1972 sur l'album « Pa' Bravo Yo ».",
       "fun_fact_nl": "\"Pa' Bravo Yo\" van Justo Betancourt, voor het eerst uitgebracht in 1972 op het album \"Pa' Bravo Yo\".",
       "uri_deezer": "deezer://track/688271922",
-      "uri_apple_music": "applemusic://track/1466115843"
+      "uri_apple_music": "applemusic://track/1466115843",
+      "fun_fact_it": "«Pa' Bravo Yo» di Justo Betancourt, pubblicata per la prima volta nel 1972 nell'album «Pa' Bravo Yo»."
     },
     {
       "year": 2022,
@@ -6260,7 +6706,8 @@
       "fun_fact_fr": "« De Qué Manera » de Mike Bahía, parue pour la première fois en 2022 sur l'album « De Qué Manera ».",
       "fun_fact_nl": "\"De Qué Manera\" van Mike Bahía, voor het eerst uitgebracht in 2022 op het album \"De Qué Manera\".",
       "uri_deezer": "deezer://track/2069303107",
-      "uri_apple_music": "applemusic://track/1659773210"
+      "uri_apple_music": "applemusic://track/1659773210",
+      "fun_fact_it": "«De Qué Manera» di Mike Bahía, pubblicata per la prima volta nel 2022 nell'album «De Qué Manera»."
     },
     {
       "year": 2015,
@@ -6274,7 +6721,8 @@
       "fun_fact_fr": "« No Quería Engañarte » de Víctor Manuelle, parue pour la première fois en 2015 sur l'album « Que Suenen los Tambores ».",
       "fun_fact_nl": "\"No Quería Engañarte\" van Víctor Manuelle, voor het eerst uitgebracht in 2015 op het album \"Que Suenen los Tambores\".",
       "uri_deezer": "deezer://track/97838678",
-      "uri_apple_music": "applemusic://track/980041201"
+      "uri_apple_music": "applemusic://track/980041201",
+      "fun_fact_it": "«No Quería Engañarte» di Víctor Manuelle, pubblicata per la prima volta nel 2015 nell'album «Que Suenen los Tambores»."
     },
     {
       "year": 2004,
@@ -6288,7 +6736,8 @@
       "fun_fact_fr": "« La Pantera Mambo » de La-33, parue pour la première fois en 2004 sur l'album « La Pantera Mambo ».",
       "fun_fact_nl": "\"La Pantera Mambo\" van La-33, voor het eerst uitgebracht in 2004 op het album \"La Pantera Mambo\".",
       "uri_deezer": "deezer://track/1853571087",
-      "uri_apple_music": "applemusic://track/733395333"
+      "uri_apple_music": "applemusic://track/733395333",
+      "fun_fact_it": "«La Pantera Mambo» di La-33, pubblicata per la prima volta nel 2004 nell'album «La Pantera Mambo»."
     },
     {
       "year": 1992,
@@ -6302,7 +6751,8 @@
       "fun_fact_fr": "« Salsa Con Coco » de Pochy Y Su Cocoband, parue pour la première fois en 1992 sur l'album « El Arrollador ».",
       "fun_fact_nl": "\"Salsa Con Coco\" van Pochy Y Su Cocoband, voor het eerst uitgebracht in 1992 op het album \"El Arrollador\".",
       "uri_deezer": "deezer://track/687077312",
-      "uri_apple_music": "applemusic://track/1465805506"
+      "uri_apple_music": "applemusic://track/1465805506",
+      "fun_fact_it": "«Salsa Con Coco» di Pochy Y Su Cocoband, pubblicata per la prima volta nel 1992 nell'album «El Arrollador»."
     },
     {
       "year": 1991,
@@ -6316,7 +6766,8 @@
       "fun_fact_fr": "« Te Propongo » de Hector Rey, parue pour la première fois en 1991 sur l'album « Al Duro ».",
       "fun_fact_nl": "\"Te Propongo\" van Hector Rey, voor het eerst uitgebracht in 1991 op het album \"Al Duro\".",
       "uri_deezer": "deezer://track/63979301",
-      "uri_apple_music": "applemusic://track/169538465"
+      "uri_apple_music": "applemusic://track/169538465",
+      "fun_fact_it": "«Te Propongo» di Hector Rey, pubblicata per la prima volta nel 1991 nell'album «Al Duro»."
     },
     {
       "year": 2004,
@@ -6330,7 +6781,8 @@
       "fun_fact_fr": "« Abre Que Voy » de Miguel Enriquez, parue pour la première fois en 2004.",
       "fun_fact_nl": "\"Abre Que Voy\" van Miguel Enriquez, voor het eerst uitgebracht in 2004.",
       "uri_deezer": "deezer://track/5216615",
-      "uri_apple_music": "applemusic://track/264723691"
+      "uri_apple_music": "applemusic://track/264723691",
+      "fun_fact_it": "«Abre Que Voy» di Miguel Enriquez, pubblicata per la prima volta nel 2004."
     },
     {
       "year": 2018,
@@ -6344,7 +6796,8 @@
       "fun_fact_fr": "« Suma y Resta » de El Micha, Gilberto Santa Rosa, parue pour la première fois en 2018 sur l'album « Suma y Resta ».",
       "fun_fact_nl": "\"Suma y Resta\" van El Micha, Gilberto Santa Rosa, voor het eerst uitgebracht in 2018 op het album \"Suma y Resta\".",
       "uri_deezer": "deezer://track/1804608407",
-      "uri_apple_music": "applemusic://track/1631609821"
+      "uri_apple_music": "applemusic://track/1631609821",
+      "fun_fact_it": "«Suma y Resta» di El Micha, Gilberto Santa Rosa, pubblicata per la prima volta nel 2018 nell'album «Suma y Resta»."
     },
     {
       "year": 2019,
@@ -6358,7 +6811,8 @@
       "fun_fact_fr": "« Tu Vida en la Mía » de Marc Anthony, parue pour la première fois en 2019 sur l'album « OPUS ».",
       "fun_fact_nl": "\"Tu Vida en la Mía\" van Marc Anthony, voor het eerst uitgebracht in 2019 op het album \"OPUS\".",
       "uri_deezer": "deezer://track/675919602",
-      "uri_apple_music": "applemusic://track/1461181034"
+      "uri_apple_music": "applemusic://track/1461181034",
+      "fun_fact_it": "«Tu Vida en la Mía» di Marc Anthony, pubblicata per la prima volta nel 2019 nell'album «OPUS»."
     },
     {
       "year": 2022,
@@ -6372,7 +6826,8 @@
       "fun_fact_fr": "« Cartas Sobre La Mesa » de Gilberto Santa Rosa, parue pour la première fois en 2022 sur l'album « Cartas Sobre La Mesa ».",
       "fun_fact_nl": "\"Cartas Sobre La Mesa\" van Gilberto Santa Rosa, voor het eerst uitgebracht in 2022 op het album \"Cartas Sobre La Mesa\".",
       "uri_deezer": "deezer://track/1591566102",
-      "uri_apple_music": "applemusic://track/1640726284"
+      "uri_apple_music": "applemusic://track/1640726284",
+      "fun_fact_it": "«Cartas Sobre La Mesa» di Gilberto Santa Rosa, pubblicata per la prima volta nel 2022 nell'album «Cartas Sobre La Mesa»."
     },
     {
       "year": 1988,
@@ -6386,7 +6841,8 @@
       "fun_fact_fr": "« Por Retenerte » de Los Titanes, parue pour la première fois en 1988 sur l'album « La Salsa, Identidad de un Pueblo - Vol. 1 Expresión de Barrio ».",
       "fun_fact_nl": "\"Por Retenerte\" van Los Titanes, voor het eerst uitgebracht in 1988 op het album \"La Salsa, Identidad de un Pueblo - Vol. 1 Expresión de Barrio\".",
       "uri_deezer": "deezer://track/131112480",
-      "uri_apple_music": "applemusic://track/26107689"
+      "uri_apple_music": "applemusic://track/26107689",
+      "fun_fact_it": "«Por Retenerte» di Los Titanes, pubblicata per la prima volta nel 1988 nell'album «La Salsa, Identidad de un Pueblo - Vol. 1 Expresión de Barrio»."
     },
     {
       "year": 2018,
@@ -6400,7 +6856,8 @@
       "fun_fact_fr": "« Enamórate Bailando » de Septeto Acarey, Gilberto Santa Rosa, parue pour la première fois en 2018 sur l'album « Enamórate Bailando ».",
       "fun_fact_nl": "\"Enamórate Bailando\" van Septeto Acarey, Gilberto Santa Rosa, voor het eerst uitgebracht in 2018 op het album \"Enamórate Bailando\".",
       "uri_deezer": "deezer://track/621128942",
-      "uri_apple_music": "applemusic://track/1450183023"
+      "uri_apple_music": "applemusic://track/1450183023",
+      "fun_fact_it": "«Enamórate Bailando» di Septeto Acarey, Gilberto Santa Rosa, pubblicata per la prima volta nel 2018 nell'album «Enamórate Bailando»."
     },
     {
       "year": 2018,
@@ -6414,7 +6871,8 @@
       "fun_fact_fr": "« Adiós Amor » de Daniela Darcourt, parue pour la première fois en 2018 sur l'album « Adiós Amor ».",
       "fun_fact_nl": "\"Adiós Amor\" van Daniela Darcourt, voor het eerst uitgebracht in 2018 op het album \"Adiós Amor\".",
       "uri_deezer": "deezer://track/1356751582",
-      "uri_apple_music": "applemusic://track/1565039677"
+      "uri_apple_music": "applemusic://track/1565039677",
+      "fun_fact_it": "«Adiós Amor» di Daniela Darcourt, pubblicata per la prima volta nel 2018 nell'album «Adiós Amor»."
     },
     {
       "year": 1962,
@@ -6428,7 +6886,8 @@
       "fun_fact_fr": "« Acuyuye » de Johnny Pacheco, parue pour la première fois en 1962 sur l'album « Pacheco Y Su Charanga Vol. 3: Que Suene La Flauta ».",
       "fun_fact_nl": "\"Acuyuye\" van Johnny Pacheco, voor het eerst uitgebracht in 1962 op het album \"Pacheco Y Su Charanga Vol. 3: Que Suene La Flauta\".",
       "uri_deezer": "deezer://track/686114592",
-      "uri_apple_music": "applemusic://track/1464289091"
+      "uri_apple_music": "applemusic://track/1464289091",
+      "fun_fact_it": "«Acuyuye» di Johnny Pacheco, pubblicata per la prima volta nel 1962 nell'album «Pacheco Y Su Charanga Vol. 3: Que Suene La Flauta»."
     },
     {
       "year": 2018,
@@ -6442,7 +6901,8 @@
       "fun_fact_fr": "« Probablemente » de Yiyo Sarante, parue pour la première fois en 2018 sur l'album « Probablemente ».",
       "fun_fact_nl": "\"Probablemente\" van Yiyo Sarante, voor het eerst uitgebracht in 2018 op het album \"Probablemente\".",
       "uri_deezer": "deezer://track/2615626852",
-      "uri_apple_music": "applemusic://track/1725171565"
+      "uri_apple_music": "applemusic://track/1725171565",
+      "fun_fact_it": "«Probablemente» di Yiyo Sarante, pubblicata per la prima volta nel 2018 nell'album «Probablemente»."
     },
     {
       "year": 2013,
@@ -6456,7 +6916,8 @@
       "fun_fact_fr": "« Loco Pero Feliz » de Pirulo y la Tribu, parue pour la première fois en 2013 sur l'album « Calle Linda ».",
       "fun_fact_nl": "\"Loco Pero Feliz\" van Pirulo y la Tribu, voor het eerst uitgebracht in 2013 op het album \"Calle Linda\".",
       "uri_deezer": "deezer://track/76845877",
-      "uri_apple_music": "applemusic://track/1445174742"
+      "uri_apple_music": "applemusic://track/1445174742",
+      "fun_fact_it": "«Loco Pero Feliz» di Pirulo y la Tribu, pubblicata per la prima volta nel 2013 nell'album «Calle Linda»."
     },
     {
       "year": 2023,
@@ -6470,7 +6931,8 @@
       "fun_fact_fr": "« Incomprendido » de Rawayana, Neutro Shorty, Orestes Gomez, parue pour la première fois en 2023 sur l'album « Incomprendido ».",
       "fun_fact_nl": "\"Incomprendido\" van Rawayana, Neutro Shorty, Orestes Gomez, voor het eerst uitgebracht in 2023 op het album \"Incomprendido\".",
       "uri_deezer": "deezer://track/2512990891",
-      "uri_apple_music": "applemusic://track/1713427275"
+      "uri_apple_music": "applemusic://track/1713427275",
+      "fun_fact_it": "«Incomprendido» di Rawayana, Neutro Shorty, Orestes Gomez, pubblicata per la prima volta nel 2023 nell'album «Incomprendido»."
     },
     {
       "year": 2019,
@@ -6484,7 +6946,8 @@
       "fun_fact_fr": "« Señor Mentira » de Daniela Darcourt, parue pour la première fois en 2019 sur l'album « Señor Mentira ».",
       "fun_fact_nl": "\"Señor Mentira\" van Daniela Darcourt, voor het eerst uitgebracht in 2019 op het album \"Señor Mentira\".",
       "uri_deezer": "deezer://track/1684408737",
-      "uri_apple_music": "applemusic://track/1619114602"
+      "uri_apple_music": "applemusic://track/1619114602",
+      "fun_fact_it": "«Señor Mentira» di Daniela Darcourt, pubblicata per la prima volta nel 2019 nell'album «Señor Mentira»."
     },
     {
       "year": 2017,
@@ -6498,7 +6961,8 @@
       "fun_fact_fr": "« Boogaloo Supreme » de Víctor Manuelle, Wisin, parue pour la première fois en 2017 sur l'album « Boogaloo Supreme ».",
       "fun_fact_nl": "\"Boogaloo Supreme\" van Víctor Manuelle, Wisin, voor het eerst uitgebracht in 2017 op het album \"Boogaloo Supreme\".",
       "uri_deezer": "deezer://track/889704342",
-      "uri_apple_music": "applemusic://track/1500810086"
+      "uri_apple_music": "applemusic://track/1500810086",
+      "fun_fact_it": "«Boogaloo Supreme» di Víctor Manuelle, Wisin, pubblicata per la prima volta nel 2017 nell'album «Boogaloo Supreme»."
     },
     {
       "year": 2019,
@@ -6512,7 +6976,8 @@
       "fun_fact_fr": "« Lo Que Te Di » de Marc Anthony, parue pour la première fois en 2019 sur l'album « OPUS ».",
       "fun_fact_nl": "\"Lo Que Te Di\" van Marc Anthony, voor het eerst uitgebracht in 2019 op het album \"OPUS\".",
       "uri_deezer": "deezer://track/675919642",
-      "uri_apple_music": "applemusic://track/1461181860"
+      "uri_apple_music": "applemusic://track/1461181860",
+      "fun_fact_it": "«Lo Que Te Di» di Marc Anthony, pubblicata per la prima volta nel 2019 nell'album «OPUS»."
     },
     {
       "year": 1994,
@@ -6526,7 +6991,8 @@
       "fun_fact_fr": "« Ven a Medellín » de Grupo Galé, parue pour la première fois en 1994 sur l'album « Afirmando ».",
       "fun_fact_nl": "\"Ven a Medellín\" van Grupo Galé, voor het eerst uitgebracht in 1994 op het album \"Afirmando\".",
       "uri_deezer": "deezer://track/1441560382",
-      "uri_apple_music": "applemusic://track/1712790734"
+      "uri_apple_music": "applemusic://track/1712790734",
+      "fun_fact_it": "«Ven a Medellín» di Grupo Galé, pubblicata per la prima volta nel 1994 nell'album «Afirmando»."
     },
     {
       "year": 1980,
@@ -6540,7 +7006,8 @@
       "fun_fact_fr": "« Tu No Sabes Querer » de Lalo Rodriguez, parue pour la première fois en 1980 sur l'album « Ven Devórame Otra Vez (Baile Total) ».",
       "fun_fact_nl": "\"Tu No Sabes Querer\" van Lalo Rodriguez, voor het eerst uitgebracht in 1980 op het album \"Ven Devórame Otra Vez (Baile Total)\".",
       "uri_deezer": "deezer://track/429987982",
-      "uri_apple_music": "applemusic://track/1445663992"
+      "uri_apple_music": "applemusic://track/1445663992",
+      "fun_fact_it": "«Tu No Sabes Querer» di Lalo Rodriguez, pubblicata per la prima volta nel 1980 nell'album «Ven Devórame Otra Vez (Baile Total)»."
     },
     {
       "year": 2022,
@@ -6554,7 +7021,8 @@
       "fun_fact_fr": "« Mamita Molona » de Los Yakis, parue pour la première fois en 2022.",
       "fun_fact_nl": "\"Mamita Molona\" van Los Yakis, voor het eerst uitgebracht in 2022.",
       "uri_deezer": "deezer://track/3358273931",
-      "uri_apple_music": "applemusic://track/1606257468"
+      "uri_apple_music": "applemusic://track/1606257468",
+      "fun_fact_it": "«Mamita Molona» di Los Yakis, pubblicata per la prima volta nel 2022."
     },
     {
       "year": 2019,
@@ -6568,7 +7036,8 @@
       "fun_fact_fr": "« Un Amor Eterno » de Marc Anthony, parue pour la première fois en 2019 sur l'album « OPUS ».",
       "fun_fact_nl": "\"Un Amor Eterno\" van Marc Anthony, voor het eerst uitgebracht in 2019 op het album \"OPUS\".",
       "uri_deezer": "deezer://track/675919612",
-      "uri_apple_music": "applemusic://track/1461181252"
+      "uri_apple_music": "applemusic://track/1461181252",
+      "fun_fact_it": "«Un Amor Eterno» di Marc Anthony, pubblicata per la prima volta nel 2019 nell'album «OPUS»."
     },
     {
       "year": 2021,
@@ -6582,7 +7051,8 @@
       "fun_fact_fr": "« El Combo del Mundo » de El Gran Combo De Puerto Rico, parue pour la première fois en 2021 sur l'album « El Combo del Mundo ».",
       "fun_fact_nl": "\"El Combo del Mundo\" van El Gran Combo De Puerto Rico, voor het eerst uitgebracht in 2021 op het album \"El Combo del Mundo\".",
       "uri_deezer": "deezer://track/1250746602",
-      "uri_apple_music": "applemusic://track/1554528574"
+      "uri_apple_music": "applemusic://track/1554528574",
+      "fun_fact_it": "«El Combo del Mundo» di El Gran Combo De Puerto Rico, pubblicata per la prima volta nel 2021 nell'album «El Combo del Mundo»."
     },
     {
       "year": 1969,
@@ -6596,7 +7066,8 @@
       "fun_fact_fr": "« Te Están Buscando » de Rubén Blades, Willie Colón, parue pour la première fois en 1969 sur l'album « Canciones Del Solar De Los Aburridos ».",
       "fun_fact_nl": "\"Te Están Buscando\" van Rubén Blades, Willie Colón, voor het eerst uitgebracht in 1969 op het album \"Canciones Del Solar De Los Aburridos\".",
       "uri_deezer": "deezer://track/687809822",
-      "uri_apple_music": "applemusic://track/1763206341"
+      "uri_apple_music": "applemusic://track/1763206341",
+      "fun_fact_it": "«Te Están Buscando» di Rubén Blades, Willie Colón, pubblicata per la prima volta nel 1969 nell'album «Canciones Del Solar De Los Aburridos»."
     },
     {
       "year": 2020,
@@ -6610,7 +7081,8 @@
       "fun_fact_fr": "« Acércate » de Jeremy Bosch, parue pour la première fois en 2020 sur l'album « Acércate ».",
       "fun_fact_nl": "\"Acércate\" van Jeremy Bosch, voor het eerst uitgebracht in 2020 op het album \"Acércate\".",
       "uri_deezer": "deezer://track/3231726311",
-      "uri_apple_music": "applemusic://track/1796679731"
+      "uri_apple_music": "applemusic://track/1796679731",
+      "fun_fact_it": "«Acércate» di Jeremy Bosch, pubblicata per la prima volta nel 2020 nell'album «Acércate»."
     },
     {
       "year": 2023,
@@ -6624,7 +7096,8 @@
       "fun_fact_fr": "« Salsa » de El Micha, parue pour la première fois en 2023 sur l'album « Salsa ».",
       "fun_fact_nl": "\"Salsa\" van El Micha, voor het eerst uitgebracht in 2023 op het album \"Salsa\".",
       "uri_deezer": "deezer://track/2258652917",
-      "uri_apple_music": "applemusic://track/1684952016"
+      "uri_apple_music": "applemusic://track/1684952016",
+      "fun_fact_it": "«Salsa» di El Micha, pubblicata per la prima volta nel 2023 nell'album «Salsa»."
     },
     {
       "year": 2001,
@@ -6638,7 +7111,8 @@
       "fun_fact_fr": "« Virgen » de Adolescent's Orquesta, parue pour la première fois en 2001.",
       "fun_fact_nl": "\"Virgen\" van Adolescent's Orquesta, voor het eerst uitgebracht in 2001.",
       "uri_deezer": "deezer://track/1385723042",
-      "uri_apple_music": "applemusic://track/1582492911"
+      "uri_apple_music": "applemusic://track/1582492911",
+      "fun_fact_it": "«Virgen» di Adolescent's Orquesta, pubblicata per la prima volta nel 2001."
     },
     {
       "year": 2007,
@@ -6652,7 +7126,8 @@
       "fun_fact_fr": "« Bururu Barara Como Estas Miguel » de Kiko Mendive, parue pour la première fois en 2007 sur l'album « La Sonora Guantanamera de Venezuela ».",
       "fun_fact_nl": "\"Bururu Barara Como Estas Miguel\" van Kiko Mendive, voor het eerst uitgebracht in 2007 op het album \"La Sonora Guantanamera de Venezuela\".",
       "uri_deezer": "deezer://track/646076842",
-      "uri_apple_music": "applemusic://track/1455491729"
+      "uri_apple_music": "applemusic://track/1455491729",
+      "fun_fact_it": "«Bururu Barara Como Estas Miguel» di Kiko Mendive, pubblicata per la prima volta nel 2007 nell'album «La Sonora Guantanamera de Venezuela»."
     },
     {
       "year": 1997,
@@ -6665,7 +7140,8 @@
       "fun_fact_es": "\"Ya No Regreso\" de Orquesta Inmensidad, publicada por primera vez en 1997.",
       "fun_fact_fr": "« Ya No Regreso » de Orquesta Inmensidad, parue pour la première fois en 1997.",
       "fun_fact_nl": "\"Ya No Regreso\" van Orquesta Inmensidad, voor het eerst uitgebracht in 1997.",
-      "uri_apple_music": "applemusic://track/1797925217"
+      "uri_apple_music": "applemusic://track/1797925217",
+      "fun_fact_it": "«Ya No Regreso» di Orquesta Inmensidad, pubblicata per la prima volta nel 1997."
     },
     {
       "year": 2020,
@@ -6679,7 +7155,8 @@
       "fun_fact_fr": "« Algo Que Se Quede » de Grupo Niche, parue pour la première fois en 2020 sur l'album « Algo Que Se Quede ».",
       "fun_fact_nl": "\"Algo Que Se Quede\" van Grupo Niche, voor het eerst uitgebracht in 2020 op het album \"Algo Que Se Quede\".",
       "uri_deezer": "deezer://track/1078473492",
-      "uri_apple_music": "applemusic://track/1531533492"
+      "uri_apple_music": "applemusic://track/1531533492",
+      "fun_fact_it": "«Algo Que Se Quede» di Grupo Niche, pubblicata per la prima volta nel 2020 nell'album «Algo Que Se Quede»."
     },
     {
       "year": 2022,
@@ -6692,7 +7169,8 @@
       "fun_fact_es": "\"DESPECHÁ\" de ROSALÍA, publicada por primera vez en 2022 en el álbum \"DESPECHÁ\".",
       "fun_fact_fr": "\"DESPECHÁ\" de ROSALÍA, sortie pour la première fois en 2022 sur l'album \"DESPECHÁ\".",
       "fun_fact_nl": "\"DESPECHÁ\" van ROSALÍA, voor het eerst uitgebracht in 2022 op het album \"DESPECHÁ\".",
-      "uri_deezer": "deezer://track/1841999507"
+      "uri_deezer": "deezer://track/1841999507",
+      "fun_fact_it": "«DESPECHÁ» di ROSALÍA, pubblicata per la prima volta nel 2022 nell'album «DESPECHÁ»."
     },
     {
       "year": 1995,
@@ -6706,7 +7184,8 @@
       "fun_fact_fr": "« Rompecintura » de Los Hermanos Rosario, parue pour la première fois en 1995 sur l'album « Y Es Fácil! ».",
       "fun_fact_nl": "\"Rompecintura\" van Los Hermanos Rosario, voor het eerst uitgebracht in 1995 op het album \"Y Es Fácil!\".",
       "uri_deezer": "deezer://track/1857090737",
-      "uri_apple_music": "applemusic://track/1526733635"
+      "uri_apple_music": "applemusic://track/1526733635",
+      "fun_fact_it": "«Rompecintura» di Los Hermanos Rosario, pubblicata per la prima volta nel 1995 nell'album «Y Es Fácil!»."
     },
     {
       "year": 2002,
@@ -6720,7 +7199,8 @@
       "fun_fact_fr": "« y entonces » de Son De Cali, parue pour la première fois en 2002 sur l'album « Estilo Propio ».",
       "fun_fact_nl": "\"y entonces\" van Son De Cali, voor het eerst uitgebracht in 2002 op het album \"Estilo Propio\".",
       "uri_deezer": "deezer://track/2357571345",
-      "uri_apple_music": "applemusic://track/1443604910"
+      "uri_apple_music": "applemusic://track/1443604910",
+      "fun_fact_it": "«y entonces» di Son De Cali, pubblicata per la prima volta nel 2002 nell'album «Estilo Propio»."
     },
     {
       "year": 1989,
@@ -6734,7 +7214,8 @@
       "fun_fact_fr": "« Pa'l Bailador » de Joe Arroyo, La Verdad, parue pour la première fois en 1989 sur l'album « La Salsa: Identidad de un Pueblo, Vol. 5 Expresión Rumbera ».",
       "fun_fact_nl": "\"Pa'l Bailador\" van Joe Arroyo, La Verdad, voor het eerst uitgebracht in 1989 op het album \"La Salsa: Identidad de un Pueblo, Vol. 5 Expresión Rumbera\".",
       "uri_deezer": "deezer://track/132093106",
-      "uri_apple_music": "applemusic://track/203978041"
+      "uri_apple_music": "applemusic://track/203978041",
+      "fun_fact_it": "«Pa'l Bailador» di Joe Arroyo, La Verdad, pubblicata per la prima volta nel 1989 nell'album «La Salsa: Identidad de un Pueblo, Vol. 5 Expresión Rumbera»."
     },
     {
       "year": 1973,
@@ -6747,7 +7228,8 @@
       "fun_fact_es": "\"Las Caleñas Son Como las Flores - Remix\" de The Latin Brothers, Piper Pimienta Diaz, publicada por primera vez en 1973.",
       "fun_fact_fr": "« Las Caleñas Son Como las Flores - Remix » de The Latin Brothers, Piper Pimienta Diaz, parue pour la première fois en 1973.",
       "fun_fact_nl": "\"Las Caleñas Son Como las Flores - Remix\" van The Latin Brothers, Piper Pimienta Diaz, voor het eerst uitgebracht in 1973.",
-      "uri_apple_music": "applemusic://track/874126077"
+      "uri_apple_music": "applemusic://track/874126077",
+      "fun_fact_it": "«Las Caleñas Son Como las Flores - Remix» di The Latin Brothers, Piper Pimienta Diaz, pubblicata per la prima volta nel 1973."
     },
     {
       "year": 1975,
@@ -6761,7 +7243,8 @@
       "fun_fact_fr": "« El Preso » de Fruko Y Sus Tesos, Wilson Saoko, parue pour la première fois en 1975 sur l'album « Fruko el Grande ».",
       "fun_fact_nl": "\"El Preso\" van Fruko Y Sus Tesos, Wilson Saoko, voor het eerst uitgebracht in 1975 op het album \"Fruko el Grande\".",
       "uri_deezer": "deezer://track/451174962",
-      "uri_apple_music": "applemusic://track/1046941805"
+      "uri_apple_music": "applemusic://track/1046941805",
+      "fun_fact_it": "«El Preso» di Fruko Y Sus Tesos, Wilson Saoko, pubblicata per la prima volta nel 1975 nell'album «Fruko el Grande»."
     },
     {
       "year": 1966,
@@ -6775,7 +7258,8 @@
       "fun_fact_fr": "« Micaela » de Pete Rodriguez, parue pour la première fois en 1966 sur l'album « I Like It Like That ».",
       "fun_fact_nl": "\"Micaela\" van Pete Rodriguez, voor het eerst uitgebracht in 1966 op het album \"I Like It Like That\".",
       "uri_deezer": "deezer://track/686070082",
-      "uri_apple_music": "applemusic://track/1523944952"
+      "uri_apple_music": "applemusic://track/1523944952",
+      "fun_fact_it": "«Micaela» di Pete Rodriguez, pubblicata per la prima volta nel 1966 nell'album «I Like It Like That»."
     },
     {
       "year": 1974,
@@ -6789,7 +7273,8 @@
       "fun_fact_fr": "« Quimbara - Remastered » de Celia Cruz, parue pour la première fois en 1974 sur l'album « Celia & Johnny (Remastered 2024) ».",
       "fun_fact_nl": "\"Quimbara - Remastered\" van Celia Cruz, voor het eerst uitgebracht in 1974 op het album \"Celia & Johnny (Remastered 2024)\".",
       "uri_deezer": "deezer://track/3584616581",
-      "uri_apple_music": "applemusic://track/1769530331"
+      "uri_apple_music": "applemusic://track/1769530331",
+      "fun_fact_it": "«Quimbara - Remastered» di Celia Cruz, pubblicata per la prima volta nel 1974 nell'album «Celia & Johnny (Remastered 2024)»."
     },
     {
       "year": 1990,
@@ -6803,7 +7288,8 @@
       "fun_fact_fr": "« Cali Aji » de Grupo Niche, parue pour la première fois en 1990 sur l'album « The Best ».",
       "fun_fact_nl": "\"Cali Aji\" van Grupo Niche, voor het eerst uitgebracht in 1990 op het album \"The Best\".",
       "uri_deezer": "deezer://track/13211923",
-      "uri_apple_music": "applemusic://track/321443667"
+      "uri_apple_music": "applemusic://track/321443667",
+      "fun_fact_it": "«Cali Aji» di Grupo Niche, pubblicata per la prima volta nel 1990 nell'album «The Best»."
     },
     {
       "year": 1986,
@@ -6817,7 +7303,8 @@
       "fun_fact_fr": "« Si Algún Día la Ves » de Sergio Vargas, parue pour la première fois en 1986 sur l'album « Los Años Dorados de Sergio Vargas ».",
       "fun_fact_nl": "\"Si Algún Día la Ves\" van Sergio Vargas, voor het eerst uitgebracht in 1986 op het album \"Los Años Dorados de Sergio Vargas\".",
       "uri_deezer": "deezer://track/1857060737",
-      "uri_apple_music": "applemusic://track/1701636802"
+      "uri_apple_music": "applemusic://track/1701636802",
+      "fun_fact_it": "«Si Algún Día la Ves» di Sergio Vargas, pubblicata per la prima volta nel 1986 nell'album «Los Años Dorados de Sergio Vargas»."
     },
     {
       "year": 1995,
@@ -6831,7 +7318,8 @@
       "fun_fact_fr": "« La Duena del Swing » de Los Hermanos Rosario, parue pour la première fois en 1995 sur l'album « Los Dueños del Swing ».",
       "fun_fact_nl": "\"La Duena del Swing\" van Los Hermanos Rosario, voor het eerst uitgebracht in 1995 op het album \"Los Dueños del Swing\".",
       "uri_deezer": "deezer://track/1857103157",
-      "uri_apple_music": "applemusic://track/1526558385"
+      "uri_apple_music": "applemusic://track/1526558385",
+      "fun_fact_it": "«La Duena del Swing» di Los Hermanos Rosario, pubblicata per la prima volta nel 1995 nell'album «Los Dueños del Swing»."
     },
     {
       "year": 1997,
@@ -6845,7 +7333,8 @@
       "fun_fact_fr": "« Fin de Semana » de Los Hermanos Rosario, parue pour la première fois en 1997 sur l'album « Y Es Fácil! ».",
       "fun_fact_nl": "\"Fin de Semana\" van Los Hermanos Rosario, voor het eerst uitgebracht in 1997 op het album \"Y Es Fácil!\".",
       "uri_deezer": "deezer://track/1857090667",
-      "uri_apple_music": "applemusic://track/1526733346"
+      "uri_apple_music": "applemusic://track/1526733346",
+      "fun_fact_it": "«Fin de Semana» di Los Hermanos Rosario, pubblicata per la prima volta nel 1997 nell'album «Y Es Fácil!»."
     },
     {
       "year": 1993,
@@ -6859,7 +7348,8 @@
       "fun_fact_fr": "« Morena Ven » de Los Hermanos Rosario, parue pour la première fois en 1993.",
       "fun_fact_nl": "\"Morena Ven\" van Los Hermanos Rosario, voor het eerst uitgebracht in 1993.",
       "uri_deezer": "deezer://track/1899381807",
-      "uri_apple_music": "applemusic://track/1526584450"
+      "uri_apple_music": "applemusic://track/1526584450",
+      "fun_fact_it": "«Morena Ven» di Los Hermanos Rosario, pubblicata per la prima volta nel 1993."
     },
     {
       "year": 1984,
@@ -6873,7 +7363,8 @@
       "fun_fact_fr": "« La Asesina » de Bonny Cepeda, parue pour la première fois en 1984 sur l'album « La Fiesta Esta Buena ».",
       "fun_fact_nl": "\"La Asesina\" van Bonny Cepeda, voor het eerst uitgebracht in 1984 op het album \"La Fiesta Esta Buena\".",
       "uri_deezer": "deezer://track/2587509032",
-      "uri_apple_music": "applemusic://track/1624844800"
+      "uri_apple_music": "applemusic://track/1624844800",
+      "fun_fact_it": "«La Asesina» di Bonny Cepeda, pubblicata per la prima volta nel 1984 nell'album «La Fiesta Esta Buena»."
     },
     {
       "year": 1982,
@@ -6887,7 +7378,8 @@
       "fun_fact_fr": "« El Comejen » de Wilfrido Vargas, Sandy Reyes, parue pour la première fois en 1982 sur l'album « Wilfrido Vargas & Sandy Reyes ».",
       "fun_fact_nl": "\"El Comejen\" van Wilfrido Vargas, Sandy Reyes, voor het eerst uitgebracht in 1982 op het album \"Wilfrido Vargas & Sandy Reyes\".",
       "uri_deezer": "deezer://track/1857027637",
-      "uri_apple_music": "applemusic://track/1526721020"
+      "uri_apple_music": "applemusic://track/1526721020",
+      "fun_fact_it": "«El Comejen» di Wilfrido Vargas, Sandy Reyes, pubblicata per la prima volta nel 1982 nell'album «Wilfrido Vargas & Sandy Reyes»."
     },
     {
       "year": 1990,
@@ -6901,7 +7393,8 @@
       "fun_fact_fr": "« Que Cara Mas Bonita » de Alex Bueno, parue pour la première fois en 1990 sur l'album « 20 Años Despues ».",
       "fun_fact_nl": "\"Que Cara Mas Bonita\" van Alex Bueno, voor het eerst uitgebracht in 1990 op het album \"20 Años Despues\".",
       "uri_deezer": "deezer://track/10962833",
-      "uri_apple_music": "applemusic://track/1526556594"
+      "uri_apple_music": "applemusic://track/1526556594",
+      "fun_fact_it": "«Que Cara Mas Bonita» di Alex Bueno, pubblicata per la prima volta nel 1990 nell'album «20 Años Despues»."
     },
     {
       "year": 1995,
@@ -6915,7 +7408,8 @@
       "fun_fact_fr": "« La Media María » de Las Chicas Del Can, parue pour la première fois en 1995 sur l'album « Fuego ».",
       "fun_fact_nl": "\"La Media María\" van Las Chicas Del Can, voor het eerst uitgebracht in 1995 op het album \"Fuego\".",
       "uri_deezer": "deezer://track/1364338962",
-      "uri_apple_music": "applemusic://track/1526720517"
+      "uri_apple_music": "applemusic://track/1526720517",
+      "fun_fact_it": "«La Media María» di Las Chicas Del Can, pubblicata per la prima volta nel 1995 nell'album «Fuego»."
     },
     {
       "year": 1995,
@@ -6929,7 +7423,8 @@
       "fun_fact_fr": "« No Hay Pesos » de Los Cantantes, parue pour la première fois en 1995 sur l'album « El Virao ».",
       "fun_fact_nl": "\"No Hay Pesos\" van Los Cantantes, voor het eerst uitgebracht in 1995 op het album \"El Virao\".",
       "uri_deezer": "deezer://track/2785762742",
-      "uri_apple_music": "applemusic://track/1744952406"
+      "uri_apple_music": "applemusic://track/1744952406",
+      "fun_fact_it": "«No Hay Pesos» di Los Cantantes, pubblicata per la prima volta nel 1995 nell'album «El Virao»."
     },
     {
       "year": 2009,
@@ -6943,7 +7438,8 @@
       "fun_fact_fr": "« Aguanile » de Héctor Lavoe, parue pour la première fois en 2009 sur l'album « Aleteo, Cumbia y Guaracha ».",
       "fun_fact_nl": "\"Aguanile\" van Héctor Lavoe, voor het eerst uitgebracht in 2009 op het album \"Aleteo, Cumbia y Guaracha\".",
       "uri_deezer": "deezer://track/3444265241",
-      "uri_apple_music": "applemusic://track/1465963965"
+      "uri_apple_music": "applemusic://track/1465963965",
+      "fun_fact_it": "«Aguanile» di Héctor Lavoe, pubblicata per la prima volta nel 2009 nell'album «Aleteo, Cumbia y Guaracha»."
     },
     {
       "year": 1995,
@@ -6957,7 +7453,8 @@
       "fun_fact_fr": "« Richie's Jala Jala » de Richie Ray, parue pour la première fois en 1995 sur l'album « La Herencia ».",
       "fun_fact_nl": "\"Richie's Jala Jala\" van Richie Ray, voor het eerst uitgebracht in 1995 op het album \"La Herencia\".",
       "uri_deezer": "deezer://track/686097262",
-      "uri_apple_music": "applemusic://track/1562606592"
+      "uri_apple_music": "applemusic://track/1562606592",
+      "fun_fact_it": "«Richie's Jala Jala» di Richie Ray, pubblicata per la prima volta nel 1995 nell'album «La Herencia»."
     },
     {
       "year": 1991,
@@ -6971,7 +7468,8 @@
       "fun_fact_fr": "« Sonido Bestial » de Richie Ray & Bobby Cruz, parue pour la première fois en 1991 sur l'album « A Lifetime of Hits... (Live At Centro de Bellas Artes, San Juan, Puerto Rico.) ».",
       "fun_fact_nl": "\"Sonido Bestial\" van Richie Ray & Bobby Cruz, voor het eerst uitgebracht in 1991 op het album \"A Lifetime of Hits... (Live At Centro de Bellas Artes, San Juan, Puerto Rico.)\".",
       "uri_deezer": "deezer://track/11111575",
-      "uri_apple_music": "applemusic://track/1464273298"
+      "uri_apple_music": "applemusic://track/1464273298",
+      "fun_fact_it": "«Sonido Bestial» di Richie Ray & Bobby Cruz, pubblicata per la prima volta nel 1991 nell'album «A Lifetime of Hits... (Live At Centro de Bellas Artes, San Juan, Puerto Rico.)»."
     },
     {
       "year": 1995,
@@ -6985,7 +7483,8 @@
       "fun_fact_fr": "« Señora Ley » de Conjunto Clásico, Tito Nieves, parue pour la première fois en 1995 sur l'album « Ray Castro Presenta...Lo Mejor De Conjunto Clasico Con Tito Nieves ».",
       "fun_fact_nl": "\"Señora Ley\" van Conjunto Clásico, Tito Nieves, voor het eerst uitgebracht in 1995 op het album \"Ray Castro Presenta...Lo Mejor De Conjunto Clasico Con Tito Nieves\".",
       "uri_deezer": "deezer://track/11174537",
-      "uri_apple_music": "applemusic://track/6795463754"
+      "uri_apple_music": "applemusic://track/6795463754",
+      "fun_fact_it": "«Señora Ley» di Conjunto Clásico, Tito Nieves, pubblicata per la prima volta nel 1995 nell'album «Ray Castro Presenta...Lo Mejor De Conjunto Clasico Con Tito Nieves»."
     },
     {
       "year": 1958,
@@ -6999,7 +7498,8 @@
       "fun_fact_fr": "« Fiesta » de La Sonora Matancera, parue pour la première fois en 1958 sur l'album « Festejando Navidad ».",
       "fun_fact_nl": "\"Fiesta\" van La Sonora Matancera, voor het eerst uitgebracht in 1958 op het album \"Festejando Navidad\".",
       "uri_deezer": "deezer://track/688241822",
-      "uri_apple_music": "applemusic://track/1656785398"
+      "uri_apple_music": "applemusic://track/1656785398",
+      "fun_fact_it": "«Fiesta» di La Sonora Matancera, pubblicata per la prima volta nel 1958 nell'album «Festejando Navidad»."
     },
     {
       "year": 1978,
@@ -7013,7 +7513,8 @@
       "fun_fact_fr": "« Mala Mujer » de La Sonora Matancera, parue pour la première fois en 1978 sur l'album « Cuando Salí de Cuba ».",
       "fun_fact_nl": "\"Mala Mujer\" van La Sonora Matancera, voor het eerst uitgebracht in 1978 op het album \"Cuando Salí de Cuba\".",
       "uri_deezer": "deezer://track/58479081",
-      "uri_apple_music": "applemusic://track/1637750135"
+      "uri_apple_music": "applemusic://track/1637750135",
+      "fun_fact_it": "«Mala Mujer» di La Sonora Matancera, pubblicata per la prima volta nel 1978 nell'album «Cuando Salí de Cuba»."
     },
     {
       "year": 1986,
@@ -7027,7 +7528,8 @@
       "fun_fact_fr": "« El Coco » de Jossie Esteban y La Patrulla 15, parue pour la première fois en 1986 sur l'album « Noches de Copas ».",
       "fun_fact_nl": "\"El Coco\" van Jossie Esteban y La Patrulla 15, voor het eerst uitgebracht in 1986 op het album \"Noches de Copas\".",
       "uri_deezer": "deezer://track/63637511",
-      "uri_apple_music": "applemusic://track/294581830"
+      "uri_apple_music": "applemusic://track/294581830",
+      "fun_fact_it": "«El Coco» di Jossie Esteban y La Patrulla 15, pubblicata per la prima volta nel 1986 nell'album «Noches de Copas»."
     },
     {
       "year": 1995,
@@ -7041,7 +7543,8 @@
       "fun_fact_fr": "« Estamos en Salsa » de Wayne Gorbea, parue pour la première fois en 1995 sur l'album « La Salsa del Conjunto Salsa ».",
       "fun_fact_nl": "\"Estamos en Salsa\" van Wayne Gorbea, voor het eerst uitgebracht in 1995 op het album \"La Salsa del Conjunto Salsa\".",
       "uri_deezer": "deezer://track/2992201601",
-      "uri_apple_music": "applemusic://track/1768113824"
+      "uri_apple_music": "applemusic://track/1768113824",
+      "fun_fact_it": "«Estamos en Salsa» di Wayne Gorbea, pubblicata per la prima volta nel 1995 nell'album «La Salsa del Conjunto Salsa»."
     },
     {
       "year": 1973,
@@ -7055,7 +7558,8 @@
       "fun_fact_fr": "« El Forastero » de Nelson Y Sus Estrellas, parue pour la première fois en 1973 sur l'album « Ritmo Y Sabor, Vol. 1 ».",
       "fun_fact_nl": "\"El Forastero\" van Nelson Y Sus Estrellas, voor het eerst uitgebracht in 1973 op het album \"Ritmo Y Sabor, Vol. 1\".",
       "uri_deezer": "deezer://track/3778530162",
-      "uri_apple_music": "applemusic://track/339950382"
+      "uri_apple_music": "applemusic://track/339950382",
+      "fun_fact_it": "«El Forastero» di Nelson Y Sus Estrellas, pubblicata per la prima volta nel 1973 nell'album «Ritmo Y Sabor, Vol. 1»."
     },
     {
       "year": 2009,
@@ -7069,7 +7573,8 @@
       "fun_fact_fr": "« Apretaito » de Edgar Gonzalon, parue pour la première fois en 2009 sur l'album « Apretaito (El Negrito de la Salsa) ».",
       "fun_fact_nl": "\"Apretaito\" van Edgar Gonzalon, voor het eerst uitgebracht in 2009 op het album \"Apretaito (El Negrito de la Salsa)\".",
       "uri_deezer": "deezer://track/2301549945",
-      "uri_apple_music": "applemusic://track/1691388516"
+      "uri_apple_music": "applemusic://track/1691388516",
+      "fun_fact_it": "«Apretaito» di Edgar Gonzalon, pubblicata per la prima volta nel 2009 nell'album «Apretaito (El Negrito de la Salsa)»."
     },
     {
       "year": 2000,
@@ -7083,7 +7588,8 @@
       "fun_fact_fr": "« Te Voy a Hacer Feliz » de Mariano Civico, parue pour la première fois en 2000 sur l'album « Costa Brava ».",
       "fun_fact_nl": "\"Te Voy a Hacer Feliz\" van Mariano Civico, voor het eerst uitgebracht in 2000 op het album \"Costa Brava\".",
       "uri_deezer": "deezer://track/1104813912",
-      "uri_apple_music": "applemusic://track/1735824620"
+      "uri_apple_music": "applemusic://track/1735824620",
+      "fun_fact_it": "«Te Voy a Hacer Feliz» di Mariano Civico, pubblicata per la prima volta nel 2000 nell'album «Costa Brava»."
     },
     {
       "year": 1989,
@@ -7097,7 +7603,8 @@
       "fun_fact_fr": "« La Flaca » de Cocoband, parue pour la première fois en 1989.",
       "fun_fact_nl": "\"La Flaca\" van Cocoband, voor het eerst uitgebracht in 1989.",
       "uri_deezer": "deezer://track/96359226",
-      "uri_apple_music": "applemusic://track/1513631032"
+      "uri_apple_music": "applemusic://track/1513631032",
+      "fun_fact_it": "«La Flaca» di Cocoband, pubblicata per la prima volta nel 1989."
     },
     {
       "year": 1986,
@@ -7111,7 +7618,8 @@
       "fun_fact_fr": "« Me Enamoro de Ella » de Juan Luis Guerra 4.40, parue pour la première fois en 1986 sur l'album « Los Merengues del Año, Vol. 4 ».",
       "fun_fact_nl": "\"Me Enamoro de Ella\" van Juan Luis Guerra 4.40, voor het eerst uitgebracht in 1986 op het album \"Los Merengues del Año, Vol. 4\".",
       "uri_deezer": "deezer://track/1857194817",
-      "uri_apple_music": "applemusic://track/19512273"
+      "uri_apple_music": "applemusic://track/19512273",
+      "fun_fact_it": "«Me Enamoro de Ella» di Juan Luis Guerra 4.40, pubblicata per la prima volta nel 1986 nell'album «Los Merengues del Año, Vol. 4»."
     },
     {
       "year": 1989,
@@ -7125,7 +7633,8 @@
       "fun_fact_fr": "« Visa para un Sueno » de Juan Luis Guerra 4.40, parue pour la première fois en 1989.",
       "fun_fact_nl": "\"Visa para un Sueno\" van Juan Luis Guerra 4.40, voor het eerst uitgebracht in 1989.",
       "uri_deezer": "deezer://track/1857061897",
-      "uri_apple_music": "applemusic://track/19468930"
+      "uri_apple_music": "applemusic://track/19468930",
+      "fun_fact_it": "«Visa para un Sueno» di Juan Luis Guerra 4.40, pubblicata per la prima volta nel 1989."
     },
     {
       "year": 1980,
@@ -7139,7 +7648,8 @@
       "fun_fact_fr": "« La Medicina » de Wilfrido Vargas, parue pour la première fois en 1980.",
       "fun_fact_nl": "\"La Medicina\" van Wilfrido Vargas, voor het eerst uitgebracht in 1980.",
       "uri_deezer": "deezer://track/2024070087",
-      "uri_apple_music": "applemusic://track/1526599759"
+      "uri_apple_music": "applemusic://track/1526599759",
+      "fun_fact_it": "«La Medicina» di Wilfrido Vargas, pubblicata per la prima volta nel 1980."
     },
     {
       "year": 1986,
@@ -7153,7 +7663,8 @@
       "fun_fact_fr": "« Mary » de Joe Arroyo, La Verdad, parue pour la première fois en 1986 sur l'album « La Salsa, Identidad de un Pueblo - Vol. 10 Expresión Bacana ».",
       "fun_fact_nl": "\"Mary\" van Joe Arroyo, La Verdad, voor het eerst uitgebracht in 1986 op het album \"La Salsa, Identidad de un Pueblo - Vol. 10 Expresión Bacana\".",
       "uri_deezer": "deezer://track/132002198",
-      "uri_apple_music": "applemusic://track/455561904"
+      "uri_apple_music": "applemusic://track/455561904",
+      "fun_fact_it": "«Mary» di Joe Arroyo, La Verdad, pubblicata per la prima volta nel 1986 nell'album «La Salsa, Identidad de un Pueblo - Vol. 10 Expresión Bacana»."
     },
     {
       "year": 2014,
@@ -7166,7 +7677,8 @@
       "fun_fact_es": "\"Checarnaval: La Rama del Tamarindo / La Danza del Garabato / De Qué Me Disfrazaré\" de Checo Acosta, publicada por primera vez en 2014 en el álbum \"Checo Acosta 30 Aniversario\".",
       "fun_fact_fr": "« Checarnaval: La Rama del Tamarindo / La Danza del Garabato / De Qué Me Disfrazaré » de Checo Acosta, parue pour la première fois en 2014 sur l'album « Checo Acosta 30 Aniversario ».",
       "fun_fact_nl": "\"Checarnaval: La Rama del Tamarindo / La Danza del Garabato / De Qué Me Disfrazaré\" van Checo Acosta, voor het eerst uitgebracht in 2014 op het album \"Checo Acosta 30 Aniversario\".",
-      "uri_deezer": "deezer://track/3894699911"
+      "uri_deezer": "deezer://track/3894699911",
+      "fun_fact_it": "«Checarnaval: La Rama del Tamarindo / La Danza del Garabato / De Qué Me Disfrazaré» di Checo Acosta, pubblicata per la prima volta nel 2014 nell'album «Checo Acosta 30 Aniversario»."
     },
     {
       "year": 1972,
@@ -7180,7 +7692,8 @@
       "fun_fact_fr": "« Merecumbe » de Johnny Colon, parue pour la première fois en 1972 sur l'album « Fania Live 02 From Miami With DJ LeSpam ».",
       "fun_fact_nl": "\"Merecumbe\" van Johnny Colon, voor het eerst uitgebracht in 1972 op het album \"Fania Live 02 From Miami With DJ LeSpam\".",
       "uri_deezer": "deezer://track/687077242",
-      "uri_apple_music": "applemusic://track/1464266823"
+      "uri_apple_music": "applemusic://track/1464266823",
+      "fun_fact_it": "«Merecumbe» di Johnny Colon, pubblicata per la prima volta nel 1972 nell'album «Fania Live 02 From Miami With DJ LeSpam»."
     },
     {
       "year": 1993,
@@ -7194,7 +7707,8 @@
       "fun_fact_fr": "« Una Mirada Tu » de The Bananas, parue pour la première fois en 1993 sur l'album « 30 Mejores ».",
       "fun_fact_nl": "\"Una Mirada Tu\" van The Bananas, voor het eerst uitgebracht in 1993 op het album \"30 Mejores\".",
       "uri_deezer": "deezer://track/1441557992",
-      "uri_apple_music": "applemusic://track/1712783791"
+      "uri_apple_music": "applemusic://track/1712783791",
+      "fun_fact_it": "«Una Mirada Tu» di The Bananas, pubblicata per la prima volta nel 1993 nell'album «30 Mejores»."
     },
     {
       "year": 1991,
@@ -7208,7 +7722,8 @@
       "fun_fact_fr": "« No Quiero Tu Amor » de Alfa 8, parue pour la première fois en 1991 sur l'album « Mas Internacional Que Nunca ».",
       "fun_fact_nl": "\"No Quiero Tu Amor\" van Alfa 8, voor het eerst uitgebracht in 1991 op het album \"Mas Internacional Que Nunca\".",
       "uri_deezer": "deezer://track/3250717491",
-      "uri_apple_music": "applemusic://track/1845906687"
+      "uri_apple_music": "applemusic://track/1845906687",
+      "fun_fact_it": "«No Quiero Tu Amor» di Alfa 8, pubblicata per la prima volta nel 1991 nell'album «Mas Internacional Que Nunca»."
     },
     {
       "year": 1986,
@@ -7222,7 +7737,8 @@
       "fun_fact_fr": "« Ay! Mujer » de Juan Luis Guerra 4.40, parue pour la première fois en 1986 sur l'album « Mientras Más Lo Pienso…Tú ».",
       "fun_fact_nl": "\"Ay! Mujer\" van Juan Luis Guerra 4.40, voor het eerst uitgebracht in 1986 op het album \"Mientras Más Lo Pienso…Tú\".",
       "uri_deezer": "deezer://track/2698668582",
-      "uri_apple_music": "applemusic://track/19512275"
+      "uri_apple_music": "applemusic://track/19512275",
+      "fun_fact_it": "«Ay! Mujer» di Juan Luis Guerra 4.40, pubblicata per la prima volta nel 1986 nell'album «Mientras Más Lo Pienso…Tú»."
     },
     {
       "year": 2020,
@@ -7235,7 +7751,8 @@
       "fun_fact_es": "\"Mesa Que Mas Aplauda (version - Española\" de Grupo Climax, publicada por primera vez en 2020 en el álbum \"Mesa Que Mas Aplauda (Versión Española)\".",
       "fun_fact_fr": "« Mesa Que Mas Aplauda (version - Española » de Grupo Climax, parue pour la première fois en 2020 sur l'album « Mesa Que Mas Aplauda (Versión Española) ».",
       "fun_fact_nl": "\"Mesa Que Mas Aplauda (version - Española\" van Grupo Climax, voor het eerst uitgebracht in 2020 op het album \"Mesa Que Mas Aplauda (Versión Española)\".",
-      "uri_deezer": "deezer://track/2818449062"
+      "uri_deezer": "deezer://track/2818449062",
+      "fun_fact_it": "«Mesa Que Mas Aplauda (version - Española» di Grupo Climax, pubblicata per la prima volta nel 2020 nell'album «Mesa Que Mas Aplauda (Versión Española)»."
     },
     {
       "year": 1998,
@@ -7249,7 +7766,8 @@
       "fun_fact_fr": "« Tuyo » de Tito Nieves, parue pour la première fois en 1998 sur l'album « Salsa sensual ».",
       "fun_fact_nl": "\"Tuyo\" van Tito Nieves, voor het eerst uitgebracht in 1998 op het album \"Salsa sensual\".",
       "uri_deezer": "deezer://track/900342522",
-      "uri_apple_music": "applemusic://track/1825451282"
+      "uri_apple_music": "applemusic://track/1825451282",
+      "fun_fact_it": "«Tuyo» di Tito Nieves, pubblicata per la prima volta nel 1998 nell'album «Salsa sensual»."
     },
     {
       "year": 2015,
@@ -7263,7 +7781,8 @@
       "fun_fact_fr": "« Swagga » de Cali Flow Latino, parue pour la première fois en 2015 sur l'album « Full HD ».",
       "fun_fact_nl": "\"Swagga\" van Cali Flow Latino, voor het eerst uitgebracht in 2015 op het album \"Full HD\".",
       "uri_deezer": "deezer://track/122544946",
-      "uri_apple_music": "applemusic://track/1758826230"
+      "uri_apple_music": "applemusic://track/1758826230",
+      "fun_fact_it": "«Swagga» di Cali Flow Latino, pubblicata per la prima volta nel 2015 nell'album «Full HD»."
     },
     {
       "year": 2013,
@@ -7277,7 +7796,8 @@
       "fun_fact_fr": "« Menea Tu Chapa » de Wilo D New, parue pour la première fois en 2013 sur l'album « KlK Llego El Tipo the Album ».",
       "fun_fact_nl": "\"Menea Tu Chapa\" van Wilo D New, voor het eerst uitgebracht in 2013 op het album \"KlK Llego El Tipo the Album\".",
       "uri_deezer": "deezer://track/75004798",
-      "uri_apple_music": "applemusic://track/1364922342"
+      "uri_apple_music": "applemusic://track/1364922342",
+      "fun_fact_it": "«Menea Tu Chapa» di Wilo D New, pubblicata per la prima volta nel 2013 nell'album «KlK Llego El Tipo the Album»."
     },
     {
       "year": 2007,
@@ -7291,7 +7811,8 @@
       "fun_fact_fr": "« La Flaca » de Pochy Y Su Cocoband, parue pour la première fois en 2007 sur l'album « Coco De Oro ».",
       "fun_fact_nl": "\"La Flaca\" van Pochy Y Su Cocoband, voor het eerst uitgebracht in 2007 op het album \"Coco De Oro\".",
       "uri_deezer": "deezer://track/971476492",
-      "uri_apple_music": "applemusic://track/1513631032"
+      "uri_apple_music": "applemusic://track/1513631032",
+      "fun_fact_it": "«La Flaca» di Pochy Y Su Cocoband, pubblicata per la prima volta nel 2007 nell'album «Coco De Oro»."
     },
     {
       "year": 1970,
@@ -7305,7 +7826,8 @@
       "fun_fact_fr": "« Mambo Rock » de Alfredo Linares, parue pour la première fois en 1970 sur l'album « Mambo Rock ».",
       "fun_fact_nl": "\"Mambo Rock\" van Alfredo Linares, voor het eerst uitgebracht in 1970 op het album \"Mambo Rock\".",
       "uri_deezer": "deezer://track/1765270697",
-      "uri_apple_music": "applemusic://track/1626128873"
+      "uri_apple_music": "applemusic://track/1626128873",
+      "fun_fact_it": "«Mambo Rock» di Alfredo Linares, pubblicata per la prima volta nel 1970 nell'album «Mambo Rock»."
     },
     {
       "year": 2011,
@@ -7319,7 +7841,8 @@
       "fun_fact_fr": "« Te Invito » de Herencia de Timbiqui, parue pour la première fois en 2011 sur l'album « Tambó ».",
       "fun_fact_nl": "\"Te Invito\" van Herencia de Timbiqui, voor het eerst uitgebracht in 2011 op het album \"Tambó\".",
       "uri_deezer": "deezer://track/3235960331",
-      "uri_apple_music": "applemusic://track/1566506511"
+      "uri_apple_music": "applemusic://track/1566506511",
+      "fun_fact_it": "«Te Invito» di Herencia de Timbiqui, pubblicata per la prima volta nel 2011 nell'album «Tambó»."
     },
     {
       "year": 2014,
@@ -7333,7 +7856,8 @@
       "fun_fact_fr": "« Sabrás » de Herencia de Timbiqui, parue pour la première fois en 2014 sur l'album « This Is Gozar (Timbiquí Edition) ».",
       "fun_fact_nl": "\"Sabrás\" van Herencia de Timbiqui, voor het eerst uitgebracht in 2014 op het album \"This Is Gozar (Timbiquí Edition)\".",
       "uri_deezer": "deezer://track/3257260471",
-      "uri_apple_music": "applemusic://track/1454694029"
+      "uri_apple_music": "applemusic://track/1454694029",
+      "fun_fact_it": "«Sabrás» di Herencia de Timbiqui, pubblicata per la prima volta nel 2014 nell'album «This Is Gozar (Timbiquí Edition)»."
     },
     {
       "year": 1983,
@@ -7347,7 +7871,8 @@
       "fun_fact_fr": "« Gitana » de Willie Colón, parue pour la première fois en 1983 sur l'album « Tiempo pa' Matar ».",
       "fun_fact_nl": "\"Gitana\" van Willie Colón, voor het eerst uitgebracht in 1983 op het album \"Tiempo pa' Matar\".",
       "uri_deezer": "deezer://track/688277692",
-      "uri_apple_music": "applemusic://track/1466117667"
+      "uri_apple_music": "applemusic://track/1466117667",
+      "fun_fact_it": "«Gitana» di Willie Colón, pubblicata per la prima volta nel 1983 nell'album «Tiempo pa' Matar»."
     },
     {
       "year": 1973,
@@ -7361,7 +7886,8 @@
       "fun_fact_fr": "« Tiahuanaco (Puerta Del Sol) » de Alfredo Linares, parue pour la première fois en 1973 sur l'album « Sensacionales!!! ».",
       "fun_fact_nl": "\"Tiahuanaco (Puerta Del Sol)\" van Alfredo Linares, voor het eerst uitgebracht in 1973 op het album \"Sensacionales!!!\".",
       "uri_deezer": "deezer://track/1763729667",
-      "uri_apple_music": "applemusic://track/1625719963"
+      "uri_apple_music": "applemusic://track/1625719963",
+      "fun_fact_it": "«Tiahuanaco (Puerta Del Sol)» di Alfredo Linares, pubblicata per la prima volta nel 1973 nell'album «Sensacionales!!!»."
     },
     {
       "year": 2002,
@@ -7374,7 +7900,8 @@
       "fun_fact_es": "\"Ganas\" de Grupo Niche, publicada por primera vez en 2002 en el álbum \"Control Absoluto\".",
       "fun_fact_fr": "« Ganas » de Grupo Niche, parue pour la première fois en 2002 sur l'album « Control Absoluto ».",
       "fun_fact_nl": "\"Ganas\" van Grupo Niche, voor het eerst uitgebracht in 2002 op het album \"Control Absoluto\".",
-      "uri_deezer": "deezer://track/1001031902"
+      "uri_deezer": "deezer://track/1001031902",
+      "fun_fact_it": "«Ganas» di Grupo Niche, pubblicata per la prima volta nel 2002 nell'album «Control Absoluto»."
     },
     {
       "year": 1996,
@@ -7388,7 +7915,8 @@
       "fun_fact_fr": "« La Canoa Ranchaa » de Grupo Niche, parue pour la première fois en 1996.",
       "fun_fact_nl": "\"La Canoa Ranchaa\" van Grupo Niche, voor het eerst uitgebracht in 1996.",
       "uri_deezer": "deezer://track/13256379",
-      "uri_apple_music": "applemusic://track/1862587272"
+      "uri_apple_music": "applemusic://track/1862587272",
+      "fun_fact_it": "«La Canoa Ranchaa» di Grupo Niche, pubblicata per la prima volta nel 1996."
     },
     {
       "year": 1992,
@@ -7402,7 +7930,8 @@
       "fun_fact_fr": "« La Vamo a Tumbar » de Grupo Saboreo, parue pour la première fois en 1992 sur l'album « Lo Mejor de la Música del Pacifico Colombiano, Vol. 2 ».",
       "fun_fact_nl": "\"La Vamo a Tumbar\" van Grupo Saboreo, voor het eerst uitgebracht in 1992 op het album \"Lo Mejor de la Música del Pacifico Colombiano, Vol. 2\".",
       "uri_deezer": "deezer://track/2981328231",
-      "uri_apple_music": "applemusic://track/1657043875"
+      "uri_apple_music": "applemusic://track/1657043875",
+      "fun_fact_it": "«La Vamo a Tumbar» di Grupo Saboreo, pubblicata per la prima volta nel 1992 nell'album «Lo Mejor de la Música del Pacifico Colombiano, Vol. 2»."
     },
     {
       "year": 1982,
@@ -7416,7 +7945,8 @@
       "fun_fact_fr": "« Yambeque » de Sonora Ponceña, parue pour la première fois en 1982 sur l'album « 50 Aniversario, Vol.2 ».",
       "fun_fact_nl": "\"Yambeque\" van Sonora Ponceña, voor het eerst uitgebracht in 1982 op het album \"50 Aniversario, Vol.2\".",
       "uri_deezer": "deezer://track/8552497",
-      "uri_apple_music": "applemusic://track/1464284879"
+      "uri_apple_music": "applemusic://track/1464284879",
+      "fun_fact_it": "«Yambeque» di Sonora Ponceña, pubblicata per la prima volta nel 1982 nell'album «50 Aniversario, Vol.2»."
     },
     {
       "year": 2006,
@@ -7430,7 +7960,8 @@
       "fun_fact_fr": "« Te Amo » de Son De Cali, Willy Garcia, parue pour la première fois en 2006 sur l'album « Cambiando La Historia ».",
       "fun_fact_nl": "\"Te Amo\" van Son De Cali, Willy Garcia, voor het eerst uitgebracht in 2006 op het album \"Cambiando La Historia\".",
       "uri_deezer": "deezer://track/2357573455",
-      "uri_apple_music": "applemusic://track/1696136226"
+      "uri_apple_music": "applemusic://track/1696136226",
+      "fun_fact_it": "«Te Amo» di Son De Cali, Willy Garcia, pubblicata per la prima volta nel 2006 nell'album «Cambiando La Historia»."
     },
     {
       "year": 1974,
@@ -7443,7 +7974,8 @@
       "fun_fact_es": "\"Se Formo la Rumbantela\" de Javier Vázquez y Su Salsa, publicada por primera vez en 1974.",
       "fun_fact_fr": "« Se Formo la Rumbantela » de Javier Vázquez y Su Salsa, parue pour la première fois en 1974.",
       "fun_fact_nl": "\"Se Formo la Rumbantela\" van Javier Vázquez y Su Salsa, voor het eerst uitgebracht in 1974.",
-      "uri_apple_music": "applemusic://track/1464956362"
+      "uri_apple_music": "applemusic://track/1464956362",
+      "fun_fact_it": "«Se Formo la Rumbantela» di Javier Vázquez y Su Salsa, pubblicata per la prima volta nel 1974."
     },
     {
       "year": 2017,
@@ -7457,7 +7989,8 @@
       "fun_fact_fr": "« Imitadora » de Romeo Santos, parue pour la première fois en 2017 sur l'album « Golden ».",
       "fun_fact_nl": "\"Imitadora\" van Romeo Santos, voor het eerst uitgebracht in 2017 op het album \"Golden\".",
       "uri_deezer": "deezer://track/385074601",
-      "uri_apple_music": "applemusic://track/1258804105"
+      "uri_apple_music": "applemusic://track/1258804105",
+      "fun_fact_it": "«Imitadora» di Romeo Santos, pubblicata per la prima volta nel 2017 nell'album «Golden»."
     },
     {
       "year": 1980,
@@ -7471,7 +8004,8 @@
       "fun_fact_fr": "« Sin Negro No Hay Guaguancó » de Lebrón Brothers, parue pour la première fois en 1980 sur l'album « Criollo ».",
       "fun_fact_nl": "\"Sin Negro No Hay Guaguancó\" van Lebrón Brothers, voor het eerst uitgebracht in 1980 op het album \"Criollo\".",
       "uri_deezer": "deezer://track/686140532",
-      "uri_apple_music": "applemusic://track/1464273107"
+      "uri_apple_music": "applemusic://track/1464273107",
+      "fun_fact_it": "«Sin Negro No Hay Guaguancó» di Lebrón Brothers, pubblicata per la prima volta nel 1980 nell'album «Criollo»."
     }
   ]
 }

--- a/custom_components/beatify/playlists/eurovision-winners.json
+++ b/custom_components/beatify/playlists/eurovision-winners.json
@@ -58,7 +58,8 @@
         "es": "applemusic://track/254285129",
         "nl": "applemusic://track/254285129",
         "it": "applemusic://track/254285129"
-      }
+      },
+      "fun_fact_it": "Refrain vinse il primissimo Eurovision Song Contest, disputato a Lugano, in Svizzera. Lys Assia era l'unica concorrente svizzera e vinse con un'esibizione semplice ed elegante. L'edizione del 1956 non prevedeva il televoto: contavano solo i voti delle giurie."
     },
     {
       "year": 1957,
@@ -111,7 +112,8 @@
         "nl": "applemusic://track/1739553677",
         "it": "applemusic://track/1739553677"
       },
-      "uri_tidal": "tidal://track/18237627"
+      "uri_tidal": "tidal://track/18237627",
+      "fun_fact_it": "Net Als Toen (Proprio come allora) diede ai Paesi Bassi la loro prima vittoria all'Eurovision. Corry Brokken aveva già gareggiato nel 1956, arrivando settima, e resta una delle poche artiste ad aver vinto dopo una precedente partecipazione."
     },
     {
       "year": 1958,
@@ -164,7 +166,8 @@
         "nl": "applemusic://track/794472283",
         "it": "applemusic://track/794472283"
       },
-      "uri_tidal": "tidal://track/73263202"
+      "uri_tidal": "tidal://track/73263202",
+      "fun_fact_it": "Dors mon amour (Dormi amore mio) era una dolce ninnananna che regalò alla Francia il suo primo titolo Eurovision. Andre Claveau era già uno chansonnier francese affermato prima della vittoria, noto per il suo stile vocale morbido."
     },
     {
       "year": 1959,
@@ -217,7 +220,8 @@
         "es": "applemusic://track/420371297",
         "nl": "applemusic://track/420371297",
         "it": "applemusic://track/420371297"
-      }
+      },
+      "fun_fact_it": "Een Beetje (Un pochino) divenne a sorpresa un successo internazionale, entrando in classifica in diversi paesi. L'esibizione giocosa di Teddy Scholten diede ai Paesi Bassi la seconda vittoria in tre anni."
     },
     {
       "year": 1960,
@@ -270,7 +274,8 @@
         "es": "applemusic://track/1484096278",
         "nl": "applemusic://track/1484096278",
         "it": "applemusic://track/1484096278"
-      }
+      },
+      "fun_fact_it": "Tom Pillibi racconta di un affascinante bugiardo che inventa storie fantastiche. Jacqueline Boyer aveva solo 18 anni quando vinse, e sua madre Lucienne Boyer era a sua volta una celebre cantante francese."
     },
     {
       "year": 1961,
@@ -323,7 +328,8 @@
         "es": "applemusic://track/1752888490",
         "nl": "applemusic://track/1752888490",
         "it": "applemusic://track/1752888490"
-      }
+      },
+      "fun_fact_it": "Nous les amoureux (Noi innamorati) fu la prima vittoria del Lussemburgo. Jean-Claude Pascal era conosciuto soprattutto come attore cinematografico prima della carriera da cantante. Il tema dell'amore proibito toccò il pubblico di tutta Europa."
     },
     {
       "year": 1962,
@@ -376,7 +382,8 @@
         "es": "applemusic://track/1682977904",
         "nl": "applemusic://track/1682977904",
         "it": "applemusic://track/1682977904"
-      }
+      },
+      "fun_fact_it": "Un premier amour (Un primo amore) assicurò alla Francia la terza vittoria all'Eurovision. Isabelle Aubret sopravvisse a un grave incidente d'auto nel 1963 e tornò con una rimonta straordinaria. Rappresentò di nuovo la Francia nel 1968, arrivando terza."
     },
     {
       "year": 1963,
@@ -429,7 +436,8 @@
         "es": "applemusic://track/693093834",
         "nl": "applemusic://track/693093834",
         "it": "applemusic://track/693093834"
-      }
+      },
+      "fun_fact_it": "Dansevise (Ballata da ballo) diede alla Danimarca la sua prima e per 37 anni unica vittoria all'Eurovision. Grethe e Jorgen Ingmann erano marito e moglie, e Jorgen era già noto a livello internazionale per il suo strumentale per chitarra 'Apache'."
     },
     {
       "year": 1964,
@@ -482,7 +490,8 @@
         "es": "applemusic://track/213591428",
         "nl": "applemusic://track/213591428",
         "it": "applemusic://track/213591428"
-      }
+      },
+      "fun_fact_it": "Non ho l'età (Per amarti) fu interpretata dalla sedicenne Gigliola Cinquetti, una delle vincitrici più giovani di sempre. Il brano divenne un enorme successo internazionale ed è considerato una delle più grandi canzoni vincitrici dell'Eurovision."
     },
     {
       "year": 1965,
@@ -525,7 +534,8 @@
         "Vincitore dell'Eurovision Song Contest 1965"
       ],
       "uri_tidal": "tidal://track/41386583",
-      "uri_apple_music": "applemusic://track/1721242740"
+      "uri_apple_music": "applemusic://track/1721242740",
+      "fun_fact_it": "Poupée de cire, poupée de son (Bambola di cera, bambola di crusca) fu scritta dal leggendario autore francese Serge Gainsbourg. France Gall aveva solo 17 anni e pare non fosse consapevole dei doppi sensi del testo. Divenne un classico assoluto del pop yé-yé."
     },
     {
       "year": 1966,
@@ -578,7 +588,8 @@
         "es": "applemusic://track/1727305541",
         "nl": "applemusic://track/1727305541",
         "it": "applemusic://track/1727305541"
-      }
+      },
+      "fun_fact_it": "Merci Chérie fu la prima vittoria dell'Austria. Udo Jürgens aveva già gareggiato due volte (1964 e 1965) prima di riuscire a vincere. Divenne uno degli artisti europei di maggior successo, con oltre 100 milioni di dischi venduti nel mondo."
     },
     {
       "year": 1967,
@@ -631,7 +642,8 @@
         "es": "applemusic://track/1467380894",
         "nl": "applemusic://track/1467380894",
         "it": "applemusic://track/1467380894"
-      }
+      },
+      "fun_fact_it": "Puppet On A String diede al Regno Unito la prima vittoria all'Eurovision. Sandie Shaw si esibì a piedi nudi, come da sua celebre abitudine. Pare che la canzone non le piacesse, eppure divenne uno dei maggiori successi del 1967."
     },
     {
       "year": 1968,
@@ -684,7 +696,8 @@
         "es": "applemusic://track/1344881200",
         "nl": "applemusic://track/1344881200",
         "it": "applemusic://track/1344881200"
-      }
+      },
+      "fun_fact_it": "La, La, La regalò alla Spagna la prima vittoria per un solo punto su 'Congratulations' di Cliff Richard. Massiel sostituì il cantante originale Joan Manuel Serrat pochi giorni prima della gara, dopo il rifiuto di lui di cantare in spagnolo anziché in catalano."
     },
     {
       "year": 1969,
@@ -727,7 +740,8 @@
       ],
       "awards_it": [
         "Vincitore dell'Eurovision Song Contest 1969 (ex aequo a quattro)"
-      ]
+      ],
+      "fun_fact_it": "De Troubadour fece parte dell'unico quadruplo ex aequo nella storia dell'Eurovision. Paesi Bassi, Francia, Spagna e Regno Unito si divisero il primo posto con 18 punti a testa. Il risultato controverso portò a un cambio di regolamento."
     },
     {
       "year": 1969,
@@ -780,7 +794,8 @@
         "es": "applemusic://track/1324132498",
         "nl": "applemusic://track/1324132498",
         "it": "applemusic://track/1324132498"
-      }
+      },
+      "fun_fact_it": "Boom Bang a Bang fu una delle quattro vincitrici a pari merito del 1969. La cantante scozzese Lulu era già famosa per 'Shout' e 'To Sir with Love'. Il brano allegro e orecchiabile entrò in classifica nel Regno Unito nonostante la vittoria condivisa."
     },
     {
       "year": 1969,
@@ -833,7 +848,8 @@
         "es": "applemusic://track/1838068722",
         "nl": "applemusic://track/1838068722",
         "it": "applemusic://track/1838068722"
-      }
+      },
+      "fun_fact_it": "Vivo Cantando diede alla Spagna una vittoria condivisa nel 1969. La voce potente e lo stile drammatico di Salomé la resero una stella in tutto il mondo di lingua spagnola. Proseguì poi con una carriera discografica di successo."
     },
     {
       "year": 1969,
@@ -886,7 +902,8 @@
         "es": "applemusic://track/1243859629",
         "nl": "applemusic://track/1243859629",
         "it": "applemusic://track/1243859629"
-      }
+      },
+      "fun_fact_it": "Un jour, un enfant (Un giorno, un bambino) completò lo storico quadruplo ex aequo del 1969. Frida Boccara, nata in Marocco, divenne una delle chanteuse più stimate di Francia. La sua ballata emozionante spiccò tra le vincitrici a pari merito."
     },
     {
       "year": 1970,
@@ -939,7 +956,8 @@
         "es": "applemusic://track/1078014787",
         "nl": "applemusic://track/1078014787",
         "it": "applemusic://track/1078014787"
-      }
+      },
+      "fun_fact_it": "All Kinds Of Everything inaugurò il dominio irlandese all'Eurovision. Dana aveva solo 18 anni ed era ancora una studentessa quando vinse. La canzone delicata arrivò in cima alle classifiche europee e lei divenne poi deputata al Parlamento europeo."
     },
     {
       "year": 1971,
@@ -992,7 +1010,8 @@
         "es": "applemusic://track/104660824",
         "nl": "applemusic://track/104660824",
         "it": "applemusic://track/104660824"
-      }
+      },
+      "fun_fact_it": "Un Banc, Un Arbre, Une Rue (Una panchina, un albero, una via) diede a Monaco la sua unica vittoria. Séverine era in realtà francese e il brano fu scritto da Yves Dessca. La vittoria arrivò nell'edizione che introdusse le nuove regole di voto."
     },
     {
       "year": 1972,
@@ -1045,7 +1064,8 @@
         "es": "applemusic://track/1442450412",
         "nl": "applemusic://track/1442450412",
         "it": "applemusic://track/1442450412"
-      }
+      },
+      "fun_fact_it": "Après toi (Dopo di te) è considerata una delle più belle canzoni vincitrici dell'Eurovision. La cantante greco-tedesca Vicky Leandros aveva già rappresentato il Lussemburgo nel 1967. Il brano divenne un enorme successo europeo in più versioni linguistiche."
     },
     {
       "year": 1973,
@@ -1098,7 +1118,8 @@
         "es": "applemusic://track/1230500284",
         "nl": "applemusic://track/1230500284",
         "it": "applemusic://track/1230500284"
-      }
+      },
+      "fun_fact_it": "Tu te reconnaîtras (Ti riconoscerai) fu la quarta vittoria del Lussemburgo in dodici anni. Anne-Marie David rappresentò la Francia nel 1979, diventando una delle poche artiste ad aver gareggiato per due paesi diversi."
     },
     {
       "year": 1974,
@@ -1160,7 +1181,8 @@
         "es": "applemusic://track/1612497895",
         "nl": "applemusic://track/1612497895",
         "it": "applemusic://track/1612497895"
-      }
+      },
+      "fun_fact_it": "Waterloo lanciò gli ABBA verso il successo mondiale ed è considerata la più grande canzone della storia dell'Eurovision. La giuria britannica le assegnò zero punti, eppure vinsero lo stesso. Nel 2005 fu eletta miglior brano di sempre nel sondaggio per il cinquantenario."
     },
     {
       "year": 1975,
@@ -1203,7 +1225,8 @@
       ],
       "uri_tidal": "tidal://track/181365005",
       "uri_apple_music": "applemusic://track/104581124",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=BPxuq4uQ0OU"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BPxuq4uQ0OU",
+      "fun_fact_it": "Ding-A-Dong diede ai Paesi Bassi la quarta vittoria all'Eurovision. Il brano pop orecchiabile affrontò una concorrenza agguerrita in un'edizione ricca di proposte forti. I Teach-In ebbero una breve carriera internazionale dopo il trionfo."
     },
     {
       "year": 1976,
@@ -1256,7 +1279,8 @@
         "es": "applemusic://track/283372785",
         "nl": "applemusic://track/283372785",
         "it": "applemusic://track/283372785"
-      }
+      },
+      "fun_fact_it": "Save Your Kisses For Me fu la terza vittoria britannica e uno dei singoli più venduti al mondo nel 1976. Sembra una canzone d'amore, ma solo alla fine rivela di essere dedicata a una figlia di tre anni."
     },
     {
       "year": 1977,
@@ -1309,7 +1333,8 @@
         "es": "applemusic://track/1222623640",
         "nl": "applemusic://track/1222623640",
         "it": "applemusic://track/1222623640"
-      }
+      },
+      "fun_fact_it": "L'oiseau et l'enfant (L'uccello e il bambino) resta a oggi l'ultima vittoria francese all'Eurovision. La voce ampia di Marie Myriam ne fece un classico. Da allora la Francia attende il ritorno al successo più a lungo di qualsiasi altro paese vincitore."
     },
     {
       "year": 1978,
@@ -1350,7 +1375,8 @@
       ],
       "awards_it": [
         "Vincitore dell'Eurovision Song Contest 1978"
-      ]
+      ],
+      "fun_fact_it": "A-Ba-Ni-Bi fu la prima vittoria di Israele e nel testo usava un gioco linguistico infantile ebraico. Izhar Cohen e gli Alphabeta si esibirono con una coreografia molto energica, all'epoca innovativa."
     },
     {
       "year": 1979,
@@ -1403,7 +1429,8 @@
         "nl": "applemusic://track/1724997885",
         "it": "applemusic://track/1724997885"
       },
-      "uri_deezer": "deezer://track/2614290962"
+      "uri_deezer": "deezer://track/2614290962",
+      "fun_fact_it": "Hallelujah diede a Israele due vittorie consecutive. Interpretata da Gali Atari con i Milk and Honey, il suo messaggio di pace toccò profondamente in un momento di tensioni in Medio Oriente. Israele ospitò l'Eurovision 1979 a Gerusalemme."
     },
     {
       "year": 1980,
@@ -1456,7 +1483,8 @@
         "es": "applemusic://track/735689364",
         "nl": "applemusic://track/735689364",
         "it": "applemusic://track/735689364"
-      }
+      },
+      "fun_fact_it": "What's Another Year aprì la leggendaria carriera eurovisiva di Johnny Logan. Avrebbe vinto di nuovo nel 1987 da interprete e nel 1992 da autore, unico ad aver vinto tre volte. È conosciuto come 'Mr. Eurovision'."
     },
     {
       "year": 1981,
@@ -1511,7 +1539,8 @@
         "es": "applemusic://track/1449906735",
         "nl": "applemusic://track/1449906735",
         "it": "applemusic://track/1449906735"
-      }
+      },
+      "fun_fact_it": "Making Your Mind Up è famosa per il numero in cui gli uomini strappano le gonne alle compagne rivelandone altre più corte. Quel momento è diventato una delle esibizioni più iconiche dell'Eurovision e lanciò i Bucks Fizz."
     },
     {
       "year": 1982,
@@ -1567,7 +1596,8 @@
         "es": "applemusic://track/284222244",
         "nl": "applemusic://track/284222244",
         "it": "applemusic://track/284222244"
-      }
+      },
+      "fun_fact_it": "Ein bisschen Frieden (Un po' di pace) fu la prima vittoria della Germania e arrivò in cima alle classifiche europee. La ballata contro la guerra colpì nel pieno delle tensioni della Guerra Fredda. Nicole aveva solo 17 anni e si presentò in modo semplice e sincero."
     },
     {
       "year": 1983,
@@ -1620,7 +1650,8 @@
         "nl": "applemusic://track/1568840214",
         "it": "applemusic://track/1568840214"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=F8y5xc8UodE"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=F8y5xc8UodE",
+      "fun_fact_it": "Si la vie est cadeau (Se la vita è un dono) diede al Lussemburgo la quinta e ultima vittoria. La ballata mise in mostra la notevole estensione vocale di Corinne Hermès. Il Lussemburgo si ritirò dall'Eurovision nel 1994 e non è più tornato."
     },
     {
       "year": 1984,
@@ -1673,7 +1704,8 @@
         "es": "applemusic://track/440309422",
         "nl": "applemusic://track/440309422",
         "it": "applemusic://track/440309422"
-      }
+      },
+      "fun_fact_it": "Diggi-Loo Diggi-Ley fu interpretata da tre fratelli con stivali dorati diventati il loro marchio di fabbrica. Il brano eurodisco diede alla Svezia la seconda vittoria dopo gli ABBA. La coreografia degli Herreys definì lo stile eurovisivo degli anni Ottanta."
     },
     {
       "year": 1985,
@@ -1726,7 +1758,8 @@
         "es": "applemusic://track/976265487",
         "nl": "applemusic://track/976265487",
         "it": "applemusic://track/976265487"
-      }
+      },
+      "fun_fact_it": "La det swinge (Lascia che swinghi) chiuse la celebre serie di pessimi risultati della Norvegia con la sua prima vittoria in assoluto. Il duo femminile Bobbysocks conquistò l'Europa con un'esibizione pop-rock piena di energia."
     },
     {
       "year": 1986,
@@ -1779,7 +1812,8 @@
         "es": "applemusic://track/910784990",
         "nl": "applemusic://track/910784990",
         "it": "applemusic://track/910784990"
-      }
+      },
+      "fun_fact_it": "J'aime la vie (Amo la vita) resta l'unica vittoria del Belgio. Sandra Kim dichiarò di avere 15 anni ma ne aveva soltanto 13, il che la rende la vincitrice più giovane di sempre. La verità emerse solo dopo il trionfo."
     },
     {
       "year": 1987,
@@ -1834,7 +1868,8 @@
         "es": "applemusic://track/429802667",
         "nl": "applemusic://track/429802667",
         "it": "applemusic://track/429802667"
-      }
+      },
+      "fun_fact_it": "Hold Me Now rese Johnny Logan il primo artista a vincere due volte l'Eurovision da interprete. Questa ballata la scrisse lui stesso, a differenza del brano del 1980. Logan avrebbe vinto una terza volta nel 1992 come autore di 'Why Me?' per Linda Martin."
     },
     {
       "year": 1988,
@@ -1887,7 +1922,8 @@
         "es": "applemusic://track/253634992",
         "nl": "applemusic://track/253634992",
         "it": "applemusic://track/253634992"
-      }
+      },
+      "fun_fact_it": "Ne partez pas sans moi (Non andate via senza di me) fece conoscere Céline Dion in Europa. Vinse per un solo punto al termine di una gara tiratissima. Rappresentava la Svizzera perché gli artisti canadesi non potevano gareggiare per il proprio paese."
     },
     {
       "year": 1989,
@@ -1940,7 +1976,8 @@
         "es": "applemusic://track/1846157477",
         "nl": "applemusic://track/1846157477",
         "it": "applemusic://track/1846157477"
-      }
+      },
+      "fun_fact_it": "Rock Me fu l'unica vittoria della Jugoslavia prima della dissoluzione del paese. La band croata Riva si esibì con energia contagiosa. Il dissolvimento della Jugoslavia fece sì che nessun paese unito potesse festeggiare a lungo quel traguardo storico."
     },
     {
       "year": 1990,
@@ -1993,7 +2030,8 @@
         "es": "applemusic://track/1329254875",
         "nl": "applemusic://track/1329254875",
         "it": "applemusic://track/1329254875"
-      }
+      },
+      "fun_fact_it": "Insieme: 1992 celebrava l'unità europea alla vigilia del mercato unico. Toto Cutugno aveva partecipato molte volte prima di riuscire a vincere. Il brano divenne un inno all'integrazione europea in un momento storico decisivo."
     },
     {
       "year": 1991,
@@ -2036,7 +2074,8 @@
       "awards_it": [
         "Vincitore dell'Eurovision Song Contest 1991"
       ],
-      "uri_apple_music": "applemusic://track/586785384"
+      "uri_apple_music": "applemusic://track/586785384",
+      "fun_fact_it": "Fångad av en stormvind (Travolta da una tempesta d'amore) vinse in un'edizione ospitata a Roma. Carola aveva già rappresentato la Svezia nel 1983. La ballata drammatica confermò il talento svedese nel produrre vincitori dell'Eurovision."
     },
     {
       "year": 1992,
@@ -2089,7 +2128,8 @@
         "es": "applemusic://track/1111959191",
         "nl": "applemusic://track/1111959191",
         "it": "applemusic://track/1111959191"
-      }
+      },
+      "fun_fact_it": "Why Me? fu scritta da Johnny Logan, che ottenne così la terza vittoria, stavolta da autore. Linda Martin aveva già gareggiato nel 1984. Da qui iniziò la striscia irlandese senza precedenti di quattro vittorie consecutive."
     },
     {
       "year": 1993,
@@ -2142,7 +2182,8 @@
         "es": "applemusic://track/348924038",
         "nl": "applemusic://track/348924038",
         "it": "applemusic://track/348924038"
-      }
+      },
+      "fun_fact_it": "In Your Eyes portò a due anni consecutivi la serie di vittorie irlandesi. La voce potente di Niamh Kavanagh ottenne il punteggio più alto fino ad allora. Tornò all'Eurovision nel 2010, di nuovo per l'Irlanda."
     },
     {
       "year": 1994,
@@ -2197,7 +2238,8 @@
         "es": "applemusic://track/212118856",
         "nl": "applemusic://track/212118856",
         "it": "applemusic://track/212118856"
-      }
+      },
+      "fun_fact_it": "Rock 'n' Roll Kids fu la terza vittoria irlandese consecutiva. Il duetto nostalgico sui sogni d'infanzia batté il record di punti. In quell'edizione andò in scena anche l'intervallo 'Riverdance', che divenne un fenomeno mondiale."
     },
     {
       "year": 1995,
@@ -2239,7 +2281,8 @@
       ],
       "awards_it": [
         "Vincitore dell'Eurovision Song Contest 1995"
-      ]
+      ],
+      "fun_fact_it": "Nocturne è l'unico brano quasi interamente strumentale ad aver vinto l'Eurovision: il testo conta appena 24 parole. Il violino struggente dei Secret Garden conquistò l'Europa. Il duo norvegese-irlandese dimostrò che l'Eurovision non è solo pop orecchiabile."
     },
     {
       "year": 1996,
@@ -2294,7 +2337,8 @@
         "es": "applemusic://track/74409108",
         "nl": "applemusic://track/74409108",
         "it": "applemusic://track/74409108"
-      }
+      },
+      "fun_fact_it": "The Voice diede all'Irlanda la settima vittoria da record, la quarta in cinque anni. L'esibizione celtica ed eterea di Eimear Quinn proseguì il dominio irlandese. Nessun paese ha vinto l'Eurovision più volte dell'Irlanda."
     },
     {
       "year": 1997,
@@ -2347,7 +2391,8 @@
         "es": "applemusic://track/1438441951",
         "nl": "applemusic://track/1438441951",
         "it": "applemusic://track/1438441951"
-      }
+      },
+      "fun_fact_it": "Love Shine a Light è la quinta e finora ultima vittoria del Regno Unito. I Katrina & The Waves vinsero con il margine più ampio mai visto fino ad allora, 70 punti sul secondo. Katrina Leskanich era già celebre per 'Walking on Sunshine'."
     },
     {
       "year": 1998,
@@ -2389,7 +2434,8 @@
       ],
       "awards_it": [
         "Vincitore dell'Eurovision Song Contest 1998"
-      ]
+      ],
+      "fun_fact_it": "Diva fece la storia: Dana International fu la prima vincitrice transgender dell'Eurovision. La sua vittoria fu contestata in alcuni ambienti e celebrata altrove come una tappa per la rappresentanza LGBTQ+. Il brano divenne un successo dance mondiale."
     },
     {
       "year": 1999,
@@ -2442,7 +2488,8 @@
         "es": "applemusic://track/1477474325",
         "nl": "applemusic://track/1477474325",
         "it": "applemusic://track/1477474325"
-      }
+      },
+      "fun_fact_it": "Take Me to Your Heaven fu la quarta vittoria svedese. Charlotte Nilsson, poi Perrelli, portò un classico pop scandinavo. Tornò all'Eurovision nel 2008 con 'Hero', chiudendo al diciottesimo posto."
     },
     {
       "year": 2000,
@@ -2495,7 +2542,8 @@
         "es": "applemusic://track/1676954239",
         "nl": "applemusic://track/1676954239",
         "it": "applemusic://track/1676954239"
-      }
+      },
+      "fun_fact_it": "Fly on the Wings of Love pose fine ai 37 anni di digiuno danese dal 1963. Gli Olsen Brothers, Jorgen e Niels, erano musicisti navigati e ultracinquantenni quando vinsero. La loro vittoria dimostrò che l'età non è un ostacolo."
     },
     {
       "year": 2001,
@@ -2536,7 +2584,8 @@
       "awards_it": [
         "Vincitore dell'Eurovision Song Contest 2001"
       ],
-      "uri_youtube_music": "https://music.youtube.com/watch?v=92TSUlqzFi8"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=92TSUlqzFi8",
+      "fun_fact_it": "Everybody fu la prima vittoria dell'Estonia e la prima di un'ex repubblica sovietica. Dave Benton divenne il vincitore più anziano a 50 anni e il primo interprete nero a vincere. L'Estonia passò dall'esordio nel 1994 al titolo in soli sette anni."
     },
     {
       "year": 2002,
@@ -2589,7 +2638,8 @@
         "it": "applemusic://track/260662904"
       },
       "uri_tidal": "tidal://track/12486339",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=_M-w89U8TEU"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_M-w89U8TEU",
+      "fun_fact_it": "I Wanna diede alla Lettonia la prima vittoria appena al terzo tentativo. L'esibizione sensuale di Marie N e i cambi d'abito durante il brano crearono uno spettacolo memorabile. La Lettonia ospitò l'Eurovision 2003 a Riga."
     },
     {
       "year": 2003,
@@ -2642,7 +2692,8 @@
         "es": "applemusic://track/1308768327",
         "nl": "applemusic://track/1308768327",
         "it": "applemusic://track/1308768327"
-      }
+      },
+      "fun_fact_it": "Everyway That I Can è la prima e unica vittoria della Turchia. La danza del ventre e il pop di ispirazione turca di Sertab Erener portarono qualcosa di nuovo alla gara. L'esibizione contava su ballerini e una coreografia elaborata."
     },
     {
       "year": 2004,
@@ -2695,7 +2746,8 @@
         "es": "applemusic://track/1682977143",
         "nl": "applemusic://track/1682977143",
         "it": "applemusic://track/1691585109"
-      }
+      },
+      "fun_fact_it": "Wild Dances fu la prima vittoria dell'Ucraina e conteneva elementi della musica popolare hutsula dei Carpazi. L'esibizione travolgente di Ruslana, con fuoco e danze tribali, fu rivoluzionaria. Divenne poi un'attivista di primo piano durante le crisi politiche ucraine."
     },
     {
       "year": 2005,
@@ -2748,7 +2800,8 @@
         "es": "applemusic://track/1782949200",
         "nl": "applemusic://track/1782949200",
         "it": "applemusic://track/1782949200"
-      }
+      },
+      "fun_fact_it": "My Number One fu la prima vittoria della Grecia dopo decenni di partecipazioni. Le origini greco-svedesi e l'esibizione pop curatissima di Helena Paparizou conquistarono il pubblico. Aveva già gareggiato nel 2001 con il duo Antique."
     },
     {
       "year": 2006,
@@ -2801,7 +2854,8 @@
         "es": "applemusic://track/389516413",
         "nl": "applemusic://track/298582521",
         "it": "applemusic://track/298582521"
-      }
+      },
+      "fun_fact_it": "Hard Rock Hallelujah sconvolse l'Eurovision: a vincere fu l'heavy metal finlandese con costumi da mostri. L'esibizione teatrale dei Lordi dimostrò che l'Eurovision può accogliere ogni genere. La Finlandia non aveva mai vinto pur partecipando dal 1961."
     },
     {
       "year": 2007,
@@ -2844,7 +2898,8 @@
       "awards_it": [
         "Vincitore dell'Eurovision Song Contest 2007"
       ],
-      "uri_apple_music": "applemusic://track/1578027079"
+      "uri_apple_music": "applemusic://track/1578027079",
+      "fun_fact_it": "Molitva (Preghiera) fu la prima partecipazione e la prima vittoria della Serbia come nazione indipendente dopo la dissoluzione della Jugoslavia. La ballata intensa di Marija Šerifović, cantata interamente in serbo, si impose nettamente. Un brano potente che non aveva bisogno di effetti."
     },
     {
       "year": 2008,
@@ -2896,7 +2951,8 @@
         "es": "applemusic://track/1859966612",
         "nl": "applemusic://track/1859966612",
         "it": "applemusic://track/1859966612"
-      }
+      },
+      "fun_fact_it": "Believe diede alla Russia la prima e unica vittoria. Dima Bilan si esibì con il violinista ungherese Edvin Marton e un pattinatore olimpico sul palco. Era arrivato secondo nel 2006: il 2008 fu la sua rivincita."
     },
     {
       "year": 2009,
@@ -2949,7 +3005,8 @@
         "es": "applemusic://track/1438988564",
         "nl": "applemusic://track/1438988564",
         "it": "applemusic://track/1438988564"
-      }
+      },
+      "fun_fact_it": "Fairytale vinse con 387 punti, il punteggio più alto mai raggiunto fino ad allora con quel sistema di voto. Il folk-pop e il violino di Alexander Rybak conquistarono tutta l'Europa. L'artista bielorusso-norvegese aveva appena 22 anni."
     },
     {
       "year": 2010,
@@ -3005,7 +3062,8 @@
         "es": "applemusic://track/1700804689",
         "nl": "applemusic://track/1667036971",
         "it": "applemusic://track/1667036971"
-      }
+      },
+      "fun_fact_it": "Satellite diede alla Germania la seconda vittoria, la prima dal 1982. L'esibizione originale e spontanea di Lena Meyer-Landrut conquistò l'Europa. Era stata scoperta dal programma televisivo tedesco 'Unser Star für Oslo'."
     },
     {
       "year": 2011,
@@ -3046,7 +3104,8 @@
       "awards_it": [
         "Vincitore dell'Eurovision Song Contest 2011"
       ],
-      "uri_youtube_music": "https://music.youtube.com/watch?v=_0tlQUW5X0U"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_0tlQUW5X0U",
+      "fun_fact_it": "Running Scared fu la prima vittoria dell'Azerbaigian, esordiente solo nel 2008. Il duetto romantico di Ell e Nikki superò di poco l'Italia. La vittoria portò il paese a ospitare l'Eurovision 2012 nella Crystal Hall costruita per l'occasione."
     },
     {
       "year": 2012,
@@ -3102,7 +3161,8 @@
         "es": "applemusic://track/1745191015",
         "nl": "applemusic://track/1675327501",
         "it": "applemusic://track/1745191015"
-      }
+      },
+      "fun_fact_it": "Euphoria è considerata una delle più grandi canzoni vincitrici di sempre. Loreen ricevette il primo posto da 18 paesi, un record. Il brano dance ipnotico scalò le classifiche di tutto il mondo e conta oltre 300 milioni di ascolti su Spotify."
     },
     {
       "year": 2013,
@@ -3157,7 +3217,8 @@
         "es": "applemusic://track/661545116",
         "nl": "applemusic://track/1442382943",
         "it": "applemusic://track/1442382943"
-      }
+      },
+      "fun_fact_it": "Only Teardrops diede alla Danimarca la terza vittoria. L'esibizione folk-pop di Emmelie de Forest, a piedi nudi e con il flauto irlandese, restò impressa. Il messaggio sul lasciar andare il dolore toccò il pubblico europeo."
     },
     {
       "year": 2014,
@@ -3213,7 +3274,8 @@
         "es": "applemusic://track/844169216",
         "nl": "applemusic://track/844169216",
         "it": "applemusic://track/844169216"
-      }
+      },
+      "fun_fact_it": "Rise Like a Phoenix rese Conchita Wurst, alter ego drag di Tom Neuwirth, un'icona mondiale e un simbolo LGBTQ+. La ballata potente della drag queen con la barba fu la seconda vittoria austriaca. Si esibì senza ballerini, prima vincitrice a farlo dal 1970."
     },
     {
       "year": 2015,
@@ -3269,7 +3331,8 @@
         "es": "applemusic://track/1612452449",
         "nl": "applemusic://track/1612452449",
         "it": "applemusic://track/1612452449"
-      }
+      },
+      "fun_fact_it": "Heroes portò sul palco effetti visivi rivoluzionari, con omini animati che interagivano dal vivo con l'interprete. L'esibizione di Måns Zelmerlöw cambiò il modo di allestire l'Eurovision. La tecnologia impiegata costò oltre un milione di euro."
     },
     {
       "year": 2016,
@@ -3324,7 +3387,8 @@
         "es": "applemusic://track/1664506710",
         "nl": "applemusic://track/1664506710",
         "it": "applemusic://track/1664506710"
-      }
+      },
+      "fun_fact_it": "1944 racconta la deportazione dei tatari di Crimea voluta da Stalin, che colpì anche la bisnonna di Jamala. Il brano dal forte contenuto politico vinse tra le polemiche, in piena tensione tra Russia e Ucraina. Resta una delle vittorie più intense della manifestazione."
     },
     {
       "year": 2017,
@@ -3377,7 +3441,8 @@
         "es": "applemusic://track/1812636468",
         "nl": "applemusic://track/1812636468",
         "it": "applemusic://track/1812636468"
-      }
+      },
+      "fun_fact_it": "Amar Pelos Dois (Amare per due) vinse con 758 punti, il punteggio più alto nella storia dell'Eurovision. La ballata jazz intima di Salvador Sobral, scritta dalla sorella Luísa, batté ogni record. Si esibì in attesa di un trapianto di cuore, ricevuto qualche mese dopo."
     },
     {
       "year": 2018,
@@ -3432,7 +3497,8 @@
         "nl": "applemusic://track/1388547847",
         "it": "applemusic://track/1388547847"
       },
-      "uri_tidal": "tidal://track/490853205"
+      "uri_tidal": "tidal://track/490853205",
+      "fun_fact_it": "Toy, con i suoi versi da gallina e il loop pedal, è rimasta indimenticabile. L'inno all'emancipazione di Netta Barzilai e il suo 'I'm not your toy' si legarono al movimento #MeToo. Il brano elettronico bizzarro divise il pubblico ma vinse nettamente."
     },
     {
       "year": 2019,
@@ -3487,7 +3553,8 @@
         "es": "applemusic://track/1748200197",
         "nl": "applemusic://track/1748200197",
         "it": "applemusic://track/1748200197"
-      }
+      },
+      "fun_fact_it": "Arcade è diventata il maggiore successo post-Eurovision di sempre dopo essere diventata virale su TikTok nel 2021, due anni dopo la vittoria. La ballata al pianoforte sull'amore perduto supera il miliardo di ascolti. Fu la quinta vittoria dei Paesi Bassi."
     },
     {
       "year": 2021,
@@ -3540,7 +3607,8 @@
         "es": "applemusic://track/1728089187",
         "nl": "applemusic://track/1591459549",
         "it": "applemusic://track/1728089187"
-      }
+      },
+      "fun_fact_it": "ZITTI E BUONI è stato il primo brano rock a vincere l'Eurovision dai Lordi del 2006. I Måneskin sono poi diventati star mondiali, in cima alle classifiche e sui palchi dei grandi festival. Il cantante Damiano fu oggetto di false accuse di droga, smentite in breve tempo."
     },
     {
       "year": 2022,
@@ -3596,7 +3664,8 @@
         "es": "applemusic://track/1614859013",
         "nl": "applemusic://track/1614859013",
         "it": "applemusic://track/1614859013"
-      }
+      },
+      "fun_fact_it": "Stefania vinse l'Eurovision durante l'invasione russa dell'Ucraina, e i membri della band tornarono a combattere dopo la gara. Scritta per la madre del cantante Oleh Psiuk, assunse un nuovo significato legato alla madrepatria. Il televoto la premiò come gesto di solidarietà."
     },
     {
       "year": 2023,
@@ -3652,7 +3721,8 @@
         "es": "applemusic://track/1872510113",
         "nl": "applemusic://track/1872510113",
         "it": "applemusic://track/1872510113"
-      }
+      },
+      "fun_fact_it": "Tattoo ha reso Loreen la seconda artista di sempre a vincere due volte l'Eurovision, dopo Johnny Logan. La sua esibizione intensa, undici anni dopo 'Euphoria', ha dimostrato che il fulmine può colpire due volte. La Svezia ha raggiunto l'Irlanda a quota sette vittorie."
     },
     {
       "year": 2024,
@@ -3705,7 +3775,8 @@
         "es": "applemusic://track/1730730673",
         "nl": "applemusic://track/1730730673",
         "it": "applemusic://track/1730730673"
-      }
+      },
+      "fun_fact_it": "The Code ha fatto la storia: Nemo è il primo artista non binario a vincere l'Eurovision. L'esibizione teatrale univa opera, rap e drum and bass. La terza vittoria svizzera è arrivata in un'edizione controversa, ospitata a Malmö, in Svezia."
     },
     {
       "year": 2025,
@@ -3758,7 +3829,8 @@
         "es": "applemusic://track/1880012757",
         "nl": "applemusic://track/1880012757",
         "it": "applemusic://track/1880012757"
-      }
+      },
+      "fun_fact_it": "Wasted Love ha messo in mostra la straordinaria voce da controtenore di JJ, in un brano che passa dagli archi a un finale da club. Johannes Pietsch, che canta all'Opera di Stato di Vienna, ha ottenuto i douze points da otto giurie. L'Austria ospiterà l'Eurovision 2026."
     }
   ]
 }

--- a/custom_components/beatify/playlists/greatest-hits-of-all-time.json
+++ b/custom_components/beatify/playlists/greatest-hits-of-all-time.json
@@ -8040,7 +8040,8 @@
       "fun_fact_de": "Ein Chart-Hit von Village People (1978).",
       "fun_fact_es": "Un éxito de Village People (1978).",
       "fun_fact_fr": "Un tube de Village People (1978).",
-      "fun_fact_nl": "Een chart-hit van Village People (1978)."
+      "fun_fact_nl": "Een chart-hit van Village People (1978).",
+      "fun_fact_it": "Un successo in classifica di Village People (1978)."
     },
     {
       "artist": "Alice Cooper",
@@ -8065,7 +8066,8 @@
       "fun_fact_de": "Ein Chart-Hit von Alice Cooper (1972).",
       "fun_fact_es": "Un éxito de Alice Cooper (1972).",
       "fun_fact_fr": "Un tube de Alice Cooper (1972).",
-      "fun_fact_nl": "Een chart-hit van Alice Cooper (1972)."
+      "fun_fact_nl": "Een chart-hit van Alice Cooper (1972).",
+      "fun_fact_it": "Un successo in classifica di Alice Cooper (1972)."
     },
     {
       "artist": "Cheap Trick",
@@ -8090,7 +8092,8 @@
       "fun_fact_de": "Ein Chart-Hit von Cheap Trick (1977).",
       "fun_fact_es": "Un éxito de Cheap Trick (1977).",
       "fun_fact_fr": "Un tube de Cheap Trick (1977).",
-      "fun_fact_nl": "Een chart-hit van Cheap Trick (1977)."
+      "fun_fact_nl": "Een chart-hit van Cheap Trick (1977).",
+      "fun_fact_it": "Un successo in classifica di Cheap Trick (1977)."
     },
     {
       "year": 1979,

--- a/custom_components/beatify/playlists/hits-2010s-2020s.json
+++ b/custom_components/beatify/playlists/hits-2010s-2020s.json
@@ -35,7 +35,8 @@
       "fun_fact_de": "Ein Chart-Hit von Dermot Kennedy (2019).",
       "fun_fact_es": "Un éxito de Dermot Kennedy (2019).",
       "fun_fact_fr": "Un tube de Dermot Kennedy (2019).",
-      "fun_fact_nl": "Een chart-hit van Dermot Kennedy (2019)."
+      "fun_fact_nl": "Een chart-hit van Dermot Kennedy (2019).",
+      "fun_fact_it": "Un successo in classifica di Dermot Kennedy (2019)."
     },
     {
       "artist": "Galantis",
@@ -60,7 +61,8 @@
       "fun_fact_de": "Ein Chart-Hit von Galantis (2016).",
       "fun_fact_es": "Un éxito de Galantis (2016).",
       "fun_fact_fr": "Un tube de Galantis (2016).",
-      "fun_fact_nl": "Een chart-hit van Galantis (2016)."
+      "fun_fact_nl": "Een chart-hit van Galantis (2016).",
+      "fun_fact_it": "Un successo in classifica di Galantis (2016)."
     },
     {
       "artist": "BTS",
@@ -85,7 +87,8 @@
       "fun_fact_de": "Ein Chart-Hit von BTS (2020).",
       "fun_fact_es": "Un éxito de BTS (2020).",
       "fun_fact_fr": "Un tube de BTS (2020).",
-      "fun_fact_nl": "Een chart-hit van BTS (2020)."
+      "fun_fact_nl": "Een chart-hit van BTS (2020).",
+      "fun_fact_it": "Un successo in classifica di BTS (2020)."
     },
     {
       "artist": "Jawsh 685",
@@ -113,7 +116,8 @@
       "fun_fact_de": "Ein Chart-Hit von Jawsh 685 (2020).",
       "fun_fact_es": "Un éxito de Jawsh 685 (2020).",
       "fun_fact_fr": "Un tube de Jawsh 685 (2020).",
-      "fun_fact_nl": "Een chart-hit van Jawsh 685 (2020)."
+      "fun_fact_nl": "Een chart-hit van Jawsh 685 (2020).",
+      "fun_fact_it": "Un successo in classifica di Jawsh 685 (2020)."
     },
     {
       "artist": "Sia",
@@ -138,7 +142,8 @@
       "fun_fact_de": "Ein Chart-Hit von Sia (2017).",
       "fun_fact_es": "Un éxito de Sia (2017).",
       "fun_fact_fr": "Un tube de Sia (2017).",
-      "fun_fact_nl": "Een chart-hit van Sia (2017)."
+      "fun_fact_nl": "Een chart-hit van Sia (2017).",
+      "fun_fact_it": "Un successo in classifica di Sia (2017)."
     },
     {
       "artist": "Jess Glynne",
@@ -163,7 +168,8 @@
       "fun_fact_de": "Ein Chart-Hit von Jess Glynne (2015).",
       "fun_fact_es": "Un éxito de Jess Glynne (2015).",
       "fun_fact_fr": "Un tube de Jess Glynne (2015).",
-      "fun_fact_nl": "Een chart-hit van Jess Glynne (2015)."
+      "fun_fact_nl": "Een chart-hit van Jess Glynne (2015).",
+      "fun_fact_it": "Un successo in classifica di Jess Glynne (2015)."
     },
     {
       "artist": "Daddy Yankee",
@@ -191,7 +197,8 @@
       "fun_fact_de": "Ein Chart-Hit von Daddy Yankee (2019).",
       "fun_fact_es": "Un éxito de Daddy Yankee (2019).",
       "fun_fact_fr": "Un tube de Daddy Yankee (2019).",
-      "fun_fact_nl": "Een chart-hit van Daddy Yankee (2019)."
+      "fun_fact_nl": "Een chart-hit van Daddy Yankee (2019).",
+      "fun_fact_it": "Un successo in classifica di Daddy Yankee (2019)."
     },
     {
       "artist": "Yolanda Be Cool",
@@ -219,7 +226,8 @@
       "fun_fact_de": "Ein Chart-Hit von Yolanda Be Cool (2010).",
       "fun_fact_es": "Un éxito de Yolanda Be Cool (2010).",
       "fun_fact_fr": "Un tube de Yolanda Be Cool (2010).",
-      "fun_fact_nl": "Een chart-hit van Yolanda Be Cool (2010)."
+      "fun_fact_nl": "Een chart-hit van Yolanda Be Cool (2010).",
+      "fun_fact_it": "Un successo in classifica di Yolanda Be Cool (2010)."
     },
     {
       "artist": "Becky G",
@@ -247,7 +255,8 @@
       "fun_fact_de": "Ein Chart-Hit von Becky G (2023).",
       "fun_fact_es": "Un éxito de Becky G (2023).",
       "fun_fact_fr": "Un tube de Becky G (2023).",
-      "fun_fact_nl": "Een chart-hit van Becky G (2023)."
+      "fun_fact_nl": "Een chart-hit van Becky G (2023).",
+      "fun_fact_it": "Un successo in classifica di Becky G (2023)."
     },
     {
       "artist": "Nina Chuba",
@@ -272,7 +281,8 @@
       "fun_fact_de": "Ein Chart-Hit von Nina Chuba (2022).",
       "fun_fact_es": "Un éxito de Nina Chuba (2022).",
       "fun_fact_fr": "Un tube de Nina Chuba (2022).",
-      "fun_fact_nl": "Een chart-hit van Nina Chuba (2022)."
+      "fun_fact_nl": "Een chart-hit van Nina Chuba (2022).",
+      "fun_fact_it": "Un successo in classifica di Nina Chuba (2022)."
     },
     {
       "artist": "DJ Snake",
@@ -300,7 +310,8 @@
       "fun_fact_de": "Ein Chart-Hit von DJ Snake (2016).",
       "fun_fact_es": "Un éxito de DJ Snake (2016).",
       "fun_fact_fr": "Un tube de DJ Snake (2016).",
-      "fun_fact_nl": "Een chart-hit van DJ Snake (2016)."
+      "fun_fact_nl": "Een chart-hit van DJ Snake (2016).",
+      "fun_fact_it": "Un successo in classifica di DJ Snake (2016)."
     },
     {
       "artist": "Dua Lipa",
@@ -325,7 +336,8 @@
       "fun_fact_de": "Ein Chart-Hit von Dua Lipa (2018).",
       "fun_fact_es": "Un éxito de Dua Lipa (2018).",
       "fun_fact_fr": "Un tube de Dua Lipa (2018).",
-      "fun_fact_nl": "Een chart-hit van Dua Lipa (2018)."
+      "fun_fact_nl": "Een chart-hit van Dua Lipa (2018).",
+      "fun_fact_it": "Un successo in classifica di Dua Lipa (2018)."
     },
     {
       "artist": "Armin van Buuren",
@@ -353,7 +365,8 @@
       "fun_fact_de": "Ein Chart-Hit von Armin van Buuren (2017).",
       "fun_fact_es": "Un éxito de Armin van Buuren (2017).",
       "fun_fact_fr": "Un tube de Armin van Buuren (2017).",
-      "fun_fact_nl": "Een chart-hit van Armin van Buuren (2017)."
+      "fun_fact_nl": "Een chart-hit van Armin van Buuren (2017).",
+      "fun_fact_it": "Un successo in classifica di Armin van Buuren (2017)."
     },
     {
       "artist": "Imagine Dragons",
@@ -378,7 +391,8 @@
       "fun_fact_de": "Ein Chart-Hit von Imagine Dragons (2013).",
       "fun_fact_es": "Un éxito de Imagine Dragons (2013).",
       "fun_fact_fr": "Un tube de Imagine Dragons (2013).",
-      "fun_fact_nl": "Een chart-hit van Imagine Dragons (2013)."
+      "fun_fact_nl": "Een chart-hit van Imagine Dragons (2013).",
+      "fun_fact_it": "Un successo in classifica di Imagine Dragons (2013)."
     },
     {
       "artist": "Owl City",
@@ -406,7 +420,8 @@
       "fun_fact_de": "Ein Chart-Hit von Owl City (2012).",
       "fun_fact_es": "Un éxito de Owl City (2012).",
       "fun_fact_fr": "Un tube de Owl City (2012).",
-      "fun_fact_nl": "Een chart-hit van Owl City (2012)."
+      "fun_fact_nl": "Een chart-hit van Owl City (2012).",
+      "fun_fact_it": "Un successo in classifica di Owl City (2012)."
     },
     {
       "artist": "Rudimental",
@@ -434,7 +449,8 @@
       "fun_fact_de": "Ein Chart-Hit von Rudimental (2013).",
       "fun_fact_es": "Un éxito de Rudimental (2013).",
       "fun_fact_fr": "Un tube de Rudimental (2013).",
-      "fun_fact_nl": "Een chart-hit van Rudimental (2013)."
+      "fun_fact_nl": "Een chart-hit van Rudimental (2013).",
+      "fun_fact_it": "Un successo in classifica di Rudimental (2013)."
     },
     {
       "artist": "Calvin Harris",
@@ -462,7 +478,8 @@
       "fun_fact_de": "Ein Chart-Hit von Calvin Harris (2021).",
       "fun_fact_es": "Un éxito de Calvin Harris (2021).",
       "fun_fact_fr": "Un tube de Calvin Harris (2021).",
-      "fun_fact_nl": "Een chart-hit van Calvin Harris (2021)."
+      "fun_fact_nl": "Een chart-hit van Calvin Harris (2021).",
+      "fun_fact_it": "Un successo in classifica di Calvin Harris (2021)."
     },
     {
       "artist": "Tones And I",
@@ -487,7 +504,8 @@
       "fun_fact_de": "Ein Chart-Hit von Tones And I (2019).",
       "fun_fact_es": "Un éxito de Tones And I (2019).",
       "fun_fact_fr": "Un tube de Tones And I (2019).",
-      "fun_fact_nl": "Een chart-hit van Tones And I (2019)."
+      "fun_fact_nl": "Een chart-hit van Tones And I (2019).",
+      "fun_fact_it": "Un successo in classifica di Tones And I (2019)."
     },
     {
       "artist": "Martin Garrix",
@@ -515,7 +533,8 @@
       "fun_fact_de": "Ein Chart-Hit von Martin Garrix (2018).",
       "fun_fact_es": "Un éxito de Martin Garrix (2018).",
       "fun_fact_fr": "Un tube de Martin Garrix (2018).",
-      "fun_fact_nl": "Een chart-hit van Martin Garrix (2018)."
+      "fun_fact_nl": "Een chart-hit van Martin Garrix (2018).",
+      "fun_fact_it": "Un successo in classifica di Martin Garrix (2018)."
     },
     {
       "artist": "Andreas Gabalier",
@@ -540,7 +559,8 @@
       "fun_fact_de": "Ein Chart-Hit von Andreas Gabalier (2018).",
       "fun_fact_es": "Un éxito de Andreas Gabalier (2018).",
       "fun_fact_fr": "Un tube de Andreas Gabalier (2018).",
-      "fun_fact_nl": "Een chart-hit van Andreas Gabalier (2018)."
+      "fun_fact_nl": "Een chart-hit van Andreas Gabalier (2018).",
+      "fun_fact_it": "Un successo in classifica di Andreas Gabalier (2018)."
     },
     {
       "artist": "INNA",
@@ -565,7 +585,8 @@
       "fun_fact_de": "Ein Chart-Hit von INNA (2011).",
       "fun_fact_es": "Un éxito de INNA (2011).",
       "fun_fact_fr": "Un tube de INNA (2011).",
-      "fun_fact_nl": "Een chart-hit van INNA (2011)."
+      "fun_fact_nl": "Een chart-hit van INNA (2011).",
+      "fun_fact_it": "Un successo in classifica di INNA (2011)."
     },
     {
       "artist": "Artemas",
@@ -590,7 +611,8 @@
       "fun_fact_de": "Ein Chart-Hit von Artemas (2024).",
       "fun_fact_es": "Un éxito de Artemas (2024).",
       "fun_fact_fr": "Un tube de Artemas (2024).",
-      "fun_fact_nl": "Een chart-hit van Artemas (2024)."
+      "fun_fact_nl": "Een chart-hit van Artemas (2024).",
+      "fun_fact_it": "Un successo in classifica di Artemas (2024)."
     },
     {
       "artist": "Calvin Harris",
@@ -610,7 +632,8 @@
       "fun_fact_de": "Ein Chart-Hit von Calvin Harris (2018).",
       "fun_fact_es": "Un éxito de Calvin Harris (2018).",
       "fun_fact_fr": "Un tube de Calvin Harris (2018).",
-      "fun_fact_nl": "Een chart-hit van Calvin Harris (2018)."
+      "fun_fact_nl": "Een chart-hit van Calvin Harris (2018).",
+      "fun_fact_it": "Un successo in classifica di Calvin Harris (2018)."
     },
     {
       "artist": "Jennifer Lopez",
@@ -638,7 +661,8 @@
       "fun_fact_de": "Ein Chart-Hit von Jennifer Lopez (2011).",
       "fun_fact_es": "Un éxito de Jennifer Lopez (2011).",
       "fun_fact_fr": "Un tube de Jennifer Lopez (2011).",
-      "fun_fact_nl": "Een chart-hit van Jennifer Lopez (2011)."
+      "fun_fact_nl": "Een chart-hit van Jennifer Lopez (2011).",
+      "fun_fact_it": "Un successo in classifica di Jennifer Lopez (2011)."
     },
     {
       "artist": "J Balvin",
@@ -666,7 +690,8 @@
       "fun_fact_de": "Ein Chart-Hit von J Balvin (2017).",
       "fun_fact_es": "Un éxito de J Balvin (2017).",
       "fun_fact_fr": "Un tube de J Balvin (2017).",
-      "fun_fact_nl": "Een chart-hit van J Balvin (2017)."
+      "fun_fact_nl": "Een chart-hit van J Balvin (2017).",
+      "fun_fact_it": "Un successo in classifica di J Balvin (2017)."
     },
     {
       "artist": "Avicii",
@@ -691,7 +716,8 @@
       "fun_fact_de": "Ein Chart-Hit von Avicii (2011).",
       "fun_fact_es": "Un éxito de Avicii (2011).",
       "fun_fact_fr": "Un tube de Avicii (2011).",
-      "fun_fact_nl": "Een chart-hit van Avicii (2011)."
+      "fun_fact_nl": "Een chart-hit van Avicii (2011).",
+      "fun_fact_it": "Un successo in classifica di Avicii (2011)."
     },
     {
       "artist": "Jessie J",
@@ -720,7 +746,8 @@
       "fun_fact_de": "Ein Chart-Hit von Jessie J (2014).",
       "fun_fact_es": "Un éxito de Jessie J (2014).",
       "fun_fact_fr": "Un tube de Jessie J (2014).",
-      "fun_fact_nl": "Een chart-hit van Jessie J (2014)."
+      "fun_fact_nl": "Een chart-hit van Jessie J (2014).",
+      "fun_fact_it": "Un successo in classifica di Jessie J (2014)."
     },
     {
       "artist": "Linkin Park",
@@ -745,7 +772,8 @@
       "fun_fact_de": "Ein Chart-Hit von Linkin Park (2024).",
       "fun_fact_es": "Un éxito de Linkin Park (2024).",
       "fun_fact_fr": "Un tube de Linkin Park (2024).",
-      "fun_fact_nl": "Een chart-hit van Linkin Park (2024)."
+      "fun_fact_nl": "Een chart-hit van Linkin Park (2024).",
+      "fun_fact_it": "Un successo in classifica di Linkin Park (2024)."
     },
     {
       "artist": "Peggy Gou",
@@ -770,7 +798,8 @@
       "fun_fact_de": "Ein Chart-Hit von Peggy Gou (2023).",
       "fun_fact_es": "Un éxito de Peggy Gou (2023).",
       "fun_fact_fr": "Un tube de Peggy Gou (2023).",
-      "fun_fact_nl": "Een chart-hit van Peggy Gou (2023)."
+      "fun_fact_nl": "Een chart-hit van Peggy Gou (2023).",
+      "fun_fact_it": "Un successo in classifica di Peggy Gou (2023)."
     },
     {
       "artist": "Beyoncé",
@@ -795,7 +824,8 @@
       "fun_fact_de": "Ein Chart-Hit von Beyoncé (2024).",
       "fun_fact_es": "Un éxito de Beyoncé (2024).",
       "fun_fact_fr": "Un tube de Beyoncé (2024).",
-      "fun_fact_nl": "Een chart-hit van Beyoncé (2024)."
+      "fun_fact_nl": "Een chart-hit van Beyoncé (2024).",
+      "fun_fact_it": "Un successo in classifica di Beyoncé (2024)."
     },
     {
       "artist": "Alan Walker",
@@ -820,7 +850,8 @@
       "fun_fact_de": "Ein Chart-Hit von Alan Walker (2015).",
       "fun_fact_es": "Un éxito de Alan Walker (2015).",
       "fun_fact_fr": "Un tube de Alan Walker (2015).",
-      "fun_fact_nl": "Een chart-hit van Alan Walker (2015)."
+      "fun_fact_nl": "Een chart-hit van Alan Walker (2015).",
+      "fun_fact_it": "Un successo in classifica di Alan Walker (2015)."
     },
     {
       "artist": "Conkarah",
@@ -848,7 +879,8 @@
       "fun_fact_de": "Ein Chart-Hit von Conkarah (2020).",
       "fun_fact_es": "Un éxito de Conkarah (2020).",
       "fun_fact_fr": "Un tube de Conkarah (2020).",
-      "fun_fact_nl": "Een chart-hit van Conkarah (2020)."
+      "fun_fact_nl": "Een chart-hit van Conkarah (2020).",
+      "fun_fact_it": "Un successo in classifica di Conkarah (2020)."
     },
     {
       "artist": "Kygo",
@@ -876,7 +908,8 @@
       "fun_fact_de": "Ein Chart-Hit von Kygo (2022).",
       "fun_fact_es": "Un éxito de Kygo (2022).",
       "fun_fact_fr": "Un tube de Kygo (2022).",
-      "fun_fact_nl": "Een chart-hit van Kygo (2022)."
+      "fun_fact_nl": "Een chart-hit van Kygo (2022).",
+      "fun_fact_it": "Un successo in classifica di Kygo (2022)."
     },
     {
       "artist": "Alexandra Stan",
@@ -901,7 +934,8 @@
       "fun_fact_de": "Ein Chart-Hit von Alexandra Stan (2011).",
       "fun_fact_es": "Un éxito de Alexandra Stan (2011).",
       "fun_fact_fr": "Un tube de Alexandra Stan (2011).",
-      "fun_fact_nl": "Een chart-hit van Alexandra Stan (2011)."
+      "fun_fact_nl": "Een chart-hit van Alexandra Stan (2011).",
+      "fun_fact_it": "Un successo in classifica di Alexandra Stan (2011)."
     },
     {
       "artist": "Madcon",
@@ -929,7 +963,8 @@
       "fun_fact_de": "Ein Chart-Hit von Madcon (2015).",
       "fun_fact_es": "Un éxito de Madcon (2015).",
       "fun_fact_fr": "Un tube de Madcon (2015).",
-      "fun_fact_nl": "Een chart-hit van Madcon (2015)."
+      "fun_fact_nl": "Een chart-hit van Madcon (2015).",
+      "fun_fact_it": "Un successo in classifica di Madcon (2015)."
     },
     {
       "artist": "LMFAO",
@@ -954,7 +989,8 @@
       "fun_fact_de": "Ein Chart-Hit von LMFAO (2011).",
       "fun_fact_es": "Un éxito de LMFAO (2011).",
       "fun_fact_fr": "Un tube de LMFAO (2011).",
-      "fun_fact_nl": "Een chart-hit van LMFAO (2011)."
+      "fun_fact_nl": "Een chart-hit van LMFAO (2011).",
+      "fun_fact_it": "Un successo in classifica di LMFAO (2011)."
     },
     {
       "artist": "Christian Steiffen",
@@ -979,7 +1015,8 @@
       "fun_fact_de": "Ein Chart-Hit von Christian Steiffen (2012).",
       "fun_fact_es": "Un éxito de Christian Steiffen (2012).",
       "fun_fact_fr": "Un tube de Christian Steiffen (2012).",
-      "fun_fact_nl": "Een chart-hit van Christian Steiffen (2012)."
+      "fun_fact_nl": "Een chart-hit van Christian Steiffen (2012).",
+      "fun_fact_it": "Un successo in classifica di Christian Steiffen (2012)."
     },
     {
       "artist": "Leony",
@@ -1004,7 +1041,8 @@
       "fun_fact_de": "Ein Chart-Hit von Leony (2023).",
       "fun_fact_es": "Un éxito de Leony (2023).",
       "fun_fact_fr": "Un tube de Leony (2023).",
-      "fun_fact_nl": "Een chart-hit van Leony (2023)."
+      "fun_fact_nl": "Een chart-hit van Leony (2023).",
+      "fun_fact_it": "Un successo in classifica di Leony (2023)."
     },
     {
       "artist": "Alcazar",
@@ -1029,7 +1067,8 @@
       "fun_fact_de": "Ein Chart-Hit von Alcazar (2000).",
       "fun_fact_es": "Un éxito de Alcazar (2000).",
       "fun_fact_fr": "Un tube de Alcazar (2000).",
-      "fun_fact_nl": "Een chart-hit van Alcazar (2000)."
+      "fun_fact_nl": "Een chart-hit van Alcazar (2000).",
+      "fun_fact_it": "Un successo in classifica di Alcazar (2000)."
     },
     {
       "artist": "Imany",
@@ -1048,7 +1087,8 @@
       "fun_fact_de": "Ein Chart-Hit von Imany (2017).",
       "fun_fact_es": "Un éxito de Imany (2017).",
       "fun_fact_fr": "Un tube de Imany (2017).",
-      "fun_fact_nl": "Een chart-hit van Imany (2017)."
+      "fun_fact_nl": "Een chart-hit van Imany (2017).",
+      "fun_fact_it": "Un successo in classifica di Imany (2017)."
     },
     {
       "artist": "OMI",
@@ -1076,7 +1116,8 @@
       "fun_fact_de": "Ein Chart-Hit von OMI (2014).",
       "fun_fact_es": "Un éxito de OMI (2014).",
       "fun_fact_fr": "Un tube de OMI (2014).",
-      "fun_fact_nl": "Een chart-hit van OMI (2014)."
+      "fun_fact_nl": "Een chart-hit van OMI (2014).",
+      "fun_fact_it": "Un successo in classifica di OMI (2014)."
     },
     {
       "artist": "Die Atzen",
@@ -1101,7 +1142,8 @@
       "fun_fact_de": "Ein Chart-Hit von Die Atzen (2010).",
       "fun_fact_es": "Un éxito de Die Atzen (2010).",
       "fun_fact_fr": "Un tube de Die Atzen (2010).",
-      "fun_fact_nl": "Een chart-hit van Die Atzen (2010)."
+      "fun_fact_nl": "Een chart-hit van Die Atzen (2010).",
+      "fun_fact_it": "Un successo in classifica di Die Atzen (2010)."
     },
     {
       "artist": "Twenty One Pilots",
@@ -1126,7 +1168,8 @@
       "fun_fact_de": "Ein Chart-Hit von Twenty One Pilots (2015).",
       "fun_fact_es": "Un éxito de Twenty One Pilots (2015).",
       "fun_fact_fr": "Un tube de Twenty One Pilots (2015).",
-      "fun_fact_nl": "Een chart-hit van Twenty One Pilots (2015)."
+      "fun_fact_nl": "Een chart-hit van Twenty One Pilots (2015).",
+      "fun_fact_it": "Un successo in classifica di Twenty One Pilots (2015)."
     },
     {
       "artist": "Clean Bandit",
@@ -1154,7 +1197,8 @@
       "fun_fact_de": "Ein Chart-Hit von Clean Bandit (2018).",
       "fun_fact_es": "Un éxito de Clean Bandit (2018).",
       "fun_fact_fr": "Un tube de Clean Bandit (2018).",
-      "fun_fact_nl": "Een chart-hit van Clean Bandit (2018)."
+      "fun_fact_nl": "Een chart-hit van Clean Bandit (2018).",
+      "fun_fact_it": "Un successo in classifica di Clean Bandit (2018)."
     },
     {
       "artist": "Taylor Swift",
@@ -1171,7 +1215,8 @@
       "fun_fact_de": "Ein Chart-Hit von Taylor Swift (2015).",
       "fun_fact_es": "Un éxito de Taylor Swift (2015).",
       "fun_fact_fr": "Un tube de Taylor Swift (2015).",
-      "fun_fact_nl": "Een chart-hit van Taylor Swift (2015)."
+      "fun_fact_nl": "Een chart-hit van Taylor Swift (2015).",
+      "fun_fact_it": "Un successo in classifica di Taylor Swift (2015)."
     },
     {
       "artist": "Panic! At The Disco",
@@ -1196,7 +1241,8 @@
       "fun_fact_de": "Ein Chart-Hit von Panic! At The Disco (2018).",
       "fun_fact_es": "Un éxito de Panic! At The Disco (2018).",
       "fun_fact_fr": "Un tube de Panic! At The Disco (2018).",
-      "fun_fact_nl": "Een chart-hit van Panic! At The Disco (2018)."
+      "fun_fact_nl": "Een chart-hit van Panic! At The Disco (2018).",
+      "fun_fact_it": "Un successo in classifica di Panic! At The Disco (2018)."
     },
     {
       "artist": "Taio Cruz",
@@ -1221,7 +1267,8 @@
       "fun_fact_de": "Ein Chart-Hit von Taio Cruz (2010).",
       "fun_fact_es": "Un éxito de Taio Cruz (2010).",
       "fun_fact_fr": "Un tube de Taio Cruz (2010).",
-      "fun_fact_nl": "Een chart-hit van Taio Cruz (2010)."
+      "fun_fact_nl": "Een chart-hit van Taio Cruz (2010).",
+      "fun_fact_it": "Un successo in classifica di Taio Cruz (2010)."
     },
     {
       "artist": "Beyoncé",
@@ -1246,7 +1293,8 @@
       "fun_fact_de": "Ein Chart-Hit von Beyoncé (2011).",
       "fun_fact_es": "Un éxito de Beyoncé (2011).",
       "fun_fact_fr": "Un tube de Beyoncé (2011).",
-      "fun_fact_nl": "Een chart-hit van Beyoncé (2011)."
+      "fun_fact_nl": "Een chart-hit van Beyoncé (2011).",
+      "fun_fact_it": "Un successo in classifica di Beyoncé (2011)."
     },
     {
       "artist": "Avicii",
@@ -1271,7 +1319,8 @@
       "fun_fact_de": "Ein Chart-Hit von Avicii (2015).",
       "fun_fact_es": "Un éxito de Avicii (2015).",
       "fun_fact_fr": "Un tube de Avicii (2015).",
-      "fun_fact_nl": "Een chart-hit van Avicii (2015)."
+      "fun_fact_nl": "Een chart-hit van Avicii (2015).",
+      "fun_fact_it": "Un successo in classifica di Avicii (2015)."
     },
     {
       "artist": "P!nk",
@@ -1296,7 +1345,8 @@
       "fun_fact_de": "Ein Chart-Hit von P!nk (2010).",
       "fun_fact_es": "Un éxito de P!nk (2010).",
       "fun_fact_fr": "Un tube de P!nk (2010).",
-      "fun_fact_nl": "Een chart-hit van P!nk (2010)."
+      "fun_fact_nl": "Een chart-hit van P!nk (2010).",
+      "fun_fact_it": "Un successo in classifica di P!nk (2010)."
     },
     {
       "artist": "AronChupa",
@@ -1321,7 +1371,8 @@
       "fun_fact_de": "Ein Chart-Hit von AronChupa (2014).",
       "fun_fact_es": "Un éxito de AronChupa (2014).",
       "fun_fact_fr": "Un tube de AronChupa (2014).",
-      "fun_fact_nl": "Een chart-hit van AronChupa (2014)."
+      "fun_fact_nl": "Een chart-hit van AronChupa (2014).",
+      "fun_fact_it": "Un successo in classifica di AronChupa (2014)."
     },
     {
       "artist": "ROSÉ",
@@ -1349,7 +1400,8 @@
       "fun_fact_de": "Ein Chart-Hit von ROSÉ (2024).",
       "fun_fact_es": "Un éxito de ROSÉ (2024).",
       "fun_fact_fr": "Un tube de ROSÉ (2024).",
-      "fun_fact_nl": "Een chart-hit van ROSÉ (2024)."
+      "fun_fact_nl": "Een chart-hit van ROSÉ (2024).",
+      "fun_fact_it": "Un successo in classifica di ROSÉ (2024)."
     },
     {
       "artist": "Vincent Gross",
@@ -1374,7 +1426,8 @@
       "fun_fact_de": "Ein Chart-Hit von Vincent Gross (2023).",
       "fun_fact_es": "Un éxito de Vincent Gross (2023).",
       "fun_fact_fr": "Un tube de Vincent Gross (2023).",
-      "fun_fact_nl": "Een chart-hit van Vincent Gross (2023)."
+      "fun_fact_nl": "Een chart-hit van Vincent Gross (2023).",
+      "fun_fact_it": "Un successo in classifica di Vincent Gross (2023)."
     },
     {
       "artist": "AFROJACK",
@@ -1402,7 +1455,8 @@
       "fun_fact_de": "Ein Chart-Hit von AFROJACK (2021).",
       "fun_fact_es": "Un éxito de AFROJACK (2021).",
       "fun_fact_fr": "Un tube de AFROJACK (2021).",
-      "fun_fact_nl": "Een chart-hit van AFROJACK (2021)."
+      "fun_fact_nl": "Een chart-hit van AFROJACK (2021).",
+      "fun_fact_it": "Un successo in classifica di AFROJACK (2021)."
     },
     {
       "artist": "Cascada",
@@ -1427,7 +1481,8 @@
       "fun_fact_de": "Ein Chart-Hit von Cascada (2010).",
       "fun_fact_es": "Un éxito de Cascada (2010).",
       "fun_fact_fr": "Un tube de Cascada (2010).",
-      "fun_fact_nl": "Een chart-hit van Cascada (2010)."
+      "fun_fact_nl": "Een chart-hit van Cascada (2010).",
+      "fun_fact_it": "Un successo in classifica di Cascada (2010)."
     },
     {
       "artist": "OneRepublic",
@@ -1452,7 +1507,8 @@
       "fun_fact_de": "Ein Chart-Hit von OneRepublic (2022).",
       "fun_fact_es": "Un éxito de OneRepublic (2022).",
       "fun_fact_fr": "Un tube de OneRepublic (2022).",
-      "fun_fact_nl": "Een chart-hit van OneRepublic (2022)."
+      "fun_fact_nl": "Een chart-hit van OneRepublic (2022).",
+      "fun_fact_it": "Un successo in classifica di OneRepublic (2022)."
     },
     {
       "artist": "Chris Brown",
@@ -1477,7 +1533,8 @@
       "fun_fact_de": "Ein Chart-Hit von Chris Brown (2011).",
       "fun_fact_es": "Un éxito de Chris Brown (2011).",
       "fun_fact_fr": "Un tube de Chris Brown (2011).",
-      "fun_fact_nl": "Een chart-hit van Chris Brown (2011)."
+      "fun_fact_nl": "Een chart-hit van Chris Brown (2011).",
+      "fun_fact_it": "Un successo in classifica di Chris Brown (2011)."
     },
     {
       "artist": "Miley Cyrus",
@@ -1502,7 +1559,8 @@
       "fun_fact_de": "Ein Chart-Hit von Miley Cyrus (2020).",
       "fun_fact_es": "Un éxito de Miley Cyrus (2020).",
       "fun_fact_fr": "Un tube de Miley Cyrus (2020).",
-      "fun_fact_nl": "Een chart-hit van Miley Cyrus (2020)."
+      "fun_fact_nl": "Een chart-hit van Miley Cyrus (2020).",
+      "fun_fact_it": "Un successo in classifica di Miley Cyrus (2020)."
     },
     {
       "artist": "Nicky Jam",
@@ -1530,7 +1588,8 @@
       "fun_fact_de": "Ein Chart-Hit von Nicky Jam (2017).",
       "fun_fact_es": "Un éxito de Nicky Jam (2017).",
       "fun_fact_fr": "Un tube de Nicky Jam (2017).",
-      "fun_fact_nl": "Een chart-hit van Nicky Jam (2017)."
+      "fun_fact_nl": "Een chart-hit van Nicky Jam (2017).",
+      "fun_fact_it": "Un successo in classifica di Nicky Jam (2017)."
     },
     {
       "artist": "USHER",
@@ -1555,7 +1614,8 @@
       "fun_fact_de": "Ein Chart-Hit von USHER (2011).",
       "fun_fact_es": "Un éxito de USHER (2011).",
       "fun_fact_fr": "Un tube de USHER (2011).",
-      "fun_fact_nl": "Een chart-hit van USHER (2011)."
+      "fun_fact_nl": "Een chart-hit van USHER (2011).",
+      "fun_fact_it": "Un successo in classifica di USHER (2011)."
     },
     {
       "artist": "SIRA",
@@ -1584,7 +1644,8 @@
       "fun_fact_de": "Ein Chart-Hit von SIRA (2023).",
       "fun_fact_es": "Un éxito de SIRA (2023).",
       "fun_fact_fr": "Un tube de SIRA (2023).",
-      "fun_fact_nl": "Een chart-hit van SIRA (2023)."
+      "fun_fact_nl": "Een chart-hit van SIRA (2023).",
+      "fun_fact_it": "Un successo in classifica di SIRA (2023)."
     },
     {
       "artist": "Olivia Rodrigo",
@@ -1609,7 +1670,8 @@
       "fun_fact_de": "Ein Chart-Hit von Olivia Rodrigo (2021).",
       "fun_fact_es": "Un éxito de Olivia Rodrigo (2021).",
       "fun_fact_fr": "Un tube de Olivia Rodrigo (2021).",
-      "fun_fact_nl": "Een chart-hit van Olivia Rodrigo (2021)."
+      "fun_fact_nl": "Een chart-hit van Olivia Rodrigo (2021).",
+      "fun_fact_it": "Un successo in classifica di Olivia Rodrigo (2021)."
     },
     {
       "artist": "Alvaro Soler",
@@ -1637,7 +1699,8 @@
       "fun_fact_de": "Ein Chart-Hit von Alvaro Soler (2022).",
       "fun_fact_es": "Un éxito de Alvaro Soler (2022).",
       "fun_fact_fr": "Un tube de Alvaro Soler (2022).",
-      "fun_fact_nl": "Een chart-hit van Alvaro Soler (2022)."
+      "fun_fact_nl": "Een chart-hit van Alvaro Soler (2022).",
+      "fun_fact_it": "Un successo in classifica di Alvaro Soler (2022)."
     },
     {
       "artist": "PSY",
@@ -1662,7 +1725,8 @@
       "fun_fact_de": "Ein Chart-Hit von PSY (2012).",
       "fun_fact_es": "Un éxito de PSY (2012).",
       "fun_fact_fr": "Un tube de PSY (2012).",
-      "fun_fact_nl": "Een chart-hit van PSY (2012)."
+      "fun_fact_nl": "Een chart-hit van PSY (2012).",
+      "fun_fact_it": "Un successo in classifica di PSY (2012)."
     },
     {
       "artist": "Axwell /\\ Ingrosso",
@@ -1691,7 +1755,8 @@
       "fun_fact_de": "Ein Chart-Hit von Axwell /\\ Ingrosso (2015).",
       "fun_fact_es": "Un éxito de Axwell /\\ Ingrosso (2015).",
       "fun_fact_fr": "Un tube de Axwell /\\ Ingrosso (2015).",
-      "fun_fact_nl": "Een chart-hit van Axwell /\\ Ingrosso (2015)."
+      "fun_fact_nl": "Een chart-hit van Axwell /\\ Ingrosso (2015).",
+      "fun_fact_it": "Un successo in classifica di Axwell /\\ Ingrosso (2015)."
     },
     {
       "artist": "Nathan Evans",
@@ -1716,7 +1781,8 @@
       "fun_fact_de": "Ein Chart-Hit von Nathan Evans (2021).",
       "fun_fact_es": "Un éxito de Nathan Evans (2021).",
       "fun_fact_fr": "Un tube de Nathan Evans (2021).",
-      "fun_fact_nl": "Een chart-hit van Nathan Evans (2021)."
+      "fun_fact_nl": "Een chart-hit van Nathan Evans (2021).",
+      "fun_fact_it": "Un successo in classifica di Nathan Evans (2021)."
     },
     {
       "artist": "Mark Ronson",
@@ -1744,7 +1810,8 @@
       "fun_fact_de": "Ein Chart-Hit von Mark Ronson (2015).",
       "fun_fact_es": "Un éxito de Mark Ronson (2015).",
       "fun_fact_fr": "Un tube de Mark Ronson (2015).",
-      "fun_fact_nl": "Een chart-hit van Mark Ronson (2015)."
+      "fun_fact_nl": "Een chart-hit van Mark Ronson (2015).",
+      "fun_fact_it": "Un successo in classifica di Mark Ronson (2015)."
     },
     {
       "artist": "Daft Punk",
@@ -1765,7 +1832,8 @@
       "fun_fact_de": "Ein Chart-Hit von Daft Punk (2013).",
       "fun_fact_es": "Un éxito de Daft Punk (2013).",
       "fun_fact_fr": "Un tube de Daft Punk (2013).",
-      "fun_fact_nl": "Een chart-hit van Daft Punk (2013)."
+      "fun_fact_nl": "Een chart-hit van Daft Punk (2013).",
+      "fun_fact_it": "Un successo in classifica di Daft Punk (2013)."
     },
     {
       "year": 2010,

--- a/custom_components/beatify/playlists/movies-100-greatest-themes.json
+++ b/custom_components/beatify/playlists/movies-100-greatest-themes.json
@@ -67,7 +67,8 @@
         "es": "applemusic://track/1369922084",
         "nl": "applemusic://track/1369922084",
         "it": "applemusic://track/1369922084"
-      }
+      },
+      "fun_fact_it": "Howard Shore compose tutte e tre le colonne sonore del Signore degli Anelli in Nuova Zelanda, nell'arco di quattro anni. Servirono oltre 100 musicisti e il lavoro valse tre premi Oscar."
     },
     {
       "year": 1962,
@@ -97,7 +98,8 @@
       "uri_tidal": "tidal://track/93266573",
       "uri_deezer": "deezer://track/538057262",
       "fun_fact_nl": "Het James Bond-thema was gecomponeerd door Monty Norman maar gearrangeerd door John Barry, wat leidde tot tientallen jaren van juridische geschillen over wie de eerste eer verdiende.",
-      "awards_nl": []
+      "awards_nl": [],
+      "fun_fact_it": "Il tema di James Bond fu composto da Monty Norman ma arrangiato da John Barry: da qui decenni di cause legali su chi meritasse la paternità principale."
     },
     {
       "year": 1997,
@@ -158,7 +160,8 @@
         "es": "applemusic://track/205743853",
         "nl": "applemusic://track/205743853",
         "it": "applemusic://track/460047956"
-      }
+      },
+      "fun_fact_it": "James Horner compose la colonna sonora di Titanic in sole tre settimane. Vi inserì un tin whistle irlandese per evocare l'epoca e le radici celtiche."
     },
     {
       "year": 1977,
@@ -224,7 +227,8 @@
         "es": "applemusic://track/1376671117",
         "nl": "applemusic://track/1375814284",
         "it": "applemusic://track/1376652184"
-      }
+      },
+      "fun_fact_it": "Il tema di Guerre stellari di John Williams fu registrato dalla London Symphony Orchestra in appena 12 giorni. È diventato una delle colonne sonore più riconoscibili della storia."
     },
     {
       "year": 1977,
@@ -285,7 +289,8 @@
         "es": "applemusic://track/1884981998",
         "nl": "applemusic://track/1884981998",
         "it": "applemusic://track/1884981998"
-      }
+      },
+      "fun_fact_it": "La colonna sonora della Febbre del sabato sera restò 24 settimane al primo posto e vendette oltre 40 milioni di copie: una delle più vendute di sempre."
     },
     {
       "year": 1966,
@@ -329,7 +334,8 @@
         "es": "applemusic://track/1714547929",
         "nl": "applemusic://track/1714547929",
         "it": "applemusic://track/1714547929"
-      }
+      },
+      "fun_fact_it": "Ennio Morricone compose il tema del Buono, il brutto, il cattivo prima delle riprese. Sergio Leone lo faceva ascoltare sul set per ispirare gli attori."
     },
     {
       "year": 1999,
@@ -384,7 +390,8 @@
         "es": "applemusic://track/1452614024",
         "nl": "applemusic://track/1437293431",
         "it": "applemusic://track/1437293431"
-      }
+      },
+      "fun_fact_it": "La partitura di American Beauty di Thomas Newman usa marimba e strumenti del gamelan per creare un paesaggio sonoro etereo e suburbano, premiato con un Grammy."
     },
     {
       "year": 1994,
@@ -423,7 +430,8 @@
         "es": "applemusic://track/371272703",
         "nl": "applemusic://track/371272703",
         "it": "applemusic://track/371272703"
-      }
+      },
+      "fun_fact_it": "Alan Silvestri compose il delicato tema al pianoforte di Forrest Gump per rispecchiare lo sguardo innocente del protagonista su decenni di storia americana."
     },
     {
       "year": 1978,
@@ -467,7 +475,8 @@
         "nl": "applemusic://track/1691911665",
         "it": "applemusic://track/1691911665"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=ZC7v2gFsCz0"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ZC7v2gFsCz0",
+      "fun_fact_it": "Frankie Valli incise la title track di Grease appositamente per il film. Divenne il suo maggior successo da solista e definì il tono nostalgico della pellicola."
     },
     {
       "year": 1971,
@@ -523,7 +532,8 @@
         "Grammy per la migliore interpretazione strumentale (1972)"
       ],
       "uri_apple_music": "applemusic://track/1440781096",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=fTU_9T5ufzY"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fTU_9T5ufzY",
+      "fun_fact_it": "Isaac Hayes vinse l'Oscar per il tema di Shaft: fu la prima canzone composta da un afroamericano a ottenere il premio per la migliore canzone originale."
     },
     {
       "year": 1963,
@@ -581,7 +591,8 @@
         "nl": "applemusic://track/1006312033",
         "it": "applemusic://track/1006312033"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=wDoDYEFIMas"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wDoDYEFIMas",
+      "fun_fact_it": "Il tema della Pantera Rosa di Henry Mancini era scritto per i titoli di testa, ma divenne così popolare da dare vita a un'intera serie animata."
     },
     {
       "year": 2002,
@@ -620,7 +631,8 @@
         "es": "applemusic://track/1636991684",
         "nl": "applemusic://track/1636991684",
         "it": "applemusic://track/1636991684"
-      }
+      },
+      "fun_fact_it": "La colonna sonora di The Bourne Identity di John Powell inaugurò il suono moderno del film d'azione, con ritmi incalzanti ed elettronica innestata sull'orchestra."
     },
     {
       "year": 1972,
@@ -661,7 +673,8 @@
         "es": "applemusic://track/1637170585",
         "nl": "applemusic://track/1637170585",
         "it": "applemusic://track/1637170585"
-      }
+      },
+      "fun_fact_it": "Il tema del Padrino di Nino Rota fu inizialmente respinto dalla produzione perché giudicato troppo etnico. Coppola si battè per tenerlo, ed è diventato leggendario."
     },
     {
       "year": 1966,
@@ -727,7 +740,8 @@
         "es": "applemusic://track/209447357",
         "nl": "applemusic://track/209447357",
         "it": "applemusic://track/209447357"
-      }
+      },
+      "fun_fact_it": "Nata libera vinse l'Oscar per la migliore canzone originale. John Barry vinse anche quello per la migliore colonna sonora, aggiudicandosi entrambe le categorie musicali dell'anno."
     },
     {
       "year": 1994,
@@ -787,7 +801,8 @@
         "es": "applemusic://track/1445732924",
         "nl": "applemusic://track/1445732924",
         "it": "applemusic://track/1445732924"
-      }
+      },
+      "fun_fact_it": "Il cerchio della vita apre Il Re Leone con un'alba sull'Africa. I versi in zulu furono tradotti dal compositore sudafricano Lebo M."
     },
     {
       "year": 1976,
@@ -847,7 +862,8 @@
         "es": "applemusic://track/1691912797",
         "nl": "applemusic://track/1691912797",
         "it": "applemusic://track/1691912797"
-      }
+      },
+      "fun_fact_it": "Gonna Fly Now, il tema di Rocky, fu scritta in un pomeriggio. La fanfara trionfale degli ottoni è diventata sinonimo di imprese impossibili."
     },
     {
       "year": 1965,
@@ -913,7 +929,8 @@
         "es": "applemusic://track/1455256248",
         "nl": "applemusic://track/1455256248",
         "it": "applemusic://track/1455256248"
-      }
+      },
+      "fun_fact_it": "Il tema del Dottor Živago di Maurice Jarre usa la balalaica per evocare la Russia. La partitura vinse l'Oscar e l'album divenne un long seller."
     },
     {
       "year": 1960,
@@ -945,7 +962,8 @@
       "fun_fact_nl": "Het Magnificent Seven-thema van Elmer Bernstein is in ontelbare reclames gebruikt en werd bekender dan de film zelf.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1444043816",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=yulmgTcGLZw"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=yulmgTcGLZw",
+      "fun_fact_it": "Il tema dei Magnifici Sette di Elmer Bernstein è stato usato in innumerevoli pubblicità ed è diventato più celebre del film stesso."
     },
     {
       "year": 1968,
@@ -987,7 +1005,8 @@
         "es": "applemusic://track/1443666197",
         "nl": "applemusic://track/1443666197",
         "it": "applemusic://track/1443666197"
-      }
+      },
+      "fun_fact_it": "Il tema della Strana coppia di Neal Hefti cattura alla perfezione lo scontro comico tra l'ordinato Felix e il disordinato Oscar, con un clavicembalo giocoso."
     },
     {
       "year": 1983,
@@ -1016,7 +1035,8 @@
       "uri_deezer": "deezer://track/1118037542",
       "fun_fact_nl": "De score van Risky Business van Tangerine Dream hielp elektronische filmmuziek populair te worden. Het synthesizergeluid beïnvloedde de jaren 80 cinema.",
       "awards_nl": [],
-      "uri_apple_music": "applemusic://track/1702922372"
+      "uri_apple_music": "applemusic://track/1702922372",
+      "fun_fact_it": "La colonna sonora di Risky Business dei Tangerine Dream contribuì a diffondere la musica elettronica al cinema. Il suono ricco di sintetizzatori segnò gli anni Ottanta."
     },
     {
       "year": 1999,
@@ -1055,7 +1075,8 @@
         "es": "applemusic://track/373216432",
         "nl": "applemusic://track/373216432",
         "it": "applemusic://track/373216432"
-      }
+      },
+      "fun_fact_it": "La partitura del Miglio verde di Thomas Newman affida a pianoforte e archi i temi della compassione e della redenzione soprannaturale del film."
     },
     {
       "year": 2014,
@@ -1110,7 +1131,8 @@
         "es": "applemusic://track/1533984393",
         "nl": "applemusic://track/1533984393",
         "it": "applemusic://track/1533984393"
-      }
+      },
+      "fun_fact_it": "La colonna sonora di Interstellar di Hans Zimmer affida a un organo da chiesa l'immensità dello spazio. All'inizio Nolan tenne nascosta la trama al compositore."
     },
     {
       "year": 1967,
@@ -1144,7 +1166,8 @@
       "uri_deezer": "deezer://track/15275788",
       "fun_fact_nl": "Simon & Garfunkel's Sound of Silence werd tegen de zin van het duo toegevoegd aan The Graduate. Het werd onlosmakelijk verbonden met de vervreemdingsthema's van de film.",
       "awards_nl": [],
-      "uri_apple_music": "applemusic://track/1463651734"
+      "uri_apple_music": "applemusic://track/1463651734",
+      "fun_fact_it": "The Sound of Silence di Simon & Garfunkel fu inserita nel Laureato contro la volontà del duo. È diventata inseparabile dai temi di alienazione del film."
     },
     {
       "year": 2015,
@@ -1205,7 +1228,8 @@
         "es": "applemusic://track/1516405842",
         "nl": "applemusic://track/1516405842",
         "it": "applemusic://track/1516405842"
-      }
+      },
+      "fun_fact_it": "Ryuichi Sakamoto compose la colonna sonora di Revenant mentre si stava curando da un tumore. Usò suoni organici e arrangiamenti scarni per evocare la natura selvaggia."
     },
     {
       "year": 2007,
@@ -1244,7 +1268,8 @@
         "es": "applemusic://track/268374723",
         "nl": "applemusic://track/268374723",
         "it": "applemusic://track/268374723"
-      }
+      },
+      "fun_fact_it": "La partitura di Beowulf di Alan Silvestri unisce orchestra, elettronica e coro per dare vita all'antico poema epico."
     },
     {
       "year": 1969,
@@ -1273,7 +1298,8 @@
       "uri_deezer": "deezer://track/3169682",
       "fun_fact_nl": "John Barry's On Her Majesty's Secret Service-thema wordt door veel Bondfans beschouwd als zijn beste werk, waarin actie en romantiek samengaan.",
       "awards_nl": [],
-      "uri_apple_music": "applemusic://track/1874771762"
+      "uri_apple_music": "applemusic://track/1874771762",
+      "fun_fact_it": "Il tema di Al servizio segreto di Sua Maestà è considerato da molti appassionati di Bond il lavoro migliore di John Barry, tra azione e romanticismo."
     },
     {
       "year": 1966,
@@ -1329,7 +1355,8 @@
         "es": "applemusic://track/546983101",
         "nl": "applemusic://track/546983101",
         "it": "applemusic://track/546983101"
-      }
+      },
+      "fun_fact_it": "Il tema di Un uomo, una donna di Francis Lai divenne un successo mondiale. La melodia semplice, con voci in scat, accompagnò il film premiato con la Palma d'oro a Cannes."
     },
     {
       "year": 2010,
@@ -1368,7 +1395,8 @@
         "es": "applemusic://track/1443410090",
         "nl": "applemusic://track/1443410090",
         "it": "applemusic://track/1443410090"
-      }
+      },
+      "fun_fact_it": "La colonna sonora di Innocenti bugie di John Powell mescola spunti d'azione ed elementi da commedia romantica, seguendo il tono ibrido del film."
     },
     {
       "year": 1995,
@@ -1434,7 +1462,8 @@
         "es": "applemusic://track/1440720182",
         "nl": "applemusic://track/1440720182",
         "it": "applemusic://track/1440720182"
-      }
+      },
+      "fun_fact_it": "I colori del vento, da Pocahontas, vinse l'Oscar per la migliore canzone originale. La versione di Vanessa Williams entrò nella top ten."
     },
     {
       "year": 1969,
@@ -1494,7 +1523,8 @@
         "es": "applemusic://track/1832973080",
         "nl": "applemusic://track/1832973080",
         "it": "applemusic://track/1832973080"
-      }
+      },
+      "fun_fact_it": "Raindrops Keep Fallin' on My Head vinse l'Oscar nonostante sembrasse fuori posto in un western. Divenne il brano simbolo di B.J. Thomas."
     },
     {
       "year": 1969,
@@ -1533,7 +1563,8 @@
         "es": "applemusic://track/1680765823",
         "nl": "applemusic://track/1680765823",
         "it": "applemusic://track/1680765823"
-      }
+      },
+      "fun_fact_it": "The Pusher degli Steppenwolf apre Easy Rider e ne fissa il tono controculturale. Il testo cupo contrasta con la libertà della strada aperta."
     },
     {
       "year": 1969,
@@ -1572,7 +1603,8 @@
         "es": "applemusic://track/697397846",
         "nl": "applemusic://track/697397846",
         "it": "applemusic://track/697397846"
-      }
+      },
+      "fun_fact_it": "Il tema di Un uomo da marciapiede di John Barry affida all'armonica la solitudine urbana. È l'unico film vietato ai minori ad aver vinto l'Oscar come miglior film."
     },
     {
       "year": 1975,
@@ -1636,7 +1668,8 @@
         "nl": "applemusic://track/1842229145",
         "it": "applemusic://track/1842229145"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=E-sX2Y0W8l0"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=E-sX2Y0W8l0",
+      "fun_fact_it": "Il tema dello Squalo di John Williams crea il terrore con due sole note. Steven Spielberg all'inizio pensò che il compositore stesse scherzando."
     },
     {
       "year": 1978,
@@ -1697,7 +1730,8 @@
         "es": "applemusic://track/1609121967",
         "nl": "applemusic://track/1609121967",
         "it": "applemusic://track/1609121967"
-      }
+      },
+      "fun_fact_it": "La colonna sonora di Fuga di mezzanotte di Giorgio Moroder vinse l'Oscar e contribuì a far riconoscere l'elettronica come musica da film a pieno titolo."
     },
     {
       "year": 1987,
@@ -1753,7 +1787,8 @@
         "Oscar per la migliore canzone originale (1987)",
         "Golden Globe per la migliore canzone originale (1988)"
       ],
-      "uri_apple_music": "applemusic://track/254938549"
+      "uri_apple_music": "applemusic://track/254938549",
+      "fun_fact_it": "(I've Had) The Time Of My Life, da Dirty Dancing, vinse l'Oscar. Bill Medley e Jennifer Warnes la incisero in appena due riprese."
     },
     {
       "year": 1995,
@@ -1810,7 +1845,8 @@
         "es": "applemusic://track/1456073416",
         "nl": "applemusic://track/1456073416",
         "it": "applemusic://track/1456073416"
-      }
+      },
+      "fun_fact_it": "Randy Newman scrisse Hai un amico in me in un solo giorno. È diventata il cuore dell'intera saga di Toy Story."
     },
     {
       "year": 1999,
@@ -1849,7 +1885,8 @@
         "es": "applemusic://track/1443853925",
         "nl": "applemusic://track/1443853925",
         "it": "applemusic://track/1443853925"
-      }
+      },
+      "fun_fact_it": "La partitura di Matrix di Don Davis fonde orchestra ed elettronica per costruire il paesaggio sonoro della realtà digitale del film."
     },
     {
       "year": 1962,
@@ -1888,7 +1925,8 @@
         "es": "applemusic://track/1514004194",
         "nl": "applemusic://track/1514004194",
         "it": "applemusic://track/1514004194"
-      }
+      },
+      "fun_fact_it": "Seventy Six Trombones, da Musica indiavolata, si regge su una coreografia elaborata da banda musicale. Robert Preston riportò al cinema il ruolo che aveva a Broadway."
     },
     {
       "year": 2012,
@@ -1927,7 +1965,8 @@
         "es": "applemusic://track/1891482072",
         "nl": "applemusic://track/1891482072",
         "it": "applemusic://track/1891482072"
-      }
+      },
+      "fun_fact_it": "Il tema degli Avengers di Alan Silvestri è diventato l'identità musicale dell'universo Marvel e ricorre in tutta la saga."
     },
     {
       "year": 1966,
@@ -1971,7 +2010,8 @@
         "es": "applemusic://track/1452614028",
         "nl": "applemusic://track/1443835386",
         "it": "applemusic://track/1443835386"
-      }
+      },
+      "fun_fact_it": "Il tema di Mission: Impossible di Lalo Schifrin è in un inconfondibile 5/4. Nasce dalla serie televisiva del 1966."
     },
     {
       "year": 1980,
@@ -2002,7 +2042,8 @@
       "uri_deezer": "deezer://track/1750232597",
       "fun_fact_nl": "Roger Daltrey speelde in en zong het thema voor McVicar, een Britse misdaadfilm gebaseerd op het waargebeurde verhaal van een ontsnapte gevangene.",
       "awards_nl": [],
-      "uri_apple_music": "applemusic://track/1623357054"
+      "uri_apple_music": "applemusic://track/1623357054",
+      "fun_fact_it": "Roger Daltrey fu protagonista di McVicar e ne cantò il tema: un poliziesco britannico tratto dalla storia vera di un evaso."
     },
     {
       "year": 1963,
@@ -2033,7 +2074,8 @@
       "fun_fact_nl": "Het Great Escape-thema van Elmer Bernstein roept zowel avontuur als verzet op. Gevangenen gebruikten het deuntje om ontsnappingspogingen te coördineren.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1444004606",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=qPAjKeR1wsw"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qPAjKeR1wsw",
+      "fun_fact_it": "Il tema della Grande fuga di Elmer Bernstein racchiude avventura e ribellione. I prigionieri usavano davvero il motivo per coordinare i tentativi di fuga."
     },
     {
       "year": 1990,
@@ -2088,7 +2130,8 @@
         "es": "applemusic://track/1712207945",
         "nl": "applemusic://track/1712207945",
         "it": "applemusic://track/1712207945"
-      }
+      },
+      "fun_fact_it": "La colonna sonora di Mamma, ho perso l'aereo di John Williams è diventata un classico natalizio. La versione corale di Somewhere in My Memory evoca lo stupore dell'infanzia."
     },
     {
       "year": 1968,
@@ -2136,7 +2179,8 @@
       "awards_it": [
         "Oscar per la migliore canzone originale (1968)"
       ],
-      "uri_apple_music": "applemusic://track/1206260997"
+      "uri_apple_music": "applemusic://track/1206260997",
+      "fun_fact_it": "I mulini a vento della mia mente vinse l'Oscar per Il caso Thomas Crown. La melodia circolare rispecchia il testo introspettivo."
     },
     {
       "year": 1984,
@@ -2191,7 +2235,8 @@
         "es": "applemusic://track/1400945114",
         "nl": "applemusic://track/1400945114",
         "it": "applemusic://track/1400945114"
-      }
+      },
+      "fun_fact_it": "Il tema di Indiana Jones di John Williams è noto come Raiders March. Fu scritto prima delle riprese e ispirò la spavalderia del personaggio."
     },
     {
       "year": 1994,
@@ -2233,7 +2278,8 @@
         "es": "applemusic://track/1442493286",
         "nl": "applemusic://track/1442493286",
         "it": "applemusic://track/1569725611"
-      }
+      },
+      "fun_fact_it": "Boom Shack-A-Lak di Apache Indian comparve in Scemo & più scemo ed è diventata sinonimo delle colonne sonore comiche anni Novanta."
     },
     {
       "year": 1964,
@@ -2259,7 +2305,8 @@
         "633 Squadron"
       ],
       "fun_fact_nl": "Het thema van 633 Squadron door Ron Goodwin is een opzwepende mars die de heldhaftigheid van de bemanningen van bommenwerpers uit de Tweede Wereldoorlog weergeeft.",
-      "awards_nl": []
+      "awards_nl": [],
+      "fun_fact_it": "Il tema di Squadriglia 633 di Ron Goodwin è una marcia trascinante che racconta l'eroismo degli equipaggi dei bombardieri della Seconda guerra mondiale."
     },
     {
       "year": 1965,
@@ -2319,7 +2366,8 @@
         "es": "applemusic://track/1550187917",
         "nl": "applemusic://track/1550187917",
         "it": "applemusic://track/1550187917"
-      }
+      },
+      "fun_fact_it": "Tutti insieme appassionatamente fu il film di maggior incasso del 1965. Julie Andrews cantò da sola tutte le sue parti."
     },
     {
       "year": 1966,
@@ -2358,7 +2406,8 @@
         "es": "applemusic://track/1714548676",
         "nl": "applemusic://track/1714548676",
         "it": "applemusic://track/1714548676"
-      }
+      },
+      "fun_fact_it": "L'estasi dell'oro accompagna la scena del cimitero nel Buono, il brutto, il cattivo. I Metallica la usano per aprire i loro concerti."
     },
     {
       "year": 1970,
@@ -2399,7 +2448,8 @@
         "es": "applemusic://track/1743285349",
         "nl": "applemusic://track/1743285349",
         "it": "applemusic://track/1743285349"
-      }
+      },
+      "fun_fact_it": "Suicide Is Painless fu scritta per M*A*S*H da Johnny Mandel. Il testo volutamente sciocco lo firmò il figlio adolescente del compositore."
     },
     {
       "year": 1955,
@@ -2433,7 +2483,8 @@
       "uri_deezer": "deezer://track/123809332",
       "fun_fact_nl": "Unchained Melody werd geschreven voor een gevangenisfilm, maar werd beroemd door Ghost (1990). De versie van The Righteous Brothers is het meest iconisch.",
       "awards_nl": [],
-      "uri_apple_music": "applemusic://track/1452253619"
+      "uri_apple_music": "applemusic://track/1452253619",
+      "fun_fact_it": "Unchained Melody nacque per un film carcerario ma divenne celebre grazie a Ghost (1990). La versione dei Righteous Brothers è la più iconica."
     },
     {
       "year": 1970,
@@ -2486,7 +2537,8 @@
       "awards_it": [
         "Oscar per la migliore colonna sonora originale (1970)",
         "Golden Globe per la migliore colonna sonora originale (1971)"
-      ]
+      ],
+      "fun_fact_it": "Il tema di Love Story di Francis Lai contribuì all'enorme successo del film. Il melodramma fu tra i maggiori incassi del 1970."
     },
     {
       "year": 1961,
@@ -2552,7 +2604,8 @@
         "nl": "applemusic://track/1719236777",
         "it": "applemusic://track/1719236777"
       },
-      "uri_deezer": "deezer://track/957356"
+      "uri_deezer": "deezer://track/957356",
+      "fun_fact_it": "Moon River vinse l'Oscar per Colazione da Tiffany. Henry Mancini la scrisse su misura per l'estensione vocale limitata di Audrey Hepburn."
     },
     {
       "year": 1994,
@@ -2607,7 +2660,8 @@
         "es": "applemusic://track/331545686",
         "nl": "applemusic://track/331545686",
         "it": "applemusic://track/331545686"
-      }
+      },
+      "fun_fact_it": "La partitura delle Ali della libertà di Thomas Newman affida ad armonica e archi delicati la speranza dentro le mura del carcere."
     },
     {
       "year": 2002,
@@ -2646,7 +2700,8 @@
         "es": "applemusic://track/297981337",
         "nl": "applemusic://track/297981337",
         "it": "applemusic://track/297981337"
-      }
+      },
+      "fun_fact_it": "Gollum's Song chiude Le due torri. La voce struggente di Emilíana Torrini racconta la tragedia di Sméagol corrotto dall'Anello."
     },
     {
       "year": 2004,
@@ -2685,7 +2740,8 @@
         "es": "applemusic://track/186379179",
         "nl": "applemusic://track/186379179",
         "it": "applemusic://track/186379179"
-      }
+      },
+      "fun_fact_it": "Il tema di Spider-Man di Danny Elfman unisce ottoni eroici e il suo tipico gusto bizzarro, definendo il suono della trilogia di Sam Raimi."
     },
     {
       "year": 1959,
@@ -2734,7 +2790,8 @@
       "awards_it": [
         "Grammy per il disco dell'anno (1960)"
       ],
-      "uri_apple_music": "applemusic://track/1440563265"
+      "uri_apple_music": "applemusic://track/1440563265",
+      "fun_fact_it": "Il tema di Scandalo al sole di Max Steiner restò nove settimane al primo posto. L'orchestrazione sontuosa divenne un simbolo del cinema romantico."
     },
     {
       "year": 1973,
@@ -2775,7 +2832,8 @@
         "nl": "applemusic://track/1612220245",
         "it": "applemusic://track/1612220245"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=jC2ZY2loo74"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jC2ZY2loo74",
+      "fun_fact_it": "La colonna sonora di Black Caesar di James Brown portò il funk nel cinema blaxploitation. Compose e suonò tutto lui."
     },
     {
       "year": 1964,
@@ -2814,7 +2872,8 @@
         "es": "applemusic://track/255979664",
         "nl": "applemusic://track/255979664",
         "it": "applemusic://track/255979664"
-      }
+      },
+      "fun_fact_it": "Uno sparo nel buio è il secondo film della Pantera Rosa. La partitura jazz di Henry Mancini esaltava la comicità fisica di Peter Sellers."
     },
     {
       "year": 1958,
@@ -2855,7 +2914,8 @@
         "nl": "applemusic://track/1657216199",
         "it": "applemusic://track/1657216199"
       },
-      "uri_deezer": "deezer://track/2044037057"
+      "uri_deezer": "deezer://track/2044037057",
+      "fun_fact_it": "Il tema del Grande paese di Jerome Moross affida ad archi ampi l'immensità del West americano."
     },
     {
       "year": 1949,
@@ -2886,7 +2946,8 @@
       "uri_deezer": "deezer://track/14305753",
       "fun_fact_nl": "Het thema van Third Man wordt volledig op citer gespeeld door Anton Karas. Regisseur Carol Reed ontdekte hem in een wijntuin in Wenen.",
       "awards_nl": [],
-      "uri_youtube_music": "https://music.youtube.com/watch?v=2oEsWi88Qv0"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=2oEsWi88Qv0",
+      "fun_fact_it": "Il tema del Terzo uomo è suonato interamente alla cetra da Anton Karas. Il regista Carol Reed lo scoprì in una osteria viennese."
     },
     {
       "year": 1976,
@@ -2952,7 +3013,8 @@
         "es": "applemusic://track/192884975",
         "nl": "applemusic://track/192884975",
         "it": "applemusic://track/192884975"
-      }
+      },
+      "fun_fact_it": "Barbra Streisand è coautrice di Evergreen per È nata una stella. Vinse l'Oscar ed è diventata uno dei suoi brani simbolo."
     },
     {
       "year": 1980,
@@ -2994,7 +3056,8 @@
         "es": "applemusic://track/6781023924",
         "nl": "applemusic://track/6781023924",
         "it": "applemusic://track/6781023924"
-      }
+      },
+      "fun_fact_it": "I Queen scrissero il tema di Flash per Flash Gordon. La voce operistica di Freddie Mercury si sposava perfettamente con il tono kitsch del film."
     },
     {
       "year": 1985,
@@ -3021,7 +3084,8 @@
       ],
       "fun_fact_nl": "A Chorus Line's One is een showstoppende finale over de anonimiteit van chorusdansers. De film bewaarde de Broadway-sensatie.",
       "awards_nl": [],
-      "uri_deezer": "deezer://track/1480164972"
+      "uri_deezer": "deezer://track/1480164972",
+      "fun_fact_it": "One, da A Chorus Line, è un finale spettacolare sull'anonimato dei ballerini di fila. Il film ha conservato il fenomeno di Broadway."
     },
     {
       "year": 1971,
@@ -3060,7 +3124,8 @@
         "es": "applemusic://track/275141212",
         "nl": "applemusic://track/275141212",
         "it": "applemusic://track/275141212"
-      }
+      },
+      "fun_fact_it": "Sunrise, Sunset, dal Violinista sul tetto, racconta una gioia agrodolce. È diventata un classico dei matrimoni ebraici in tutto il mondo."
     },
     {
       "year": 1969,
@@ -3104,7 +3169,8 @@
         "es": "applemusic://track/1657796080",
         "nl": "applemusic://track/1657796080",
         "it": "applemusic://track/1657796080"
-      }
+      },
+      "fun_fact_it": "Wand'rin' Star, cantata dalla voce roca di Lee Marvin in La ballata della città senza nome, arrivò a sorpresa al primo posto nel Regno Unito, battendo i Beatles."
     },
     {
       "year": 1980,
@@ -3143,7 +3209,8 @@
         "es": "applemusic://track/1567146201",
         "nl": "applemusic://track/1567146201",
         "it": "applemusic://track/1567146201"
-      }
+      },
+      "fun_fact_it": "La colonna sonora di Foxes di Giorgio Moroder schiera Donna Summer e altri artisti disco, catturando la scena dei club di Los Angeles di fine anni Settanta."
     },
     {
       "year": 1968,
@@ -3182,7 +3249,8 @@
         "nl": "applemusic://track/1551819861",
         "it": "applemusic://track/1551819861"
       },
-      "uri_deezer": "deezer://track/1230194742"
+      "uri_deezer": "deezer://track/1230194742",
+      "fun_fact_it": "La partitura di Bullitt di Lalo Schifrin inaugurò il jazz elegante nel cinema d'azione. L'inseguimento in auto non ebbe bisogno di musica."
     },
     {
       "year": 1965,
@@ -3221,7 +3289,8 @@
         "es": "applemusic://track/1452187664",
         "nl": "applemusic://track/1452187664",
         "it": "applemusic://track/1452187664"
-      }
+      },
+      "fun_fact_it": "La colonna sonora di C'era una volta a... Hollywood pesca a fondo negli anni Sessanta. Tarantino ha scelto personalmente ogni brano."
     },
     {
       "year": 1983,
@@ -3278,7 +3347,8 @@
         "es": "applemusic://track/1500818278",
         "nl": "applemusic://track/1500818278",
         "it": "applemusic://track/1500818278"
-      }
+      },
+      "fun_fact_it": "Ryuichi Sakamoto compose Furyo e ne fu anche interprete. David Sylvian aggiunse la voce dando vita a Forbidden Colours."
     },
     {
       "year": 1978,
@@ -3325,7 +3395,8 @@
       "awards_it": [
         "Grammy per la migliore colonna sonora (1979)"
       ],
-      "uri_apple_music": "applemusic://track/50235862"
+      "uri_apple_music": "applemusic://track/50235862",
+      "fun_fact_it": "Il tema di Superman di John Williams incarna eroismo e speranza. Christopher Reeve disse che la musica lo aiutava a credere di poter volare."
     },
     {
       "year": 1997,
@@ -3364,7 +3435,8 @@
         "es": "applemusic://track/279366740",
         "nl": "applemusic://track/279366740",
         "it": "applemusic://track/279366740"
-      }
+      },
+      "fun_fact_it": "Il tema di Men in Black di Danny Elfman unisce la tensione dello spionaggio alla commedia fantascientifica, in linea con l'irriverenza del film."
     },
     {
       "year": 1969,
@@ -3403,7 +3475,8 @@
         "es": "applemusic://track/1675583296",
         "nl": "applemusic://track/1675583296",
         "it": "applemusic://track/1675583296"
-      }
+      },
+      "fun_fact_it": "In Elvis (2022) Austin Butler canta di persona molti brani. In alcune scene il film usa le incisioni originali di Presley."
     },
     {
       "year": 1960,
@@ -3448,7 +3521,8 @@
         "Golden Globe per la migliore colonna sonora originale (1961)"
       ],
       "uri_apple_music": "applemusic://track/1705329406",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=DZ6e8-94JRE"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=DZ6e8-94JRE",
+      "fun_fact_it": "La partitura di Spartacus di Alex North fu innovativa per l'epoca. Stanley Kubrick in seguito la rinnegò, preferendo brani classici."
     },
     {
       "year": 1985,
@@ -3493,7 +3567,8 @@
         "es": "applemusic://track/1681196890",
         "nl": "applemusic://track/1681196890",
         "it": "applemusic://track/1681196890"
-      }
+      },
+      "fun_fact_it": "We Don't Need Another Hero di Tina Turner divenne un inno degli anni Ottanta. Mad Max oltre la sfera del tuono avviò la sua carriera cinematografica."
     },
     {
       "year": 1964,
@@ -3538,7 +3613,8 @@
         "es": "applemusic://track/1358615271",
         "nl": "applemusic://track/1358615271",
         "it": "applemusic://track/1358615271"
-      }
+      },
+      "fun_fact_it": "Goldfinger di Shirley Bassey fu il primo tema di Bond a diventare un successo. La sua voce potente ha fatto scuola per tutte le canzoni successive."
     },
     {
       "year": 1978,
@@ -3576,7 +3652,8 @@
         "es": "applemusic://track/1478145271",
         "nl": "applemusic://track/1478145271",
         "it": "applemusic://track/1426559304"
-      }
+      },
+      "fun_fact_it": "John Carpenter compose da solo il tema di Halloween al sintetizzatore. Il semplice motivo per pianoforte in 5/4 non costò quasi nulla."
     },
     {
       "year": 1942,
@@ -3618,7 +3695,8 @@
         "es": "applemusic://track/1455698341",
         "nl": "applemusic://track/1455698341",
         "it": "applemusic://track/1455698341"
-      }
+      },
+      "fun_fact_it": "As Time Goes By fu scritta nel 1931, non per Casablanca. La produzione voleva toglierla, ma il pubblico delle anteprime la amò."
     },
     {
       "year": 1966,
@@ -3657,7 +3735,8 @@
         "es": "applemusic://track/1440874258",
         "nl": "applemusic://track/1440874258",
         "it": "applemusic://track/1440874258"
-      }
+      },
+      "fun_fact_it": "Django Unchained si apre con il tema originale di Django del 1966 di Luis Bacalov, che lega il film di Tarantino allo spaghetti western."
     },
     {
       "year": 1969,
@@ -3696,7 +3775,8 @@
         "es": "applemusic://track/1443835382",
         "nl": "applemusic://track/1443835382",
         "it": "applemusic://track/1443835382"
-      }
+      },
+      "fun_fact_it": "La serie cinematografica di Mission: Impossible ha continuato a usare il tema televisivo di Lalo Schifrin. Resta uno dei motivi spionistici più riconoscibili."
     },
     {
       "year": 1968,
@@ -3727,7 +3807,8 @@
       "fun_fact_nl": "Also sprach Zarathustra opent 2001: A Space Odyssey. Kubrick's gebruik van Strauss' toongedicht herdefinieerde hoe klassieke muziek werkt in film.",
       "awards_nl": [],
       "uri_deezer": "deezer://track/1396836502",
-      "uri_apple_music": "applemusic://track/1456334023"
+      "uri_apple_music": "applemusic://track/1456334023",
+      "fun_fact_it": "Also sprach Zarathustra apre 2001: Odissea nello spazio. L'uso che Kubrick fece del poema sinfonico di Strauss ridefinì il ruolo della musica classica al cinema."
     },
     {
       "year": 1960,
@@ -3793,7 +3874,8 @@
         "es": "applemusic://track/483793979",
         "nl": "applemusic://track/483793979",
         "it": "applemusic://track/483793979"
-      }
+      },
+      "fun_fact_it": "Il tema di Exodus di Ernest Gold divenne un inno non ufficiale per Israele. L'orchestrazione ampia evoca la nascita di una nazione."
     },
     {
       "year": 1999,
@@ -3834,7 +3916,8 @@
         "es": "applemusic://track/1376604929",
         "nl": "applemusic://track/1375814326",
         "it": "applemusic://track/1376604746"
-      }
+      },
+      "fun_fact_it": "Duel of the Fates di John Williams portò il coro nell'universo di Guerre stellari. Il testo, ispirato al sanscrito, fu scritto apposta per la partitura."
     },
     {
       "year": 1939,
@@ -3889,7 +3972,8 @@
         "es": "applemusic://track/1454324974",
         "nl": "applemusic://track/1454324974",
         "it": "applemusic://track/1454324974"
-      }
+      },
+      "fun_fact_it": "La colonna sonora di Via col vento di Max Steiner fu la più lunga mai scritta fino ad allora: tre ore di musica in appena tre mesi."
     },
     {
       "year": 1986,
@@ -3923,7 +4007,8 @@
       "uri_deezer": "deezer://track/7675051",
       "fun_fact_nl": "Danger Zone van Kenny Loggins werd synoniem met Top Gun. Het nummer werd door verschillende andere artiesten afgewezen voordat Loggins het opnam.",
       "awards_nl": [],
-      "uri_apple_music": "applemusic://track/405600306"
+      "uri_apple_music": "applemusic://track/405600306",
+      "fun_fact_it": "Danger Zone di Kenny Loggins è diventata sinonimo di Top Gun. Diversi altri artisti l'avevano rifiutata prima che la incidesse lui."
     },
     {
       "year": 1965,
@@ -3962,7 +4047,8 @@
         "es": "applemusic://track/1718039376",
         "nl": "applemusic://track/1718039376",
         "it": "applemusic://track/1718039376"
-      }
+      },
+      "fun_fact_it": "Per qualche dollaro in più di Ennio Morricone si regge su un carillon da orologio da tasca. Il rintocco della melodia diventa un elemento della trama."
     },
     {
       "year": 1981,
@@ -4022,7 +4108,8 @@
         "es": "applemusic://track/1450958727",
         "nl": "applemusic://track/1450958727",
         "it": "applemusic://track/1450958727"
-      }
+      },
+      "fun_fact_it": "Il tema di Momenti di gloria di Vangelis affida ai sintetizzatori la corsa al rallentatore. Vinse l'Oscar per la migliore colonna sonora."
     },
     {
       "year": 1984,
@@ -4082,7 +4169,8 @@
         "es": "applemusic://track/1719230705",
         "nl": "applemusic://track/1719230705",
         "it": "applemusic://track/1719230705"
-      }
+      },
+      "fun_fact_it": "Ray Parker Jr. scrisse Ghostbusters dopo aver visto il film. Huey Lewis lo citò in giudizio per la somiglianza con I Want a New Drug."
     },
     {
       "year": 1973,
@@ -4132,7 +4220,8 @@
       "awards_it": [
         "Oscar per la migliore colonna sonora originale (1973)"
       ],
-      "uri_apple_music": "applemusic://track/1684775318"
+      "uri_apple_music": "applemusic://track/1684775318",
+      "fun_fact_it": "The Entertainer di Scott Joplin tornò in auge grazie alla Stangata. Il classico ragtime valse a Marvin Hamlisch l'Oscar per la migliore colonna sonora."
     },
     {
       "year": 1987,
@@ -4175,7 +4264,8 @@
         "es": "applemusic://track/1748181688",
         "nl": "applemusic://track/1748181688",
         "it": "applemusic://track/1748181688"
-      }
+      },
+      "fun_fact_it": "The Living Daylights degli a-ha fu il primo tema di Bond firmato da un gruppo rock. I norvegesi portarono i sintetizzatori nella saga di 007."
     },
     {
       "year": 1958,
@@ -4214,7 +4304,8 @@
         "es": "applemusic://track/1444008064",
         "nl": "applemusic://track/1444008064",
         "it": "applemusic://track/1444008064"
-      }
+      },
+      "fun_fact_it": "La partitura della Donna che visse due volte di Bernard Herrmann usa archi vorticosi per rispecchiare l'ossessione. Hitchcock la riteneva essenziale all'effetto del film."
     },
     {
       "year": 1967,
@@ -4256,7 +4347,8 @@
         "es": "applemusic://track/1530113036",
         "nl": "applemusic://track/1530113036",
         "it": "applemusic://track/1530113036"
-      }
+      },
+      "fun_fact_it": "Casino Royale del 1967 era una parodia girata da più registi. Il tema di Herb Alpert ne cattura il tono comico e caotico."
     },
     {
       "year": 1982,
@@ -4317,7 +4409,8 @@
         "es": "applemusic://track/1046366480",
         "nl": "applemusic://track/1046366480",
         "it": "applemusic://track/1046366480"
-      }
+      },
+      "fun_fact_it": "Il tema del volo di E.T. di John Williams combacia alla perfezione con la scena della bicicletta in cielo. Spielberg rimontò il film per seguire la musica."
     },
     {
       "year": 1991,
@@ -4356,7 +4449,8 @@
         "es": "applemusic://track/1714547761",
         "nl": "applemusic://track/1714547761",
         "it": "applemusic://track/1714547761"
-      }
+      },
+      "fun_fact_it": "Il tema di Terminator 2 di Brad Fiedel usa suoni metallici e sintetizzatori per evocare insieme le macchine e i battiti del cuore."
     },
     {
       "year": 1972,
@@ -4400,7 +4494,8 @@
         "es": "applemusic://track/1548478990",
         "nl": "applemusic://track/1548478990",
         "it": "applemusic://track/1548478990"
-      }
+      },
+      "fun_fact_it": "Dueling Banjos fu registrata per Un tranquillo weekend di paura in una sola ripresa. La scena in cui un cittadino improvvisa con un ragazzo del posto è entrata nella storia."
     },
     {
       "year": 1976,
@@ -4434,7 +4529,8 @@
       "uri_deezer": "deezer://track/2230407",
       "fun_fact_nl": "Rose Royce's Car Wash is geschreven door Norman Whitfield. De funky hymne past perfect bij de werkplekkomedie uit de jaren 70.",
       "awards_nl": [],
-      "uri_apple_music": "applemusic://track/1600580977"
+      "uri_apple_music": "applemusic://track/1600580977",
+      "fun_fact_it": "Car Wash dei Rose Royce fu scritta da Norman Whitfield. L'inno funky racconta alla perfezione la commedia sul lavoro degli anni Settanta."
     },
     {
       "year": 1952,
@@ -4473,7 +4569,8 @@
         "es": "applemusic://track/1455420758",
         "nl": "applemusic://track/1455420758",
         "it": "applemusic://track/1455420758"
-      }
+      },
+      "fun_fact_it": "Gene Kelly girò Cantando sotto la pioggia con la febbre a quasi 40 gradi. Nelle pozzanghere fu aggiunto del latte per renderle visibili."
     },
     {
       "year": 2011,
@@ -4517,7 +4614,8 @@
       "awards_it": [
         "Grammy per la migliore colonna sonora (2012)"
       ],
-      "uri_youtube_music": "https://music.youtube.com/watch?v=7Ys-t436d1Y"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7Ys-t436d1Y",
+      "fun_fact_it": "La versione di Immigrant Song firmata da Trent Reznor e Atticus Ross apre Millennium - Uomini che odiano le donne con un'intensità aggressiva."
     },
     {
       "year": 1982,
@@ -4556,7 +4654,8 @@
         "nl": "applemusic://track/1452656167",
         "it": "applemusic://track/1452656167"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=meU2gAU7Xss"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=meU2gAU7Xss",
+      "fun_fact_it": "La partitura della Cosa di Ennio Morricone fu respinta da John Carpenter, che la trovava troppo strana. Oggi è considerata un classico."
     },
     {
       "year": 1982,
@@ -4587,7 +4686,8 @@
       "uri_deezer": "deezer://track/89339015",
       "fun_fact_nl": "Carly Simons Why werd geschreven voor Soup for One. De uitgebreide versie laat de Chic-beïnvloede productie van die tijd zien.",
       "awards_nl": [],
-      "uri_apple_music": "applemusic://track/1539179856"
+      "uri_apple_music": "applemusic://track/1539179856",
+      "fun_fact_it": "Why di Carly Simon fu scritta per Soup for One. La versione estesa mette in mostra la produzione di scuola Chic tipica dell'epoca."
     },
     {
       "year": 1959,
@@ -4626,7 +4726,8 @@
         "es": "applemusic://track/1455885358",
         "nl": "applemusic://track/1455885358",
         "it": "applemusic://track/1455885358"
-      }
+      },
+      "fun_fact_it": "Il tema di Intrigo internazionale di Bernard Herrmann è un fandango che sostiene la suspense del film. Hitchcock definiva Herrmann indispensabile."
     },
     {
       "year": 1939,
@@ -4686,7 +4787,8 @@
         "es": "applemusic://track/1455918432",
         "nl": "applemusic://track/1455918432",
         "it": "applemusic://track/1455918432"
-      }
+      },
+      "fun_fact_it": "Over the Rainbow rischiò di essere tagliata dal Mago di Oz. Vinse l'Oscar e divenne il brano simbolo di Judy Garland."
     },
     {
       "year": 1982,
@@ -4728,7 +4830,8 @@
         "es": "applemusic://track/1443427544",
         "nl": "applemusic://track/1443427544",
         "it": "applemusic://track/1443427544"
-      }
+      },
+      "fun_fact_it": "Il tema di Cat People di David Bowie nacque insieme a Giorgio Moroder. La canzone, ipnotica, è sopravvissuta al film per cui era stata scritta."
     },
     {
       "year": 1968,
@@ -4756,7 +4859,8 @@
       "uri_tidal": "tidal://track/424038123",
       "uri_deezer": "deezer://track/75643473",
       "fun_fact_nl": "Ennio Morricone's Once Upon a Time in the West gebruikt harmonica als karaktermotief. De beklemmende melodie drijft het wraakcomplot aan.",
-      "awards_nl": []
+      "awards_nl": [],
+      "fun_fact_it": "C'era una volta il West di Ennio Morricone affida all'armonica il motivo di un personaggio. La melodia struggente muove tutta la vicenda di vendetta."
     },
     {
       "year": 1979,
@@ -4784,7 +4888,8 @@
       "uri_tidal": "tidal://track/1183285",
       "uri_deezer": "deezer://track/1109685",
       "fun_fact_nl": "Het synthesizerthema van The Warriors geeft het New York van eind jaren 70 weer. De cultfilm heeft een toegewijde aanhang en een videogame voortgebracht.",
-      "awards_nl": []
+      "awards_nl": [],
+      "fun_fact_it": "Il tema ricco di sintetizzatori dei Guerrieri della notte racconta la New York di fine anni Settanta. Il film di culto ha generato una schiera di fedelissimi e un videogioco."
     },
     {
       "year": 1960,
@@ -4823,7 +4928,8 @@
         "es": "applemusic://track/1440795713",
         "nl": "applemusic://track/1440795713",
         "it": "applemusic://track/1440795713"
-      }
+      },
+      "fun_fact_it": "La partitura di Psyco di Bernard Herrmann usa soltanto archi. I violini stridenti della scena della doccia hanno cambiato per sempre la musica dell'horror."
     },
     {
       "year": 1955,
@@ -4871,7 +4977,8 @@
         "Oscar per la migliore canzone originale (1955)"
       ],
       "uri_apple_music": "applemusic://track/551962523",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=xM96O-Yk5YU"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xM96O-Yk5YU",
+      "fun_fact_it": "L'amore è una cosa meravigliosa vinse l'Oscar per la migliore canzone. Il tema romantico e travolgente definì il romanticismo hollywoodiano degli anni Cinquanta."
     },
     {
       "year": 2002,
@@ -4916,7 +5023,8 @@
       "awards_it": [
         "Candidatura al Grammy per la migliore colonna sonora (2003)"
       ],
-      "uri_apple_music": "applemusic://track/1443084900"
+      "uri_apple_music": "applemusic://track/1443084900",
+      "fun_fact_it": "La partitura di Prova a prendermi di John Williams usa il jazz per evocare gli anni Sessanta. Il tema giocoso segue il gioco del gatto col topo del film."
     },
     {
       "year": 1973,
@@ -4978,7 +5086,8 @@
         "es": "applemusic://track/1647479393",
         "nl": "applemusic://track/1647479393",
         "it": "applemusic://track/1647479393"
-      }
+      },
+      "fun_fact_it": "Tubular Bells di Mike Oldfield divenne celebre grazie all'Esorcista. L'album vendette milioni di copie dopo l'uso nel classico dell'horror."
     },
     {
       "year": 1959,
@@ -5033,7 +5142,8 @@
         "es": "applemusic://track/1455700172",
         "nl": "applemusic://track/1455700172",
         "it": "applemusic://track/1455700172"
-      }
+      },
+      "fun_fact_it": "La partitura di Ben-Hur di Miklós Rózsa richiese la più grande orchestra mai riunita per un film. Vinse l'Oscar per la migliore colonna sonora."
     },
     {
       "year": 1992,
@@ -5061,7 +5171,8 @@
       "uri_tidal": "tidal://track/73832667",
       "uri_deezer": "deezer://track/359793201",
       "fun_fact_nl": "Jerry Goldsmiths score voor Basic Instinct mengt sensualiteit met dreiging. De controversiële film werd een cultureel fenomeen.",
-      "awards_nl": []
+      "awards_nl": [],
+      "fun_fact_it": "La partitura di Basic Instinct di Jerry Goldsmith mescola sensualità e minaccia. Il film, molto discusso, divenne un fenomeno di costume."
     },
     {
       "year": 1962,
@@ -5119,7 +5230,8 @@
         "es": "applemusic://track/1663023916",
         "nl": "applemusic://track/1663023916",
         "it": "applemusic://track/1663023916"
-      }
+      },
+      "fun_fact_it": "Il tema di Lawrence d'Arabia di Maurice Jarre evoca l'immensità del deserto. La partitura vinse l'Oscar e definì il cinema epico."
     },
     {
       "year": 1976,
@@ -5158,7 +5270,8 @@
         "es": "applemusic://track/174892425",
         "nl": "applemusic://track/174892425",
         "it": "applemusic://track/174892425"
-      }
+      },
+      "fun_fact_it": "La partitura di Taxi Driver fu l'ultima di Bernard Herrmann. Morì la notte successiva alla fine delle registrazioni."
     },
     {
       "year": 1964,
@@ -5197,7 +5310,8 @@
         "es": "applemusic://track/1718039373",
         "nl": "applemusic://track/1718039373",
         "it": "applemusic://track/1718039373"
-      }
+      },
+      "fun_fact_it": "Il tema di Per un pugno di dollari di Ennio Morricone creò il suono dello spaghetti western. Il fischio e le frustate sono diventati inconfondibili."
     },
     {
       "year": 1971,
@@ -5239,7 +5353,8 @@
         "es": "applemusic://track/716176922",
         "nl": "applemusic://track/716176922",
         "it": "applemusic://track/697275610"
-      }
+      },
+      "fun_fact_it": "Una cascata di diamanti fu il secondo tema di Bond per Shirley Bassey, l'unica artista ad averne cantati tre."
     },
     {
       "year": 1979,
@@ -5278,7 +5393,8 @@
         "nl": "applemusic://track/927346120",
         "it": "applemusic://track/927346120"
       },
-      "uri_deezer": "deezer://track/87754349"
+      "uri_deezer": "deezer://track/87754349",
+      "fun_fact_it": "La Cavalcata delle Valchirie di Wagner accompagna l'attacco degli elicotteri in Apocalypse Now. Coppola rese terrificante la musica classica."
     },
     {
       "year": 1962,
@@ -5333,7 +5449,8 @@
         "es": "applemusic://track/1444004606",
         "nl": "applemusic://track/1444004606",
         "it": "applemusic://track/1444004606"
-      }
+      },
+      "fun_fact_it": "La partitura del Buio oltre la siepe di Elmer Bernstein affida a un semplice tema per pianoforte l'innocenza dell'infanzia e le atmosfere del Sud."
     },
     {
       "year": 1980,
@@ -5379,7 +5496,8 @@
         "es": "applemusic://track/324213374",
         "nl": "applemusic://track/1502404626",
         "it": "applemusic://track/324213374"
-      }
+      },
+      "fun_fact_it": "Xanadu di Olivia Newton-John univa la disco al rock degli ELO. Il film fu un fiasco, ma la colonna sonora vendette benissimo."
     },
     {
       "year": 1961,
@@ -5428,7 +5546,8 @@
       ],
       "awards_it": [
         "Oscar per il miglior film (1961)"
-      ]
+      ],
+      "fun_fact_it": "West Side Story di Leonard Bernstein trasporta Romeo e Giulietta nella New York degli anni Cinquanta. Il film vinse dieci premi Oscar."
     },
     {
       "year": 1967,
@@ -5485,7 +5604,8 @@
         "es": "applemusic://track/1463094850",
         "nl": "applemusic://track/1463094850",
         "it": "applemusic://track/1463094850"
-      }
+      },
+      "fun_fact_it": "Lo stretto indispensabile, dal Libro della giungla, fu l'ultima canzone approvata da Walt Disney prima della sua morte nel 1966."
     },
     {
       "year": 1973,
@@ -5527,7 +5647,8 @@
         "es": "applemusic://track/260129227",
         "nl": "applemusic://track/260129227",
         "it": "applemusic://track/260129227"
-      }
+      },
+      "fun_fact_it": "Day by Day, da Godspell, divenne un successo pop. Il brano folk-rock delicato diffuse in tutto il mondo il messaggio evangelico del musical."
     },
     {
       "year": 1942,
@@ -5566,7 +5687,8 @@
         "nl": "applemusic://track/1455697817",
         "it": "applemusic://track/1455697817"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=UIUVC6xc2f0"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UIUVC6xc2f0",
+      "fun_fact_it": "La colonna sonora di Casablanca intreccia classica, jazz e la Marsigliese in una celebre scena al locale."
     },
     {
       "year": 1979,
@@ -5621,7 +5743,8 @@
         "es": "applemusic://track/1798286213",
         "nl": "applemusic://track/1798286213",
         "it": "applemusic://track/1798286213"
-      }
+      },
+      "fun_fact_it": "La partitura di Alien di Jerry Goldsmith costruisce l'angoscia con archi atonali e suoni estranei. Il silenzio è efficace quanto la musica."
     },
     {
       "year": 1971,
@@ -5660,7 +5783,8 @@
         "it": "applemusic://track/1227748545"
       },
       "uri_deezer": "deezer://track/139354685",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=Qqa_NADTVQw"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Qqa_NADTVQw",
+      "fun_fact_it": "L'ouverture della Gazza ladra di Rossini accompagna la ultraviolenza di Arancia meccanica. Le scelte classiche di Kubrick sono diventate il suo marchio."
     },
     {
       "year": 1981,
@@ -5726,7 +5850,8 @@
         "es": "applemusic://track/1549643307",
         "nl": "applemusic://track/1549643307",
         "it": "applemusic://track/1549643307"
-      }
+      },
+      "fun_fact_it": "Il tema di Arturo di Christopher Cross vinse l'Oscar. La canzone su chi resta sospeso tra la luna e New York è diventata un classico."
     },
     {
       "year": 2000,
@@ -5787,7 +5912,8 @@
         "it": "applemusic://track/1452552843"
       },
       "uri_deezer": "deezer://track/2919225",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=mQQKZ5cgybU"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mQQKZ5cgybU",
+      "fun_fact_it": "Now We Are Free, il tema del Gladiatore di Hans Zimmer e Lisa Gerrard, usa una voce senza parole per evocare l'antica Roma e l'aldilà."
     },
     {
       "year": 1995,
@@ -5842,7 +5968,8 @@
         "es": "applemusic://track/1440773543",
         "nl": "applemusic://track/1440773543",
         "it": "applemusic://track/1440773543"
-      }
+      },
+      "fun_fact_it": "La partitura di Braveheart di James Horner impiega strumenti scozzesi, tra cui cornamusa e uilleann pipes. Vinse l'Oscar."
     },
     {
       "year": 1954,
@@ -5897,7 +6024,8 @@
         "nl": "applemusic://track/1658406090",
         "it": "applemusic://track/1658406090"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=ymIQ_oDGsDs"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ymIQ_oDGsDs",
+      "fun_fact_it": "Sette spose per sette fratelli si regge su una coreografia elaborata attorno alla costruzione di un fienile. Il musical fu girato in 30 giorni."
     },
     {
       "year": 1968,
@@ -5936,7 +6064,8 @@
         "es": "applemusic://track/1443095011",
         "nl": "applemusic://track/1443095011",
         "it": "applemusic://track/1443095011"
-      }
+      },
+      "fun_fact_it": "La partitura del Pianeta delle scimmie di Jerry Goldsmith usa strumenti insoliti, dai corni di montone alle ciotole da cucina."
     },
     {
       "year": 1965,
@@ -5997,7 +6126,8 @@
         "es": "applemusic://track/1442492045",
         "nl": "applemusic://track/1442492045",
         "it": "applemusic://track/1440717481"
-      }
+      },
+      "fun_fact_it": "What's New Pussycat di Burt Bacharach ottenne una candidatura all'Oscar. L'interpretazione travolgente di Tom Jones ne fece un successo bizzarro."
     },
     {
       "year": 1957,
@@ -6031,7 +6161,8 @@
       ],
       "uri_tidal": "tidal://track/5012160",
       "fun_fact_nl": "De Colonel Bogey March in Bridge on the River Kwai wordt gefloten door gevangenen. Het deuntje stamt uit 1914.",
-      "awards_nl": []
+      "awards_nl": [],
+      "fun_fact_it": "La marcia del colonnello Bogey, nel Ponte sul fiume Kwai, è fischiata dai prigionieri. Il motivo risale al 1914."
     },
     {
       "year": 1980,
@@ -6070,7 +6201,8 @@
         "es": "applemusic://track/1535496635",
         "nl": "applemusic://track/1535496635",
         "it": "applemusic://track/1535496635"
-      }
+      },
+      "fun_fact_it": "La partitura di Shining di Wendy Carlos comprende versioni elettroniche di Berlioz e Bartók, che creano un'atmosfera inquietante."
     },
     {
       "year": 1969,
@@ -6109,7 +6241,8 @@
         "nl": "applemusic://track/1802763015",
         "it": "applemusic://track/1802763015"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=KQIRbV_noi8"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=KQIRbV_noi8",
+      "fun_fact_it": "La partitura di Un colpo all'italiana di Quincy Jones contiene On Days Like These cantata da Matt Monro. L'inseguimento con le Mini Cooper è leggendario."
     },
     {
       "year": 1964,
@@ -6175,7 +6308,8 @@
         "nl": "applemusic://track/1377468571",
         "it": "applemusic://track/1377468571"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=-9012SGz-yY"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-9012SGz-yY",
+      "fun_fact_it": "I fratelli Sherman scrissero tutte le canzoni di Mary Poppins. La partitura valse loro due premi Oscar nella stessa serata."
     },
     {
       "year": 1965,
@@ -6221,7 +6355,8 @@
         "es": "applemusic://track/1441164536",
         "nl": "applemusic://track/1441164536",
         "it": "applemusic://track/1441164536"
-      }
+      },
+      "fun_fact_it": "I Beatles scrissero Help! per il loro secondo film. La title track divenne una delle composizioni più personali di John Lennon."
     },
     {
       "year": 1985,
@@ -6266,7 +6401,8 @@
         "es": "applemusic://track/1443234133",
         "nl": "applemusic://track/1443234133",
         "it": "applemusic://track/1443234133"
-      }
+      },
+      "fun_fact_it": "Don't You Forget About Me dei Simple Minds ha definito Breakfast Club. Il gruppo in un primo momento rifiutò la canzone, prima di inciderla."
     },
     {
       "year": 1954,
@@ -6321,7 +6457,8 @@
         "es": "applemusic://track/1816013634",
         "nl": "applemusic://track/1816013634",
         "it": "applemusic://track/1816013634"
-      }
+      },
+      "fun_fact_it": "La partitura di Fronte del porto di Leonard Bernstein portò il jazz nel cinema drammatico. Vinse l'Oscar."
     },
     {
       "year": 1960,
@@ -6360,7 +6497,8 @@
         "es": "applemusic://track/285167010",
         "nl": "applemusic://track/285167010",
         "it": "applemusic://track/285167010"
-      }
+      },
+      "fun_fact_it": "La partitura di Questo pazzo, pazzo, pazzo, pazzo mondo di Ernest Gold segue la comicità forsennata del film, che riunì tutti i grandi comici dell'epoca."
     },
     {
       "year": 1962,
@@ -6418,7 +6556,8 @@
         "es": "applemusic://track/306820503",
         "nl": "applemusic://track/306820503",
         "it": "applemusic://track/306820503"
-      }
+      },
+      "fun_fact_it": "Baby Elephant Walk di Henry Mancini, da Hatari!, divenne un successo curioso. Il motivo giocoso si sposava con l'ambientazione da safari."
     },
     {
       "year": 1991,
@@ -6457,7 +6596,8 @@
         "nl": "applemusic://track/1443219466",
         "it": "applemusic://track/1443219466"
       },
-      "uri_deezer": "deezer://track/2523696"
+      "uri_deezer": "deezer://track/2523696",
+      "fun_fact_it": "La partitura del Silenzio degli innocenti di Howard Shore costruisce un'angoscia psicologica. La musica, discreta, non sovrasta mai la suspense."
     },
     {
       "year": 1955,
@@ -6505,7 +6645,8 @@
       "awards_it": [
         "Oscar per la migliore musica da film (1955)"
       ],
-      "uri_apple_music": "applemusic://track/1440787711"
+      "uri_apple_music": "applemusic://track/1440787711",
+      "fun_fact_it": "Oklahoma! fu il primo musical di Rodgers e Hammerstein portato al cinema. Oh, What a Beautiful Morning si apre con puro ottimismo."
     },
     {
       "year": 1971,
@@ -6544,7 +6685,8 @@
         "es": "applemusic://track/205808260",
         "nl": "applemusic://track/205808260",
         "it": "applemusic://track/205808260"
-      }
+      },
+      "fun_fact_it": "La partitura dell'Ispettore Callaghan di Lalo Schifrin usa il jazz per raccontare le strade ruvide di San Francisco. Clint Eastwood ne uscì come un'icona."
     },
     {
       "year": 1955,
@@ -6572,7 +6714,8 @@
       "uri_tidal": "tidal://track/227830521",
       "uri_deezer": "deezer://track/3908709",
       "fun_fact_nl": "Leonard Rosenman's Rebel Without a Cause score was baanbrekend voor het gebruik van dissonantie om tienerangst uit te drukken.",
-      "awards_nl": []
+      "awards_nl": [],
+      "fun_fact_it": "La partitura di Gioventù bruciata di Leonard Rosenman fu innovativa per l'uso della dissonanza come linguaggio dell'inquietudine adolescenziale."
     },
     {
       "year": 1977,
@@ -6630,7 +6773,8 @@
         "es": "applemusic://track/306664733",
         "nl": "applemusic://track/306664733",
         "it": "applemusic://track/306664733"
-      }
+      },
+      "fun_fact_it": "Incontri ravvicinati del terzo tipo di John Williams affida a un motivo di cinque note la comunicazione con gli alieni. La sequenza è entrata nel linguaggio comune."
     },
     {
       "year": 1959,
@@ -6658,7 +6802,8 @@
       "uri_tidal": "tidal://track/37441357",
       "uri_deezer": "deezer://track/68071723",
       "fun_fact_nl": "De score van Some Like It Hot is een weergave van jazz uit de jaren 1920. Marilyn Monroe's Sugar treedt op met een meidenband op het scherm.",
-      "awards_nl": []
+      "awards_nl": [],
+      "fun_fact_it": "La musica di A qualcuno piace caldo restituisce il jazz degli anni Venti. Sullo schermo, la Sugar di Marilyn Monroe suona in un'orchestra tutta femminile."
     },
     {
       "year": 1978,
@@ -6692,7 +6837,8 @@
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1052784975",
       "uri_deezer": "deezer://track/120866262",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=gGycDDqBuX8"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gGycDDqBuX8",
+      "fun_fact_it": "Il cacciatore usa Cavatina di Stanley Myers. Il brano delicato per chitarra contrasta in modo devastante con la violenza del film."
     },
     {
       "year": 2001,
@@ -6731,7 +6877,8 @@
         "es": "applemusic://track/323714096",
         "nl": "applemusic://track/323714096",
         "it": "applemusic://track/323714096"
-      }
+      },
+      "fun_fact_it": "Concerning Hobbits di Howard Shore racconta la quiete domestica della Contea. Il tema gentile si affida a tin whistle e violino."
     },
     {
       "year": 1971,
@@ -6777,7 +6924,8 @@
       ],
       "awards_it": [
         "Oscar per la migliore colonna sonora originale (1971)"
-      ]
+      ],
+      "fun_fact_it": "Il tema di Quell'estate del '42 di Michel Legrand vinse l'Oscar. La partitura nostalgica racconta un primo amore in tempo di guerra."
     },
     {
       "year": 1961,
@@ -6818,7 +6966,8 @@
         "es": "applemusic://track/826934339",
         "nl": "applemusic://track/826934339",
         "it": "applemusic://track/826934339"
-      }
+      },
+      "fun_fact_it": "Viaggio in fondo al mare avviò la carriera di Irwin Allen nel cinema catastrofico. La title track è cantata da Frankie Avalon."
     },
     {
       "year": 2002,
@@ -6859,7 +7008,8 @@
         "es": "applemusic://track/1436539081",
         "nl": "applemusic://track/1436539081",
         "it": "applemusic://track/1436539081"
-      }
+      },
+      "fun_fact_it": "Extreme Ways di Moby chiude ogni film della saga di Bourne. Il brano elettronico è diventato essenziale quanto l'azione."
     },
     {
       "year": 1973,
@@ -6920,7 +7070,8 @@
         "es": "applemusic://track/1440942228",
         "nl": "applemusic://track/1440942228",
         "it": "applemusic://track/1440942228"
-      }
+      },
+      "fun_fact_it": "Live and Let Die dei Wings fu l'esplosivo tema di Bond firmato da Paul McCartney: il primo brano rock della saga."
     },
     {
       "year": 1968,
@@ -6959,7 +7110,8 @@
         "es": "applemusic://track/1452655336",
         "nl": "applemusic://track/1452655336",
         "it": "applemusic://track/1452655336"
-      }
+      },
+      "fun_fact_it": "L'uomo dell'armonica, da C'era una volta il West, racconta una storia con la sola musica. La melodia svela il passato del personaggio."
     },
     {
       "year": 1999,
@@ -6998,7 +7150,8 @@
         "es": "applemusic://track/1714548385",
         "nl": "applemusic://track/1714548385",
         "it": "applemusic://track/1714548385"
-      }
+      },
+      "fun_fact_it": "Il secondo brano di Thomas Newman per American Beauty racconta la noia suburbana. La partitura si affida a percussioni e suoni d'ambiente."
     },
     {
       "year": 1959,
@@ -7046,7 +7199,8 @@
       ],
       "awards_it": [
         "Grammy per il disco dell'anno (1961)"
-      ]
+      ],
+      "fun_fact_it": "Il tema di Scandalo al sole nella versione di Percy Faith restò nove settimane al primo posto. L'arrangiamento sontuoso definì il cinema romantico."
     },
     {
       "year": 1997,
@@ -7120,7 +7274,8 @@
         "es": "applemusic://track/506688835",
         "nl": "applemusic://track/506688835",
         "it": "applemusic://track/506688835"
-      }
+      },
+      "fun_fact_it": "My Heart Will Go On di Céline Dion è inseparabile da Titanic. All'inizio lei non voleva inciderla."
     },
     {
       "year": 1969,
@@ -7161,7 +7316,8 @@
         "es": "applemusic://track/692547737",
         "nl": "applemusic://track/692547737",
         "it": "applemusic://track/692547737"
-      }
+      },
+      "fun_fact_it": "We Have All the Time in the World di Louis Armstrong chiude Al servizio segreto di Sua Maestà. Fu l'ultimo brano che incise."
     },
     {
       "year": 1969,
@@ -7221,7 +7377,8 @@
         "es": "applemusic://track/1296522889",
         "nl": "applemusic://track/1296522889",
         "it": "applemusic://track/1296522889"
-      }
+      },
+      "fun_fact_it": "Everybody's Talkin' di Harry Nilsson vinse un Grammy per Un uomo da marciapiede. La canzone malinconica racconta il sogno di fuggire."
     },
     {
       "year": 1980,
@@ -7260,7 +7417,8 @@
         "es": "applemusic://track/1550210611",
         "nl": "applemusic://track/1550210611",
         "it": "applemusic://track/1550210611"
-      }
+      },
+      "fun_fact_it": "Fly Too High di Janis Ian compare in Foxes. Il film di formazione raccontava la Los Angeles del punk e della disco."
     },
     {
       "year": 1963,
@@ -7291,7 +7449,8 @@
       "fun_fact_nl": "John Barry's From Russia with Love vestigde de muzikale stijl van Bond. Het was de eerste Bondfilm met een titelsong.",
       "awards_nl": [],
       "uri_apple_music": "applemusic://track/1542637867",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=UDZEZxHdq5k"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UDZEZxHdq5k",
+      "fun_fact_it": "Il tema di Dalla Russia con amore di John Barry fissò lo stile musicale di Bond. Fu il primo film della saga con una canzone dei titoli."
     },
     {
       "year": 1946,
@@ -7330,7 +7489,8 @@
         "nl": "applemusic://track/1597777326",
         "it": "applemusic://track/1597777326"
       },
-      "uri_youtube_music": "https://music.youtube.com/watch?v=Ncbod0QSLJA"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Ncbod0QSLJA",
+      "fun_fact_it": "La vita è meravigliosa fu un insuccesso all'uscita, ma divenne un classico natalizio grazie ai passaggi televisivi quando scadde il copyright."
     },
     {
       "year": 1942,
@@ -7380,7 +7540,8 @@
         "Oscar per la migliore canzone originale (1942)"
       ],
       "uri_apple_music": "applemusic://track/1300642506",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=v5ryZdpEHqM"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=v5ryZdpEHqM",
+      "fun_fact_it": "White Christmas di Bing Crosby, da La taverna dell'allegria, è il singolo più venduto di sempre. Vinse l'Oscar per la migliore canzone."
     },
     {
       "year": 1958,
@@ -7408,7 +7569,8 @@
       "uri_deezer": "deezer://track/2357173085",
       "fun_fact_nl": "Het Pearl & Dean-thema speelt al sinds 1958 voor reclames in Britse bioscopen. De fanfare is bekend bij generaties bioscoopbezoekers.",
       "awards_nl": [],
-      "uri_youtube_music": "https://music.youtube.com/watch?v=cxU6LT6DonE"
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cxU6LT6DonE",
+      "fun_fact_it": "Il tema della Pearl & Dean precede la pubblicità nei cinema britannici dal 1958. La fanfara è nota a generazioni di spettatori."
     }
   ],
   "movie_quiz_enabled": true

--- a/custom_components/beatify/playlists/top-songs-der-60er.json
+++ b/custom_components/beatify/playlists/top-songs-der-60er.json
@@ -1802,7 +1802,8 @@
       "fun_fact_de": "Ein Chart-Hit von Small Faces (1967).",
       "fun_fact_es": "Un éxito de Small Faces (1967).",
       "fun_fact_fr": "Un tube de Small Faces (1967).",
-      "fun_fact_nl": "Een chart-hit van Small Faces (1967)."
+      "fun_fact_nl": "Een chart-hit van Small Faces (1967).",
+      "fun_fact_it": "Un successo in classifica di Small Faces (1967)."
     },
     {
       "artist": "Sly & The Family Stone",
@@ -1827,7 +1828,8 @@
       "fun_fact_de": "Ein Chart-Hit von Sly & The Family Stone (1969).",
       "fun_fact_es": "Un éxito de Sly & The Family Stone (1969).",
       "fun_fact_fr": "Un tube de Sly & The Family Stone (1969).",
-      "fun_fact_nl": "Een chart-hit van Sly & The Family Stone (1969)."
+      "fun_fact_nl": "Een chart-hit van Sly & The Family Stone (1969).",
+      "fun_fact_it": "Un successo in classifica di Sly & The Family Stone (1969)."
     },
     {
       "artist": "The 5th Dimension",
@@ -1852,7 +1854,8 @@
       "fun_fact_de": "Ein Chart-Hit von The 5th Dimension (1969).",
       "fun_fact_es": "Un éxito de The 5th Dimension (1969).",
       "fun_fact_fr": "Un tube de The 5th Dimension (1969).",
-      "fun_fact_nl": "Een chart-hit van The 5th Dimension (1969)."
+      "fun_fact_nl": "Een chart-hit van The 5th Dimension (1969).",
+      "fun_fact_it": "Un successo in classifica di The 5th Dimension (1969)."
     },
     {
       "artist": "The Spencer Davis Group",
@@ -1877,7 +1880,8 @@
       "fun_fact_de": "Ein Chart-Hit von The Spencer Davis Group (1965).",
       "fun_fact_es": "Un éxito de The Spencer Davis Group (1965).",
       "fun_fact_fr": "Un tube de The Spencer Davis Group (1965).",
-      "fun_fact_nl": "Een chart-hit van The Spencer Davis Group (1965)."
+      "fun_fact_nl": "Een chart-hit van The Spencer Davis Group (1965).",
+      "fun_fact_it": "Un successo in classifica di The Spencer Davis Group (1965)."
     },
     {
       "artist": "Little Eva",
@@ -1902,7 +1906,8 @@
       "fun_fact_de": "Ein Chart-Hit von Little Eva (1962).",
       "fun_fact_es": "Un éxito de Little Eva (1962).",
       "fun_fact_fr": "Un tube de Little Eva (1962).",
-      "fun_fact_nl": "Een chart-hit van Little Eva (1962)."
+      "fun_fact_nl": "Een chart-hit van Little Eva (1962).",
+      "fun_fact_it": "Un successo in classifica di Little Eva (1962)."
     },
     {
       "artist": "The Surfaris",
@@ -1927,7 +1932,8 @@
       "fun_fact_de": "Ein Chart-Hit von The Surfaris (1963).",
       "fun_fact_es": "Un éxito de The Surfaris (1963).",
       "fun_fact_fr": "Un tube de The Surfaris (1963).",
-      "fun_fact_nl": "Een chart-hit van The Surfaris (1963)."
+      "fun_fact_nl": "Een chart-hit van The Surfaris (1963).",
+      "fun_fact_it": "Un successo in classifica di The Surfaris (1963)."
     },
     {
       "artist": "The Crystals",
@@ -1952,7 +1958,8 @@
       "fun_fact_de": "Ein Chart-Hit von The Crystals (1963).",
       "fun_fact_es": "Un éxito de The Crystals (1963).",
       "fun_fact_fr": "Un tube de The Crystals (1963).",
-      "fun_fact_nl": "Een chart-hit van The Crystals (1963)."
+      "fun_fact_nl": "Een chart-hit van The Crystals (1963).",
+      "fun_fact_it": "Un successo in classifica di The Crystals (1963)."
     },
     {
       "artist": "France Gall",
@@ -1977,7 +1984,8 @@
       "fun_fact_de": "Ein Chart-Hit von France Gall (1965).",
       "fun_fact_es": "Un éxito de France Gall (1965).",
       "fun_fact_fr": "Un tube de France Gall (1965).",
-      "fun_fact_nl": "Een chart-hit van France Gall (1965)."
+      "fun_fact_nl": "Een chart-hit van France Gall (1965).",
+      "fun_fact_it": "Un successo in classifica di France Gall (1965)."
     },
     {
       "artist": "Aretha Franklin",
@@ -2002,7 +2010,8 @@
       "fun_fact_de": "Ein Chart-Hit von Aretha Franklin (1968).",
       "fun_fact_es": "Un éxito de Aretha Franklin (1968).",
       "fun_fact_fr": "Un tube de Aretha Franklin (1968).",
-      "fun_fact_nl": "Een chart-hit van Aretha Franklin (1968)."
+      "fun_fact_nl": "Een chart-hit van Aretha Franklin (1968).",
+      "fun_fact_it": "Un successo in classifica di Aretha Franklin (1968)."
     },
     {
       "artist": "Martha Reeves & The Vandellas",
@@ -2027,7 +2036,8 @@
       "fun_fact_de": "Ein Chart-Hit von Martha Reeves & The Vandellas (1963).",
       "fun_fact_es": "Un éxito de Martha Reeves & The Vandellas (1963).",
       "fun_fact_fr": "Un tube de Martha Reeves & The Vandellas (1963).",
-      "fun_fact_nl": "Een chart-hit van Martha Reeves & The Vandellas (1963)."
+      "fun_fact_nl": "Een chart-hit van Martha Reeves & The Vandellas (1963).",
+      "fun_fact_it": "Un successo in classifica di Martha Reeves & The Vandellas (1963)."
     },
     {
       "artist": "Arthur Conley",
@@ -2052,7 +2062,8 @@
       "fun_fact_de": "Ein Chart-Hit von Arthur Conley (1967).",
       "fun_fact_es": "Un éxito de Arthur Conley (1967).",
       "fun_fact_fr": "Un tube de Arthur Conley (1967).",
-      "fun_fact_nl": "Een chart-hit van Arthur Conley (1967)."
+      "fun_fact_nl": "Een chart-hit van Arthur Conley (1967).",
+      "fun_fact_it": "Un successo in classifica di Arthur Conley (1967)."
     },
     {
       "artist": "Helen Shapiro",
@@ -2077,7 +2088,8 @@
       "fun_fact_de": "Ein Chart-Hit von Helen Shapiro (1961).",
       "fun_fact_es": "Un éxito de Helen Shapiro (1961).",
       "fun_fact_fr": "Un tube de Helen Shapiro (1961).",
-      "fun_fact_nl": "Een chart-hit van Helen Shapiro (1961)."
+      "fun_fact_nl": "Een chart-hit van Helen Shapiro (1961).",
+      "fun_fact_it": "Un successo in classifica di Helen Shapiro (1961)."
     },
     {
       "artist": "Roy Orbison",
@@ -2102,7 +2114,8 @@
       "fun_fact_de": "Ein Chart-Hit von Roy Orbison (1964).",
       "fun_fact_es": "Un éxito de Roy Orbison (1964).",
       "fun_fact_fr": "Un tube de Roy Orbison (1964).",
-      "fun_fact_nl": "Een chart-hit van Roy Orbison (1964)."
+      "fun_fact_nl": "Een chart-hit van Roy Orbison (1964).",
+      "fun_fact_it": "Un successo in classifica di Roy Orbison (1964)."
     },
     {
       "artist": "The Ronettes",
@@ -2127,7 +2140,8 @@
       "fun_fact_de": "Ein Chart-Hit von The Ronettes (1963).",
       "fun_fact_es": "Un éxito de The Ronettes (1963).",
       "fun_fact_fr": "Un tube de The Ronettes (1963).",
-      "fun_fact_nl": "Een chart-hit van The Ronettes (1963)."
+      "fun_fact_nl": "Een chart-hit van The Ronettes (1963).",
+      "fun_fact_it": "Un successo in classifica di The Ronettes (1963)."
     },
     {
       "artist": "The Supremes",
@@ -2152,7 +2166,8 @@
       "fun_fact_de": "Ein Chart-Hit von The Supremes (1964).",
       "fun_fact_es": "Un éxito de The Supremes (1964).",
       "fun_fact_fr": "Un tube de The Supremes (1964).",
-      "fun_fact_nl": "Een chart-hit van The Supremes (1964)."
+      "fun_fact_nl": "Een chart-hit van The Supremes (1964).",
+      "fun_fact_it": "Un successo in classifica di The Supremes (1964)."
     },
     {
       "artist": "Bobby Lewis",
@@ -2177,7 +2192,8 @@
       "fun_fact_de": "Ein Chart-Hit von Bobby Lewis (1961).",
       "fun_fact_es": "Un éxito de Bobby Lewis (1961).",
       "fun_fact_fr": "Un tube de Bobby Lewis (1961).",
-      "fun_fact_nl": "Een chart-hit van Bobby Lewis (1961)."
+      "fun_fact_nl": "Een chart-hit van Bobby Lewis (1961).",
+      "fun_fact_it": "Un successo in classifica di Bobby Lewis (1961)."
     },
     {
       "artist": "The Rolling Stones",
@@ -2202,7 +2218,8 @@
       "fun_fact_de": "Ein Chart-Hit von The Rolling Stones (1969).",
       "fun_fact_es": "Un éxito de The Rolling Stones (1969).",
       "fun_fact_fr": "Un tube de The Rolling Stones (1969).",
-      "fun_fact_nl": "Een chart-hit van The Rolling Stones (1969)."
+      "fun_fact_nl": "Een chart-hit van The Rolling Stones (1969).",
+      "fun_fact_it": "Un successo in classifica di The Rolling Stones (1969)."
     },
     {
       "artist": "Lesley Gore",
@@ -2227,7 +2244,8 @@
       "fun_fact_de": "Ein Chart-Hit von Lesley Gore (1963).",
       "fun_fact_es": "Un éxito de Lesley Gore (1963).",
       "fun_fact_fr": "Un tube de Lesley Gore (1963).",
-      "fun_fact_nl": "Een chart-hit van Lesley Gore (1963)."
+      "fun_fact_nl": "Een chart-hit van Lesley Gore (1963).",
+      "fun_fact_it": "Un successo in classifica di Lesley Gore (1963)."
     },
     {
       "artist": "The Edwin Hawkins Singers",
@@ -2252,7 +2270,8 @@
       "fun_fact_de": "Ein Chart-Hit von The Edwin Hawkins Singers (1968).",
       "fun_fact_es": "Un éxito de The Edwin Hawkins Singers (1968).",
       "fun_fact_fr": "Un tube de The Edwin Hawkins Singers (1968).",
-      "fun_fact_nl": "Een chart-hit van The Edwin Hawkins Singers (1968)."
+      "fun_fact_nl": "Een chart-hit van The Edwin Hawkins Singers (1968).",
+      "fun_fact_it": "Un successo in classifica di The Edwin Hawkins Singers (1968)."
     },
     {
       "artist": "Elvis Presley",
@@ -2280,7 +2299,8 @@
       "fun_fact_de": "Ein Chart-Hit von Elvis Presley (1968).",
       "fun_fact_es": "Un éxito de Elvis Presley (1968).",
       "fun_fact_fr": "Un tube de Elvis Presley (1968).",
-      "fun_fact_nl": "Een chart-hit van Elvis Presley (1968)."
+      "fun_fact_nl": "Een chart-hit van Elvis Presley (1968).",
+      "fun_fact_it": "Un successo in classifica di Elvis Presley (1968)."
     },
     {
       "artist": "The Jackson 5",

--- a/custom_components/beatify/playlists/world-cup-anthems.json
+++ b/custom_components/beatify/playlists/world-cup-anthems.json
@@ -34,7 +34,8 @@
       "uri_tidal": "tidal://track/41490418",
       "uri_deezer": "deezer://track/3245977",
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "La primissima canzone ufficiale di un Mondiale FIFA, incisa per il torneo cileno del 1962. Divenne un successo rock and roll in tutta la regione."
     },
     {
       "year": 1966,
@@ -59,7 +60,8 @@
       "uri_tidal": "tidal://track/493949975",
       "uri_deezer": "deezer://track/3141989511",
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "Scritta per il Mondiale del 1966 organizzato dall'Inghilterra e intitolata alla mascotte, un leone di nome Willie."
     },
     {
       "year": 1970,
@@ -84,7 +86,8 @@
       "uri_tidal": null,
       "uri_deezer": null,
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "Inno di stampo folk messicano per il Mondiale del 1970 in Messico, il primo torneo trasmesso a colori in tutto il mondo."
     },
     {
       "year": 1973,
@@ -112,7 +115,8 @@
       "uri_tidal": "tidal://track/13342489",
       "uri_deezer": "deezer://track/7558171",
       "isrc": "DEF067312220",
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "La nazionale della Germania Ovest incise questo inno nel 1973 e l'anno dopo vinse il Mondiale in casa."
     },
     {
       "year": 1982,
@@ -137,7 +141,8 @@
       "uri_tidal": null,
       "uri_deezer": null,
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "Il tenore Plácido Domingo prestò la voce all'inno ufficiale del Mondiale di Spagna 1982."
     },
     {
       "year": 1986,
@@ -162,7 +167,8 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2160233807",
       "isrc": "USCGJ2341061",
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "Il titolo significa «Il mondo unito da un pallone»: è la canzone ufficiale del Mondiale messicano del 1986, quello della Mano de Dios di Maradona."
     },
     {
       "year": 1990,
@@ -189,7 +195,8 @@
       "uri_tidal": "tidal://track/150210063",
       "uri_deezer": "deezer://track/1035795002",
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "Canzone ufficiale italiana di Italia '90: la sua melodia resta l'inno mondiale più riconoscibile in Europa."
     },
     {
       "year": 1990,
@@ -216,7 +223,8 @@
       "uri_tidal": "tidal://track/150210255",
       "uri_deezer": "deezer://track/1035796702",
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "Versione in inglese dell'inno di Italia '90, prodotta dal pioniere della disco Giorgio Moroder."
     },
     {
       "year": 1994,
@@ -243,7 +251,8 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/32981961",
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "Canzone ufficiale di USA '94, il primo Mondiale ospitato dagli Stati Uniti."
     },
     {
       "year": 1998,
@@ -270,7 +279,8 @@
       "uri_tidal": "tidal://track/33833948",
       "uri_deezer": "deezer://track/13111375",
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "L'inno di Francia '98 di Ricky Martin lanciò la sua carriera mondiale e dominò le classifiche di 60 paesi."
     },
     {
       "year": 1998,
@@ -297,7 +307,8 @@
       "uri_tidal": "tidal://track/17819979",
       "uri_deezer": "deezer://track/15209177",
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "Inno ufficiale di Francia '98, tra il mbalax senegalese e la chanson francese: una dichiarazione multiculturale."
     },
     {
       "year": 2002,
@@ -322,7 +333,8 @@
       "uri_tidal": "tidal://track/432943122",
       "uri_deezer": "deezer://track/3345558141",
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "La canzone ufficiale di Anastacia per Corea/Giappone 2002, il primo Mondiale organizzato da due paesi insieme."
     },
     {
       "year": 2002,
@@ -351,7 +363,8 @@
       "uri_tidal": null,
       "uri_deezer": null,
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "Canzone dei paesi ospitanti di Corea/Giappone 2002, nata dalla collaborazione tra star del pop coreano e giapponese per simboleggiare il torneo condiviso."
     },
     {
       "year": 2006,
@@ -379,7 +392,8 @@
       "uri_tidal": "tidal://track/75257171",
       "uri_deezer": "deezer://track/563270",
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "Canzone ufficiale di Germania 2006: il quartetto pop-lirico Il Divo insieme alla leggenda dell'R&B Toni Braxton."
     },
     {
       "year": 2006,
@@ -406,7 +420,8 @@
       "uri_tidal": "tidal://track/2950975",
       "uri_deezer": "deezer://track/2651438972",
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "Inno ufficiale di Germania 2006, cantato in tedesco, francese e inglese: Grönemeyer divenne la voce del Sommermärchen, la favola d'estate tedesca."
     },
     {
       "year": 2010,
@@ -434,7 +449,8 @@
       "uri_tidal": "tidal://track/3863314",
       "uri_deezer": "deezer://track/68473089",
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "L'inno di Shakira per il Sudafrica 2010 è diventato la canzone mondiale più venduta di sempre, con oltre 10 milioni di copie."
     },
     {
       "year": 2010,
@@ -461,7 +477,8 @@
       "uri_tidal": "tidal://track/4044191",
       "uri_deezer": "deezer://track/6237416",
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "Inno ufficiale del Sudafrica 2010, tra l'R&B di R. Kelly e il coro gospel dei Soweto Spiritual Singers."
     },
     {
       "year": 2014,
@@ -489,7 +506,8 @@
       "uri_tidal": "tidal://track/37617779",
       "uri_deezer": "deezer://track/76575944",
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "Canzone ufficiale di Brasile 2014, con la nobiltà del pop americano (Pitbull e JLo) accanto alla brasiliana Claudia Leitte."
     },
     {
       "year": 2014,
@@ -517,7 +535,8 @@
       "uri_tidal": "tidal://track/29173798",
       "uri_deezer": "deezer://track/77913076",
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "Inno ufficiale di Brasile 2014: la chitarra di Carlos Santana insieme ai ritmi EDM di Avicii e alla voce di Wyclef."
     },
     {
       "year": 2018,
@@ -545,7 +564,8 @@
       "uri_tidal": "tidal://track/89285249",
       "uri_deezer": "deezer://track/504079942",
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "Canzone ufficiale di Russia 2018, che mette insieme il reggaeton latino di Nicky Jam, l'hip hop americano di Will Smith e il pop kosovaro di Era Istrefi."
     },
     {
       "year": 2022,
@@ -572,7 +592,8 @@
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1702248727",
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "Primo brano della colonna sonora a più episodi di Qatar 2022, pubblicato un anno prima del torneo per costruire l'attesa."
     },
     {
       "year": 2022,
@@ -600,7 +621,8 @@
       "uri_tidal": "tidal://track/341429509",
       "uri_deezer": "deezer://track/1874882997",
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "Brano della colonna sonora di Qatar 2022: «Arhbo» significa «benvenuto» in arabo, firmato dalla star del reggaeton Ozuna e dal rapper francese GIMS."
     },
     {
       "year": 2022,
@@ -628,7 +650,8 @@
       "uri_tidal": "tidal://track/341428967",
       "uri_deezer": "deezer://track/2023640587",
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "Eseguita da Jung Kook dei BTS alla cerimonia di apertura di Qatar 2022, arrivò all'undicesimo posto della Billboard Hot 100."
     },
     {
       "year": 2022,
@@ -656,7 +679,8 @@
       "uri_tidal": "tidal://track/259859918",
       "uri_deezer": "deezer://track/2010847937",
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "Inno ufficiale del FIFA Fan Festival di Qatar 2022, con inglese, spagnolo e arabo mescolati in un unico brano."
     },
     {
       "year": 2026,
@@ -684,7 +708,8 @@
       "uri_tidal": "tidal://track/523693880",
       "uri_deezer": "deezer://track/4015341011",
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "La seconda canzone mondiale di Shakira, in coppia con la star nigeriana dell'afrobeats Burna Boy per il torneo 2026 di USA, Messico e Canada."
     },
     {
       "year": 2026,
@@ -712,7 +737,8 @@
       "uri_tidal": "tidal://track/506686850",
       "uri_deezer": "deezer://track/3898098401",
       "isrc": null,
-      "uri_apple_music_by_region": {}
+      "uri_apple_music_by_region": {},
+      "fun_fact_it": "Incontro tra country e musica regionale messicana per la colonna sonora del Mondiale 2026: Jelly Roll con la star messicana Carín León."
     }
   ]
 }


### PR DESCRIPTION
Italian became a game language in v4.3.0. The interface, the spoken
announcements and the award names were translated; the catalogue was
not. `fun_fact_it` stood at **182 of 7,789** — and those 182 are exactly
`musica-italiana` and `sanremo-vincitori`, both complete. The Italian
repertoire got Italian trivia and the rest of the catalogue did not.

`getLocalizedSongField` falls back to English without a word, so an
Italian player has been getting the whole game in Italian and then the
song trivia in English, in 97.7% of rounds.

This closes the part that can be closed mechanically. Of the 7,607
missing texts, 850 follow one of four templates:

- `A chart hit by X (YYYY).` — 198
- `"T" by A, first released in YYYY on the album "AL".` — 443
- `"T" by A, first released in YYYY.` — 91
- `From the Spanish-language version of Disney's "F" (YYYY).` — 118

Each is translated from its structure, not from its wording, so no
statement changes: `«La Murga» di Héctor Lavoe, Willie Colón, pubblicata
per la prima volta nel 1970 nell'album «Asalto Navideño: Vol. 1 & 2».`
Italian quotation marks throughout, matching the French entries' use of
guillemets rather than the English straight quotes.

Coverage goes from 2.3% to **13.2%**.

The remaining 6,757 are free prose with a median of 121 characters —
"The song samples ABBA's 'Gimme! Gimme! Gimme!' — ABBA had only ever
granted sampling permission once before". Those are real translations,
not substitutions, and they are not in this PR.

Tests: 2133 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Njn3vxDz6tKKas427onhL7