### PR TITLE
data(90s): seventeen additions from the Bayern 1 request (#2374)

### DIFF
--- a/custom_components/beatify/playlists/90er-hits.json
+++ b/custom_components/beatify/playlists/90er-hits.json
@@ -3780,6 +3780,26 @@
       "fun_fact_fr": "Le chanteur jamaïcain travaillait avec Michael Cretu d'Enigma quand il a réenregistré cette ballade d'Air Supply, et la reprise s'est mieux vendue que l'original en Europe.",
       "fun_fact_nl": "De Jamaicaanse zanger werkte met Michael Cretu van Enigma toen hij deze Air Supply-ballade opnieuw opnam, en de remake verkocht in Europa beter dan het origineel.",
       "fun_fact_it": "Il cantante giamaicano lavorava con Michael Cretu degli Enigma quando reincise questa ballata degli Air Supply, e il rifacimento vendette in Europa più dell'originale."
+    },
+    {
+      "year": 1999,
+      "uri": "spotify:track:7bOYOD0d7ByMTXvJnQVl8d",
+      "artist": "Blondie",
+      "alt_artists": [
+        "Debbie Harry",
+        "The Pretenders",
+        "Garbage"
+      ],
+      "title": "Maria",
+      "isrc": "USBY29800018",
+      "uri_apple_music": null,
+      "uri_deezer": "deezer://track/3805884212",
+      "fun_fact": "Blondie returned after seventeen years apart and went straight to number one in Britain, seventeen years after 'Atomic' had done the same.",
+      "fun_fact_de": "Blondie kehrten nach siebzehn Jahren Trennung zurück und gingen in Britannien direkt auf Platz eins — siebzehn Jahre nachdem 'Atomic' dasselbe geschafft hatte.",
+      "fun_fact_es": "Blondie volvió tras diecisiete años separados y llegó directa al número uno en Gran Bretaña, diecisiete años después de que 'Atomic' hiciera lo mismo.",
+      "fun_fact_fr": "Blondie est revenu après dix-sept ans de séparation et est allé droit à la première place britannique, dix-sept ans après qu'« Atomic » eut fait de même.",
+      "fun_fact_nl": "Blondie keerde na zeventien jaar terug en ging in Groot-Brittannië rechtstreeks naar nummer één, zeventien jaar nadat 'Atomic' hetzelfde had gedaan.",
+      "fun_fact_it": "I Blondie tornarono dopo diciassette anni di separazione e andarono dritti al primo posto in Gran Bretagna, diciassette anni dopo che 'Atomic' aveva fatto lo stesso."
     }
   ]
 }

--- a/custom_components/beatify/playlists/90er-hits.json
+++ b/custom_components/beatify/playlists/90er-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "90s Hits",
-  "version": "1.29",
+  "version": "1.30",
   "tags": [
     "1990s",
     "pop",
@@ -3440,6 +3440,346 @@
         "nl": "applemusic://track/98318466",
         "it": "applemusic://track/98318466"
       }
+    },
+    {
+      "year": 1990,
+      "uri": "spotify:track:0XwjdpwvEwukcg3XU4Ibzt",
+      "artist": "Jon Bon Jovi",
+      "alt_artists": [
+        "Bon Jovi",
+        "Richie Sambora",
+        "Bryan Adams"
+      ],
+      "title": "Blaze Of Glory",
+      "isrc": "USPG19090003",
+      "uri_apple_music": "applemusic://track/1440657907",
+      "uri_deezer": "deezer://track/1104054",
+      "fun_fact": "Written for Young Guns II after Emilio Estevez asked to use 'Wanted Dead or Alive' and Bon Jovi decided to write something new instead — it won him a Golden Globe.",
+      "fun_fact_de": "Geschrieben für Young Guns II, nachdem Emilio Estevez um 'Wanted Dead or Alive' gebeten hatte und Bon Jovi lieber etwas Neues schrieb — es brachte ihm einen Golden Globe.",
+      "fun_fact_es": "Escrita para Young Guns II después de que Emilio Estevez pidiera usar 'Wanted Dead or Alive' y Bon Jovi prefiriera componer algo nuevo; le valió un Globo de Oro.",
+      "fun_fact_fr": "Écrite pour Young Guns II après qu'Emilio Estevez eut demandé 'Wanted Dead or Alive' et que Bon Jovi eut préféré composer du neuf — elle lui a valu un Golden Globe.",
+      "fun_fact_nl": "Geschreven voor Young Guns II nadat Emilio Estevez om 'Wanted Dead or Alive' vroeg en Bon Jovi liever iets nieuws schreef — het leverde hem een Golden Globe op.",
+      "fun_fact_it": "Scritta per Young Guns II dopo che Emilio Estevez chiese 'Wanted Dead or Alive' e Bon Jovi preferì comporre qualcosa di nuovo: gli valse un Golden Globe."
+    },
+    {
+      "year": 1991,
+      "uri": "spotify:track:6O7nMW8pIAk8m9ub6azaF9",
+      "artist": "Bee Gees",
+      "alt_artists": [
+        "Barry Gibb",
+        "Robin Gibb",
+        "Andy Gibb"
+      ],
+      "title": "Secret Love",
+      "isrc": "USWB10104657",
+      "uri_apple_music": "applemusic://track/1445670131",
+      "uri_deezer": "deezer://track/139138769",
+      "fun_fact": "By 1991 the Bee Gees had been written off as a disco act twice over; this single put them back in the UK top five without a trace of falsetto disco.",
+      "fun_fact_de": "1991 galten die Bee Gees zweimal als abgeschriebene Disco-Band; diese Single brachte sie ohne eine Spur Falsett-Disco zurück in die britischen Top fünf.",
+      "fun_fact_es": "En 1991 a los Bee Gees se les había dado por acabados como grupo disco dos veces; este sencillo les devolvió al top cinco británico sin rastro de falsete disco.",
+      "fun_fact_fr": "En 1991, les Bee Gees avaient été enterrés deux fois comme groupe disco ; ce single les a ramenés dans le top cinq britannique sans la moindre trace de falsetto disco.",
+      "fun_fact_nl": "In 1991 waren de Bee Gees al twee keer afgeschreven als discoband; deze single bracht ze zonder een spoor van falsetdisco terug in de Britse top vijf.",
+      "fun_fact_it": "Nel 1991 i Bee Gees erano stati dati per finiti come gruppo disco due volte; questo singolo li riportò nella top cinque britannica senza traccia di falsetto disco."
+    },
+    {
+      "year": 1991,
+      "uri": "spotify:track:5hkDVHllJDgj4ynguaT2Ax",
+      "artist": "Mike + The Mechanics",
+      "alt_artists": [
+        "Genesis",
+        "Phil Collins",
+        "Marillion"
+      ],
+      "title": "Word Of Mouth",
+      "isrc": "GB5KW1900093",
+      "uri_apple_music": "applemusic://track/1721958582",
+      "uri_deezer": "deezer://track/2598565422",
+      "fun_fact": "Mike Rutherford ran this band alongside Genesis, and for a while the side project charted in Britain more reliably than the main one.",
+      "fun_fact_de": "Mike Rutherford betrieb diese Band neben Genesis, und eine Zeit lang war das Nebenprojekt in Britannien chartsicherer als die Hauptband.",
+      "fun_fact_es": "Mike Rutherford llevaba este grupo en paralelo a Genesis, y durante un tiempo el proyecto paralelo entraba en las listas británicas con más fiabilidad que el principal.",
+      "fun_fact_fr": "Mike Rutherford menait ce groupe en parallèle de Genesis, et pendant un temps le projet parallèle se classait plus sûrement que le principal au Royaume-Uni.",
+      "fun_fact_nl": "Mike Rutherford leidde deze band naast Genesis, en een tijdlang scoorde het zijproject in Groot-Brittannië betrouwbaarder dan de hoofdband.",
+      "fun_fact_it": "Mike Rutherford portava avanti questa band accanto ai Genesis, e per un periodo il progetto parallelo entrava in classifica in Gran Bretagna più del principale."
+    },
+    {
+      "year": 1991,
+      "uri": "spotify:track:5o5U2r5F3ojvkhLSqRbY1Y",
+      "artist": "Chesney Hawkes",
+      "alt_artists": [
+        "Nik Kershaw",
+        "Bros",
+        "Rick Astley"
+      ],
+      "title": "The One and Only",
+      "isrc": "GBAYK9100001",
+      "uri_apple_music": "applemusic://track/1629183924",
+      "uri_deezer": "deezer://track/1787674467",
+      "fun_fact": "Nik Kershaw wrote it, Hawkes was nineteen when it went to number one for five weeks, and he never had another top forty hit — the definition of the term.",
+      "fun_fact_de": "Nik Kershaw schrieb den Song, Hawkes war neunzehn, als er fünf Wochen auf Platz eins stand, und er hatte nie wieder einen Top-vierzig-Hit — die Definition des Begriffs.",
+      "fun_fact_es": "La escribió Nik Kershaw, Hawkes tenía diecinueve años cuando estuvo cinco semanas en el número uno, y nunca volvió al top cuarenta: la definición del término.",
+      "fun_fact_fr": "Nik Kershaw l'a écrite, Hawkes avait dix-neuf ans quand elle est restée cinq semaines première, et il n'a jamais eu d'autre top quarante — la définition du terme.",
+      "fun_fact_nl": "Nik Kershaw schreef het, Hawkes was negentien toen het vijf weken op nummer één stond, en hij had nooit meer een top-veertig-hit — de definitie van het begrip.",
+      "fun_fact_it": "La scrisse Nik Kershaw, Hawkes aveva diciannove anni quando restò cinque settimane al primo posto, e non ebbe mai più una top quaranta: la definizione del termine."
+    },
+    {
+      "year": 1992,
+      "uri": "spotify:track:28CbxqvoML43nJMU68VPx1",
+      "artist": "Shakespears Sister",
+      "alt_artists": [
+        "Bananarama",
+        "Siobhan Fahey",
+        "Eurythmics"
+      ],
+      "title": "Hello (Turn Your Radio On)",
+      "isrc": "GBANP9200003",
+      "uri_apple_music": "applemusic://track/1321520085",
+      "uri_deezer": "deezer://track/432716532",
+      "fun_fact": "Siobhan Fahey had left Bananarama for this duo, and the follow-up to 'Stay' turned the same gothic pop towards the radio dial itself.",
+      "fun_fact_de": "Siobhan Fahey hatte Bananarama für dieses Duo verlassen, und der Nachfolger von 'Stay' richtete denselben gotischen Pop auf die Radioskala selbst.",
+      "fun_fact_es": "Siobhan Fahey había dejado Bananarama por este dúo, y la continuación de 'Stay' dirigió el mismo pop gótico hacia el propio dial de la radio.",
+      "fun_fact_fr": "Siobhan Fahey avait quitté Bananarama pour ce duo, et la suite de 'Stay' a tourné la même pop gothique vers le cadran de la radio.",
+      "fun_fact_nl": "Siobhan Fahey had Bananarama verlaten voor dit duo, en de opvolger van 'Stay' richtte diezelfde gotische pop op de radioschaal zelf.",
+      "fun_fact_it": "Siobhan Fahey aveva lasciato le Bananarama per questo duo, e il seguito di 'Stay' rivolse lo stesso pop gotico alla manopola della radio."
+    },
+    {
+      "year": 1993,
+      "uri": "spotify:track:4t1fWWJQs5V9YErfsrDslC",
+      "artist": "Aerosmith",
+      "alt_artists": [
+        "Guns N Roses",
+        "Bon Jovi",
+        "Alice Cooper"
+      ],
+      "title": "Cryin",
+      "isrc": "USIR10000430",
+      "uri_apple_music": "applemusic://track/1680799490",
+      "uri_deezer": "deezer://track/2246520677",
+      "fun_fact": "The video made Alicia Silverstone a star and Aerosmith an MTV band again; the three clips from that album are still shown as a trilogy.",
+      "fun_fact_de": "Das Video machte Alicia Silverstone zum Star und Aerosmith wieder zur MTV-Band; die drei Clips dieses Albums werden bis heute als Trilogie gezeigt.",
+      "fun_fact_es": "El vídeo convirtió a Alicia Silverstone en estrella y devolvió a Aerosmith a la MTV; los tres clips de aquel disco se siguen mostrando como trilogía.",
+      "fun_fact_fr": "Le clip a fait d'Alicia Silverstone une star et d'Aerosmith un groupe MTV à nouveau ; les trois clips de cet album sont encore présentés comme une trilogie.",
+      "fun_fact_nl": "De video maakte Alicia Silverstone een ster en Aerosmith weer een MTV-band; de drie clips van dat album worden nog steeds als trilogie getoond.",
+      "fun_fact_it": "Il video rese Alicia Silverstone una star e riportò gli Aerosmith su MTV; i tre clip di quell'album sono ancora mostrati come trilogia."
+    },
+    {
+      "year": 1993,
+      "uri": "spotify:track:4LxrmBgBLQc2oU60r6cBPW",
+      "artist": "Mr. Big",
+      "alt_artists": [
+        "Cat Stevens",
+        "Extreme",
+        "Nelson"
+      ],
+      "title": "Wild World",
+      "isrc": "USDEI0907987",
+      "uri_apple_music": "applemusic://track/1270576307",
+      "uri_deezer": "deezer://track/6063716",
+      "fun_fact": "The band followed their acoustic number one with another Cat Stevens cover, and the softer route worked in Europe long after it stopped working at home.",
+      "fun_fact_de": "Die Band ließ ihrer akustischen Nummer eins ein weiteres Cat-Stevens-Cover folgen, und der weichere Weg trug in Europa noch lange, als er daheim nicht mehr trug.",
+      "fun_fact_es": "El grupo siguió su número uno acústico con otra versión de Cat Stevens, y la vía más suave funcionó en Europa mucho después de dejar de funcionar en casa.",
+      "fun_fact_fr": "Le groupe a fait suivre son numéro un acoustique d'une autre reprise de Cat Stevens, et cette voie plus douce a marché en Europe bien après avoir cessé de marcher chez eux.",
+      "fun_fact_nl": "De band liet hun akoestische nummer één volgen door nog een Cat Stevens-cover, en de zachtere weg werkte in Europa nog lang nadat hij thuis niet meer werkte.",
+      "fun_fact_it": "La band fece seguire al suo numero uno acustico un'altra cover di Cat Stevens, e la via più morbida funzionò in Europa molto dopo che a casa aveva smesso."
+    },
+    {
+      "year": 1994,
+      "uri": "spotify:track:1vyWVgVwYfd15EGzz5zeej",
+      "artist": "Erasure",
+      "alt_artists": [
+        "Pet Shop Boys",
+        "Depeche Mode",
+        "Yazoo"
+      ],
+      "title": "Always",
+      "isrc": "GBAJH9400001",
+      "uri_apple_music": "applemusic://track/1436488400",
+      "uri_deezer": "deezer://track/3783086782",
+      "fun_fact": "A decade after the fact the song found a second life inside a video game, where a level built around it introduced it to players born after it charted.",
+      "fun_fact_de": "Ein Jahrzehnt später fand der Song ein zweites Leben in einem Videospiel, dessen um ihn herum gebautes Level ihn Spielern nahebrachte, die nach seiner Chartzeit geboren waren.",
+      "fun_fact_es": "Una década después la canción tuvo una segunda vida dentro de un videojuego, cuyo nivel construido a su alrededor la presentó a jugadores nacidos después de su paso por las listas.",
+      "fun_fact_fr": "Une décennie plus tard, la chanson a connu une seconde vie dans un jeu vidéo, dont un niveau bâti autour d'elle l'a fait découvrir à des joueurs nés après son passage en tête.",
+      "fun_fact_nl": "Een decennium later kreeg het nummer een tweede leven in een videospel, waarvan een level eromheen het introduceerde bij spelers die na de hitperiode waren geboren.",
+      "fun_fact_it": "Un decennio dopo la canzone ebbe una seconda vita in un videogioco, il cui livello costruito attorno a essa la fece conoscere a giocatori nati dopo il suo passaggio in classifica."
+    },
+    {
+      "year": 1994,
+      "uri": "spotify:track:4wYCe9tSmUolNU4WmJKbZy",
+      "artist": "East 17",
+      "alt_artists": [
+        "Take That",
+        "Boyzone",
+        "Bad Boys Inc"
+      ],
+      "title": "Stay Another Day",
+      "isrc": "GBANP9400042",
+      "uri_apple_music": "applemusic://track/1313407184",
+      "uri_deezer": "deezer://track/428735552",
+      "fun_fact": "Tony Mortimer wrote it about his brother's suicide; it was released as a Christmas single with sleigh bells added, and most listeners heard only the bells.",
+      "fun_fact_de": "Tony Mortimer schrieb den Song über den Suizid seines Bruders; er erschien als Weihnachtssingle mit hinzugefügten Schlittenglocken, und die meisten hörten nur die Glocken.",
+      "fun_fact_es": "Tony Mortimer la escribió sobre el suicidio de su hermano; salió como sencillo navideño con cascabeles añadidos, y la mayoría solo oyó los cascabeles.",
+      "fun_fact_fr": "Tony Mortimer l'a écrite sur le suicide de son frère ; elle est sortie comme single de Noël avec des grelots ajoutés, et la plupart n'ont entendu que les grelots.",
+      "fun_fact_nl": "Tony Mortimer schreef het over de zelfdoding van zijn broer; het verscheen als kerstsingle met toegevoegde sleebellen, en de meesten hoorden alleen de bellen.",
+      "fun_fact_it": "Tony Mortimer la scrisse sul suicidio del fratello; uscì come singolo natalizio con sonagli aggiunti, e i più sentirono solo i sonagli."
+    },
+    {
+      "year": 1996,
+      "uri": "spotify:track:0KPWi8mDRagwxnwaA0di8a",
+      "artist": "Skunk Anansie",
+      "alt_artists": [
+        "Garbage",
+        "No Doubt",
+        "Placebo"
+      ],
+      "title": "Hedonism (Just Because You Feel Good)",
+      "isrc": "GBBTF9600005",
+      "uri_apple_music": "applemusic://track/336927563",
+      "uri_deezer": "deezer://track/2629609432",
+      "fun_fact": "Skin wrote the line about wanting someone to fail as a study of spite, and the band's one ballad became their biggest hit by a distance.",
+      "fun_fact_de": "Skin schrieb die Zeile über den Wunsch, jemanden scheitern zu sehen, als Studie über Missgunst, und die eine Ballade der Band wurde mit Abstand ihr größter Hit.",
+      "fun_fact_es": "Skin escribió el verso sobre desear que alguien fracase como un estudio del rencor, y la única balada del grupo se convirtió con diferencia en su mayor éxito.",
+      "fun_fact_fr": "Skin a écrit ce vers sur le désir de voir quelqu'un échouer comme une étude de la rancœur, et l'unique ballade du groupe est devenue de loin son plus grand succès.",
+      "fun_fact_nl": "Skin schreef de regel over willen dat iemand faalt als een studie in wrok, en de enige ballade van de band werd veruit hun grootste hit.",
+      "fun_fact_it": "Skin scrisse il verso sul desiderare il fallimento altrui come studio del rancore, e l'unica ballata della band divenne di gran lunga il loro successo maggiore."
+    },
+    {
+      "year": 1996,
+      "uri": "spotify:track:0Uqs7ilt5kGX9NzFDWTBrP",
+      "artist": "Backstreet Boys",
+      "alt_artists": [
+        "NSYNC",
+        "Boyzone",
+        "Take That"
+      ],
+      "title": "Quit Playing Games (With My Heart)",
+      "isrc": "USJI19710152",
+      "uri_apple_music": "applemusic://track/217939769",
+      "uri_deezer": "deezer://track/4274199",
+      "fun_fact": "The group were a European act for two full years before America noticed; this single charted in Germany long before it charted at home.",
+      "fun_fact_de": "Die Gruppe war zwei volle Jahre eine europäische Band, bevor Amerika sie bemerkte; diese Single stand in Deutschland lange vor der Heimat in den Charts.",
+      "fun_fact_es": "El grupo fue una banda europea durante dos años completos antes de que América los notara; este sencillo entró en listas en Alemania mucho antes que en casa.",
+      "fun_fact_fr": "Le groupe a été européen pendant deux années entières avant que l'Amérique ne les remarque ; ce single a été classé en Allemagne bien avant chez eux.",
+      "fun_fact_nl": "De groep was twee volle jaren een Europese act voordat Amerika hen opmerkte; deze single stond in Duitsland allang in de lijsten voordat dat thuis gebeurde.",
+      "fun_fact_it": "Il gruppo fu una band europea per due anni interi prima che l'America se ne accorgesse; questo singolo entrò in classifica in Germania molto prima che in patria."
+    },
+    {
+      "year": 1996,
+      "uri": "spotify:track:1PEqh7awkpuepLBSq8ZwqD",
+      "artist": "Donna Lewis",
+      "alt_artists": [
+        "Natalie Imbruglia",
+        "Sixpence None the Richer",
+        "Des ree"
+      ],
+      "title": "I Love You Always Forever",
+      "isrc": "USAT29600040",
+      "uri_apple_music": "applemusic://track/281708889",
+      "uri_deezer": "deezer://track/846048",
+      "fun_fact": "The Welsh singer took the title from a line in a Henry David Thoreau-quoting novel by H. E. Bates, and it spent nine weeks stuck at number two in America.",
+      "fun_fact_de": "Die walisische Sängerin nahm den Titel aus einer Zeile eines Romans von H. E. Bates, und er hing in Amerika neun Wochen auf Platz zwei fest.",
+      "fun_fact_es": "La cantante galesa tomó el título de un verso de una novela de H. E. Bates, y se quedó nueve semanas atascada en el número dos en Estados Unidos.",
+      "fun_fact_fr": "La chanteuse galloise a tiré le titre d'une phrase d'un roman de H. E. Bates, et le morceau est resté bloqué neuf semaines à la deuxième place aux États-Unis.",
+      "fun_fact_nl": "De Welshe zangeres ontleende de titel aan een zin uit een roman van H. E. Bates, en het bleef negen weken steken op nummer twee in Amerika.",
+      "fun_fact_it": "La cantante gallese prese il titolo da una frase di un romanzo di H. E. Bates, e restò bloccata nove settimane al secondo posto in America."
+    },
+    {
+      "year": 1997,
+      "uri": "spotify:track:2YOuBWIyHgyvHnLMpjzBf2",
+      "artist": "Dario G",
+      "alt_artists": [
+        "Faithless",
+        "Robert Miles",
+        "Chicane"
+      ],
+      "title": "Sunchyme",
+      "isrc": "GBAHT9802853",
+      "uri_apple_music": "applemusic://track/1629187353",
+      "uri_deezer": "deezer://track/1787703427",
+      "fun_fact": "The whole record is built on a Dream Academy song from 1985, and the trio named themselves after a football manager rather than any of its members.",
+      "fun_fact_de": "Die ganze Platte baut auf einem Song von The Dream Academy aus dem Jahr 1985 auf, und das Trio benannte sich nach einem Fußballtrainer statt nach einem seiner Mitglieder.",
+      "fun_fact_es": "Todo el disco se construye sobre una canción de The Dream Academy de 1985, y el trío se puso el nombre de un entrenador de fútbol y no de ninguno de sus miembros.",
+      "fun_fact_fr": "Tout le disque repose sur un morceau de The Dream Academy de 1985, et le trio s'est nommé d'après un entraîneur de football plutôt que d'après l'un de ses membres.",
+      "fun_fact_nl": "De hele plaat is gebouwd op een nummer van The Dream Academy uit 1985, en het trio noemde zich naar een voetbaltrainer in plaats van naar een van de leden.",
+      "fun_fact_it": "L'intero disco è costruito su un brano dei Dream Academy del 1985, e il trio prese il nome da un allenatore di calcio anziché da uno dei suoi membri."
+    },
+    {
+      "year": 1998,
+      "uri": "spotify:track:2II03llydk4YnkBBvoYB3B",
+      "artist": "Madonna",
+      "alt_artists": [
+        "Björk",
+        "Kylie Minogue",
+        "Sinéad O Connor"
+      ],
+      "title": "Frozen",
+      "isrc": "USWB19800001",
+      "uri_apple_music": "applemusic://track/952683",
+      "uri_deezer": "deezer://track/778758",
+      "fun_fact": "A Belgian court briefly banned the song from sale in the country over a plagiarism claim that was overturned years later on appeal.",
+      "fun_fact_de": "Ein belgisches Gericht verbot den Verkauf des Songs im Land vorübergehend wegen eines Plagiatsvorwurfs, der Jahre später in der Berufung aufgehoben wurde.",
+      "fun_fact_es": "Un tribunal belga prohibió brevemente la venta de la canción en el país por una demanda de plagio que años después se anuló en apelación.",
+      "fun_fact_fr": "Un tribunal belge a brièvement interdit la vente du morceau dans le pays pour une accusation de plagiat annulée des années plus tard en appel.",
+      "fun_fact_nl": "Een Belgische rechtbank verbood de verkoop van het nummer in het land tijdelijk wegens een plagiaatclaim die jaren later in hoger beroep werd vernietigd.",
+      "fun_fact_it": "Un tribunale belga vietò brevemente la vendita del brano nel paese per un'accusa di plagio annullata anni dopo in appello."
+    },
+    {
+      "year": 1998,
+      "uri": "spotify:track:4AstOWewI6yGeMh6ysWFCW",
+      "artist": "Sasha",
+      "alt_artists": [
+        "Xavier Naidoo",
+        "Nena",
+        "Peter Maffay"
+      ],
+      "title": "If You Believe",
+      "isrc": "DEA629862595",
+      "uri_apple_music": "applemusic://track/124952477",
+      "uri_deezer": "deezer://track/686338",
+      "fun_fact": "Sascha Schmitz sang in English throughout and was routinely taken for a British act by German listeners who had never seen his name written down.",
+      "fun_fact_de": "Sascha Schmitz sang durchgehend auf Englisch und wurde von deutschen Hörern, die seinen Namen nie geschrieben gesehen hatten, regelmäßig für einen Briten gehalten.",
+      "fun_fact_es": "Sascha Schmitz cantaba siempre en inglés y los oyentes alemanes que nunca habían visto su nombre escrito lo tomaban habitualmente por un artista británico.",
+      "fun_fact_fr": "Sascha Schmitz chantait toujours en anglais et les auditeurs allemands qui n'avaient jamais vu son nom écrit le prenaient couramment pour un Britannique.",
+      "fun_fact_nl": "Sascha Schmitz zong altijd in het Engels en werd door Duitse luisteraars die zijn naam nooit geschreven hadden gezien geregeld voor een Brit aangezien.",
+      "fun_fact_it": "Sascha Schmitz cantava sempre in inglese e gli ascoltatori tedeschi che non avevano mai visto il suo nome scritto lo scambiavano abitualmente per un britannico."
+    },
+    {
+      "year": 1999,
+      "uri": "spotify:track:5MmWgG5KgiqSxkOZdVXRQA",
+      "artist": "Travis",
+      "alt_artists": [
+        "Oasis",
+        "Coldplay",
+        "Snow Patrol"
+      ],
+      "title": "Why Does It Always Rain On Me?",
+      "isrc": "GBBPF9900287",
+      "uri_apple_music": "applemusic://track/1458139090",
+      "uri_deezer": "deezer://track/657189912",
+      "fun_fact": "Fran Healy wrote it on a rare sunny holiday in Israel, and at Glastonbury the year it charted the rain began during the first chorus.",
+      "fun_fact_de": "Fran Healy schrieb den Song in einem seltenen sonnigen Urlaub in Israel, und in Glastonbury setzte im Chartjahr der Regen während des ersten Refrains ein.",
+      "fun_fact_es": "Fran Healy la escribió en unas raras vacaciones soleadas en Israel, y en Glastonbury, el año que entró en listas, la lluvia empezó durante el primer estribillo.",
+      "fun_fact_fr": "Fran Healy l'a écrite lors de rares vacances ensoleillées en Israël, et à Glastonbury, l'année de son classement, la pluie a commencé pendant le premier refrain.",
+      "fun_fact_nl": "Fran Healy schreef het tijdens een zeldzame zonnige vakantie in Israël, en op Glastonbury begon in het hitjaar de regen tijdens het eerste refrein.",
+      "fun_fact_it": "Fran Healy la scrisse durante una rara vacanza soleggiata in Israele, e a Glastonbury, l'anno in cui entrò in classifica, la pioggia iniziò durante il primo ritornello."
+    },
+    {
+      "year": 1999,
+      "uri": "spotify:track:0Fr54TvVCUMH9gdA6JMopJ",
+      "artist": "Andru Donalds",
+      "alt_artists": [
+        "Air Supply",
+        "Enigma",
+        "Des ree"
+      ],
+      "title": "All Out Of Love",
+      "isrc": "DEG129902203",
+      "uri_apple_music": "applemusic://track/723608871",
+      "uri_deezer": "deezer://track/3380088",
+      "fun_fact": "The Jamaican singer was working with Michael Cretu of Enigma when he recut this Air Supply ballad, and the remake outsold the original across Europe.",
+      "fun_fact_de": "Der jamaikanische Sänger arbeitete mit Michael Cretu von Enigma, als er diese Air-Supply-Ballade neu aufnahm, und die Neufassung verkaufte sich europaweit besser als das Original.",
+      "fun_fact_es": "El cantante jamaicano trabajaba con Michael Cretu de Enigma cuando regrabó esta balada de Air Supply, y la nueva versión vendió más que el original en Europa.",
+      "fun_fact_fr": "Le chanteur jamaïcain travaillait avec Michael Cretu d'Enigma quand il a réenregistré cette ballade d'Air Supply, et la reprise s'est mieux vendue que l'original en Europe.",
+      "fun_fact_nl": "De Jamaicaanse zanger werkte met Michael Cretu van Enigma toen hij deze Air Supply-ballade opnieuw opnam, en de remake verkocht in Europa beter dan het origineel.",
+      "fun_fact_it": "Il cantante giamaicano lavorava con Michael Cretu degli Enigma quando reincise questa ballata degli Air Supply, e il rifacimento vendette in Europa più dell'originale."
     }
   ]
 }


### PR DESCRIPTION
Fourth batch from the Bayern 1 expansion (#2374), which is not being added as a playlist of its own.

`90er-hits` goes from 108 to 125 songs, version 1.29 to 1.30.

## What is in here

1990 Jon Bon Jovi · 1991 Bee Gees, Mike + The Mechanics, Chesney Hawkes · 1992 Shakespears Sister · 1993 Aerosmith, Mr. Big · 1994 Erasure, East 17 · 1996 Skunk Anansie, Backstreet Boys, Donna Lewis · 1997 Dario G · 1998 Madonna, Sasha · 1999 Travis, Andru Donalds

Each carries the original release year, a Spotify URI, Apple and Deezer URIs, an ISRC, alt_artists and fun facts in six languages.

## Two more years corrected against the signal

`Hello (Turn Your Radio On)` came back as 1989 and Erasure's `Always` as 1995. Both are entered at the year of the original release, 1992 and 1994. This is now the fourth batch in a row in which the provider date disagreed with the work — the pattern behind #2450.

Refs #2374