### PR TITLE
data(playlists): bump versions for the 13 files changed in #2434

### DIFF
--- a/custom_components/beatify/playlists/2000s-pop-anthems.json
+++ b/custom_components/beatify/playlists/2000s-pop-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "2000s Pop Anthems",
-  "version": "1.24",
+  "version": "1.25",
   "tags": [
     "2000s",
     "pop",

--- a/custom_components/beatify/playlists/70s-hits.json
+++ b/custom_components/beatify/playlists/70s-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "70s Hits",
-  "version": "1.19",
+  "version": "1.20",
   "tags": [
     "1970s",
     "classic-rock",

--- a/custom_components/beatify/playlists/80er-hits.json
+++ b/custom_components/beatify/playlists/80er-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "80s Hits",
-  "version": "2.24",
+  "version": "2.25",
   "tags": [
     "1980s",
     "pop",

--- a/custom_components/beatify/playlists/90er-hits.json
+++ b/custom_components/beatify/playlists/90er-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "90s Hits",
-  "version": "1.28",
+  "version": "1.29",
   "tags": [
     "1990s",
     "pop",

--- a/custom_components/beatify/playlists/community/clasicos-disney-castellano.json
+++ b/custom_components/beatify/playlists/community/clasicos-disney-castellano.json
@@ -1,6 +1,6 @@
 {
   "name": "Clásicos Disney (Castellano)",
-  "version": "0.1",
+  "version": "0.2",
   "tags": [
     "disney",
     "movies",

--- a/custom_components/beatify/playlists/community/deutschpop-klassiker.json
+++ b/custom_components/beatify/playlists/community/deutschpop-klassiker.json
@@ -1,6 +1,6 @@
 {
   "name": "Deutschpop Klassiker 🇩🇪",
-  "version": "0.15",
+  "version": "0.16",
   "tags": [
     "german",
     "pop",

--- a/custom_components/beatify/playlists/community/disney-latino.json
+++ b/custom_components/beatify/playlists/community/disney-latino.json
@@ -1,6 +1,6 @@
 {
   "name": "Disney Latino",
-  "version": "0.1",
+  "version": "0.2",
   "tags": [
     "disney",
     "movies",

--- a/custom_components/beatify/playlists/eurovision-winners.json
+++ b/custom_components/beatify/playlists/eurovision-winners.json
@@ -1,6 +1,6 @@
 {
   "name": "Eurovision Winners (1956-2025)",
-  "version": "1.15",
+  "version": "1.16",
   "tags": [
     "eurovision",
     "contest",

--- a/custom_components/beatify/playlists/greatest-hits-of-all-time.json
+++ b/custom_components/beatify/playlists/greatest-hits-of-all-time.json
@@ -1,6 +1,6 @@
 {
   "name": "Greatest Hits of All Time",
-  "version": "2.22",
+  "version": "2.23",
   "tags": [
     "classics",
     "top-hits",

--- a/custom_components/beatify/playlists/hits-2010s-2020s.json
+++ b/custom_components/beatify/playlists/hits-2010s-2020s.json
@@ -1,6 +1,6 @@
 {
   "name": "2010s & 2020s Hits",
-  "version": "1.14",
+  "version": "1.15",
   "tags": [
     "pop",
     "charts",

--- a/custom_components/beatify/playlists/movies-100-greatest-themes.json
+++ b/custom_components/beatify/playlists/movies-100-greatest-themes.json
@@ -1,6 +1,6 @@
 {
   "name": "100 Greatest Movie Themes 🎬",
-  "version": "1.23",
+  "version": "1.24",
   "tags": [
     "movies",
     "soundtrack",

--- a/custom_components/beatify/playlists/top-songs-der-60er.json
+++ b/custom_components/beatify/playlists/top-songs-der-60er.json
@@ -1,6 +1,6 @@
 {
   "name": "60s Classics 🎸",
-  "version": "1.15",
+  "version": "1.16",
   "source": "https://open.spotify.com/playlist/6rtsNFUv2UK3j78PRVMpSd",
   "tags": [
     "1960s",

--- a/custom_components/beatify/playlists/world-cup-anthems.json
+++ b/custom_components/beatify/playlists/world-cup-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "World Cup Anthems",
-  "version": "1.13",
+  "version": "1.14",
   "tags": [
     "world-cup",
     "fifa",


### PR DESCRIPTION
## What

PR #2434 added Italian fun facts to 14 playlist files and raised the `version` field in **none** of them. This bumps the last version component by one in the 13 affected files.

| Playlist | Version |
|---|---|
| `2000s-pop-anthems` | 1.24 → 1.25 |
| `70s-hits` | 1.19 → 1.20 |
| `80er-hits` | 2.24 → 2.25 |
| `90er-hits` | 1.28 → 1.29 |
| `eurovision-winners` | 1.15 → 1.16 |
| `greatest-hits-of-all-time` | 2.22 → 2.23 |
| `hits-2010s-2020s` | 1.14 → 1.15 |
| `movies-100-greatest-themes` | 1.23 → 1.24 |
| `top-songs-der-60er` | 1.15 → 1.16 |
| `world-cup-anthems` | 1.13 → 1.14 |
| `community/clasicos-disney-castellano` | 0.1 → 0.2 |
| `community/deutschpop-klassiker` | 0.15 → 0.16 |
| `community/disney-latino` | 0.1 → 0.2 |

## Why

`_copy_bundled_playlists` (`custom_components/beatify/game/playlist.py:542`) overwrites an already installed playlist **only when the bundled version is strictly higher**:

```python
elif _compare_versions(bundled_ver, existing_ver) > 0:
    # Bundled version is newer - update
```

Without the bump the Italian fun facts reach **fresh installations only** — every existing install keeps its old copy of the file.

`_compare_versions` parses into an int tuple, so `1.24 → 1.25` compares correctly and is not a lexicographic trap.

## Not in the list

`salsa-y-merengue` also changed in #2434 but is already handled: PR #2435 took it from 1.8 to 1.9 for the duplicate removal, and that bump carries the fun facts along.

The two Disney playlists were created earlier the same day in #2433 and have not shipped in any release yet, so their bump is a formality rather than a fix — included for consistency, since anyone tracking `main` between the two merges holds the pre-#2434 copy.

## Verification

- Diff is **13 lines, one per file**, and touches nothing but the `version` key.
- `scripts/validate_playlists.py` — all 61 playlists valid, schema gate passed.
- `pytest tests/` — 2125 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184GyBkpCUC8uNJsDnp6rjv