### PR TITLE
chore(playlists): deezer backfill — +3 deezer uris

### DIFF
--- a/custom_components/beatify/playlists/community/clasicos-disney-castellano.json
+++ b/custom_components/beatify/playlists/community/clasicos-disney-castellano.json
@@ -1,6 +1,6 @@
 {
   "name": "Clásicos Disney (Castellano)",
-  "version": "0.3",
+  "version": "0.4",
   "tags": [
     "disney",
     "movies",
@@ -362,7 +362,9 @@
         "Malú",
         "Sleeping Beauty"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «La Bella Durmiente» della Disney (1959)."
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella Durmiente» della Disney (1959).",
+      "uri_apple_music": "applemusic://track/1443804803",
+      "uri_deezer": "deezer://track/1761711397"
     },
     {
       "year": 1995,
@@ -715,7 +717,8 @@
         "Gipsy Kings",
         "Jesús Aguirre"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «La Bella Durmiente» della Disney (1959)."
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella Durmiente» della Disney (1959).",
+      "uri_apple_music": "applemusic://track/1561428721"
     },
     {
       "year": 2016,
@@ -751,7 +754,8 @@
         "Carmen López",
         "Marco Antonio Solís"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Mulán» della Disney (1998)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Mulán» della Disney (1998).",
+      "uri_deezer": "deezer://track/613917582"
     },
     {
       "year": 1937,

--- a/custom_components/beatify/playlists/community/disney-latino.json
+++ b/custom_components/beatify/playlists/community/disney-latino.json
@@ -1,6 +1,6 @@
 {
   "name": "Disney Latino",
-  "version": "0.2",
+  "version": "0.3",
   "tags": [
     "disney",
     "movies",
@@ -629,7 +629,8 @@
         "Marco Antonio Solís",
         "Olga Lucía Vives"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Tini: El gran cambio de Violetta» della Disney (2016)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Tini: El gran cambio de Violetta» della Disney (2016).",
+      "uri_deezer": "deezer://track/123791408"
     },
     {
       "year": 2019,


### PR DESCRIPTION
A `provider-uri-backfill` run focused on Deezer, driven automatically by `com.beatify.deezer-backfill`.

- `clasicos-disney-castellano` Deezer 35 -> **37**/64
- `disney-latino` Deezer 37 -> **38**/54

Filled in along the way, because Odesli answers with every provider at once: apple +2.

**The run stopped at its cap rather than finishing** (`reached --max-minutes 35`). The remaining tracks of the playlist are untouched and are not a catalogue gap.

**Draft on purpose** — merged only once the maintainer approves. This agent has deliberately NO auto-merge.