### PR TITLE
data(movies): first batch from the HITSTER Soundtracks request (#2377)

### DIFF
--- a/custom_components/beatify/playlists/movies-100-greatest-themes.json
+++ b/custom_components/beatify/playlists/movies-100-greatest-themes.json
@@ -1,6 +1,6 @@
 {
   "name": "Movie & TV Soundtracks 🎬",
-  "version": "1.26",
+  "version": "1.27",
   "tags": [
     "movies",
     "soundtrack",
@@ -8065,6 +8065,310 @@
       "fun_fact_fr": "Chantée dans A Star Is Born au moment où le personnage a déjà gagné et où la relation commence déjà à perdre. Gaga l'a écrite avec trois auteurs de Nashville.",
       "fun_fact_nl": "Gezongen in A Star Is Born op het punt waar het personage al gewonnen heeft en de relatie al begint te verliezen. Gaga schreef het met drie songwriters uit Nashville.",
       "fun_fact_it": "Cantata in A Star Is Born nel punto in cui il personaggio ha già vinto e la relazione comincia già a perdere. Gaga la scrisse con tre autori di Nashville."
+    },
+    {
+      "artist": "Doris Day",
+      "title": "Que Sera Sera (Whatever Will Be, Will Be)",
+      "year": 1956,
+      "uri": "spotify:track:4Ylqc711Eq763XbTAOABu3",
+      "uri_apple_music": "applemusic://track/1500610595",
+      "uri_deezer": "deezer://track/10317163",
+      "isrc": "GBZTD1101612",
+      "alt_artists": [
+        "Peggy Lee",
+        "Rosemary Clooney"
+      ],
+      "fun_fact": "Written for Hitchcock's The Man Who Knew Too Much, where Day sings it to be heard by her kidnapped son two floors up. It won the Oscar and became her signature.",
+      "fun_fact_de": "Für Hitchcocks Der Mann, der zuviel wußte geschrieben, wo Day es singt, damit ihr entführter Sohn zwei Stockwerke höher sie hört. Es gewann den Oscar und wurde ihr Erkennungslied.",
+      "fun_fact_es": "Escrita para El hombre que sabía demasiado de Hitchcock, donde Day la canta para que su hijo secuestrado la oiga dos pisos más arriba. Ganó el Óscar y se convirtió en su seña de identidad.",
+      "fun_fact_fr": "Écrite pour L'Homme qui en savait trop de Hitchcock, où Day la chante pour être entendue de son fils enlevé, deux étages plus haut. Elle a remporté l'Oscar et est devenue sa signature.",
+      "fun_fact_nl": "Geschreven voor Hitchcocks The Man Who Knew Too Much, waarin Day het zingt zodat haar ontvoerde zoon twee verdiepingen hoger haar hoort. Het won de Oscar en werd haar herkenningsmelodie.",
+      "fun_fact_it": "Scritta per L'uomo che sapeva troppo di Hitchcock, dove la Day la canta perché il figlio rapito la senta due piani più su. Vinse l'Oscar e divenne il suo marchio."
+    },
+    {
+      "artist": "The Beatles",
+      "title": "Yellow Submarine",
+      "year": 1966,
+      "uri": "spotify:track:1tdltVUBkiBCW1C3yB4zyD",
+      "uri_apple_music": "applemusic://track/1441164526",
+      "uri_deezer": "deezer://track/116348724",
+      "isrc": "GBAYE0601677",
+      "alt_artists": [
+        "The Kinks",
+        "The Monkees"
+      ],
+      "fun_fact": "Ringo Starr sings it on Revolver, two years before the animated film took its name. The sound effects were built in the studio from chains, bells and a tin bath.",
+      "fun_fact_de": "Ringo Starr singt es auf Revolver, zwei Jahre bevor der Zeichentrickfilm seinen Namen davon nahm. Die Geräusche entstanden im Studio aus Ketten, Glocken und einer Blechwanne.",
+      "fun_fact_es": "Ringo Starr la canta en Revolver, dos años antes de que la película de animación tomara su nombre. Los efectos se construyeron en el estudio con cadenas, campanas y una bañera de hojalata.",
+      "fun_fact_fr": "Ringo Starr la chante sur Revolver, deux ans avant que le film d'animation n'en reprenne le titre. Les bruitages ont été fabriqués en studio avec des chaînes, des cloches et une baignoire en fer-blanc.",
+      "fun_fact_nl": "Ringo Starr zingt het op Revolver, twee jaar voordat de tekenfilm er zijn naam aan ontleende. De geluidseffecten werden in de studio gemaakt met kettingen, bellen en een blikken teil.",
+      "fun_fact_it": "Ringo Starr la canta in Revolver, due anni prima che il film d'animazione ne prendesse il nome. Gli effetti sonori furono costruiti in studio con catene, campanelli e una tinozza di latta."
+    },
+    {
+      "artist": "Monty Python",
+      "title": "Always Look On The Bright Side Of Life",
+      "year": 1979,
+      "uri": "spotify:track:4DEcdqqKokU7UAE4wCGQEy",
+      "uri_apple_music": "applemusic://track/724459701",
+      "uri_deezer": "deezer://track/3133043",
+      "isrc": "GBAAA7900265",
+      "alt_artists": [
+        "Eric Idle",
+        "The Rutles"
+      ],
+      "fun_fact": "Eric Idle wrote it to be whistled from a cross at the end of Life of Brian. It has since been sung at football grounds and, often enough, at funerals.",
+      "fun_fact_de": "Eric Idle schrieb es, damit es am Ende von Das Leben des Brian vom Kreuz herab gepfiffen wird. Seither wird es in Fußballstadien gesungen und, oft genug, auf Beerdigungen.",
+      "fun_fact_es": "Eric Idle la escribió para que se silbara desde una cruz al final de La vida de Brian. Desde entonces se canta en los estadios de fútbol y, con bastante frecuencia, en los funerales.",
+      "fun_fact_fr": "Eric Idle l'a écrite pour être sifflée depuis une croix à la fin de La Vie de Brian. Depuis, on la chante dans les stades de football et, assez souvent, aux enterrements.",
+      "fun_fact_nl": "Eric Idle schreef het om aan het eind van Life of Brian vanaf een kruis gefloten te worden. Sindsdien wordt het gezongen in voetbalstadions en, vaak genoeg, op begrafenissen.",
+      "fun_fact_it": "Eric Idle la scrisse perché fosse fischiettata da una croce alla fine di Brian di Nazareth. Da allora si canta negli stadi di calcio e, abbastanza spesso, ai funerali."
+    },
+    {
+      "artist": "Gary Portnoy",
+      "title": "Where Everybody Knows Your Name (Cheers Theme)",
+      "year": 1982,
+      "uri": "spotify:track:2uE8l7sar0JT0tZYhrPz8S",
+      "uri_apple_music": "applemusic://track/7197543",
+      "uri_deezer": "deezer://track/2083623",
+      "isrc": "USA560319104",
+      "alt_artists": [
+        "Jonathan Wolff",
+        "Vic Mizzy"
+      ],
+      "fun_fact": "Portnoy and Judy Hart Angelo wrote it after an earlier song for the series was rejected. The bar it describes was modelled on a real one in Boston.",
+      "fun_fact_de": "Portnoy und Judy Hart Angelo schrieben es, nachdem ein früheres Lied für die Serie abgelehnt worden war. Die Kneipe, die es beschreibt, hat ein reales Vorbild in Boston.",
+      "fun_fact_es": "Portnoy y Judy Hart Angelo la escribieron después de que rechazaran una canción anterior para la serie. El bar que describe tiene un modelo real en Boston.",
+      "fun_fact_fr": "Portnoy et Judy Hart Angelo l'ont écrite après le refus d'une première chanson pour la série. Le bar qu'elle décrit a un modèle réel à Boston.",
+      "fun_fact_nl": "Portnoy en Judy Hart Angelo schreven het nadat een eerder lied voor de serie was afgewezen. De kroeg die het beschrijft heeft een echt voorbeeld in Boston.",
+      "fun_fact_it": "Portnoy e Judy Hart Angelo la scrissero dopo che una canzone precedente per la serie era stata rifiutata. Il bar che descrive ha un modello reale a Boston."
+    },
+    {
+      "artist": "Harold Faltermeyer",
+      "title": "Axel F",
+      "year": 1984,
+      "uri": "spotify:track:5w4DKOH3EsOPUuoHXieLtB",
+      "uri_apple_music": "applemusic://track/1458388103",
+      "uri_deezer": "deezer://track/80538212",
+      "isrc": "USMC18416586",
+      "alt_artists": [
+        "Jan Hammer",
+        "Giorgio Moroder"
+      ],
+      "fun_fact": "The Munich-born Faltermeyer built the Beverly Hills Cop theme on a Roland Jupiter-8 and named it after Eddie Murphy's character. It became a hit as an instrumental, which was unusual then and is rarer now.",
+      "fun_fact_de": "Der Münchner Faltermeyer baute das Thema zu Beverly Hills Cop auf einem Roland Jupiter-8 und benannte es nach Eddie Murphys Figur. Es wurde als Instrumentalstück ein Hit — damals ungewöhnlich, heute noch seltener.",
+      "fun_fact_es": "El muniqués Faltermeyer construyó el tema de Superdetective en Hollywood con un Roland Jupiter-8 y lo bautizó con el nombre del personaje de Eddie Murphy. Triunfó como instrumental, algo insólito entonces y aún más raro hoy.",
+      "fun_fact_fr": "Le Munichois Faltermeyer a bâti le thème du Flic de Beverly Hills sur un Roland Jupiter-8 et l'a nommé d'après le personnage d'Eddie Murphy. Il est devenu un tube en instrumental, chose inhabituelle alors et plus rare encore aujourd'hui.",
+      "fun_fact_nl": "De uit München afkomstige Faltermeyer bouwde het thema van Beverly Hills Cop op een Roland Jupiter-8 en noemde het naar het personage van Eddie Murphy. Het werd een hit als instrumentaal, toen ongebruikelijk en nu nog zeldzamer.",
+      "fun_fact_it": "Il monacense Faltermeyer costruì il tema di Beverly Hills Cop su un Roland Jupiter-8 e lo intitolò al personaggio di Eddie Murphy. Divenne un successo da strumentale, cosa insolita allora e ancor più rara oggi."
+    },
+    {
+      "artist": "John Barry",
+      "title": "I Had A Farm (Main Title) - From \"Out Of Africa\"",
+      "year": 1985,
+      "uri": "spotify:track:6qLLYJGpPhHPF7M4o53qJB",
+      "uri_apple_music": "applemusic://track/1440735219",
+      "uri_deezer": "deezer://track/119876610",
+      "isrc": "US3M59781601",
+      "alt_artists": [
+        "Maurice Jarre",
+        "Ennio Morricone"
+      ],
+      "fun_fact": "Barry had already written five Bond scores when he wrote this one, and it won him his fourth Oscar. The theme takes its title from the film's first spoken line.",
+      "fun_fact_de": "Barry hatte schon fünf Bond-Partituren geschrieben, als diese entstand, und sie brachte ihm seinen vierten Oscar. Das Thema trägt den Titel des ersten gesprochenen Satzes im Film.",
+      "fun_fact_es": "Barry ya había escrito cinco bandas sonoras de Bond cuando compuso esta, que le valió su cuarto Óscar. El tema toma su título de la primera frase hablada de la película.",
+      "fun_fact_fr": "Barry avait déjà écrit cinq partitions de Bond quand il a composé celle-ci, qui lui a valu son quatrième Oscar. Le thème tire son titre de la première réplique du film.",
+      "fun_fact_nl": "Barry had al vijf Bond-partituren geschreven toen hij deze componeerde, die hem zijn vierde Oscar opleverde. Het thema ontleent zijn titel aan de eerste gesproken zin van de film.",
+      "fun_fact_it": "Barry aveva già scritto cinque partiture di Bond quando compose questa, che gli valse il quarto Oscar. Il tema prende il titolo dalla prima battuta del film."
+    },
+    {
+      "artist": "Berlin",
+      "title": "Take My Breath Away",
+      "year": 1986,
+      "uri": "spotify:track:15MJ5NThPjj6xhPcts8MiY",
+      "uri_apple_music": "applemusic://track/387194076",
+      "uri_deezer": "deezer://track/7675055",
+      "isrc": "USSM19801613",
+      "alt_artists": [
+        "Kenny Loggins",
+        "Survivor"
+      ],
+      "fun_fact": "Giorgio Moroder and Tom Whitlock wrote the love theme for Top Gun, and it won the Oscar over Kenny Loggins's Danger Zone from the same film.",
+      "fun_fact_de": "Giorgio Moroder und Tom Whitlock schrieben das Liebesthema für Top Gun, und es gewann den Oscar — gegen Kenny Loggins' Danger Zone aus demselben Film.",
+      "fun_fact_es": "Giorgio Moroder y Tom Whitlock escribieron el tema de amor de Top Gun, y ganó el Óscar por delante de Danger Zone de Kenny Loggins, de la misma película.",
+      "fun_fact_fr": "Giorgio Moroder et Tom Whitlock ont écrit le thème d'amour de Top Gun, qui a remporté l'Oscar devant Danger Zone de Kenny Loggins, tiré du même film.",
+      "fun_fact_nl": "Giorgio Moroder en Tom Whitlock schreven het liefdesthema voor Top Gun, en het won de Oscar vóór Danger Zone van Kenny Loggins uit dezelfde film.",
+      "fun_fact_it": "Giorgio Moroder e Tom Whitlock scrissero il tema d'amore di Top Gun, che vinse l'Oscar davanti a Danger Zone di Kenny Loggins, dallo stesso film."
+    },
+    {
+      "artist": "Queen",
+      "title": "Princes Of The Universe",
+      "year": 1986,
+      "uri": "spotify:track:0Uy8lcDHiPDicBQ7rnDgcK",
+      "uri_apple_music": "applemusic://track/6781081254",
+      "uri_deezer": "deezer://track/4091934451",
+      "isrc": "GBUM71103763",
+      "alt_artists": [
+        "Freddie Mercury",
+        "Brian May"
+      ],
+      "fun_fact": "Written for Highlander, a film Queen scored almost entirely. The line about there being only one belongs to the film and has outlived it as a phrase.",
+      "fun_fact_de": "Für Highlander geschrieben, einen Film, den Queen fast vollständig vertonten. Die Zeile davon, dass es nur einen geben kann, stammt aus dem Film und hat ihn als Redewendung überlebt.",
+      "fun_fact_es": "Escrita para Los inmortales, una película cuya música Queen firmó casi por completo. La frase sobre que solo puede quedar uno viene del filme y le ha sobrevivido como dicho.",
+      "fun_fact_fr": "Écrite pour Highlander, un film dont Queen a signé presque toute la musique. La réplique disant qu'il ne peut en rester qu'un vient du film et lui a survécu comme expression.",
+      "fun_fact_nl": "Geschreven voor Highlander, een film die Queen bijna volledig van muziek voorzag. De regel dat er maar één kan zijn komt uit de film en heeft hem als gezegde overleefd.",
+      "fun_fact_it": "Scritta per Highlander, film che i Queen musicarono quasi per intero. La battuta secondo cui ne può restare soltanto uno viene dal film e gli è sopravvissuta come modo di dire."
+    },
+    {
+      "artist": "Danny Elfman",
+      "title": "The Batman Theme",
+      "year": 1989,
+      "uri": "spotify:track:50csT5Qb2qOF7lHdDQ1Sbx",
+      "uri_apple_music": "applemusic://track/41229142",
+      "uri_deezer": "deezer://track/722927",
+      "isrc": "USWB10000074",
+      "alt_artists": [
+        "Hans Zimmer",
+        "Shirley Walker"
+      ],
+      "fun_fact": "Elfman's march for Tim Burton's Batman was carried straight into the animated series that followed, which is why a whole generation knows it from television rather than the cinema.",
+      "fun_fact_de": "Elfmans Marsch für Tim Burtons Batman wurde direkt in die anschließende Zeichentrickserie übernommen — weshalb ihn eine ganze Generation aus dem Fernsehen kennt und nicht aus dem Kino.",
+      "fun_fact_es": "La marcha de Elfman para el Batman de Tim Burton pasó directamente a la serie animada posterior, por lo que toda una generación la conoce por televisión y no por el cine.",
+      "fun_fact_fr": "La marche d'Elfman pour le Batman de Tim Burton est passée telle quelle dans la série animée qui a suivi, ce qui fait que toute une génération la connaît par la télévision et non par le cinéma.",
+      "fun_fact_nl": "Elfmans mars voor Tim Burtons Batman ging rechtstreeks over in de daaropvolgende tekenfilmserie, waardoor een hele generatie hem van televisie kent en niet uit de bioscoop.",
+      "fun_fact_it": "La marcia di Elfman per il Batman di Tim Burton passò direttamente nella serie animata successiva, ed è per questo che un'intera generazione la conosce dalla televisione e non dal cinema."
+    },
+    {
+      "artist": "DJ Jazzy Jeff & The Fresh Prince",
+      "title": "The Fresh Prince of Bel-Air",
+      "year": 1990,
+      "uri": "spotify:track:0UREO3QWbXJW3gOUXpK1am",
+      "uri_apple_music": "applemusic://track/206201765",
+      "uri_deezer": "deezer://track/13138687",
+      "isrc": "USJI19000013",
+      "alt_artists": [
+        "Run-DMC",
+        "Kid 'n Play"
+      ],
+      "fun_fact": "The theme tells the show's premise in under a minute, which was the point: a sitcom whose opening credits are also its exposition. Will Smith raps his own backstory.",
+      "fun_fact_de": "Die Titelmelodie erzählt die Prämisse der Serie in weniger als einer Minute — genau das war die Absicht: ein Vorspann, der zugleich die Vorgeschichte ist. Will Smith rappt seine eigene.",
+      "fun_fact_es": "La sintonía cuenta la premisa de la serie en menos de un minuto, y esa era la idea: unos créditos iniciales que son también la exposición. Will Smith rapea su propia historia previa.",
+      "fun_fact_fr": "Le générique raconte le principe de la série en moins d'une minute, et c'était l'intention : un générique qui fait aussi office d'exposition. Will Smith rappe sa propre histoire.",
+      "fun_fact_nl": "De tune vertelt de premisse van de serie in minder dan een minuut, en dat was de bedoeling: een titelsequentie die tegelijk de voorgeschiedenis is. Will Smith rapt zijn eigen verhaal.",
+      "fun_fact_it": "La sigla racconta la premessa della serie in meno di un minuto, ed era proprio l'intento: titoli di testa che sono anche l'antefatto. Will Smith rappa il proprio passato."
+    },
+    {
+      "artist": "Angelo Badalamenti",
+      "title": "Twin Peaks Theme",
+      "year": 1990,
+      "uri": "spotify:track:7FO7BolIZsl1o8DDSjeOph",
+      "uri_apple_music": "applemusic://track/374382372",
+      "uri_deezer": "deezer://track/7337260",
+      "isrc": "USWB10102633",
+      "alt_artists": [
+        "Julee Cruise",
+        "Michael Nyman"
+      ],
+      "fun_fact": "David Lynch sat beside Badalamenti and described a dark wood while the composer played. What came out of that session became the sound of the series and won a Grammy.",
+      "fun_fact_de": "David Lynch saß neben Badalamenti und beschrieb einen dunklen Wald, während der Komponist spielte. Was aus dieser Sitzung entstand, wurde der Klang der Serie und gewann einen Grammy.",
+      "fun_fact_es": "David Lynch se sentó junto a Badalamenti y le describió un bosque oscuro mientras el compositor tocaba. Lo que salió de aquella sesión se convirtió en el sonido de la serie y ganó un Grammy.",
+      "fun_fact_fr": "David Lynch s'est assis à côté de Badalamenti et lui a décrit une forêt sombre pendant qu'il jouait. Ce qui est sorti de cette séance est devenu le son de la série et a remporté un Grammy.",
+      "fun_fact_nl": "David Lynch zat naast Badalamenti en beschreef een donker bos terwijl de componist speelde. Wat uit die sessie kwam werd het geluid van de serie en won een Grammy.",
+      "fun_fact_it": "David Lynch sedette accanto a Badalamenti e gli descrisse un bosco scuro mentre il compositore suonava. Ciò che nacque da quella seduta divenne il suono della serie e vinse un Grammy."
+    },
+    {
+      "artist": "Alan Silvestri",
+      "title": "Forrest Gump Suite",
+      "year": 1994,
+      "uri": "spotify:track:655OjsI6LbHdo3565qEfbE",
+      "uri_apple_music": "applemusic://track/418557001",
+      "uri_deezer": "deezer://track/17479922",
+      "isrc": "USLIC0601869",
+      "alt_artists": [
+        "Thomas Newman",
+        "James Horner"
+      ],
+      "fun_fact": "The feather theme is a piano line that never resolves the way a listener expects, which is the film's argument about chance in a single melody.",
+      "fun_fact_de": "Das Federthema ist eine Klavierlinie, die sich nie so auflöst, wie man es erwartet — die Aussage des Films über den Zufall, in eine einzige Melodie gefasst.",
+      "fun_fact_es": "El tema de la pluma es una línea de piano que nunca resuelve como uno espera: el argumento de la película sobre el azar, condensado en una sola melodía.",
+      "fun_fact_fr": "Le thème de la plume est une ligne de piano qui ne se résout jamais comme on l'attend : le propos du film sur le hasard, tenu en une seule mélodie.",
+      "fun_fact_nl": "Het verenthema is een pianolijn die zich nooit oplost zoals je verwacht — het betoog van de film over toeval, gevat in één melodie.",
+      "fun_fact_it": "Il tema della piuma è una linea di pianoforte che non si risolve mai come ci si aspetta: la tesi del film sul caso, racchiusa in una sola melodia."
+    },
+    {
+      "artist": "Nicola Piovani",
+      "title": "La vita è bella",
+      "year": 1997,
+      "uri": "spotify:track:7ob7mrVX7FEQIT2gSClVtA",
+      "uri_apple_music": "applemusic://track/437514899",
+      "uri_deezer": "deezer://track/11554108",
+      "isrc": "IT0681100457",
+      "alt_artists": [
+        "Ennio Morricone",
+        "Nino Rota"
+      ],
+      "fun_fact": "Piovani won the Oscar for a score that has to be light enough for a father's game and heavy enough for what the game is hiding.",
+      "fun_fact_de": "Piovani gewann den Oscar für eine Musik, die leicht genug für das Spiel eines Vaters sein muss und schwer genug für das, was dieses Spiel verbirgt.",
+      "fun_fact_es": "Piovani ganó el Óscar por una partitura que ha de ser lo bastante ligera para el juego de un padre y lo bastante grave para lo que ese juego esconde.",
+      "fun_fact_fr": "Piovani a remporté l'Oscar pour une partition qui doit être assez légère pour le jeu d'un père et assez lourde pour ce que ce jeu dissimule.",
+      "fun_fact_nl": "Piovani won de Oscar voor muziek die licht genoeg moet zijn voor het spel van een vader en zwaar genoeg voor wat dat spel verbergt.",
+      "fun_fact_it": "Piovani vinse l'Oscar per una partitura che deve essere abbastanza leggera per il gioco di un padre e abbastanza grave per ciò che quel gioco nasconde."
+    },
+    {
+      "artist": "Hans Zimmer",
+      "title": "Now We Are Free",
+      "year": 2000,
+      "uri": "spotify:track:1elGwF4VwkwglV4nCBPJtv",
+      "uri_apple_music": "applemusic://track/1440563274",
+      "uri_deezer": "deezer://track/2919225",
+      "isrc": "USUMC0110060",
+      "alt_artists": [
+        "Lisa Gerrard",
+        "Klaus Badelt"
+      ],
+      "fun_fact": "Lisa Gerrard sings the closing piece of Gladiator in no language at all — syllables chosen for sound rather than meaning, a method she had used for years with Dead Can Dance.",
+      "fun_fact_de": "Lisa Gerrard singt das Schlussstück von Gladiator in gar keiner Sprache — Silben nach Klang statt nach Bedeutung gewählt, eine Methode, die sie jahrelang bei Dead Can Dance benutzt hatte.",
+      "fun_fact_es": "Lisa Gerrard canta la pieza final de Gladiator en ningún idioma: sílabas elegidas por su sonido y no por su significado, un método que llevaba años usando con Dead Can Dance.",
+      "fun_fact_fr": "Lisa Gerrard chante le morceau final de Gladiator dans aucune langue — des syllabes choisies pour leur son et non leur sens, une méthode qu'elle pratiquait depuis des années avec Dead Can Dance.",
+      "fun_fact_nl": "Lisa Gerrard zingt het slotstuk van Gladiator in geen enkele taal — lettergrepen gekozen om hun klank en niet om hun betekenis, een methode die ze jarenlang bij Dead Can Dance gebruikte.",
+      "fun_fact_it": "Lisa Gerrard canta il brano finale del Gladiatore in nessuna lingua: sillabe scelte per il suono e non per il significato, un metodo che usava da anni con i Dead Can Dance."
+    },
+    {
+      "artist": "Kyle Dixon & Michael Stein",
+      "title": "Stranger Things",
+      "year": 2016,
+      "uri": "spotify:track:0kwuKfWntoGh0EWyYb7Mpf",
+      "uri_apple_music": "applemusic://track/1651958175",
+      "uri_deezer": "deezer://track/130871168",
+      "isrc": "USLS51683401",
+      "alt_artists": [
+        "John Carpenter",
+        "Tangerine Dream"
+      ],
+      "fun_fact": "The two were in a synthesiser band in Austin when the Duffer brothers asked them for a title sequence. The arpeggio is a deliberate echo of John Carpenter's scores from the early eighties.",
+      "fun_fact_de": "Die beiden spielten in einer Synthesizer-Band in Austin, als die Duffer-Brüder sie um einen Vorspann baten. Das Arpeggio ist ein bewusstes Echo auf John Carpenters Musiken der frühen Achtziger.",
+      "fun_fact_es": "Los dos tocaban en una banda de sintetizadores en Austin cuando los hermanos Duffer les pidieron una cabecera. El arpegio es un eco deliberado de las partituras de John Carpenter de principios de los ochenta.",
+      "fun_fact_fr": "Tous deux jouaient dans un groupe de synthétiseurs à Austin quand les frères Duffer leur ont demandé un générique. L'arpège est un écho délibéré des partitions de John Carpenter du début des années quatre-vingt.",
+      "fun_fact_nl": "De twee speelden in een synthesizerband in Austin toen de gebroeders Duffer hun om een titelsequentie vroegen. Het arpeggio is een bewuste echo van John Carpenters muziek uit de vroege jaren tachtig.",
+      "fun_fact_it": "I due suonavano in una band di sintetizzatori ad Austin quando i fratelli Duffer chiesero loro una sigla. L'arpeggio è un'eco voluta delle partiture di John Carpenter dei primi anni Ottanta."
+    },
+    {
+      "artist": "Kendrick Lamar",
+      "title": "All The Stars (with SZA)",
+      "year": 2018,
+      "uri": "spotify:track:3GCdLUSnKSMJhs4Tj6CV3s",
+      "uri_apple_music": "applemusic://track/1773138034",
+      "uri_deezer": "deezer://track/446082632",
+      "isrc": "USUM71713947",
+      "alt_artists": [
+        "SZA",
+        "The Weeknd"
+      ],
+      "fun_fact": "Lamar curated the whole Black Panther album rather than writing a single song for it, which was unusual for a superhero film and set a pattern others followed.",
+      "fun_fact_de": "Lamar kuratierte das gesamte Black-Panther-Album, statt ein einzelnes Lied dafür zu schreiben — für einen Superheldenfilm ungewöhnlich und seither vielfach nachgeahmt.",
+      "fun_fact_es": "Lamar comisarió el álbum entero de Black Panther en lugar de escribir una sola canción, algo insólito en una película de superhéroes que después muchos imitaron.",
+      "fun_fact_fr": "Lamar a supervisé l'album entier de Black Panther plutôt que d'écrire une seule chanson, chose inhabituelle pour un film de super-héros et souvent imitée depuis.",
+      "fun_fact_nl": "Lamar stelde het hele Black Panther-album samen in plaats van er één lied voor te schrijven, wat ongebruikelijk was voor een superheldenfilm en daarna veel navolging kreeg.",
+      "fun_fact_it": "Lamar curò l'intero album di Black Panther invece di scrivere una sola canzone: cosa insolita per un film di supereroi, poi molto imitata."
     }
   ],
   "movie_quiz_enabled": true

--- a/custom_components/beatify/playlists/movies-100-greatest-themes.json
+++ b/custom_components/beatify/playlists/movies-100-greatest-themes.json
@@ -1,6 +1,6 @@
 {
   "name": "Movie & TV Soundtracks 🎬",
-  "version": "1.27",
+  "version": "1.28",
   "tags": [
     "movies",
     "soundtrack",
@@ -8369,6 +8369,310 @@
       "fun_fact_fr": "Lamar a supervisé l'album entier de Black Panther plutôt que d'écrire une seule chanson, chose inhabituelle pour un film de super-héros et souvent imitée depuis.",
       "fun_fact_nl": "Lamar stelde het hele Black Panther-album samen in plaats van er één lied voor te schrijven, wat ongebruikelijk was voor een superheldenfilm en daarna veel navolging kreeg.",
       "fun_fact_it": "Lamar curò l'intero album di Black Panther invece di scrivere una sola canzone: cosa insolita per un film di supereroi, poi molto imitata."
+    },
+    {
+      "artist": "Dick Dale & His Del-Tones",
+      "title": "Misirlou",
+      "year": 1962,
+      "uri": "spotify:track:6wmb6Mi0XcPEALiyCGWi2N",
+      "uri_apple_music": "applemusic://track/1533203882",
+      "uri_deezer": "deezer://track/7680019",
+      "isrc": "US29S0400634",
+      "alt_artists": [
+        "The Ventures",
+        "Link Wray"
+      ],
+      "fun_fact": "A Greek folk melody played on a Fender at a speed nobody had tried before. Tarantino put it under the opening titles of Pulp Fiction three decades later and gave it a second life.",
+      "fun_fact_de": "Eine griechische Volksweise, auf einer Fender in einem Tempo gespielt, das vorher niemand versucht hatte. Tarantino legte sie drei Jahrzehnte später unter den Vorspann von Pulp Fiction und gab ihr ein zweites Leben.",
+      "fun_fact_es": "Una melodía popular griega tocada en una Fender a una velocidad que nadie había intentado. Tarantino la puso bajo los títulos de Pulp Fiction tres décadas después y le dio una segunda vida.",
+      "fun_fact_fr": "Une mélodie populaire grecque jouée sur une Fender à une vitesse que personne n'avait tentée. Trente ans plus tard, Tarantino l'a placée sur le générique de Pulp Fiction et lui a offert une seconde vie.",
+      "fun_fact_nl": "Een Griekse volksmelodie op een Fender gespeeld in een tempo dat niemand eerder had geprobeerd. Tarantino zette hem drie decennia later onder de titels van Pulp Fiction en gaf hem een tweede leven.",
+      "fun_fact_it": "Una melodia popolare greca suonata su una Fender a una velocità che nessuno aveva tentato. Tarantino la mise sotto i titoli di testa di Pulp Fiction trent'anni dopo, dandole una seconda vita."
+    },
+    {
+      "artist": "Ennio Morricone",
+      "title": "The Good, The Bad and The Ugly",
+      "year": 1966,
+      "uri": "spotify:track:2IJJszwGK4NWmh3bNK6CPD",
+      "uri_apple_music": "applemusic://track/486088027",
+      "uri_deezer": "deezer://track/3089012",
+      "isrc": "USNPD0714249",
+      "alt_artists": [
+        "Nino Rota",
+        "Bruno Nicolai"
+      ],
+      "fun_fact": "The two-note coyote call was made with a human voice, an ocarina and an electric guitar. Morricone wrote the music before the film was shot, and Leone cut the scenes to fit it.",
+      "fun_fact_de": "Der zweitönige Kojotenruf entstand aus Menschenstimme, Okarina und E-Gitarre. Morricone schrieb die Musik vor dem Dreh, und Leone schnitt die Szenen darauf zu.",
+      "fun_fact_es": "El aullido de dos notas se hizo con voz humana, ocarina y guitarra eléctrica. Morricone escribió la música antes del rodaje, y Leone montó las escenas para que encajaran.",
+      "fun_fact_fr": "Le cri de coyote à deux notes a été fabriqué avec une voix humaine, un ocarina et une guitare électrique. Morricone a écrit la musique avant le tournage, et Leone a monté les scènes pour qu'elles s'y ajustent.",
+      "fun_fact_nl": "De tweetonige coyoteroep werd gemaakt met een menselijke stem, een ocarina en een elektrische gitaar. Morricone schreef de muziek vóór de opnames, en Leone monteerde de scènes erop.",
+      "fun_fact_it": "Il richiamo di coyote a due note fu ottenuto con voce umana, ocarina e chitarra elettrica. Morricone scrisse la musica prima delle riprese e Leone montò le scene per adattarle."
+    },
+    {
+      "artist": "Burt Bacharach",
+      "title": "Raindrops Keep Fallin' On My Head",
+      "year": 1969,
+      "uri": "spotify:track:039tOvW37VzuntOfrUVS8L",
+      "uri_apple_music": "applemusic://track/1443639296",
+      "uri_deezer": "deezer://track/1761620077",
+      "isrc": "USAM16900347",
+      "alt_artists": [
+        "Hal David",
+        "B.J. Thomas"
+      ],
+      "fun_fact": "Written for the bicycle scene in Butch Cassidy and the Sundance Kid, a sequence with no dialogue at all. It won the Oscar and Bacharach won a second the same evening for the score.",
+      "fun_fact_de": "Für die Fahrradszene in Zwei Banditen geschrieben, eine Sequenz ganz ohne Dialog. Es gewann den Oscar, und Bacharach gewann am selben Abend einen zweiten für die Filmmusik.",
+      "fun_fact_es": "Escrita para la escena de la bicicleta en Dos hombres y un destino, una secuencia sin diálogo alguno. Ganó el Óscar, y Bacharach ganó esa misma noche otro por la partitura.",
+      "fun_fact_fr": "Écrite pour la scène du vélo dans Butch Cassidy et le Kid, une séquence sans le moindre dialogue. Elle a remporté l'Oscar, et Bacharach en a gagné un second le même soir pour la partition.",
+      "fun_fact_nl": "Geschreven voor de fietsscène in Butch Cassidy and the Sundance Kid, een sequentie zonder enige dialoog. Het won de Oscar, en Bacharach won diezelfde avond een tweede voor de filmmuziek.",
+      "fun_fact_it": "Scritta per la scena della bicicletta in Butch Cassidy, una sequenza senza una sola battuta. Vinse l'Oscar, e Bacharach ne vinse un secondo la stessa sera per la colonna sonora."
+    },
+    {
+      "artist": "Nino Rota",
+      "title": "The Godfather Waltz",
+      "year": 1972,
+      "uri": "spotify:track:3WoSJF85H0qywD4qLp4HDd",
+      "uri_apple_music": "applemusic://track/1440844680",
+      "uri_deezer": "deezer://track/85456314",
+      "isrc": "CH6321405074",
+      "alt_artists": [
+        "Ennio Morricone",
+        "Carmine Coppola"
+      ],
+      "fun_fact": "Rota's waltz was disqualified from the Oscars because he had used part of it in an earlier Italian film. He won two years later for the sequel instead.",
+      "fun_fact_de": "Rotas Walzer wurde von den Oscars ausgeschlossen, weil er einen Teil davon in einem früheren italienischen Film verwendet hatte. Zwei Jahre später gewann er stattdessen für die Fortsetzung.",
+      "fun_fact_es": "El vals de Rota fue descalificado en los Óscar porque había usado parte de él en una película italiana anterior. Dos años después ganó por la segunda parte.",
+      "fun_fact_fr": "La valse de Rota a été disqualifiée aux Oscars parce qu'il en avait utilisé une partie dans un film italien antérieur. Il a gagné deux ans plus tard pour la suite.",
+      "fun_fact_nl": "Rota's wals werd van de Oscars uitgesloten omdat hij een deel ervan in een eerdere Italiaanse film had gebruikt. Twee jaar later won hij alsnog, voor het vervolg.",
+      "fun_fact_it": "Il valzer di Rota fu squalificato agli Oscar perché ne aveva usato una parte in un film italiano precedente. Vinse due anni dopo con il seguito."
+    },
+    {
+      "artist": "Gato Barbieri",
+      "title": "Last Tango in Paris",
+      "year": 1972,
+      "uri": "spotify:track:2dRjEirtMproK2r4gzda1j",
+      "uri_apple_music": "applemusic://track/865006383",
+      "uri_deezer": "deezer://track/77738472",
+      "isrc": "ITC460500427",
+      "alt_artists": [
+        "Astor Piazzolla",
+        "Stan Getz"
+      ],
+      "fun_fact": "The Argentine saxophonist recorded the score in a single week and won a Grammy for it. The tango is played rather than danced — the film keeps the music at arm's length from its characters.",
+      "fun_fact_de": "Der argentinische Saxofonist nahm die Musik in einer einzigen Woche auf und gewann dafür einen Grammy. Der Tango wird gespielt, nicht getanzt — der Film hält die Musik auf Abstand zu seinen Figuren.",
+      "fun_fact_es": "El saxofonista argentino grabó la partitura en una sola semana y ganó un Grammy. El tango se toca, no se baila: la película mantiene la música a distancia de sus personajes.",
+      "fun_fact_fr": "Le saxophoniste argentin a enregistré la partition en une seule semaine et remporté un Grammy. Le tango se joue et ne se danse pas — le film tient la musique à distance de ses personnages.",
+      "fun_fact_nl": "De Argentijnse saxofonist nam de muziek in één week op en won er een Grammy mee. De tango wordt gespeeld, niet gedanst — de film houdt de muziek op afstand van zijn personages.",
+      "fun_fact_it": "Il sassofonista argentino incise la partitura in una sola settimana e vinse un Grammy. Il tango si suona e non si balla: il film tiene la musica a distanza dai suoi personaggi."
+    },
+    {
+      "artist": "Barbra Streisand",
+      "title": "The Way We Were",
+      "year": 1973,
+      "uri": "spotify:track:1vZTgn4JXWMahR8r99ug5H",
+      "uri_apple_music": "applemusic://track/193022060",
+      "uri_deezer": "deezer://track/626294",
+      "isrc": "USSM10024187",
+      "alt_artists": [
+        "Bette Midler",
+        "Carole King"
+      ],
+      "fun_fact": "Streisand recorded two versions and the producers could not choose, so both were kept — one opens the film, the other closes it.",
+      "fun_fact_de": "Streisand nahm zwei Fassungen auf, und die Produzenten konnten sich nicht entscheiden, also blieben beide — eine eröffnet den Film, die andere beschließt ihn.",
+      "fun_fact_es": "Streisand grabó dos versiones y los productores no supieron elegir, así que se quedaron ambas: una abre la película y la otra la cierra.",
+      "fun_fact_fr": "Streisand a enregistré deux versions et les producteurs n'ont pas su choisir : les deux ont été gardées, l'une ouvre le film, l'autre le referme.",
+      "fun_fact_nl": "Streisand nam twee versies op en de producenten konden niet kiezen, dus bleven ze allebei — de ene opent de film, de andere sluit hem af.",
+      "fun_fact_it": "La Streisand incise due versioni e i produttori non seppero scegliere: rimasero entrambe, una apre il film e l'altra lo chiude."
+    },
+    {
+      "artist": "David Rose",
+      "title": "Little House On The Prairie",
+      "year": 1974,
+      "uri": "spotify:track:132I6UhRKQoslXIVSgoKuk",
+      "uri_apple_music": "applemusic://track/395793674",
+      "uri_deezer": "deezer://track/1541110502",
+      "isrc": "FXR022104627",
+      "alt_artists": [
+        "John Williams",
+        "Jerry Goldsmith"
+      ],
+      "fun_fact": "Rose had already written the music for Bonanza when he took on this series. The theme runs under an opening sequence of children rolling down a hill, and it has been shorthand for that image ever since.",
+      "fun_fact_de": "Rose hatte schon die Musik zu Bonanza geschrieben, als er diese Serie übernahm. Das Thema läuft unter einem Vorspann rollender Kinder am Hang — und steht seither als Kürzel für dieses Bild.",
+      "fun_fact_es": "Rose ya había escrito la música de Bonanza cuando aceptó esta serie. El tema suena bajo una cabecera de niñas rodando por una colina, y desde entonces es sinónimo de esa imagen.",
+      "fun_fact_fr": "Rose avait déjà écrit la musique de Bonanza quand il a pris cette série. Le thème accompagne un générique d'enfants dévalant une colline, et il en est resté le raccourci.",
+      "fun_fact_nl": "Rose had de muziek voor Bonanza al geschreven toen hij deze serie aannam. Het thema klinkt onder een titelsequentie van kinderen die van een heuvel rollen, en staat sindsdien voor dat beeld.",
+      "fun_fact_it": "Rose aveva già scritto la musica di Bonanza quando prese questa serie. Il tema accompagna una sigla di bambine che rotolano giù da una collina, e da allora ne è il simbolo."
+    },
+    {
+      "artist": "Jerry Goldsmith",
+      "title": "Star Trek - The Motion Picture: Main Title",
+      "year": 1979,
+      "uri": "spotify:track:43B5NwirruWiXQi5V1LaOd",
+      "uri_apple_music": "applemusic://track/49266664",
+      "uri_deezer": "deezer://track/119439166",
+      "isrc": "US3M50016302",
+      "alt_artists": [
+        "James Horner",
+        "John Williams"
+      ],
+      "fun_fact": "Goldsmith wrote this fanfare for the first Star Trek film, and it was later taken up as the theme for The Next Generation — a piece of music that outlasted the production it was made for.",
+      "fun_fact_de": "Goldsmith schrieb diese Fanfare für den ersten Star-Trek-Film; später wurde sie als Thema für Das nächste Jahrhundert übernommen — eine Musik, die ihre Produktion überlebt hat.",
+      "fun_fact_es": "Goldsmith escribió esta fanfarria para la primera película de Star Trek, y más tarde se adoptó como tema de La nueva generación: una música que sobrevivió a la producción para la que se hizo.",
+      "fun_fact_fr": "Goldsmith a écrit cette fanfare pour le premier film Star Trek ; elle a ensuite été reprise comme thème de La Nouvelle Génération — une musique qui a survécu à la production pour laquelle elle fut écrite.",
+      "fun_fact_nl": "Goldsmith schreef deze fanfare voor de eerste Star Trek-film; later werd ze overgenomen als thema voor The Next Generation — muziek die haar productie overleefde.",
+      "fun_fact_it": "Goldsmith scrisse questa fanfara per il primo film di Star Trek; fu poi ripresa come tema di The Next Generation, una musica sopravvissuta alla produzione per cui era nata."
+    },
+    {
+      "artist": "Stu Phillips",
+      "title": "Knight Rider Main Title",
+      "year": 1982,
+      "uri": "spotify:track:2R2gMe3zb9BgCdT2PZh1s3",
+      "uri_apple_music": "applemusic://track/1528121767",
+      "uri_deezer": "deezer://track/1053752862",
+      "isrc": "USQ4E1904295",
+      "alt_artists": [
+        "Jan Hammer",
+        "Mike Post"
+      ],
+      "fun_fact": "A synthesiser pulse for a series whose real star was a talking car. Phillips also wrote the theme for Battlestar Galactica, which is the other sound eighties television borrowed from him.",
+      "fun_fact_de": "Ein Synthesizer-Puls für eine Serie, deren eigentlicher Star ein sprechendes Auto war. Phillips schrieb auch das Thema zu Kampfstern Galactica — der andere Klang, den das Achtziger-Fernsehen bei ihm lieh.",
+      "fun_fact_es": "Un pulso de sintetizador para una serie cuya verdadera estrella era un coche que hablaba. Phillips escribió también el tema de Galáctica, el otro sonido que la televisión de los ochenta le tomó prestado.",
+      "fun_fact_fr": "Une pulsation de synthétiseur pour une série dont la vraie vedette était une voiture qui parle. Phillips a aussi écrit le thème de Galactica, l'autre son que la télévision des années quatre-vingt lui a emprunté.",
+      "fun_fact_nl": "Een synthesizerpuls voor een serie waarvan de echte ster een pratende auto was. Phillips schreef ook het thema van Battlestar Galactica, het andere geluid dat de jaren-tachtigtelevisie van hem leende.",
+      "fun_fact_it": "Un impulso di sintetizzatore per una serie la cui vera star era un'auto parlante. Phillips scrisse anche il tema di Galactica, l'altro suono che la televisione degli anni Ottanta gli prese in prestito."
+    },
+    {
+      "artist": "Harold Faltermeyer",
+      "title": "Top Gun Anthem",
+      "year": 1986,
+      "uri": "spotify:track:0Eodsilv1jAn83TGezUzaE",
+      "uri_apple_music": "applemusic://track/387194700",
+      "uri_deezer": "deezer://track/7675060",
+      "isrc": "USSM19904574",
+      "alt_artists": [
+        "Steve Stevens",
+        "Giorgio Moroder"
+      ],
+      "fun_fact": "Steve Stevens, better known as Billy Idol's guitarist, plays the solo. The piece won a Grammy and returned unchanged in the sequel thirty-six years later.",
+      "fun_fact_de": "Steve Stevens, besser bekannt als Billy Idols Gitarrist, spielt das Solo. Das Stück gewann einen Grammy und kehrte sechsunddreißig Jahre später unverändert in der Fortsetzung zurück.",
+      "fun_fact_es": "Steve Stevens, más conocido como guitarrista de Billy Idol, toca el solo. La pieza ganó un Grammy y volvió sin cambios en la secuela treinta y seis años después.",
+      "fun_fact_fr": "Steve Stevens, plus connu comme guitariste de Billy Idol, joue le solo. Le morceau a remporté un Grammy et est revenu inchangé dans la suite trente-six ans plus tard.",
+      "fun_fact_nl": "Steve Stevens, beter bekend als gitarist van Billy Idol, speelt de solo. Het stuk won een Grammy en keerde zesendertig jaar later ongewijzigd terug in het vervolg.",
+      "fun_fact_it": "Steve Stevens, più noto come chitarrista di Billy Idol, suona l'assolo. Il pezzo vinse un Grammy e tornò immutato nel seguito trentasei anni dopo."
+    },
+    {
+      "artist": "Inner Circle",
+      "title": "Bad Boys",
+      "year": 1987,
+      "uri": "spotify:track:1NojrDCqDLh4dWRZ7F589Q",
+      "uri_apple_music": "applemusic://track/1718311590",
+      "uri_deezer": "deezer://track/2557399732",
+      "isrc": "USA2P1004784",
+      "alt_artists": [
+        "Bob Marley",
+        "Shaggy"
+      ],
+      "fun_fact": "Written by a Jamaican reggae band years before the American documentary series Cops adopted it. The question in the chorus is now inseparable from footage neither the band nor the song had anything to do with.",
+      "fun_fact_de": "Von einer jamaikanischen Reggaeband geschrieben, Jahre bevor die amerikanische Doku-Serie Cops es übernahm. Die Frage im Refrain ist heute untrennbar mit Bildern verbunden, mit denen weder Band noch Lied etwas zu tun hatten.",
+      "fun_fact_es": "Escrita por una banda jamaicana de reggae años antes de que la serie documental estadounidense Cops la adoptara. La pregunta del estribillo es hoy inseparable de unas imágenes ajenas a la banda y a la canción.",
+      "fun_fact_fr": "Écrite par un groupe de reggae jamaïcain des années avant que la série documentaire américaine Cops ne l'adopte. La question du refrain est aujourd'hui indissociable d'images étrangères au groupe comme à la chanson.",
+      "fun_fact_nl": "Geschreven door een Jamaicaanse reggaeband, jaren voordat de Amerikaanse documentaireserie Cops het overnam. De vraag in het refrein is nu onlosmakelijk verbonden met beelden waar band noch lied iets mee te maken had.",
+      "fun_fact_it": "Scritta da una band reggae giamaicana anni prima che la serie documentaria americana Cops la adottasse. La domanda del ritornello è oggi inseparabile da immagini estranee sia al gruppo sia alla canzone."
+    },
+    {
+      "artist": "Madonna",
+      "title": "Who's That Girl",
+      "year": 1987,
+      "uri": "spotify:track:3G0NNqwQ1sqRpySr6soHlH",
+      "uri_apple_music": "applemusic://track/953642",
+      "uri_deezer": "deezer://track/4094775",
+      "isrc": "USWB10002766",
+      "alt_artists": [
+        "Cyndi Lauper",
+        "Kim Wilde"
+      ],
+      "fun_fact": "The film was a failure and the song went to number one anyway. Madonna sings part of it in Spanish, which was unusual for an American number one that year.",
+      "fun_fact_de": "Der Film floppte, das Lied ging trotzdem auf Platz eins. Madonna singt einen Teil auf Spanisch — für eine amerikanische Nummer eins jenes Jahres ungewöhnlich.",
+      "fun_fact_es": "La película fracasó y la canción llegó igualmente al número uno. Madonna canta parte en español, algo insólito en un número uno estadounidense de aquel año.",
+      "fun_fact_fr": "Le film a échoué et la chanson est tout de même montée en tête. Madonna en chante une partie en espagnol, chose inhabituelle pour un numéro un américain cette année-là.",
+      "fun_fact_nl": "De film flopte en het nummer werd toch nummer één. Madonna zingt een deel in het Spaans, ongebruikelijk voor een Amerikaanse nummer één van dat jaar.",
+      "fun_fact_it": "Il film fu un insuccesso e la canzone arrivò comunque al primo posto. Madonna ne canta una parte in spagnolo, cosa insolita per un numero uno americano di quell'anno."
+    },
+    {
+      "artist": "James Horner",
+      "title": "Willow's Theme",
+      "year": 1988,
+      "uri": "spotify:track:2Dy9bSUlnypC8Rm5O1iTOZ",
+      "uri_apple_music": "applemusic://track/1687005036",
+      "uri_deezer": "deezer://track/2281044207",
+      "isrc": "USWD12214295",
+      "alt_artists": [
+        "John Williams",
+        "Basil Poledouris"
+      ],
+      "fun_fact": "Horner borrowed openly from Schumann's Rhenish symphony for the main theme, which he said afterwards he would have handled differently. The score is still among the most performed of his early work.",
+      "fun_fact_de": "Horner lehnte sich beim Hauptthema offen an Schumanns Rheinische an, was er später anders gemacht hätte, wie er sagte. Die Musik gehört trotzdem zu den meistgespielten seines Frühwerks.",
+      "fun_fact_es": "Horner se apoyó abiertamente en la Renana de Schumann para el tema principal, algo que después dijo que habría resuelto de otro modo. La partitura sigue entre las más interpretadas de su obra temprana.",
+      "fun_fact_fr": "Horner s'est ouvertement appuyé sur la Rhénane de Schumann pour le thème principal, ce qu'il aurait, dit-il plus tard, traité autrement. La partition reste parmi les plus jouées de ses débuts.",
+      "fun_fact_nl": "Horner leunde voor het hoofdthema openlijk op Schumanns Rijnlandse, iets wat hij later naar eigen zeggen anders zou hebben aangepakt. De partituur behoort nog altijd tot de meest gespeelde uit zijn vroege werk.",
+      "fun_fact_it": "Horner si appoggiò apertamente alla Renana di Schumann per il tema principale, cosa che disse poi che avrebbe trattato diversamente. La partitura resta tra le più eseguite del suo primo periodo."
+    },
+    {
+      "artist": "Annie Lennox",
+      "title": "Love Song for a Vampire",
+      "year": 1992,
+      "uri": "spotify:track:3ik79qXV15D3ae33uveasw",
+      "uri_apple_music": "applemusic://track/158458647",
+      "uri_deezer": "deezer://track/1068248",
+      "isrc": "USSM10028116",
+      "alt_artists": [
+        "Kate Bush",
+        "Sinéad O'Connor"
+      ],
+      "fun_fact": "Lennox wrote it for the closing credits of Coppola's Dracula, her first release after leaving Eurythmics. The film has no other song in it at all.",
+      "fun_fact_de": "Lennox schrieb es für den Abspann von Coppolas Dracula — ihre erste Veröffentlichung nach dem Ende von Eurythmics. Der Film enthält sonst kein einziges Lied.",
+      "fun_fact_es": "Lennox la escribió para los créditos finales del Drácula de Coppola, su primera publicación tras dejar Eurythmics. La película no contiene ninguna otra canción.",
+      "fun_fact_fr": "Lennox l'a écrite pour le générique de fin du Dracula de Coppola, sa première parution après Eurythmics. Le film ne contient aucune autre chanson.",
+      "fun_fact_nl": "Lennox schreef het voor de aftiteling van Coppola's Dracula, haar eerste uitgave na Eurythmics. De film bevat verder geen enkel lied.",
+      "fun_fact_it": "La Lennox la scrisse per i titoli di coda del Dracula di Coppola, la sua prima uscita dopo gli Eurythmics. Il film non contiene nessun'altra canzone."
+    },
+    {
+      "artist": "Eric Clapton",
+      "title": "Change the World",
+      "year": 1996,
+      "uri": "spotify:track:5Ds0VGkTSQ1jf4KzLUpZPb",
+      "uri_apple_music": "applemusic://track/1648144410",
+      "uri_deezer": "deezer://track/1940201257",
+      "isrc": "USRE19600049",
+      "alt_artists": [
+        "Babyface",
+        "Sting"
+      ],
+      "fun_fact": "Produced by Babyface for the film Phenomenon, and it won Record of the Year at the Grammys — a soundtrack single beating everything released as an album track that year.",
+      "fun_fact_de": "Von Babyface für den Film Phenomenon produziert, und es gewann bei den Grammys die Aufnahme des Jahres — eine Soundtrack-Single, die alles schlug, was in jenem Jahr als Albumtitel erschien.",
+      "fun_fact_es": "Producida por Babyface para la película Phenomenon, ganó el Grammy a la grabación del año: un sencillo de banda sonora por delante de todo lo publicado como tema de álbum aquel año.",
+      "fun_fact_fr": "Produite par Babyface pour le film Phénomène, elle a remporté le Grammy de l'enregistrement de l'année — un single de bande originale devant tout ce qui est paru en album cette année-là.",
+      "fun_fact_nl": "Geproduceerd door Babyface voor de film Phenomenon, en het won de Grammy voor opname van het jaar — een soundtracksingle die alles versloeg wat dat jaar als albumtrack verscheen.",
+      "fun_fact_it": "Prodotta da Babyface per il film Phenomenon, vinse il Grammy come registrazione dell'anno: un singolo da colonna sonora davanti a tutto ciò che uscì come brano d'album quell'anno."
+    },
+    {
+      "artist": "Randy Newman",
+      "title": "Monsters, Inc.",
+      "year": 2001,
+      "uri": "spotify:track:5e0O7MjhNHq9G67qDFM8nR",
+      "uri_apple_music": "applemusic://track/724376322",
+      "uri_deezer": "deezer://track/3203370",
+      "isrc": "USWD10321170",
+      "alt_artists": [
+        "Thomas Newman",
+        "Alan Silvestri"
+      ],
+      "fun_fact": "Newman had been nominated fifteen times without winning before this song took the Oscar. He opened his acceptance speech by thanking the Academy for not making him wait for a sixteenth.",
+      "fun_fact_de": "Newman war fünfzehnmal nominiert gewesen, ohne zu gewinnen, bevor dieses Lied den Oscar holte. Seine Dankesrede begann er damit, der Akademie dafür zu danken, ihn nicht auf ein sechzehntes Mal warten zu lassen.",
+      "fun_fact_es": "Newman había sido nominado quince veces sin ganar antes de que esta canción se llevara el Óscar. Empezó su discurso agradeciendo a la Academia que no le hiciera esperar a una decimosexta.",
+      "fun_fact_fr": "Newman avait été nommé quinze fois sans gagner avant que cette chanson ne remporte l'Oscar. Il a ouvert son discours en remerciant l'Académie de ne pas lui avoir imposé une seizième attente.",
+      "fun_fact_nl": "Newman was vijftien keer genomineerd zonder te winnen voordat dit lied de Oscar pakte. Hij opende zijn dankwoord door de Academy te bedanken dat ze hem geen zestiende keer lieten wachten.",
+      "fun_fact_it": "Newman era stato candidato quindici volte senza vincere prima che questa canzone prendesse l'Oscar. Aprì il discorso ringraziando l'Academy per non avergli fatto attendere una sedicesima."
     }
   ],
   "movie_quiz_enabled": true

--- a/custom_components/beatify/playlists/movies-100-greatest-themes.json
+++ b/custom_components/beatify/playlists/movies-100-greatest-themes.json
@@ -1,6 +1,6 @@
 {
-  "name": "100 Greatest Movie Themes 🎬",
-  "version": "1.24",
+  "name": "Movie & TV Soundtracks 🎬",
+  "version": "1.25",
   "tags": [
     "movies",
     "soundtrack",
@@ -7571,6 +7571,310 @@
       "awards_nl": [],
       "uri_youtube_music": "https://music.youtube.com/watch?v=cxU6LT6DonE",
       "fun_fact_it": "Il tema della Pearl & Dean precede la pubblicità nei cinema britannici dal 1958. La fanfara è nota a generazioni di spettatori."
+    },
+    {
+      "artist": "Liza Minnelli",
+      "title": "Cabaret",
+      "year": 1972,
+      "uri": "spotify:track:7AFy1aN1RQVgGOXzCtrK87",
+      "uri_apple_music": "applemusic://track/1475841307",
+      "uri_deezer": "deezer://track/729599422",
+      "isrc": "USMC17251142",
+      "alt_artists": [
+        "Barbra Streisand",
+        "Shirley Bassey"
+      ],
+      "fun_fact": "The title song of the film that won Liza Minnelli an Oscar and Bob Fosse the directing award over The Godfather. Minnelli sings it as the last number before the Kit Kat Club goes dark.",
+      "fun_fact_de": "Der Titelsong des Films, der Liza Minnelli einen Oscar einbrachte und Bob Fosse die Regie-Auszeichnung vor Der Pate. Minnelli singt ihn als letzte Nummer, bevor im Kit Kat Club das Licht ausgeht.",
+      "fun_fact_es": "La canción que da título a la película que le valió un Óscar a Liza Minnelli y a Bob Fosse el premio a la dirección por delante de El Padrino. Minnelli la canta como último número antes de que el Kit Kat Club se apague.",
+      "fun_fact_fr": "La chanson-titre du film qui a valu un Oscar à Liza Minnelli et à Bob Fosse le prix de la mise en scène devant Le Parrain. Minnelli la chante en dernier numéro avant que le Kit Kat Club ne s'éteigne.",
+      "fun_fact_nl": "Het titelnummer van de film die Liza Minnelli een Oscar opleverde en Bob Fosse de regieprijs vóór The Godfather. Minnelli zingt het als laatste nummer voordat de Kit Kat Club dooft.",
+      "fun_fact_it": "La canzone che dà il titolo al film che valse un Oscar a Liza Minnelli e a Bob Fosse il premio per la regia davanti al Padrino. Minnelli la canta come ultimo numero prima che il Kit Kat Club si spenga."
+    },
+    {
+      "artist": "Jonathan Wolff",
+      "title": "Seinfeld Theme",
+      "year": 1989,
+      "uri": "spotify:track:1oo7pneuUHUEKdbH0TgiGc",
+      "uri_apple_music": "applemusic://track/1572502517",
+      "uri_deezer": "deezer://track/1405392692",
+      "isrc": "USNLR2100315",
+      "alt_artists": [
+        "Danny Elfman",
+        "Gary Portnoy"
+      ],
+      "fun_fact": "The slap bass and mouth pops were a solution to a problem: the theme had to fit between Jerry Seinfeld's stand-up lines, which were a different length every week. Wolff built it so it could stretch.",
+      "fun_fact_de": "Der Slap-Bass und die Mundgeräusche waren die Lösung für ein Problem: Die Melodie musste zwischen Jerry Seinfelds Stand-up-Zeilen passen, und die waren jede Woche unterschiedlich lang. Wolff baute sie dehnbar.",
+      "fun_fact_es": "El bajo slap y los sonidos bucales resolvían un problema: el tema debía encajar entre las frases de monólogo de Jerry Seinfeld, que cada semana duraban algo distinto. Wolff lo construyó elástico.",
+      "fun_fact_fr": "La basse slappée et les bruits de bouche répondaient à un problème : le thème devait s'insérer entre les répliques de stand-up de Jerry Seinfeld, différentes chaque semaine. Wolff l'a conçu extensible.",
+      "fun_fact_nl": "De slapbas en mondgeluiden waren de oplossing voor een probleem: de tune moest tussen Jerry Seinfelds stand-upregels passen, en die duurden elke week anders. Wolff maakte hem rekbaar.",
+      "fun_fact_it": "Il basso slap e i suoni con la bocca risolvevano un problema: il tema doveva incastrarsi tra le battute di stand-up di Jerry Seinfeld, diverse ogni settimana. Wolff lo costruì elastico."
+    },
+    {
+      "artist": "John Williams",
+      "title": "Theme From Jurassic Park",
+      "year": 1993,
+      "uri": "spotify:track:2TZbQZXOuR8osP2AK8yYMN",
+      "uri_apple_music": "applemusic://track/1440800213",
+      "uri_deezer": "deezer://track/2296192",
+      "isrc": "USMC19340943",
+      "alt_artists": [
+        "Hans Zimmer",
+        "James Horner"
+      ],
+      "fun_fact": "Williams wrote two main themes for the film — one for the wonder of seeing the animals, one for the island itself. This is the first, and it plays over the moment the characters stop running and simply look up.",
+      "fun_fact_de": "Williams schrieb zwei Hauptthemen für den Film — eines für das Staunen beim Anblick der Tiere, eines für die Insel selbst. Dies ist das erste, und es erklingt in dem Moment, in dem die Figuren aufhören zu rennen und einfach nach oben sehen.",
+      "fun_fact_es": "Williams escribió dos temas principales para la película: uno para el asombro de ver a los animales y otro para la isla. Este es el primero, y suena en el momento en que los personajes dejan de correr y simplemente miran hacia arriba.",
+      "fun_fact_fr": "Williams a écrit deux thèmes principaux pour le film : l'un pour l'émerveillement devant les animaux, l'autre pour l'île. Voici le premier, celui qui accompagne l'instant où les personnages cessent de courir et lèvent les yeux.",
+      "fun_fact_nl": "Williams schreef twee hoofdthema's voor de film — één voor de verwondering bij het zien van de dieren, één voor het eiland zelf. Dit is de eerste, en hij klinkt op het moment dat de personages stoppen met rennen en simpelweg omhoogkijken.",
+      "fun_fact_it": "Williams scrisse due temi principali per il film: uno per lo stupore di vedere gli animali, uno per l'isola. Questo è il primo, e suona nel momento in cui i personaggi smettono di correre e alzano semplicemente lo sguardo."
+    },
+    {
+      "artist": "Tina Turner",
+      "title": "Goldeneye",
+      "year": 1995,
+      "uri": "spotify:track:528QhCT2v3HgD71RmrSUNW",
+      "uri_apple_music": "applemusic://track/712850997",
+      "uri_deezer": "deezer://track/3147390",
+      "isrc": "GBAYE9500713",
+      "alt_artists": [
+        "Shirley Bassey",
+        "Adele"
+      ],
+      "fun_fact": "Bono and The Edge of U2 wrote the song for Turner, deliberately in the mould of Shirley Bassey's sixties Bond themes. It introduced Pierce Brosnan's first outing as 007.",
+      "fun_fact_de": "Bono und The Edge von U2 schrieben das Lied für Turner, bewusst in der Machart von Shirley Basseys Bond-Titeln der Sechziger. Es eröffnete Pierce Brosnans ersten Einsatz als 007.",
+      "fun_fact_es": "Bono y The Edge, de U2, escribieron la canción para Turner, deliberadamente al modo de los temas Bond de Shirley Bassey en los sesenta. Presentó el primer trabajo de Pierce Brosnan como 007.",
+      "fun_fact_fr": "Bono et The Edge de U2 ont écrit la chanson pour Turner, délibérément dans la veine des thèmes de Bond signés Shirley Bassey dans les années soixante. Elle ouvrait la première apparition de Pierce Brosnan en 007.",
+      "fun_fact_nl": "Bono en The Edge van U2 schreven het nummer voor Turner, bewust in de trant van Shirley Bassey's Bond-thema's uit de jaren zestig. Het opende Pierce Brosnans eerste optreden als 007.",
+      "fun_fact_it": "Bono e The Edge degli U2 scrissero il brano per la Turner, deliberatamente sulla falsariga dei temi di Bond firmati Shirley Bassey negli anni Sessanta. Apriva il primo film di Pierce Brosnan come 007."
+    },
+    {
+      "artist": "The Wonders",
+      "title": "That Thing You Do!",
+      "year": 1996,
+      "uri": "spotify:track:4O6ZaZrRCFfiZZKjnrXqlk",
+      "uri_apple_music": "applemusic://track/217281662",
+      "uri_deezer": "deezer://track/1032839",
+      "isrc": "USSM19602550",
+      "alt_artists": [
+        "The Beatles",
+        "The Monkees"
+      ],
+      "fun_fact": "The Wonders are a fictional band from Tom Hanks's film about a one-hit wonder. The joke is that the song had to be good enough to plausibly be a hit — and it was nominated for an Oscar.",
+      "fun_fact_de": "The Wonders sind eine erfundene Band aus Tom Hanks' Film über ein One-Hit-Wonder. Der Witz daran: Das Lied musste gut genug sein, um glaubhaft ein Hit zu sein — und wurde für einen Oscar nominiert.",
+      "fun_fact_es": "The Wonders son una banda ficticia de la película de Tom Hanks sobre un artista de un solo éxito. La gracia es que la canción debía ser lo bastante buena para resultar creíble como éxito, y fue nominada al Óscar.",
+      "fun_fact_fr": "The Wonders est un groupe fictif du film de Tom Hanks sur un one-hit wonder. Le sel de l'affaire : la chanson devait être assez bonne pour passer pour un vrai tube — et elle fut nommée aux Oscars.",
+      "fun_fact_nl": "The Wonders is een verzonnen band uit Tom Hanks' film over een eendagsvlieg. De grap is dat het nummer goed genoeg moest zijn om geloofwaardig een hit te zijn — en het werd genomineerd voor een Oscar.",
+      "fun_fact_it": "The Wonders è una band inventata dal film di Tom Hanks su una meteora musicale. Il bello è che la canzone doveva essere abbastanza buona da sembrare davvero un successo — e fu candidata all'Oscar."
+    },
+    {
+      "artist": "Éric Serra",
+      "title": "The Diva Dance",
+      "year": 1997,
+      "uri": "spotify:track:5BZAhQYLSqjtF4Xio5MIQd",
+      "uri_apple_music": "applemusic://track/1469434280",
+      "uri_deezer": "deezer://track/707345202",
+      "isrc": "FRR419700014",
+      "alt_artists": [
+        "Hans Zimmer",
+        "Vangelis"
+      ],
+      "fun_fact": "Written for The Fifth Element as a piece no human could sing at speed. The soprano Inva Mula recorded it in sections, and the impossible passages were assembled afterwards.",
+      "fun_fact_de": "Für Das fünfte Element als Stück geschrieben, das kein Mensch in diesem Tempo singen kann. Die Sopranistin Inva Mula nahm es in Abschnitten auf, die unmöglichen Passagen wurden hinterher zusammengesetzt.",
+      "fun_fact_es": "Escrita para El quinto elemento como una pieza que ningún ser humano podría cantar a esa velocidad. La soprano Inva Mula la grabó por secciones y los pasajes imposibles se montaron después.",
+      "fun_fact_fr": "Écrite pour Le Cinquième Élément comme un morceau qu'aucun humain ne peut chanter à cette vitesse. La soprano Inva Mula l'a enregistré par sections, et les passages impossibles ont été assemblés ensuite.",
+      "fun_fact_nl": "Geschreven voor The Fifth Element als een stuk dat geen mens op die snelheid kan zingen. Sopraan Inva Mula nam het in delen op; de onmogelijke passages werden achteraf samengevoegd.",
+      "fun_fact_it": "Scritta per Il quinto elemento come un pezzo che nessun essere umano potrebbe cantare a quella velocità. Il soprano Inva Mula lo registrò a sezioni e i passaggi impossibili furono montati dopo."
+    },
+    {
+      "artist": "Jamiroquai",
+      "title": "Deeper Underground",
+      "year": 1998,
+      "uri": "spotify:track:0y8kwqOr9OfodZeBOGPdPp",
+      "uri_apple_music": "applemusic://track/1583963907",
+      "uri_deezer": "deezer://track/832854",
+      "isrc": "GBBBL9802020",
+      "alt_artists": [
+        "Massive Attack",
+        "Moloko"
+      ],
+      "fun_fact": "Written for the American Godzilla remake and darker than anything Jamiroquai had released before. It went to number one in Britain — their only single to do so.",
+      "fun_fact_de": "Für das amerikanische Godzilla-Remake geschrieben und düsterer als alles, was Jamiroquai davor veröffentlicht hatten. In Großbritannien stand es auf Platz eins — als ihre einzige Single.",
+      "fun_fact_es": "Escrita para el remake estadounidense de Godzilla y más oscura que todo lo publicado antes por Jamiroquai. Llegó al número uno en Gran Bretaña, su único sencillo en lograrlo.",
+      "fun_fact_fr": "Écrite pour le remake américain de Godzilla et plus sombre que tout ce que Jamiroquai avait publié auparavant. Le titre est monté en tête des classements britanniques — leur seul single à y parvenir.",
+      "fun_fact_nl": "Geschreven voor de Amerikaanse Godzilla-remake en donkerder dan alles wat Jamiroquai daarvoor uitbracht. Het werd nummer één in Groot-Brittannië — hun enige single die dat haalde.",
+      "fun_fact_it": "Scritta per il remake americano di Godzilla e più cupa di tutto ciò che i Jamiroquai avessero pubblicato prima. Arrivò al primo posto in Gran Bretagna, l'unico loro singolo a riuscirci."
+    },
+    {
+      "artist": "Ronan Keating",
+      "title": "When You Say Nothing At All",
+      "year": 1999,
+      "uri": "spotify:track:2cq26EEiqgUDP1VBKm9r6Z",
+      "uri_apple_music": "applemusic://track/1443996763",
+      "uri_deezer": "deezer://track/2461244",
+      "isrc": "GBAKW9900139",
+      "alt_artists": [
+        "Boyzone",
+        "Westlife"
+      ],
+      "fun_fact": "A country song from 1988, first a hit for Keith Whitley, rebuilt for Notting Hill. Keating's version was his first solo single and spent weeks at the top in Britain and Ireland.",
+      "fun_fact_de": "Ein Country-Lied von 1988, zuerst ein Hit für Keith Whitley, umgebaut für Notting Hill. Keatings Fassung war seine erste Solosingle und stand in Großbritannien und Irland wochenlang an der Spitze.",
+      "fun_fact_es": "Una canción country de 1988, primero un éxito de Keith Whitley, reconstruida para Notting Hill. La versión de Keating fue su primer sencillo en solitario y estuvo semanas en lo más alto en Gran Bretaña e Irlanda.",
+      "fun_fact_fr": "Une chanson country de 1988, d'abord un succès de Keith Whitley, remodelée pour Coup de foudre à Notting Hill. La version de Keating fut son premier single solo et resta des semaines en tête au Royaume-Uni et en Irlande.",
+      "fun_fact_nl": "Een countrynummer uit 1988, eerst een hit voor Keith Whitley, herbouwd voor Notting Hill. Keatings versie was zijn eerste solosingle en stond weken bovenaan in Groot-Brittannië en Ierland.",
+      "fun_fact_it": "Una canzone country del 1988, prima un successo di Keith Whitley, rifatta per Notting Hill. La versione di Keating fu il suo primo singolo da solista e restò settimane in vetta in Gran Bretagna e Irlanda."
+    },
+    {
+      "artist": "LeAnn Rimes",
+      "title": "Can't Fight The Moonlight",
+      "year": 2000,
+      "uri": "spotify:track:2AogRMqARWyUP7VQ3gmSoY",
+      "uri_apple_music": "applemusic://track/72267206",
+      "uri_deezer": "deezer://track/75779409",
+      "isrc": "USCRB0000703",
+      "alt_artists": [
+        "Shania Twain",
+        "Jennifer Lopez"
+      ],
+      "fun_fact": "Written by Diane Warren for Coyote Ugly, where Rimes also appears on screen. The film did modest business; the song became a worldwide hit and outlived it by decades.",
+      "fun_fact_de": "Von Diane Warren für Coyote Ugly geschrieben, wo Rimes auch vor der Kamera auftritt. Der Film lief mäßig, das Lied wurde ein weltweiter Hit und überlebte ihn um Jahrzehnte.",
+      "fun_fact_es": "Escrita por Diane Warren para Coyote Ugly, donde Rimes también aparece en pantalla. La película funcionó discretamente; la canción se convirtió en un éxito mundial y la sobrevivió décadas.",
+      "fun_fact_fr": "Écrite par Diane Warren pour Coyote Girls, où Rimes apparaît aussi à l'écran. Le film a fait des recettes modestes ; la chanson est devenue un succès mondial et lui a survécu des décennies.",
+      "fun_fact_nl": "Geschreven door Diane Warren voor Coyote Ugly, waarin Rimes ook in beeld verschijnt. De film deed het matig; het nummer werd een wereldhit en overleefde hem decennia.",
+      "fun_fact_it": "Scritta da Diane Warren per Le ragazze del Coyote Ugly, dove la Rimes appare anche sullo schermo. Il film andò discretamente; la canzone divenne un successo mondiale e gli sopravvisse per decenni."
+    },
+    {
+      "artist": "Clint Mansell",
+      "title": "Lux Aeterna",
+      "year": 2000,
+      "uri": "spotify:track:62Da3JOu9H9EIgmqV7DoLG",
+      "uri_apple_music": "applemusic://track/41228839",
+      "uri_deezer": "deezer://track/5416678",
+      "isrc": "USNO10061132",
+      "alt_artists": [
+        "Hans Zimmer",
+        "Philip Glass"
+      ],
+      "fun_fact": "Written for Requiem for a Dream with the Kronos Quartet. Within a few years the piece had been borrowed by so many film trailers that it became shorthand for impending doom.",
+      "fun_fact_de": "Für Requiem for a Dream mit dem Kronos Quartet geschrieben. Binnen weniger Jahre hatten so viele Filmtrailer das Stück entliehen, dass es zum Kürzel für drohendes Unheil wurde.",
+      "fun_fact_es": "Escrita para Réquiem por un sueño con el Kronos Quartet. En pocos años tantos tráileres la habían tomado prestada que se convirtió en sinónimo de catástrofe inminente.",
+      "fun_fact_fr": "Écrite pour Requiem for a Dream avec le Kronos Quartet. En quelques années, tant de bandes-annonces l'avaient empruntée qu'elle est devenue le raccourci du désastre imminent.",
+      "fun_fact_nl": "Geschreven voor Requiem for a Dream met het Kronos Quartet. Binnen enkele jaren hadden zoveel filmtrailers het stuk geleend dat het synoniem werd voor naderend onheil.",
+      "fun_fact_it": "Scritta per Requiem for a Dream con il Kronos Quartet. In pochi anni tanti trailer l'avevano presa in prestito da farne il simbolo della catastrofe imminente."
+    },
+    {
+      "artist": "Bryan Adams",
+      "title": "Here I Am",
+      "year": 2002,
+      "uri": "spotify:track:0gJBPDy458wPeWGHei3TvO",
+      "uri_apple_music": "applemusic://track/1440870497",
+      "uri_deezer": "deezer://track/2487325",
+      "isrc": "USAM10200173",
+      "alt_artists": [
+        "Phil Collins",
+        "Sting"
+      ],
+      "fun_fact": "Adams wrote and sang the whole score for Spirit: Stallion of the Cimarron, a film whose horses never speak. The songs carry what the animals cannot say.",
+      "fun_fact_de": "Adams schrieb und sang die komplette Liedmusik zu Spirit — Der wilde Mustang, einem Film, in dem die Pferde nie sprechen. Die Lieder tragen, was die Tiere nicht sagen können.",
+      "fun_fact_es": "Adams escribió y cantó toda la banda sonora de Spirit: el corcel indomable, una película en la que los caballos nunca hablan. Las canciones sostienen lo que los animales no pueden decir.",
+      "fun_fact_fr": "Adams a écrit et chanté toute la bande originale de Spirit, l'étalon des plaines, un film où les chevaux ne parlent jamais. Les chansons portent ce que les animaux ne peuvent pas dire.",
+      "fun_fact_nl": "Adams schreef en zong de volledige liedmuziek voor Spirit: Stallion of the Cimarron, een film waarin de paarden nooit spreken. De liedjes dragen wat de dieren niet kunnen zeggen.",
+      "fun_fact_it": "Adams scrisse e cantò l'intera colonna sonora di Spirit — Cavallo selvaggio, un film in cui i cavalli non parlano mai. Le canzoni portano ciò che gli animali non possono dire."
+    },
+    {
+      "artist": "Billy Mack",
+      "title": "Christmas Is All Around",
+      "year": 2003,
+      "uri": "spotify:track:2bWizjWMdoTFUmMdaZsZsi",
+      "uri_apple_music": "applemusic://track/1593301763",
+      "uri_deezer": "deezer://track/1540441292",
+      "isrc": "GBAAN0300603",
+      "alt_artists": [
+        "Wet Wet Wet",
+        "The Troggs"
+      ],
+      "fun_fact": "Billy Mack is Bill Nighy's washed-up rocker in Love Actually, and the song is a shameless Christmas rewrite of Wet Wet Wet's Love Is All Around — which was itself a cover of The Troggs.",
+      "fun_fact_de": "Billy Mack ist Bill Nighys abgehalfterter Rocker in Tatsächlich… Liebe, und das Lied ist eine schamlose Weihnachtsfassung von Wet Wet Wets Love Is All Around — das selbst eine Coverversion der Troggs war.",
+      "fun_fact_es": "Billy Mack es el rockero acabado que interpreta Bill Nighy en Love Actually, y la canción es una desvergonzada versión navideña de Love Is All Around de Wet Wet Wet, que a su vez versionaba a The Troggs.",
+      "fun_fact_fr": "Billy Mack est le rockeur sur le retour incarné par Bill Nighy dans Love Actually, et la chanson est une réécriture de Noël sans vergogne de Love Is All Around de Wet Wet Wet — elle-même une reprise des Troggs.",
+      "fun_fact_nl": "Billy Mack is Bill Nighy's afgeschreven rocker in Love Actually, en het nummer is een schaamteloze kerstversie van Love Is All Around van Wet Wet Wet — zelf al een cover van The Troggs.",
+      "fun_fact_it": "Billy Mack è il rocker sul viale del tramonto interpretato da Bill Nighy in Love Actually, e la canzone è una spudorata riscrittura natalizia di Love Is All Around dei Wet Wet Wet — a sua volta una cover dei Troggs."
+    },
+    {
+      "artist": "Bear McCreary",
+      "title": "Theme from the Walking Dead",
+      "year": 2010,
+      "uri": "spotify:track:2cji350vUbvxQ9QwyL5Nkp",
+      "uri_apple_music": "applemusic://track/1275301945",
+      "uri_deezer": "deezer://track/414308332",
+      "isrc": "USLS51702801",
+      "alt_artists": [
+        "Ramin Djawadi",
+        "Hans Zimmer"
+      ],
+      "fun_fact": "McCreary built the title music out of detuned strings and a hammered dulcimer, aiming for something that sounds like an instrument left outdoors too long. It ran for eleven seasons.",
+      "fun_fact_de": "McCreary baute die Titelmusik aus verstimmten Streichern und einem Hackbrett — er wollte etwas, das klingt wie ein zu lange draußen vergessenes Instrument. Sie lief elf Staffeln lang.",
+      "fun_fact_es": "McCreary construyó la sintonía con cuerdas desafinadas y un salterio, buscando algo que sonara como un instrumento olvidado demasiado tiempo a la intemperie. Duró once temporadas.",
+      "fun_fact_fr": "McCreary a bâti le générique avec des cordes désaccordées et un tympanon, cherchant un son d'instrument laissé trop longtemps dehors. Il a tenu onze saisons.",
+      "fun_fact_nl": "McCreary bouwde de titelmuziek uit ontstemde strijkers en een hakkebord, op zoek naar iets dat klinkt als een instrument dat te lang buiten heeft gelegen. Ze liep elf seizoenen.",
+      "fun_fact_it": "McCreary costruì la sigla con archi scordati e un salterio, cercando qualcosa che suonasse come uno strumento lasciato troppo a lungo all'aperto. È andata avanti undici stagioni."
+    },
+    {
+      "artist": "Adele",
+      "title": "Skyfall",
+      "year": 2012,
+      "uri": "spotify:track:6VObnIkLVruX4UVyxWhlqm",
+      "uri_apple_music": "applemusic://track/566322365",
+      "uri_deezer": "deezer://track/82715364",
+      "isrc": "GBBKS1200164",
+      "alt_artists": [
+        "Shirley Bassey",
+        "Sam Smith"
+      ],
+      "fun_fact": "The first Bond theme to win an Academy Award, fifty years after Dr. No. Adele and Paul Epworth wrote it to sound like the sixties entries rather than to modernise them.",
+      "fun_fact_de": "Der erste Bond-Titel, der einen Oscar gewann — fünfzig Jahre nach James Bond jagt Dr. No. Adele und Paul Epworth schrieben ihn so, dass er klingt wie die Sechziger-Beiträge, statt sie zu modernisieren.",
+      "fun_fact_es": "El primer tema de Bond que ganó un Óscar, cincuenta años después de Agente 007 contra el Dr. No. Adele y Paul Epworth lo escribieron para que sonara como los de los sesenta, no para modernizarlos.",
+      "fun_fact_fr": "Le premier thème de Bond à remporter un Oscar, cinquante ans après James Bond 007 contre Dr No. Adele et Paul Epworth l'ont écrit pour sonner comme ceux des années soixante, non pour les moderniser.",
+      "fun_fact_nl": "Het eerste Bond-thema dat een Oscar won, vijftig jaar na Dr. No. Adele en Paul Epworth schreven het om te klinken als de jaren-zestignummers, niet om ze te moderniseren.",
+      "fun_fact_it": "Il primo tema di Bond a vincere un Oscar, cinquant'anni dopo Agente 007 - Licenza di uccidere. Adele e Paul Epworth lo scrissero perché suonasse come quelli degli anni Sessanta, non per modernizzarli."
+    },
+    {
+      "artist": "Ludwig Göransson",
+      "title": "The Mandalorian",
+      "year": 2019,
+      "uri": "spotify:track:6tJFtthY0rI1x06qb8NjK0",
+      "uri_apple_music": "applemusic://track/1486687344",
+      "uri_deezer": "deezer://track/798742662",
+      "isrc": "USWD11995118",
+      "alt_artists": [
+        "John Williams",
+        "Ramin Djawadi"
+      ],
+      "fun_fact": "Göransson answered a Star Wars series with a bass recorder and a solo voice instead of an orchestra — a deliberate distance from John Williams, in the same universe.",
+      "fun_fact_de": "Göransson beantwortete eine Star-Wars-Serie mit Bassblockflöte und einer Solostimme statt eines Orchesters — ein bewusster Abstand zu John Williams, im selben Universum.",
+      "fun_fact_es": "Göransson respondió a una serie de Star Wars con una flauta de pico baja y una voz solista en lugar de una orquesta: una distancia deliberada respecto a John Williams, dentro del mismo universo.",
+      "fun_fact_fr": "Göransson a répondu à une série Star Wars par une flûte à bec basse et une voix soliste plutôt qu'un orchestre — une distance délibérée avec John Williams, dans le même univers.",
+      "fun_fact_nl": "Göransson beantwoordde een Star Wars-serie met een basblokfluit en een solostem in plaats van een orkest — een bewuste afstand tot John Williams, binnen hetzelfde universum.",
+      "fun_fact_it": "Göransson rispose a una serie di Star Wars con un flauto dolce basso e una voce solista invece di un'orchestra: una distanza voluta da John Williams, nello stesso universo."
+    },
+    {
+      "artist": "Danny Elfman",
+      "title": "Wednesday Main Titles",
+      "year": 2022,
+      "uri": "spotify:track:3dd9uXh41vmFLO3UvqLJL6",
+      "uri_apple_music": "applemusic://track/1653660161",
+      "uri_deezer": "deezer://track/2005660777",
+      "isrc": "USLS52232101",
+      "alt_artists": [
+        "Vic Mizzy",
+        "Bear McCreary"
+      ],
+      "fun_fact": "Elfman had already scored Tim Burton's Addams Family films; here he returns to the same household for television. The harpsichord is a nod to Vic Mizzy's 1964 theme without quoting it.",
+      "fun_fact_de": "Elfman hatte schon Tim Burtons Addams-Family-Filme vertont; hier kehrt er für das Fernsehen in denselben Haushalt zurück. Das Cembalo verneigt sich vor Vic Mizzys Titelmelodie von 1964, ohne sie zu zitieren.",
+      "fun_fact_es": "Elfman ya había puesto música a las películas de la Familia Addams de Tim Burton; aquí vuelve a la misma casa para la televisión. El clavecín saluda al tema de Vic Mizzy de 1964 sin citarlo.",
+      "fun_fact_fr": "Elfman avait déjà composé pour les films de la Famille Addams de Tim Burton ; il revient ici dans la même maison, pour la télévision. Le clavecin salue le thème de Vic Mizzy de 1964 sans le citer.",
+      "fun_fact_nl": "Elfman had de Addams Family-films van Tim Burton al van muziek voorzien; hier keert hij voor televisie terug in hetzelfde huishouden. Het klavecimbel groet Vic Mizzy's tune uit 1964 zonder hem te citeren.",
+      "fun_fact_it": "Elfman aveva già musicato i film della Famiglia Addams di Tim Burton; qui torna nella stessa casa per la televisione. Il clavicembalo saluta il tema di Vic Mizzy del 1964 senza citarlo."
     }
   ],
   "movie_quiz_enabled": true

--- a/custom_components/beatify/playlists/movies-100-greatest-themes.json
+++ b/custom_components/beatify/playlists/movies-100-greatest-themes.json
@@ -1,6 +1,6 @@
 {
   "name": "Movie & TV Soundtracks 🎬",
-  "version": "1.28",
+  "version": "1.29",
   "tags": [
     "movies",
     "soundtrack",
@@ -8673,6 +8673,215 @@
       "fun_fact_fr": "Newman avait été nommé quinze fois sans gagner avant que cette chanson ne remporte l'Oscar. Il a ouvert son discours en remerciant l'Académie de ne pas lui avoir imposé une seizième attente.",
       "fun_fact_nl": "Newman was vijftien keer genomineerd zonder te winnen voordat dit lied de Oscar pakte. Hij opende zijn dankwoord door de Academy te bedanken dat ze hem geen zestiende keer lieten wachten.",
       "fun_fact_it": "Newman era stato candidato quindici volte senza vincere prima che questa canzone prendesse l'Oscar. Aprì il discorso ringraziando l'Academy per non avergli fatto attendere una sedicesima."
+    },
+    {
+      "artist": "The Tokens",
+      "title": "The Lion Sleeps Tonight",
+      "year": 1961,
+      "uri": "spotify:track:4x6QL8zCkeKRlRx05NBPQh",
+      "uri_apple_music": "applemusic://track/640833380",
+      "uri_deezer": "deezer://track/13157911",
+      "isrc": "USRC16100933",
+      "alt_artists": [
+        "Solomon Linda",
+        "Robert John"
+      ],
+      "fun_fact": "The melody is Solomon Linda's Mbube, recorded in Johannesburg in 1939. The Tokens made it a number one, Disney used it decades later, and Linda's family had to go to court to be paid.",
+      "fun_fact_de": "Die Melodie ist Solomon Lindas Mbube, 1939 in Johannesburg aufgenommen. The Tokens machten daraus eine Nummer eins, Disney nutzte sie Jahrzehnte später, und Lindas Familie musste vor Gericht ziehen, um bezahlt zu werden.",
+      "fun_fact_es": "La melodía es Mbube de Solomon Linda, grabada en Johannesburgo en 1939. The Tokens la llevaron al número uno, Disney la usó décadas después y la familia de Linda tuvo que ir a juicio para cobrar.",
+      "fun_fact_fr": "La mélodie est Mbube de Solomon Linda, enregistrée à Johannesburg en 1939. Les Tokens en ont fait un numéro un, Disney l'a utilisée des décennies plus tard, et la famille de Linda a dû aller en justice pour être payée.",
+      "fun_fact_nl": "De melodie is Solomon Linda's Mbube, in 1939 opgenomen in Johannesburg. The Tokens maakten er een nummer één van, Disney gebruikte hem decennia later, en Linda's familie moest naar de rechter om betaald te krijgen.",
+      "fun_fact_it": "La melodia è Mbube di Solomon Linda, incisa a Johannesburg nel 1939. I Tokens ne fecero un numero uno, Disney la usò decenni dopo, e la famiglia di Linda dovette andare in tribunale per essere pagata."
+    },
+    {
+      "artist": "John Barry",
+      "title": "James Bond Theme",
+      "year": 1962,
+      "uri": "spotify:track:2VSFOKsNSH9dBQ8BIZ8o2m",
+      "uri_apple_music": "applemusic://track/1443115379",
+      "uri_deezer": "deezer://track/1037326",
+      "isrc": "GBBBN6600001",
+      "alt_artists": [
+        "Monty Norman",
+        "Vic Flick"
+      ],
+      "fun_fact": "Who wrote it has been argued in court: Monty Norman holds the credit, John Barry made the arrangement everyone knows, and Vic Flick played the guitar line for a session fee of six pounds.",
+      "fun_fact_de": "Wer es geschrieben hat, wurde vor Gericht verhandelt: Monty Norman hält die Urheberschaft, John Barry schuf das Arrangement, das alle kennen, und Vic Flick spielte die Gitarrenlinie für sechs Pfund Sessionhonorar.",
+      "fun_fact_es": "Quién la escribió se discutió en los tribunales: el crédito es de Monty Norman, John Barry hizo el arreglo que todos conocen, y Vic Flick tocó la línea de guitarra por seis libras de caché.",
+      "fun_fact_fr": "La paternité s'est réglée au tribunal : le crédit revient à Monty Norman, John Barry a signé l'arrangement que tout le monde connaît, et Vic Flick a joué la ligne de guitare pour six livres de cachet.",
+      "fun_fact_nl": "Wie het schreef is voor de rechter uitgevochten: Monty Norman heeft de credit, John Barry maakte het arrangement dat iedereen kent, en Vic Flick speelde de gitaarlijn voor zes pond sessiegeld.",
+      "fun_fact_it": "Chi l'abbia scritta si è discusso in tribunale: il credito è di Monty Norman, John Barry firmò l'arrangiamento che tutti conoscono, e Vic Flick suonò la linea di chitarra per sei sterline di cachet."
+    },
+    {
+      "artist": "Jimi Jamison",
+      "title": "I'm Always Here",
+      "year": 1991,
+      "uri": "spotify:track:3e6pMd60bzt4Kd72qmPRfA",
+      "uri_apple_music": "applemusic://track/504188470",
+      "uri_deezer": "deezer://track/11344488",
+      "isrc": "US3L80600018",
+      "alt_artists": [
+        "Survivor",
+        "Bonnie Tyler"
+      ],
+      "fun_fact": "Sung by the voice of Survivor, and written for a series about lifeguards running in slow motion. It is one of the few television themes that sounds like a stadium rock single because it essentially is one.",
+      "fun_fact_de": "Gesungen von der Stimme von Survivor und geschrieben für eine Serie über Rettungsschwimmer in Zeitlupe. Es ist eine der wenigen Serienmelodien, die wie eine Stadionrock-Single klingt — weil sie im Grunde eine ist.",
+      "fun_fact_es": "Cantada por la voz de Survivor y escrita para una serie sobre socorristas corriendo a cámara lenta. Es una de las pocas sintonías que suenan como un sencillo de rock de estadio, porque en el fondo lo es.",
+      "fun_fact_fr": "Chantée par la voix de Survivor et écrite pour une série sur des sauveteurs courant au ralenti. C'est l'un des rares génériques qui sonnent comme un single de rock de stade — parce que c'en est un.",
+      "fun_fact_nl": "Gezongen door de stem van Survivor en geschreven voor een serie over strandwachten in slow motion. Het is een van de weinige tunes die klinken als een stadionrocksingle, omdat het er in wezen een is.",
+      "fun_fact_it": "Cantata dalla voce dei Survivor e scritta per una serie su bagnini che corrono al rallentatore. È una delle poche sigle che suonano come un singolo rock da stadio, perché in fondo lo è."
+    },
+    {
+      "artist": "GABRIELLE",
+      "title": "Out Of Reach",
+      "year": 2001,
+      "uri": "spotify:track:0g9ne3xgPwtCj4W7QR7RFY",
+      "uri_apple_music": "applemusic://track/1440912139",
+      "uri_deezer": "deezer://track/2461263",
+      "isrc": "GBARA0100008",
+      "alt_artists": [
+        "Dido",
+        "Sade"
+      ],
+      "fun_fact": "Written for Bridget Jones's Diary and used at the point in the film where nothing has been resolved. It became a bigger hit in Europe than in Gabrielle's native Britain.",
+      "fun_fact_de": "Für Bridget Jones — Schokolade zum Frühstück geschrieben und an der Stelle eingesetzt, an der noch nichts geklärt ist. In Europa wurde es ein größerer Hit als in Gabrielles britischer Heimat.",
+      "fun_fact_es": "Escrita para El diario de Bridget Jones y usada en el punto de la película en que nada se ha resuelto. Fue más éxito en Europa que en la Gran Bretaña natal de Gabrielle.",
+      "fun_fact_fr": "Écrite pour Le Journal de Bridget Jones et placée au moment où rien n'est encore résolu. Elle a mieux marché en Europe que dans la Grande-Bretagne natale de Gabrielle.",
+      "fun_fact_nl": "Geschreven voor Bridget Jones's Diary en gebruikt op het punt in de film waar nog niets is opgelost. Het werd in Europa een grotere hit dan in Gabrielles eigen Groot-Brittannië.",
+      "fun_fact_it": "Scritta per Il diario di Bridget Jones e usata nel punto del film in cui nulla è ancora risolto. In Europa fu un successo maggiore che nella natia Gran Bretagna di Gabrielle."
+    },
+    {
+      "artist": "Catherine Zeta-Jones",
+      "title": "Cell Block Tango",
+      "year": 2002,
+      "uri": "spotify:track:28Tmk14BdrfaV2YzxpB35c",
+      "uri_apple_music": "applemusic://track/197901373",
+      "uri_deezer": "deezer://track/850087",
+      "isrc": "USSM10213102",
+      "alt_artists": [
+        "Renée Zellweger",
+        "Queen Latifah"
+      ],
+      "fun_fact": "Six women explain their murders over a tango that never resolves. Zeta-Jones won the Oscar for the role, and the number was staged as a fantasy inside a prison.",
+      "fun_fact_de": "Sechs Frauen erklären ihre Morde über einem Tango, der sich nie auflöst. Zeta-Jones gewann für die Rolle den Oscar, und die Nummer ist als Fantasie im Gefängnis inszeniert.",
+      "fun_fact_es": "Seis mujeres explican sus asesinatos sobre un tango que nunca resuelve. Zeta-Jones ganó el Óscar por el papel, y el número está montado como una fantasía dentro de una cárcel.",
+      "fun_fact_fr": "Six femmes expliquent leurs meurtres sur un tango qui ne se résout jamais. Zeta-Jones a remporté l'Oscar pour ce rôle, et le numéro est mis en scène comme un fantasme en prison.",
+      "fun_fact_nl": "Zes vrouwen verklaren hun moorden over een tango die nooit oplost. Zeta-Jones won de Oscar voor de rol, en het nummer is geënsceneerd als een fantasie in een gevangenis.",
+      "fun_fact_it": "Sei donne spiegano i loro omicidi su un tango che non si risolve mai. La Zeta-Jones vinse l'Oscar per il ruolo, e il numero è messo in scena come una fantasia dentro un carcere."
+    },
+    {
+      "artist": "Glen Hansard",
+      "title": "Falling Slowly",
+      "year": 2007,
+      "uri": "spotify:track:6EIVLz5xM1xE29r0OmIkWt",
+      "uri_apple_music": "applemusic://track/254347632",
+      "uri_deezer": "deezer://track/15439785",
+      "isrc": "USLIC0700662",
+      "alt_artists": [
+        "Markéta Irglová",
+        "Damien Rice"
+      ],
+      "fun_fact": "Once was shot for about a hundred thousand euros with two musicians instead of actors, and this song won it the Oscar. Hansard and Irglová performed it at the ceremony after being played off the stage.",
+      "fun_fact_de": "Once wurde für rund hunderttausend Euro gedreht, mit zwei Musikern statt Schauspielern, und dieses Lied brachte ihm den Oscar. Hansard und Irglová trugen es bei der Verleihung vor, nachdem man sie von der Bühne gespielt hatte.",
+      "fun_fact_es": "Once se rodó por unos cien mil euros con dos músicos en lugar de actores, y esta canción le valió el Óscar. Hansard e Irglová la interpretaron en la ceremonia después de que la orquesta los echara del escenario.",
+      "fun_fact_fr": "Once a été tourné pour environ cent mille euros avec deux musiciens plutôt que des acteurs, et cette chanson lui a valu l'Oscar. Hansard et Irglová l'ont interprétée à la cérémonie après avoir été chassés de scène par l'orchestre.",
+      "fun_fact_nl": "Once werd voor zo'n honderdduizend euro opgenomen met twee muzikanten in plaats van acteurs, en dit lied leverde de film de Oscar op. Hansard en Irglová brachten het op de ceremonie nadat ze van het podium waren gespeeld.",
+      "fun_fact_it": "Once fu girato con circa centomila euro e due musicisti al posto degli attori, e questa canzone gli valse l'Oscar. Hansard e Irglová la eseguirono alla cerimonia dopo essere stati cacciati dal palco dall'orchestra."
+    },
+    {
+      "artist": "Barenaked Ladies",
+      "title": "Big Bang Theory Theme",
+      "year": 2007,
+      "uri": "spotify:track:5FCPN8g30PRH7lLgxDh9LQ",
+      "uri_apple_music": "applemusic://track/464675958",
+      "uri_deezer": "deezer://track/13805986",
+      "isrc": "USRH11102320",
+      "alt_artists": [
+        "They Might Be Giants",
+        "Weezer"
+      ],
+      "fun_fact": "The band wrote the whole history of the universe into a theme lasting under thirty seconds, at the producers' request. A full-length version followed once the series took off.",
+      "fun_fact_de": "Die Band schrieb auf Wunsch der Produzenten die gesamte Geschichte des Universums in eine Titelmelodie von unter dreißig Sekunden. Eine lange Fassung folgte, als die Serie einschlug.",
+      "fun_fact_es": "La banda metió toda la historia del universo en una sintonía de menos de treinta segundos, a petición de los productores. Una versión larga llegó cuando la serie despegó.",
+      "fun_fact_fr": "Le groupe a fait tenir toute l'histoire de l'univers dans un générique de moins de trente secondes, à la demande des producteurs. Une version longue a suivi quand la série a décollé.",
+      "fun_fact_nl": "De band propte op verzoek van de producenten de hele geschiedenis van het heelal in een tune van minder dan dertig seconden. Een lange versie volgde toen de serie aansloeg.",
+      "fun_fact_it": "Il gruppo fece stare l'intera storia dell'universo in una sigla di meno di trenta secondi, su richiesta dei produttori. Una versione lunga arrivò quando la serie decollò."
+    },
+    {
+      "artist": "Sukhwinder Singh",
+      "title": "Jai Ho",
+      "year": 2008,
+      "uri": "spotify:track:0BlMvHfyilCmgKrNUQabR6",
+      "uri_apple_music": "applemusic://track/1159292108",
+      "uri_deezer": "deezer://track/3185022381",
+      "isrc": "INS180810552",
+      "alt_artists": [
+        "A.R. Rahman",
+        "Shreya Ghoshal"
+      ],
+      "fun_fact": "A.R. Rahman won two Oscars in one evening for Slumdog Millionaire, and this is the song that closes it over a dance number on a railway platform.",
+      "fun_fact_de": "A. R. Rahman gewann für Slumdog Millionär an einem Abend zwei Oscars, und dies ist das Lied, das den Film über einer Tanznummer auf einem Bahnsteig beschließt.",
+      "fun_fact_es": "A. R. Rahman ganó dos Óscar en una noche por Slumdog Millionaire, y esta es la canción que cierra la película sobre un número de baile en un andén.",
+      "fun_fact_fr": "A. R. Rahman a remporté deux Oscars en une soirée pour Slumdog Millionaire, et voici la chanson qui referme le film sur un numéro de danse dans une gare.",
+      "fun_fact_nl": "A.R. Rahman won op één avond twee Oscars voor Slumdog Millionaire, en dit is het lied dat de film afsluit over een dansnummer op een perron.",
+      "fun_fact_it": "A. R. Rahman vinse due Oscar in una sera per The Millionaire, e questa è la canzone che chiude il film su un numero di ballo in una stazione."
+    },
+    {
+      "artist": "Karen O",
+      "title": "The Moon Song",
+      "year": 2013,
+      "uri": "spotify:track:6E0YEPzjMvUymYOvmDIgp4",
+      "uri_apple_music": "applemusic://track/1455882303",
+      "uri_deezer": "deezer://track/647374392",
+      "isrc": "USNLR1400039",
+      "alt_artists": [
+        "Arcade Fire",
+        "Feist"
+      ],
+      "fun_fact": "Sung in the film by a man and an operating system, which is the whole premise of Her in one duet. Karen O wrote it on a ukulele and kept the arrangement that small.",
+      "fun_fact_de": "Im Film von einem Mann und einem Betriebssystem gesungen — die ganze Prämisse von Her in einem Duett. Karen O schrieb es auf einer Ukulele und ließ das Arrangement so klein.",
+      "fun_fact_es": "En la película la cantan un hombre y un sistema operativo, que es toda la premisa de Her en un dueto. Karen O la escribió con un ukelele y mantuvo el arreglo así de pequeño.",
+      "fun_fact_fr": "Dans le film, elle est chantée par un homme et un système d'exploitation, ce qui résume tout le principe de Her en un duo. Karen O l'a écrite au ukulélé et a gardé cet arrangement minuscule.",
+      "fun_fact_nl": "In de film wordt het gezongen door een man en een besturingssysteem, wat de hele premisse van Her in één duet is. Karen O schreef het op een ukelele en hield het arrangement zo klein.",
+      "fun_fact_it": "Nel film la cantano un uomo e un sistema operativo, che è tutta la premessa di Lei in un duetto. Karen O la scrisse con un ukulele e mantenne l'arrangiamento così essenziale."
+    },
+    {
+      "artist": "Rodrigo Amarante",
+      "title": "Tuyo (Narcos Theme)",
+      "year": 2015,
+      "uri": "spotify:track:6g2BiiVQqY5v1S4HIrM54F",
+      "uri_apple_music": "applemusic://track/1030042399",
+      "uri_deezer": "deezer://track/585426702",
+      "isrc": "FR3X61800160",
+      "alt_artists": [
+        "Caetano Veloso",
+        "Gilberto Gil"
+      ],
+      "fun_fact": "The Brazilian musician wrote a bolero in Spanish for a series about Colombia, deliberately in the style of the seventies rather than of the streaming era it belongs to.",
+      "fun_fact_de": "Der brasilianische Musiker schrieb für eine Serie über Kolumbien einen Bolero auf Spanisch — bewusst im Stil der Siebziger statt der Streaming-Ära, in die er gehört.",
+      "fun_fact_es": "El músico brasileño escribió un bolero en español para una serie sobre Colombia, deliberadamente al estilo de los setenta y no de la era del streaming a la que pertenece.",
+      "fun_fact_fr": "Le musicien brésilien a écrit un boléro en espagnol pour une série sur la Colombie, délibérément dans le style des années soixante-dix plutôt que de l'ère du streaming dont il relève.",
+      "fun_fact_nl": "De Braziliaanse muzikant schreef voor een serie over Colombia een bolero in het Spaans, bewust in de stijl van de jaren zeventig in plaats van het streamingtijdperk waartoe hij behoort.",
+      "fun_fact_it": "Il musicista brasiliano scrisse un bolero in spagnolo per una serie sulla Colombia, deliberatamente nello stile degli anni Settanta e non dell'era dello streaming a cui appartiene."
+    },
+    {
+      "artist": "Nicholas Britell",
+      "title": "Succession (Main Title Theme)",
+      "year": 2018,
+      "uri": "spotify:track:0bSHwuTOZVJUXWT03H9oD2",
+      "uri_apple_music": "applemusic://track/1500926127",
+      "uri_deezer": "deezer://track/890421312",
+      "isrc": "US5941411059",
+      "alt_artists": [
+        "Hans Zimmer",
+        "Ramin Djawadi"
+      ],
+      "fun_fact": "A piano figure that keeps stumbling against a hip-hop drum pattern, for a family that keeps stumbling against itself. Britell won two Emmys for it.",
+      "fun_fact_de": "Eine Klavierfigur, die immer wieder gegen ein Hip-Hop-Schlagzeugmuster stolpert — für eine Familie, die immer wieder über sich selbst stolpert. Britell gewann dafür zwei Emmys.",
+      "fun_fact_es": "Una figura de piano que tropieza una y otra vez con un patrón de batería de hip-hop, para una familia que tropieza consigo misma. Britell ganó dos Emmy por ella.",
+      "fun_fact_fr": "Une figure de piano qui trébuche sans cesse sur un motif de batterie hip-hop, pour une famille qui trébuche sur elle-même. Britell a remporté deux Emmy pour ce thème.",
+      "fun_fact_nl": "Een pianofiguur die telkens struikelt over een hiphopdrumpatroon, voor een familie die telkens over zichzelf struikelt. Britell won er twee Emmy's mee.",
+      "fun_fact_it": "Una figura di pianoforte che inciampa di continuo su un pattern di batteria hip-hop, per una famiglia che inciampa su se stessa. Britell vinse due Emmy."
     }
   ],
   "movie_quiz_enabled": true

--- a/custom_components/beatify/playlists/movies-100-greatest-themes.json
+++ b/custom_components/beatify/playlists/movies-100-greatest-themes.json
@@ -1,6 +1,6 @@
 {
   "name": "Movie & TV Soundtracks 🎬",
-  "version": "1.25",
+  "version": "1.26",
   "tags": [
     "movies",
     "soundtrack",
@@ -7875,6 +7875,196 @@
       "fun_fact_fr": "Elfman avait déjà composé pour les films de la Famille Addams de Tim Burton ; il revient ici dans la même maison, pour la télévision. Le clavecin salue le thème de Vic Mizzy de 1964 sans le citer.",
       "fun_fact_nl": "Elfman had de Addams Family-films van Tim Burton al van muziek voorzien; hier keert hij voor televisie terug in hetzelfde huishouden. Het klavecimbel groet Vic Mizzy's tune uit 1964 zonder hem te citeren.",
       "fun_fact_it": "Elfman aveva già musicato i film della Famiglia Addams di Tim Burton; qui torna nella stessa casa per la televisione. Il clavicembalo saluta il tema di Vic Mizzy del 1964 senza citarlo."
+    },
+    {
+      "artist": "Malcolm Arnold",
+      "title": "The Bridge On The River Kwai - The Colonel Bogey March",
+      "year": 1957,
+      "uri": "spotify:track:0GJdlmUYa1oBqjcj93Z5GC",
+      "uri_apple_music": "applemusic://track/333499783",
+      "uri_deezer": "deezer://track/4380625",
+      "isrc": "DEB519500060",
+      "alt_artists": [
+        "Elmer Bernstein",
+        "Maurice Jarre"
+      ],
+      "fun_fact": "Arnold won an Oscar for the score in six weeks of work. The march the prisoners whistle is older than the film — Kenneth Alford wrote it in 1914 — and Arnold built his own theme to answer it.",
+      "fun_fact_de": "Arnold gewann für die Musik einen Oscar, geschrieben in sechs Wochen. Der Marsch, den die Gefangenen pfeifen, ist älter als der Film — Kenneth Alford schrieb ihn 1914 — und Arnold setzte ihm sein eigenes Thema entgegen.",
+      "fun_fact_es": "Arnold ganó un Óscar por una partitura escrita en seis semanas. La marcha que silban los prisioneros es más antigua que la película — Kenneth Alford la compuso en 1914 — y Arnold le opuso un tema propio.",
+      "fun_fact_fr": "Arnold a remporté un Oscar pour une partition écrite en six semaines. La marche que sifflent les prisonniers est plus ancienne que le film — Kenneth Alford l'a composée en 1914 — et Arnold lui a opposé son propre thème.",
+      "fun_fact_nl": "Arnold won een Oscar voor een partituur die hij in zes weken schreef. De mars die de gevangenen fluiten is ouder dan de film — Kenneth Alford schreef hem in 1914 — en Arnold zette er zijn eigen thema tegenover.",
+      "fun_fact_it": "Arnold vinse un Oscar per una partitura scritta in sei settimane. La marcia che i prigionieri fischiettano è più antica del film — Kenneth Alford la compose nel 1914 — e Arnold le contrappose un tema proprio."
+    },
+    {
+      "artist": "José Feliciano",
+      "title": "El Tango De Roxanne",
+      "year": 2001,
+      "uri": "spotify:track:2aXDWWlbLUapMZnYNDErmv",
+      "uri_apple_music": "applemusic://track/1440892663",
+      "uri_deezer": "deezer://track/2438255",
+      "isrc": "USIR10110330",
+      "alt_artists": [
+        "Ewan McGregor",
+        "Nicole Kidman"
+      ],
+      "fun_fact": "Baz Luhrmann set The Police's Roxanne to a tango and let three voices fight over it. The film's whole method is here: a pop song from 1978 dropped into 1899 Paris without apology.",
+      "fun_fact_de": "Baz Luhrmann legte Roxanne von The Police auf einen Tango und ließ drei Stimmen darum kämpfen. Die ganze Methode des Films steckt darin: ein Popsong von 1978, ohne Entschuldigung ins Paris von 1899 gesetzt.",
+      "fun_fact_es": "Baz Luhrmann puso Roxanne de The Police sobre un tango y dejó que tres voces se disputaran la canción. Todo el método de la película está ahí: un tema pop de 1978 trasladado sin disculpas al París de 1899.",
+      "fun_fact_fr": "Baz Luhrmann a posé Roxanne de The Police sur un tango et laissé trois voix se la disputer. Toute la méthode du film est là : une chanson pop de 1978 transplantée sans excuses dans le Paris de 1899.",
+      "fun_fact_nl": "Baz Luhrmann zette Roxanne van The Police op een tango en liet drie stemmen erom vechten. De hele methode van de film zit erin: een popnummer uit 1978, zonder verontschuldiging neergezet in het Parijs van 1899.",
+      "fun_fact_it": "Baz Luhrmann mise Roxanne dei Police su un tango e lasciò che tre voci se la contendessero. Tutto il metodo del film è qui: una canzone pop del 1978 trapiantata senza scuse nella Parigi del 1899."
+    },
+    {
+      "artist": "Beyoncé",
+      "title": "Listen",
+      "year": 2006,
+      "uri": "spotify:track:0Ai8kxhieTjlqrdHBz9ZPC",
+      "uri_apple_music": "applemusic://track/211540699",
+      "uri_deezer": "deezer://track/5429931",
+      "isrc": "USSM10603618",
+      "alt_artists": [
+        "Jennifer Hudson",
+        "Jazmine Sullivan"
+      ],
+      "fun_fact": "Written for Dreamgirls, where Beyoncé plays a singer being managed out of her own voice. The song is the moment the character takes it back.",
+      "fun_fact_de": "Für Dreamgirls geschrieben, wo Beyoncé eine Sängerin spielt, der man die eigene Stimme wegverwaltet. Das Lied ist der Moment, in dem die Figur sie sich zurückholt.",
+      "fun_fact_es": "Escrita para Dreamgirls, donde Beyoncé interpreta a una cantante a la que le administran su propia voz. La canción es el momento en que el personaje la recupera.",
+      "fun_fact_fr": "Écrite pour Dreamgirls, où Beyoncé incarne une chanteuse dépossédée de sa propre voix par son management. La chanson est l'instant où le personnage la reprend.",
+      "fun_fact_nl": "Geschreven voor Dreamgirls, waarin Beyoncé een zangeres speelt die haar eigen stem wordt afgenomen. Het nummer is het moment waarop het personage die terugpakt.",
+      "fun_fact_it": "Scritta per Dreamgirls, dove Beyoncé interpreta una cantante a cui viene sottratta la propria voce. La canzone è il momento in cui il personaggio se la riprende."
+    },
+    {
+      "artist": "Leona Lewis",
+      "title": "I See You (Theme from Avatar)",
+      "year": 2009,
+      "uri": "spotify:track:02TVrXmI9EBYpuSdmTr4gn",
+      "uri_apple_music": "applemusic://track/342383917",
+      "uri_deezer": "deezer://track/4828165",
+      "isrc": "USAT20904005",
+      "alt_artists": [
+        "Céline Dion",
+        "Sarah Brightman"
+      ],
+      "fun_fact": "James Horner wrote the end-credits song for a film whose title greeting is also its central idea: to see someone is to understand them. It plays as the audience leaves Pandora.",
+      "fun_fact_de": "James Horner schrieb das Abspannlied für einen Film, dessen Grußformel zugleich sein Kerngedanke ist: jemanden zu sehen heißt, ihn zu verstehen. Es läuft, während das Publikum Pandora verlässt.",
+      "fun_fact_es": "James Horner escribió la canción de los créditos finales para una película cuyo saludo es también su idea central: ver a alguien es comprenderlo. Suena mientras el público abandona Pandora.",
+      "fun_fact_fr": "James Horner a écrit la chanson du générique de fin pour un film dont la formule de salut est aussi l'idée centrale : voir quelqu'un, c'est le comprendre. Elle passe quand le public quitte Pandora.",
+      "fun_fact_nl": "James Horner schreef het aftitelnummer voor een film waarin de begroeting ook het kernidee is: iemand zien betekent hem begrijpen. Het klinkt terwijl het publiek Pandora verlaat.",
+      "fun_fact_it": "James Horner scrisse la canzone dei titoli di coda per un film il cui saluto è anche la sua idea centrale: vedere qualcuno significa comprenderlo. Suona mentre il pubblico lascia Pandora."
+    },
+    {
+      "artist": "Christina Perri",
+      "title": "A Thousand Years",
+      "year": 2011,
+      "uri": "spotify:track:6lanRgr6wXibZr8KgzXxBl",
+      "uri_apple_music": "applemusic://track/1728225920",
+      "uri_deezer": "deezer://track/14499484",
+      "isrc": "USAT21102141",
+      "alt_artists": [
+        "Sara Bareilles",
+        "Colbie Caillat"
+      ],
+      "fun_fact": "Written for the fourth Twilight film and now heard mostly at weddings, which is not where it started. It has outsold the films it was made for.",
+      "fun_fact_de": "Für den vierten Twilight-Film geschrieben und heute vor allem auf Hochzeiten zu hören, wo es nicht herkommt. Verkauft hat es sich besser als die Filme, für die es entstand.",
+      "fun_fact_es": "Escrita para la cuarta película de Crepúsculo y hoy sobre todo presente en bodas, que no es de donde viene. Ha vendido más que las películas para las que se hizo.",
+      "fun_fact_fr": "Écrite pour le quatrième film Twilight et entendue aujourd'hui surtout aux mariages, ce qui n'est pas son origine. Elle s'est mieux vendue que les films pour lesquels elle fut composée.",
+      "fun_fact_nl": "Geschreven voor de vierde Twilight-film en tegenwoordig vooral op bruiloften te horen, wat niet de oorsprong is. Het verkocht beter dan de films waarvoor het gemaakt werd.",
+      "fun_fact_it": "Scritta per il quarto film di Twilight e oggi ascoltata soprattutto ai matrimoni, che non è da dove viene. Ha venduto più dei film per cui fu composta."
+    },
+    {
+      "artist": "José González",
+      "title": "Stay Alive",
+      "year": 2013,
+      "uri": "spotify:track:0ZNYGrmcehorhh9JOeg5Iv",
+      "uri_apple_music": "applemusic://track/1440857570",
+      "uri_deezer": "deezer://track/72688336",
+      "isrc": "USFM91300095",
+      "alt_artists": [
+        "Sufjan Stevens",
+        "Bon Iver"
+      ],
+      "fun_fact": "González sings it in the film as well as on the soundtrack, over the sequence where Walter Mitty finally does the thing he has only imagined. Guitar and one voice, nothing else.",
+      "fun_fact_de": "González singt es im Film wie auf dem Soundtrack, über der Sequenz, in der Walter Mitty endlich tut, was er sich bislang nur vorgestellt hat. Gitarre und eine Stimme, mehr nicht.",
+      "fun_fact_es": "González la canta tanto en la película como en la banda sonora, sobre la secuencia en que Walter Mitty por fin hace lo que solo había imaginado. Guitarra y una voz, nada más.",
+      "fun_fact_fr": "González la chante dans le film comme sur la bande originale, sur la séquence où Walter Mitty fait enfin ce qu'il n'avait qu'imaginé. Une guitare et une voix, rien d'autre.",
+      "fun_fact_nl": "González zingt het zowel in de film als op de soundtrack, over de scène waarin Walter Mitty eindelijk doet wat hij zich alleen had verbeeld. Gitaar en één stem, meer niet.",
+      "fun_fact_it": "González la canta sia nel film sia nella colonna sonora, sulla sequenza in cui Walter Mitty fa finalmente ciò che aveva solo immaginato. Chitarra e una voce, nient'altro."
+    },
+    {
+      "artist": "Demi Lovato",
+      "title": "Let It Go",
+      "year": 2013,
+      "uri": "spotify:track:4cbJwuAEbaodP4InQDfAmW",
+      "uri_apple_music": "applemusic://track/1440825904",
+      "uri_deezer": "deezer://track/72391069",
+      "isrc": "USWD11366344",
+      "alt_artists": [
+        "Idina Menzel",
+        "Kristen Bell"
+      ],
+      "fun_fact": "The pop version that runs over the closing credits of Frozen, alongside Idina Menzel's version from the film itself. Two recordings of one song, released the same day.",
+      "fun_fact_de": "Die Popfassung, die über dem Abspann von Die Eiskönigin läuft, neben Idina Menzels Version aus dem Film selbst. Zwei Aufnahmen eines Liedes, am selben Tag veröffentlicht.",
+      "fun_fact_es": "La versión pop que suena en los créditos finales de Frozen, junto a la de Idina Menzel dentro de la película. Dos grabaciones de una misma canción, publicadas el mismo día.",
+      "fun_fact_fr": "La version pop du générique de fin de La Reine des neiges, à côté de celle d'Idina Menzel dans le film. Deux enregistrements d'une même chanson, parus le même jour.",
+      "fun_fact_nl": "De popversie die over de aftiteling van Frozen loopt, naast die van Idina Menzel in de film zelf. Twee opnames van één lied, op dezelfde dag uitgebracht.",
+      "fun_fact_it": "La versione pop che scorre sui titoli di coda di Frozen, accanto a quella di Idina Menzel nel film stesso. Due incisioni di una sola canzone, uscite lo stesso giorno."
+    },
+    {
+      "artist": "Gustavo Santaolalla",
+      "title": "The Last of Us",
+      "year": 2013,
+      "uri": "spotify:track:285ieonEuLkll3zknYK2TY",
+      "uri_apple_music": "applemusic://track/655118443",
+      "uri_deezer": "deezer://track/67770820",
+      "isrc": "USGSS1300097",
+      "alt_artists": [
+        "Hans Zimmer",
+        "Ramin Djawadi"
+      ],
+      "fun_fact": "Santaolalla scored the game on a ronroco, an Andean lute, and recorded it before seeing much of the story. When the television adaptation came, the same theme came with it unchanged.",
+      "fun_fact_de": "Santaolalla vertonte das Spiel auf einem Ronroco, einer andinen Laute, und nahm es auf, bevor er viel von der Geschichte gesehen hatte. Als die Fernsehfassung kam, kam dasselbe Thema unverändert mit.",
+      "fun_fact_es": "Santaolalla compuso la música del juego con un ronroco, un laúd andino, y la grabó antes de haber visto gran parte de la historia. Cuando llegó la adaptación televisiva, el mismo tema vino sin cambios.",
+      "fun_fact_fr": "Santaolalla a composé la musique du jeu au ronroco, un luth andin, et l'a enregistrée avant d'avoir vu grand-chose de l'histoire. Quand l'adaptation télévisée est arrivée, le même thème l'a suivie sans changement.",
+      "fun_fact_nl": "Santaolalla componeerde de muziek voor het spel op een ronroco, een Andesluit, en nam die op voordat hij veel van het verhaal had gezien. Toen de tv-bewerking kwam, kwam hetzelfde thema onveranderd mee.",
+      "fun_fact_it": "Santaolalla musicò il videogioco con un ronroco, un liuto andino, e lo registrò prima di aver visto gran parte della storia. Quando arrivò l'adattamento televisivo, lo stesso tema lo accompagnò invariato."
+    },
+    {
+      "artist": "Hans Zimmer",
+      "title": "The Crown Main Title",
+      "year": 2016,
+      "uri": "spotify:track:21u2gUlh5Iun4ogGGqKVum",
+      "uri_apple_music": "applemusic://track/1168757720",
+      "uri_deezer": "deezer://track/135370914",
+      "isrc": "USJPL1600301",
+      "alt_artists": [
+        "Ramin Djawadi",
+        "Rupert Gregson-Williams"
+      ],
+      "fun_fact": "Zimmer wrote the title music for a series about a crown rather than a person, and the theme behaves accordingly: a machine of brass and strings that turns over regardless of who is wearing it.",
+      "fun_fact_de": "Zimmer schrieb die Titelmusik für eine Serie über eine Krone, nicht über einen Menschen — und das Thema verhält sich entsprechend: eine Maschine aus Blech und Streichern, die läuft, gleich wer sie trägt.",
+      "fun_fact_es": "Zimmer escribió la sintonía para una serie sobre una corona, no sobre una persona, y el tema se comporta en consecuencia: una máquina de metales y cuerdas que gira sin importar quién la lleve.",
+      "fun_fact_fr": "Zimmer a écrit le générique d'une série qui parle d'une couronne et non d'une personne, et le thème se comporte en conséquence : une machine de cuivres et de cordes qui tourne, peu importe qui la porte.",
+      "fun_fact_nl": "Zimmer schreef de titelmuziek voor een serie over een kroon en niet over een mens, en het thema gedraagt zich navenant: een machine van koper en strijkers die doordraait, wie hem ook draagt.",
+      "fun_fact_it": "Zimmer scrisse la sigla per una serie che parla di una corona e non di una persona, e il tema si comporta di conseguenza: una macchina di ottoni e archi che gira comunque, chiunque la indossi."
+    },
+    {
+      "artist": "Lady Gaga",
+      "title": "Always Remember Us This Way",
+      "year": 2018,
+      "uri": "spotify:track:74iZuPGwyL33VlTr6jTnab",
+      "uri_apple_music": "applemusic://track/1437668523",
+      "uri_deezer": "deezer://track/561856792",
+      "isrc": "USUM71813195",
+      "alt_artists": [
+        "Bradley Cooper",
+        "Adele"
+      ],
+      "fun_fact": "Sung in A Star Is Born at the point where the character has already won and the relationship has already started to lose. Gaga wrote it with three Nashville songwriters.",
+      "fun_fact_de": "In A Star Is Born an der Stelle gesungen, an der die Figur schon gewonnen hat und die Beziehung schon zu verlieren beginnt. Gaga schrieb es mit drei Songwritern aus Nashville.",
+      "fun_fact_es": "Se canta en Ha nacido una estrella en el punto en que el personaje ya ha ganado y la relación ya empieza a perder. Gaga la escribió con tres compositores de Nashville.",
+      "fun_fact_fr": "Chantée dans A Star Is Born au moment où le personnage a déjà gagné et où la relation commence déjà à perdre. Gaga l'a écrite avec trois auteurs de Nashville.",
+      "fun_fact_nl": "Gezongen in A Star Is Born op het punt waar het personage al gewonnen heeft en de relatie al begint te verliezen. Gaga schreef het met drie songwriters uit Nashville.",
+      "fun_fact_it": "Cantata in A Star Is Born nel punto in cui il personaggio ha già vinto e la relazione comincia già a perdere. Gaga la scrisse con tre autori di Nashville."
     }
   ],
   "movie_quiz_enabled": true


### PR DESCRIPTION
Refs #2377

Adds **16 film and television titles**, 162 → 178, version 1.24 → 1.25, and renames the playlist from **"100 Greatest Movie Themes 🎬"** to **"Movie & TV Soundtracks 🎬"**.

| Year | Artist | Title |
|---|---|---|
| 1972 | Liza Minnelli | Cabaret |
| 1989 | Jonathan Wolff | Seinfeld Theme |
| 1993 | John Williams | Theme From Jurassic Park |
| 1995 | Tina Turner | Goldeneye |
| 1996 | The Wonders | That Thing You Do! |
| 1997 | Éric Serra | The Diva Dance |
| 1998 | Jamiroquai | Deeper Underground |
| 1999 | Ronan Keating | When You Say Nothing At All |
| 2000 | LeAnn Rimes | Can't Fight The Moonlight |
| 2000 | Clint Mansell | Lux Aeterna |
| 2002 | Bryan Adams | Here I Am |
| 2003 | Billy Mack | Christmas Is All Around |
| 2010 | Bear McCreary | Theme from the Walking Dead |
| 2012 | Adele | Skyfall |
| 2019 | Ludwig Göransson | The Mandalorian |
| 2022 | Danny Elfman | Wednesday Main Titles |

## The rename is the point

The request holds 164 tracks, **110 of them new catalogue-wide**, and they include television themes. A playlist called "100 Greatest Movie Themes" already carried **162** songs before this batch — it had outgrown its own name by 62 before anything was merged. With the request worked through it lands near 272, and it is no longer movie themes only.

`movies-100-greatest-themes.json` **keeps its file name**. That name is the playlist's identity towards installed copies; changing it would be a relocation, not a rename, and would touch every installation. The displayed name lives in its own field.

## Two corrected years, and why they matter

MusicBrainz, the ISRC year field and the Apple album **all three agreed** on:

- **2021** for the Seinfeld theme — Jonathan Wolff wrote it in **1989**
- **2017** for the Walking Dead theme — Bear McCreary wrote it in **2010**

Both are reissue dates. Film and television music is re-released on compilations constantly, so three independent signals can agree on a year that is decades off the work. **The three-signal gate is weaker for soundtracks than it was for the Schlager batches**, where it held up well. For this playlist the film or series year decides.

## No YouTube links in this batch

The YouTube daily quota was exhausted at **07:35** — `spent_today 96/96`, HTTP 429 — so every lookup would have come back empty. Nothing was guessed.

The playlist stood at **162/162** for `uri_youtube_music` and now has 16 gaps. That is a real regression in a previously complete field, and it is left standing on purpose: the backfill agent selects playlists by gap count, so this one moves up its queue and fills them without intervention.

## Verification

- `scripts/validate_playlists.py` — all 61 playlists valid, schema gate passed.
- `pytest tests/` — 2132 passed, 2 skipped.
- Every entry carries a fun fact in **all six languages** this playlist uses (en, de, es, fr, nl, it) plus `alt_artists`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184GyBkpCUC8uNJsDnp6rjv