### PR TITLE
data(salsa-y-merengue): remove three duplicate songs

### DIFF
--- a/custom_components/beatify/playlists/community/salsa-y-merengue.json
+++ b/custom_components/beatify/playlists/community/salsa-y-merengue.json
@@ -1,6 +1,6 @@
 {
   "name": "Salsa y Merengue",
-  "version": "1.8",
+  "version": "1.9",
   "tags": [
     "salsa",
     "merengue",
@@ -4593,21 +4593,6 @@
       "fun_fact_it": "«Qué Precio Tiene el Cielo - Salsa Version» di Marc Anthony, pubblicata per la prima volta nel 2006."
     },
     {
-      "year": 1978,
-      "uri": "spotify:track:09PGyODYYlVsL49N7TR914",
-      "artist": "Rubén Blades, Willie Colon Y Ruben Blades",
-      "title": "Pedro Navaja",
-      "isrc": "QMFMG1593985",
-      "fun_fact": "\"Pedro Navaja\" by Rubén Blades, Willie Colon Y Ruben Blades, first released in 1978 on the album \"El Poliedro de Caracas Tembló\".",
-      "fun_fact_de": "„Pedro Navaja\" von Rubén Blades, Willie Colon Y Ruben Blades, erstmals 1978 auf dem Album „El Poliedro de Caracas Tembló\" erschienen.",
-      "fun_fact_es": "\"Pedro Navaja\" de Rubén Blades, Willie Colon Y Ruben Blades, publicada por primera vez en 1978 en el álbum \"El Poliedro de Caracas Tembló\".",
-      "fun_fact_fr": "« Pedro Navaja » de Rubén Blades, Willie Colon Y Ruben Blades, parue pour la première fois en 1978 sur l'album « El Poliedro de Caracas Tembló ».",
-      "fun_fact_nl": "\"Pedro Navaja\" van Rubén Blades, Willie Colon Y Ruben Blades, voor het eerst uitgebracht in 1978 op het album \"El Poliedro de Caracas Tembló\".",
-      "uri_deezer": "deezer://track/600766432",
-      "uri_apple_music": "applemusic://track/1464957419",
-      "fun_fact_it": "«Pedro Navaja» di Rubén Blades, Willie Colon Y Ruben Blades, pubblicata per la prima volta nel 1978 nell'album «El Poliedro de Caracas Tembló»."
-    },
-    {
       "year": 1994,
       "uri": "spotify:track:4ZVgDysve5dcNK6TX84t8e",
       "artist": "Víctor Manuelle",
@@ -5529,21 +5514,6 @@
       "uri_deezer": "deezer://track/13207217",
       "uri_apple_music": "applemusic://track/321352677",
       "fun_fact_it": "«I Love Salsa» di N'Klabe, pubblicata per la prima volta nel 2001 nell'album «I Love Salsa (re-release)»."
-    },
-    {
-      "year": 2000,
-      "uri": "spotify:track:1d9LhayPyXx9lkCpJhKT9P",
-      "artist": "Mariano Civico",
-      "title": "-Te Voy A Hacer Feliz",
-      "isrc": "TCAFC2086575",
-      "fun_fact": "\"-Te Voy A Hacer Feliz\" by Mariano Civico, first released in 2000 on the album \"Costa Brava\".",
-      "fun_fact_de": "„-Te Voy A Hacer Feliz\" von Mariano Civico, erstmals 2000 auf dem Album „Costa Brava\" erschienen.",
-      "fun_fact_es": "\"-Te Voy A Hacer Feliz\" de Mariano Civico, publicada por primera vez en 2000 en el álbum \"Costa Brava\".",
-      "fun_fact_fr": "« -Te Voy A Hacer Feliz » de Mariano Civico, parue pour la première fois en 2000 sur l'album « Costa Brava ».",
-      "fun_fact_nl": "\"-Te Voy A Hacer Feliz\" van Mariano Civico, voor het eerst uitgebracht in 2000 op het album \"Costa Brava\".",
-      "uri_deezer": "deezer://track/1104813912",
-      "uri_apple_music": "applemusic://track/1735824620",
-      "fun_fact_it": "«-Te Voy A Hacer Feliz» di Mariano Civico, pubblicata per la prima volta nel 2000 nell'album «Costa Brava»."
     },
     {
       "year": 2006,
@@ -7305,21 +7275,6 @@
       "uri_deezer": "deezer://track/1857060737",
       "uri_apple_music": "applemusic://track/1701636802",
       "fun_fact_it": "«Si Algún Día la Ves» di Sergio Vargas, pubblicata per la prima volta nel 1986 nell'album «Los Años Dorados de Sergio Vargas»."
-    },
-    {
-      "year": 1995,
-      "uri": "spotify:track:47zBUo7uN3OEJcZqLlfZWC",
-      "artist": "Los Hermanos Rosario",
-      "title": "La Duena del Swing",
-      "isrc": "USJ3V1497673",
-      "fun_fact": "\"La Duena del Swing\" by Los Hermanos Rosario, first released in 1995 on the album \"Los Dueños del Swing\".",
-      "fun_fact_de": "„La Duena del Swing\" von Los Hermanos Rosario, erstmals 1995 auf dem Album „Los Dueños del Swing\" erschienen.",
-      "fun_fact_es": "\"La Duena del Swing\" de Los Hermanos Rosario, publicada por primera vez en 1995 en el álbum \"Los Dueños del Swing\".",
-      "fun_fact_fr": "« La Duena del Swing » de Los Hermanos Rosario, parue pour la première fois en 1995 sur l'album « Los Dueños del Swing ».",
-      "fun_fact_nl": "\"La Duena del Swing\" van Los Hermanos Rosario, voor het eerst uitgebracht in 1995 op het album \"Los Dueños del Swing\".",
-      "uri_deezer": "deezer://track/1857103157",
-      "uri_apple_music": "applemusic://track/1526558385",
-      "fun_fact_it": "«La Duena del Swing» di Los Hermanos Rosario, pubblicata per la prima volta nel 1995 nell'album «Los Dueños del Swing»."
     },
     {
       "year": 1997,


### PR DESCRIPTION
The three duplicates reported after #2432. Each is the same song listed twice; the build-time duplicate check compares exact strings and matched none of them.

| Removed | Kept | Why |
|---|---|---|
| `09PGyODYYlVsL49N7TR914` — "Pedro Navaja", artist `Rubén Blades, Willie Colon Y Ruben Blades`, live album | `0CkMfgAoB1rsDafz2TkLaD` — artist `Willie Colón, Rubén Blades`, album Siembra (1978) | Artist order swapped and Ruben Blades named twice in the dropped entry; the kept one is the Fania original and is the only one with a YouTube Music link. Both already pointed at the same Apple Music track. |
| `47zBUo7uN3OEJcZqLlfZWC` — "La Duena del Swing" | `3vCeDhrInX8te6SoaqZbvu` — "La Dueña del Swing" | Same artist, same year, **same ISRC** `USJ3V1497673`, same Deezer track. Only the ñ differs. |
| `1d9LhayPyXx9lkCpJhKT9P` — "-Te Voy A Hacer Feliz" | `4jBkRRscUmbKtUbngf2WQf` — "Te Voy a Hacer Feliz" | Leading dash from the Spotify harvest. Same artist, year, **ISRC** `TCAFC2086575`, Deezer and Apple track. |

534 → 531 songs.

**Version 1.8 → 1.9.** Without the bump the fix does not reach existing installations: `_copy_bundled_playlists` (`game/playlist.py:542`) overwrites a playlist only when the bundled version compares higher.

**Left in place on purpose:** thirteen other same-title pairs. They are covers or unrelated songs by different artists — "Aguanile" by Héctor Lavoe and by Marc Anthony are two legitimate questions. One deserves a second look and is not part of this PR: "La Flaca" by Cocoband (1989) and by Pochy Y Su Cocoband (2007) have different Spotify and Deezer ids but **the same Apple Music track** `1513631032`, which suggests one recording filed under two spellings of the band name.

Verified: 2133 pytest green, playlist schema gate passes, no remaining duplicate Spotify URI in the file, Italian trivia still complete at 531/531.