### PR TITLE
fix(backfill): count the YouTube budget on the Pacific day, not the local one

### DIFF
--- a/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
+++ b/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
@@ -554,6 +554,27 @@ class YouTubeBudget:
         self.spent_today += 1
 
 
+def _quota_day() -> str:
+    """The day Google's YouTube quota counts against (midnight Pacific).
+
+    Falls back to the local clock when timezone data is missing. That restores
+    the old behaviour, but says so instead of failing quietly.
+    """
+    try:
+        from datetime import datetime
+        from zoneinfo import ZoneInfo
+
+        return datetime.now(ZoneInfo("America/Los_Angeles")).strftime("%Y-%m-%d")
+    except (ImportError, KeyError, OSError) as err:  # pragma: no cover - no tzdata
+        print(
+            f"  Warning: cannot determine the Pacific date ({err.__class__.__name__}), "
+            "the YouTube budget will count on the local clock and most slots "
+            "will run empty (#2452)",
+            file=sys.stderr,
+        )
+        return time.strftime("%Y-%m-%d")
+
+
 def load_state(path: Path, today: str, budget: int) -> YouTubeBudget:
     data = {}
     if path.exists():
@@ -1095,7 +1116,13 @@ def run(args: argparse.Namespace) -> int:
         if args.state
         else (Path(__file__).resolve().parent.parent / ".backfill-state.json")
     )
-    today = time.strftime("%Y-%m-%d")
+    # #2452: Google resets the YouTube quota at midnight Pacific, not at local
+    # midnight. This script used to count on the local clock, and on CEST the two
+    # boundaries sit nine hours apart: the 03:32 run spent all 96 units, Google
+    # refreshed them at 09:00 local, but the counter stayed at 96/96 until local
+    # midnight, so every later slot skipped. Measured 2026-09-01: HTTP 429 at
+    # 07:35, a fresh result at 09:43.
+    today = _quota_day()
     yt_key = os.environ.get("YOUTUBE_API_KEY")
     yt_state = load_state(state_path, today, args.youtube_budget)
 


### PR DESCRIPTION
Fixes #2452

Google resets the YouTube Data API quota at **midnight Pacific**. This script reset its own counter with `time.strftime("%Y-%m-%d")` — the **local** calendar day. On CEST those two boundaries sit nine hours apart, so the counter reported an exhausted budget through most of a day in which Google had already refreshed it.

## Measured, not inferred

On 1 September 2026 the agent got **HTTP 429 at 07:35** and a **fresh result at 09:43**. The boundary falls at 09:00 local time, which is midnight Pacific.

The six slices run at 03:32, 07:32, 11:32, 15:32, 19:32 and 23:32. The 03:32 run spends all 96 units against the *previous* Pacific day; from 09:00 a fresh Pacific day is available, but the local counter still reads 96/96 and keeps reading it until local midnight.

## The change

A `_quota_day()` helper returning the Pacific date, used where `today` is computed. If timezone data is unavailable it falls back to the local clock and prints a warning — the old behaviour, but stated rather than silent.

## The state file needed one migration

The stored `date` was written by the old code and held a local date. Left alone, the fix would have looked like a no-op until the next rollover. `date` was reinterpreted once from `2026-09-01` to `2026-08-31`, which is the Pacific day the 96 units were actually spent on. Verified afterwards: `_quota_day()` returns `2026-09-01`, `spent_today` reads 0, the full budget is available.

`ruff format --check` clean; `ruff check` reports the same three pre-existing `BLE001` findings as `main`, none of them new.

## One note on this file

`.claude/` is listed in `.gitignore`, but these four skill files are tracked, so the change needs `git add -f` to stage. Same trap that dropped the release notes from #2440.
