### PR TITLE
fix(game): send the final standings before end-game tears the game down

### DIFF
--- a/custom_components/beatify/__init__.py
+++ b/custom_components/beatify/__init__.py
@@ -88,7 +88,7 @@ from .server.library_views import (
 )
 from .server.setup_state import clear_setup
 from .server.websocket import BeatifyWebSocketHandler
-from .server.ws_handlers.admin import _finalize_and_end
+from .server.ws_handlers._helpers import finalize_and_end
 from .services.media_player import async_get_media_players
 from .services.stats import StatsService
 
@@ -186,7 +186,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # auto-advance final round records stats + runs the podium ceremony through
     # the same claim as the admin sockets (no double record / double podium TTS).
     game_state.set_game_end_callback(
-        functools.partial(_finalize_and_end, ws_handler, game_state)
+        functools.partial(finalize_and_end, ws_handler, game_state)
     )
 
     # Set up metadata update callback for fast transitions (Issue #42)

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -346,7 +346,7 @@ class GameState(
         self._on_round_end: Callable[[], Awaitable[None]] | None = None
 
         # #1753: callback for the terminal game-end. Wired by the WS handler to
-        # `_finalize_and_end` so the unattended REVEAL auto-advance final round
+        # `finalize_and_end` so the unattended REVEAL auto-advance final round
         # runs the SAME one-shot (claim + record_game + advance_to_end) as the
         # two admin sockets — recording stats + firing the podium TTS exactly
         # once. When unset (REST/service path or tests) the auto-advance falls
@@ -607,7 +607,7 @@ class GameState(
     def set_game_end_callback(self, callback: Callable[[], Awaitable[None]]) -> None:
         """Set the terminal game-end callback (#1753).
 
-        The WS handler wires this to ``_finalize_and_end`` so the unattended
+        The WS handler wires this to ``finalize_and_end`` so the unattended
         REVEAL auto-advance final round records stats + runs the podium ceremony
         through the SAME one-shot claim as the two admin sockets, instead of
         calling ``advance_to_end`` directly (which skipped ``record_game`` and
@@ -1102,7 +1102,7 @@ class GameState(
     async def maybe_start_finale_playoff(self) -> bool:
         """Arm + start a finale tiebreaker playoff round, if one is warranted.
 
-        Called at the game-end decision point (the ``_finalize_and_end`` WS
+        Called at the game-end decision point (the ``finalize_and_end`` WS
         chokepoint) BEFORE stats are finalized. When the game is about to end on
         a **tie for first** while **unplayed songs remain** and the host opted
         in (``finale_tiebreaker_enabled``), rather than declaring a shared winner

--- a/custom_components/beatify/game/state_auto_advance.py
+++ b/custom_components/beatify/game/state_auto_advance.py
@@ -55,7 +55,7 @@ The mixin relies on attributes / methods the host class owns and that live on
 * ``self._on_round_end`` — the async WebSocket broadcast callback mirrored after
   the auto-advance ``start_round`` so the new PLAYING state reaches clients.
 * ``self._on_game_end`` — the terminal game-end callback (#1753), wired by the
-  WS handler to ``_finalize_and_end`` (claim + record_game + advance_to_end).
+  WS handler to ``finalize_and_end`` (claim + record_game + advance_to_end).
   The auto-advance final round routes through it so the unattended end records
   stats + fires the podium TTS through the SAME one-shot claim as the two admin
   sockets. Falls back to ``self.advance_to_end`` when unset (REST/service path
@@ -212,7 +212,7 @@ class RevealAutoAdvanceMixin:
             # REVEAL.
             #
             # #1753: route through the shared game-end gate (_on_game_end =
-            # ws_handler._finalize_and_end) rather than calling advance_to_end()
+            # ws_handler finalize_and_end) rather than calling advance_to_end()
             # directly. The old direct call (a) never recorded stats on the
             # unattended final round and (b) never claimed the game_id, so a
             # concurrently-parked admin_next_round could still win the claim and

--- a/custom_components/beatify/server/game_views.py
+++ b/custom_components/beatify/server/game_views.py
@@ -39,6 +39,7 @@ from custom_components.beatify.game.playlist import (
     async_discover_playlists_detailed,
 )
 from custom_components.beatify.game.state import GamePhase, GameState
+from custom_components.beatify.server.ws_handlers._helpers import finalize_and_end
 from custom_components.beatify.server.base import (
     BeatifyAdminView,
     RateLimitMixin,
@@ -50,7 +51,6 @@ from custom_components.beatify.server.serializers import (
     build_state_message,
 )
 from custom_components.beatify.server.setup_state import clear_setup
-from custom_components.beatify.server.ws_handlers.admin import _finalize_and_end
 from custom_components.beatify.services.media_player import (
     async_get_native_twin_remap,
     get_platform_capabilities,
@@ -661,13 +661,39 @@ class EndGameView(BeatifyAdminView):
         if not game_state or not game_state.game_id:
             return _json_error("No active game", 404, code="GAME_NOT_STARTED")
 
+        ws_handler = data.get("ws_handler")
+
+        # #2442: finalize BEFORE the teardown. end_game() clears the state, so
+        # a broadcast_state() after it serialises nothing and players never see
+        # a `phase: END` — no podium, no scoreboard, no share card. This path
+        # is the admin UI's fallback for a closed admin socket, so it runs
+        # exactly when the host's connection is already shaky.
+        if game_state.phase in (
+            GamePhase.PLAYING,
+            GamePhase.REVEAL,
+            GamePhase.PAUSED,
+        ):
+            await game_state.stop_media()
+            # #1698: title/artist scoring for the running round is deferred
+            # until the vote window closes; resolve it or the podium misses
+            # the last round entirely.
+            await game_state.resolve_title_artist_if_pending()
+            # allow_playoff=False: this endpoint tears the game down in the
+            # same request, so arming one more round here would contradict
+            # its own response.
+            if ws_handler:
+                await finalize_and_end(ws_handler, game_state, allow_playoff=False)
+                # The END state carries the final standings. It has to reach
+                # the clients before end_game() empties the state below.
+                await ws_handler.broadcast_state()
+            else:
+                await game_state.advance_to_end()
+
         await game_state.end_game()
 
         # Broadcast game_ended to WebSocket clients so players clean up properly
-        ws_handler = data.get("ws_handler")
         if ws_handler:
             await ws_handler.broadcast({"type": "game_ended"})
-            await ws_handler.broadcast_state()
 
         return web.json_response({"success": True})
 
@@ -1209,7 +1235,7 @@ class StartGameplayView(BeatifyAdminView):
             # auto-advance final round records stats + runs the podium ceremony
             # through the same claim as the admin sockets.
             game_state.set_game_end_callback(
-                functools.partial(_finalize_and_end, ws_handler, game_state)
+                functools.partial(finalize_and_end, ws_handler, game_state)
             )
             # Set metadata update callback for fast transitions (Issue #42)
             game_state.set_metadata_update_callback(

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -168,7 +168,7 @@ class BeatifyWebSocketHandler:
     def _release_game_end(self, game_id: str | None) -> None:
         """Release a claimed game-end so the terminal sequence can be retried (#1754).
 
-        ``_finalize_and_end`` claims BEFORE its side effects (``record_game``
+        ``finalize_and_end`` claims BEFORE its side effects (``record_game``
         storage I/O + ``advance_to_end``). If either raises, the claim would
         otherwise be burned: every retry hits "already claimed" and returns
         without advancing, stranding the game in REVEAL/PAUSED. Discarding the
@@ -250,7 +250,7 @@ class BeatifyWebSocketHandler:
                     # the log concludes the client sent malformed JSON and
                     # looks there.
                     #
-                    # The case that made it visible: `_finalize_and_end`
+                    # The case that made it visible: `finalize_and_end`
                     # re-raises on purpose (#1754) so the game-end claim is
                     # released and a retry can re-run the terminal sequence.
                     # The design works — but the admin got no frame back, so

--- a/custom_components/beatify/server/ws_handlers/_helpers.py
+++ b/custom_components/beatify/server/ws_handlers/_helpers.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 from aiohttp import web
 
+from custom_components.beatify.const import DOMAIN
 from custom_components.beatify.game.state import GameState
 from custom_components.beatify.server.companion_auth import is_companion_trusted_meta
 from custom_components.beatify.server.serializers import redact_state_for_player
@@ -131,3 +132,58 @@ def _ws_companion_trusted(
         return False
     meta = getattr(ws, "beatify_request_meta", None)
     return is_companion_trusted_meta(meta, hass)
+
+
+async def finalize_and_end(
+    handler: BeatifyWebSocketHandler,
+    game_state: GameState,
+    *,
+    allow_playoff: bool = True,
+) -> None:
+    """Record game stats + run the game-end ceremony exactly once (#1702/#1753).
+
+    The final-round terminal path is reachable from THREE places at the same
+    time: the two admin-capable sockets (participant WS + spectator
+    ``_admin_ws``) driving ``next_round``/``end_game``, and the unattended
+    REVEAL auto-advance carrying the final round (#1753, wired via
+    ``GameState.set_game_end_callback``). Gating on the handler's one-shot claim
+    keyed by ``game_id`` makes ``finalize_game`` / ``record_game`` (double
+    stats) and ``advance_to_end`` (double podium TTS) fire at most once per
+    game. The loser skips straight to the broadcast its caller performs.
+
+    #1754: the claim is taken BEFORE the side effects (``record_game`` storage
+    I/O + ``advance_to_end``). If either raises, the claim is released so a
+    retry can re-run the terminal sequence instead of stranding the game in
+    REVEAL/PAUSED — then the error propagates to the caller.
+
+    #1725: before claiming/finalizing, offer a finale sudden-death tiebreaker.
+    When the host opted in and the game would end on a tie for first with
+    unplayed songs left, ``maybe_start_finale_playoff`` eliminates the non-tied
+    players and starts one more playoff round; the game stays in PLAYING and we
+    return WITHOUT finalizing, so the caller re-broadcasts the live round. On a
+    clear winner / 0 songs left / cap reached it's a no-op and the normal
+    finalize path runs.
+    """
+    if allow_playoff and await game_state.maybe_start_finale_playoff():
+        _LOGGER.info("Finale tiebreaker armed — playoff round started, not ending")
+        return
+
+    if not handler._claim_game_end(game_state.game_id):
+        _LOGGER.debug("Game-end already claimed for %s — skipping", game_state.game_id)
+        return
+
+    try:
+        stats_service = handler.hass.data.get(DOMAIN, {}).get("stats")
+        if stats_service:
+            game_summary = game_state.finalize_game()
+            await stats_service.record_game(
+                game_summary, difficulty=game_state.difficulty
+            )
+            _LOGGER.debug("Game stats recorded")
+
+        await game_state.advance_to_end()
+    except Exception:
+        # #1754: release the claim so a retry re-runs the end sequence rather
+        # than hitting "already claimed" and stranding the game in REVEAL.
+        handler._release_game_end(game_state.game_id)
+        raise

--- a/custom_components/beatify/server/ws_handlers/admin.py
+++ b/custom_components/beatify/server/ws_handlers/admin.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING
 from aiohttp import web
 
 from custom_components.beatify.const import (
-    DOMAIN,
     ERR_GAME_NOT_STARTED,
     ERR_INVALID_ACTION,
     ERR_MEDIA_PLAYER_UNAVAILABLE,
@@ -24,64 +23,15 @@ from custom_components.beatify.const import (
 )
 from custom_components.beatify.game.state import GamePhase, GameState
 from custom_components.beatify.server.serializers import build_state_message
-from custom_components.beatify.server.ws_handlers._helpers import _is_ha_authenticated
+from custom_components.beatify.server.ws_handlers._helpers import (
+    _is_ha_authenticated,
+    finalize_and_end,
+)
 
 if TYPE_CHECKING:
     from custom_components.beatify.server.websocket import BeatifyWebSocketHandler
 
 _LOGGER = logging.getLogger(__name__)
-
-
-async def _finalize_and_end(
-    handler: BeatifyWebSocketHandler, game_state: GameState
-) -> None:
-    """Record game stats + run the game-end ceremony exactly once (#1702/#1753).
-
-    The final-round terminal path is reachable from THREE places at the same
-    time: the two admin-capable sockets (participant WS + spectator
-    ``_admin_ws``) driving ``next_round``/``end_game``, and the unattended
-    REVEAL auto-advance carrying the final round (#1753, wired via
-    ``GameState.set_game_end_callback``). Gating on the handler's one-shot claim
-    keyed by ``game_id`` makes ``finalize_game`` / ``record_game`` (double
-    stats) and ``advance_to_end`` (double podium TTS) fire at most once per
-    game. The loser skips straight to the broadcast its caller performs.
-
-    #1754: the claim is taken BEFORE the side effects (``record_game`` storage
-    I/O + ``advance_to_end``). If either raises, the claim is released so a
-    retry can re-run the terminal sequence instead of stranding the game in
-    REVEAL/PAUSED — then the error propagates to the caller.
-
-    #1725: before claiming/finalizing, offer a finale sudden-death tiebreaker.
-    When the host opted in and the game would end on a tie for first with
-    unplayed songs left, ``maybe_start_finale_playoff`` eliminates the non-tied
-    players and starts one more playoff round; the game stays in PLAYING and we
-    return WITHOUT finalizing, so the caller re-broadcasts the live round. On a
-    clear winner / 0 songs left / cap reached it's a no-op and the normal
-    finalize path runs.
-    """
-    if await game_state.maybe_start_finale_playoff():
-        _LOGGER.info("Finale tiebreaker armed — playoff round started, not ending")
-        return
-
-    if not handler._claim_game_end(game_state.game_id):
-        _LOGGER.debug("Game-end already claimed for %s — skipping", game_state.game_id)
-        return
-
-    try:
-        stats_service = handler.hass.data.get(DOMAIN, {}).get("stats")
-        if stats_service:
-            game_summary = game_state.finalize_game()
-            await stats_service.record_game(
-                game_summary, difficulty=game_state.difficulty
-            )
-            _LOGGER.debug("Game stats recorded")
-
-        await game_state.advance_to_end()
-    except Exception:
-        # #1754: release the claim so a retry re-runs the end sequence rather
-        # than hitting "already claimed" and stranding the game in REVEAL.
-        handler._release_game_end(game_state.game_id)
-        raise
 
 
 async def handle_admin_connect(
@@ -255,7 +205,7 @@ async def admin_next_round(
         if game_state.last_round:
             # #1702: finalize + record + advance run exactly once per game even
             # if both admin sockets reach here.
-            await _finalize_and_end(handler, game_state)
+            await finalize_and_end(handler, game_state)
             await handler.broadcast_state()
         else:
             success = await game_state.start_round()
@@ -272,7 +222,7 @@ async def admin_next_round(
                 )
                 await handler.broadcast_state()
             else:
-                await _finalize_and_end(handler, game_state)
+                await finalize_and_end(handler, game_state)
                 await handler.broadcast_state()
     else:
         await ws.send_json(
@@ -389,7 +339,7 @@ async def admin_end_game(
 
     # #1702: record + end ceremony run once per game (shared claim with the
     # next_round terminal path).
-    await _finalize_and_end(handler, game_state)
+    await finalize_and_end(handler, game_state)
     _LOGGER.info(
         "Admin ended game early at round %d - players preserved for rematch",
         game_state.round,

--- a/tests/unit/test_end_game_rest_final_standings_2442.py
+++ b/tests/unit/test_end_game_rest_final_standings_2442.py
@@ -1,0 +1,130 @@
+"""EndGameView must finalize before it tears the game down (#2442).
+
+`end_game()` clears the state. Broadcasting *after* it therefore serialises
+nothing, and the players never receive a `phase: END` — no podium, no
+scoreboard, no share card. The endpoint is the admin UI's fallback for a closed
+admin socket, so it runs exactly when the host's connection is already shaky.
+
+The order these tests pin down is: finalize → broadcast the END state →
+tear down → announce `game_ended`.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.beatify.const import DOMAIN
+from custom_components.beatify.game.state import GamePhase
+from custom_components.beatify.server.game_views import EndGameView
+
+
+def _hass(phase: GamePhase, *, with_ws: bool = True):
+    """Mock hass holding a game in `phase`, plus an optional WS handler."""
+    calls: list[str] = []
+
+    game = MagicMock()
+    game.game_id = "game-2442"
+    game.phase = phase
+    game.stop_media = AsyncMock(side_effect=lambda: calls.append("stop_media"))
+    game.resolve_title_artist_if_pending = AsyncMock(
+        side_effect=lambda: calls.append("resolve_title_artist")
+    )
+    game.advance_to_end = AsyncMock(side_effect=lambda: calls.append("advance_to_end"))
+    game.end_game = AsyncMock(side_effect=lambda: calls.append("end_game"))
+
+    ws = None
+    if with_ws:
+        ws = MagicMock()
+        ws.broadcast_state = AsyncMock(
+            side_effect=lambda: calls.append("broadcast_state")
+        )
+        ws.broadcast = AsyncMock(
+            side_effect=lambda msg: calls.append(f"broadcast:{msg['type']}")
+        )
+
+    hass = MagicMock()
+    hass.data = {DOMAIN: {"game": game, "ws_handler": ws}}
+    return hass, game, ws, calls
+
+
+def _request():
+    request = MagicMock()
+    request.remote = "1.2.3.4"
+    return request
+
+
+@pytest.fixture
+def authorized():
+    with patch(
+        "custom_components.beatify.server.game_views.is_authorized_http",
+        return_value=True,
+    ):
+        yield
+
+
+@pytest.mark.usefixtures("authorized")
+class TestEndGameRestFinalStandings:
+    @pytest.mark.parametrize(
+        "phase", [GamePhase.PLAYING, GamePhase.REVEAL, GamePhase.PAUSED]
+    )
+    async def test_end_state_is_broadcast_before_teardown(self, phase):
+        """The END state has to leave the server while there is still a game."""
+        hass, game, ws, calls = _hass(phase)
+        with patch(
+            "custom_components.beatify.server.game_views.finalize_and_end",
+            new=AsyncMock(side_effect=lambda *a, **k: calls.append("finalize")),
+        ):
+            resp = await EndGameView(hass).post(_request())
+
+        assert resp.status == 200
+        assert calls.index("finalize") < calls.index("broadcast_state")
+        assert calls.index("broadcast_state") < calls.index("end_game")
+        # game_ended is the cleanup signal and comes last, after the podium.
+        assert calls.index("broadcast_state") < calls.index("broadcast:game_ended")
+
+    async def test_playoff_is_not_armed(self):
+        """A teardown request must not start one more round (#1725)."""
+        hass, game, ws, calls = _hass(GamePhase.REVEAL)
+        spy = AsyncMock()
+        with patch(
+            "custom_components.beatify.server.game_views.finalize_and_end", new=spy
+        ):
+            await EndGameView(hass).post(_request())
+
+        assert spy.await_count == 1
+        assert spy.await_args.kwargs["allow_playoff"] is False
+
+    async def test_last_round_scoring_is_resolved_first(self):
+        """Title/artist scoring is deferred; without this the podium loses a round."""
+        hass, game, ws, calls = _hass(GamePhase.REVEAL)
+        with patch(
+            "custom_components.beatify.server.game_views.finalize_and_end",
+            new=AsyncMock(side_effect=lambda *a, **k: calls.append("finalize")),
+        ):
+            await EndGameView(hass).post(_request())
+
+        assert calls.index("resolve_title_artist") < calls.index("finalize")
+        game.stop_media.assert_awaited_once()
+
+    async def test_lobby_game_is_only_torn_down(self):
+        """Nothing was played, so there is no podium to send."""
+        hass, game, ws, calls = _hass(GamePhase.LOBBY)
+        spy = AsyncMock()
+        with patch(
+            "custom_components.beatify.server.game_views.finalize_and_end", new=spy
+        ):
+            resp = await EndGameView(hass).post(_request())
+
+        assert resp.status == 200
+        spy.assert_not_awaited()
+        assert calls == ["end_game", "broadcast:game_ended"]
+
+    async def test_without_ws_handler_the_game_still_ends(self):
+        """No sockets to serve, but the state must still reach END and tear down."""
+        hass, game, ws, calls = _hass(GamePhase.PLAYING, with_ws=False)
+        resp = await EndGameView(hass).post(_request())
+
+        assert resp.status == 200
+        assert calls.index("advance_to_end") < calls.index("end_game")

--- a/tests/unit/test_round_advance_serialization.py
+++ b/tests/unit/test_round_advance_serialization.py
@@ -29,7 +29,7 @@ from custom_components.beatify.server.ws_handlers import (
     admin_next_round,
     admin_rematch_game,
 )
-from custom_components.beatify.server.ws_handlers.admin import _finalize_and_end
+from custom_components.beatify.server.ws_handlers._helpers import finalize_and_end
 from tests.conftest import make_game_state
 from tests.unit.test_websocket import _make_handler_and_game, _make_ws
 
@@ -225,7 +225,7 @@ class TestAdminDisconnectTaskCleanup:
 def _wire_game_end(handler, game_state) -> None:
     """Wire the terminal game-end callback exactly like setup does."""
     game_state.set_game_end_callback(
-        functools.partial(_finalize_and_end, handler, game_state)
+        functools.partial(finalize_and_end, handler, game_state)
     )
 
 

--- a/tests/unit/test_ws_handler_error_frame_2336.py
+++ b/tests/unit/test_ws_handler_error_frame_2336.py
@@ -5,7 +5,7 @@ loggte beides als ``Failed to parse WebSocket message``. Das beschreibt den
 Fehler nicht nur ungenau — es **zeigt auf die falsche Partei**. Wer die Zeile
 liest, schliesst auf einen Client, der kaputtes JSON schickt, und sucht dort.
 
-Sichtbar wurde es an ``_finalize_and_end``: das wirft **absichtlich** weiter
+Sichtbar wurde es an ``finalize_and_end``: das wirft **absichtlich** weiter
 (#1754), damit der Game-End-Claim freigegeben wird und ein zweiter Versuch die
 Endsequenz erneut fahren kann. Der Entwurf stimmt — aber der Admin bekam kein
 Frame zurueck, also war „Spiel beenden" ein toter Knopf mit einer irrefuehrenden


### PR DESCRIPTION
Closes #2442

## The change

`EndGameView` now finalizes before it clears, mirroring what the WebSocket path already did:

```python
if game_state.phase in (GamePhase.PLAYING, GamePhase.REVEAL, GamePhase.PAUSED):
    await game_state.stop_media()
    await game_state.resolve_title_artist_if_pending()
    if ws_handler:
        await finalize_and_end(ws_handler, game_state, allow_playoff=False)
        await ws_handler.broadcast_state()      # the END state, with the podium
    else:
        await game_state.advance_to_end()

await game_state.end_game()                     # teardown, unchanged
if ws_handler:
    await ws_handler.broadcast({"type": "game_ended"})
```

`game_ended` stays, and stays last. The player client's handler for it leaves an already-visible end view alone, so the podium it just rendered survives the cleanup signal.

## Three decisions worth reviewing

**The helper moved rather than being imported across modules.** `_finalize_and_end` lived in `ws_handlers/admin.py`, and `__init__.py`, `game_views.py` and two tests already reached into that module for it. It is now `finalize_and_end` in `ws_handlers/_helpers.py`, next to the other cross-handler helpers. Its one-shot claim keyed by `game_id` is what stops `record_game` and the podium TTS from firing twice when the auto-advance and an admin socket race — the REST path needs that guarantee as much as the others, which is the actual reason to share it rather than inline a second copy.

**`allow_playoff=False` is used by this endpoint only.** The #1725 finale tiebreaker can arm one more round instead of ending. That is right for the WebSocket path and wrong here: this endpoint tears the game down in the same request, so a playoff would be armed and immediately destroyed, and the response would claim success on a game that was supposed to continue. The WebSocket path is untouched and still offers the tiebreaker.

**LOBBY is left alone.** A game that never started has no standings, so the phase guard skips straight to teardown — same three phases the WebSocket handler accepts.

## Verification

- `pytest tests/` — **2132 passed**, 2 skipped (2125 before, +7 new).
- `ruff check` and `ruff format --check` clean over `custom_components` and `tests`.
- New `tests/unit/test_end_game_rest_final_standings_2442.py` pins the ordering: finalize → END broadcast → teardown → `game_ended`, plus the playoff argument, the deferred-scoring resolution, the LOBBY case and the no-socket case.

**On what the tests prove:** they lock the order this PR introduces. The defect itself was reproduced on a live install (4.4.0-rc2, real speaker) twice — once inside a full end-to-end run and once with a probe that recorded every message after `end-game` and received exactly one, `game_ended`. The unit tests are the regression guard, not the original evidence.

## Not covered

The frontend is untouched. If the player client should render a podium from `game_ended` alone as a belt-and-braces measure, that is a separate change — this PR fixes the server, which is where the state went missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184GyBkpCUC8uNJsDnp6rjv