### PR TITLE
data(2000s): nineteen additions from the Bayern 1 request (#2374)

### DIFF
--- a/custom_components/beatify/playlists/2000s-pop-anthems.json
+++ b/custom_components/beatify/playlists/2000s-pop-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "2000s Pop Anthems",
-  "version": "1.25",
+  "version": "1.26",
   "tags": [
     "2000s",
     "pop",
@@ -7477,6 +7477,386 @@
       "fun_fact_fr": "Un tube de Tiësto (2004).",
       "fun_fact_nl": "Een chart-hit van Tiësto (2004).",
       "fun_fact_it": "Un successo in classifica di Tiësto (2004)."
+    },
+    {
+      "year": 2000,
+      "uri": "spotify:track:3FhNJaCNypOAnZccdYGAWN",
+      "artist": "Reamonn",
+      "alt_artists": [
+        "Silbermond",
+        "Juli",
+        "Rea Garvey"
+      ],
+      "title": "Supergirl",
+      "isrc": "DEG120000973",
+      "uri_apple_music": "applemusic://track/712743105",
+      "uri_deezer": "deezer://track/3135405",
+      "fun_fact": "The band formed in Ravensburg around an Irish singer, and their first single is still the one German radio reaches for twenty-five years later.",
+      "fun_fact_de": "Die Band entstand in Ravensburg um einen irischen Sänger, und ihre erste Single ist auch fünfundzwanzig Jahre später die, zu der das deutsche Radio greift.",
+      "fun_fact_es": "El grupo se formó en Ravensburg en torno a un cantante irlandés, y su primer sencillo sigue siendo el que la radio alemana elige veinticinco años después.",
+      "fun_fact_fr": "Le groupe s'est formé à Ravensburg autour d'un chanteur irlandais, et leur premier single reste celui que la radio allemande choisit vingt-cinq ans plus tard.",
+      "fun_fact_nl": "De band ontstond in Ravensburg rond een Ierse zanger, en hun eerste single is vijfentwintig jaar later nog steeds waar de Duitse radio naar grijpt.",
+      "fun_fact_it": "Il gruppo nacque a Ravensburg attorno a un cantante irlandese, e il loro primo singolo è ancora quello che la radio tedesca sceglie venticinque anni dopo."
+    },
+    {
+      "year": 2001,
+      "uri": "spotify:track:15f8Cv8RXUlOOCIf2oaceN",
+      "artist": "Shakira",
+      "alt_artists": [
+        "Jennifer Lopez",
+        "Alanis Morissette",
+        "Nelly Furtado"
+      ],
+      "title": "Underneath Your Clothes",
+      "isrc": "NLB630100361",
+      "uri_apple_music": "applemusic://track/1593887500",
+      "uri_deezer": "deezer://track/15210161",
+      "fun_fact": "It came from the album on which Shakira crossed into English, written with Lester Mendez while she was still learning to write lyrics in the language.",
+      "fun_fact_de": "Der Song stammt aus dem Album, mit dem Shakira ins Englische wechselte, geschrieben mit Lester Mendez, während sie das Texten in dieser Sprache noch lernte.",
+      "fun_fact_es": "Viene del disco con el que Shakira dio el salto al inglés, escrita con Lester Mendez cuando aún estaba aprendiendo a componer letras en ese idioma.",
+      "fun_fact_fr": "Elle vient de l'album avec lequel Shakira est passée à l'anglais, écrite avec Lester Mendez alors qu'elle apprenait encore à écrire des textes dans cette langue.",
+      "fun_fact_nl": "Het komt van het album waarmee Shakira overstapte op het Engels, geschreven met Lester Mendez toen ze nog leerde teksten in die taal te schrijven.",
+      "fun_fact_it": "Viene dall'album con cui Shakira passò all'inglese, scritta con Lester Mendez mentre stava ancora imparando a scrivere testi in quella lingua."
+    },
+    {
+      "year": 2001,
+      "uri": "spotify:track:78PKCefXwDLbl4FVO1Pjzh",
+      "artist": "Ozzy Osbourne",
+      "alt_artists": [
+        "Black Sabbath",
+        "Alice Cooper",
+        "Meat Loaf"
+      ],
+      "title": "Dreamer",
+      "isrc": "USSM10110213",
+      "uri_apple_music": "applemusic://track/307631403",
+      "uri_deezer": "deezer://track/1513119462",
+      "fun_fact": "Osbourne wrote an environmental ballad in the manner of 'Imagine' and got the closest thing to a soft-rock hit of his career out of it.",
+      "fun_fact_de": "Osbourne schrieb eine Umweltballade in der Art von 'Imagine' und bekam daraus den am ehesten als Softrock-Hit durchgehenden Song seiner Laufbahn.",
+      "fun_fact_es": "Osbourne escribió una balada ecologista al estilo de 'Imagine' y obtuvo con ella lo más parecido a un éxito de soft rock de toda su carrera.",
+      "fun_fact_fr": "Osbourne a écrit une ballade écologiste à la manière d'« Imagine » et en a tiré ce qui ressemble le plus à un tube soft rock de sa carrière.",
+      "fun_fact_nl": "Osbourne schreef een milieuballade in de trant van 'Imagine' en kreeg er het dichtst bij een softrockhit uit zijn loopbaan mee.",
+      "fun_fact_it": "Osbourne scrisse una ballata ambientalista alla maniera di 'Imagine' e ne ricavò la cosa più simile a un successo soft rock della sua carriera."
+    },
+    {
+      "year": 2001,
+      "uri": "spotify:track:4SAHTVRe6EBhgAOWl49yPf",
+      "artist": "Westlife",
+      "alt_artists": [
+        "Boyzone",
+        "Take That",
+        "Blue"
+      ],
+      "title": "World of Our Own",
+      "isrc": "GBARL0100292",
+      "uri_apple_music": "applemusic://track/1267957350",
+      "uri_deezer": "deezer://track/391575942",
+      "fun_fact": "The Irish group had already put seven singles straight to number one in Britain, a run no act had managed before them.",
+      "fun_fact_de": "Die irische Gruppe hatte in Britannien bereits sieben Singles direkt auf Platz eins gebracht — eine Serie, die vor ihnen niemand geschafft hatte.",
+      "fun_fact_es": "El grupo irlandés ya había colocado siete sencillos directamente en el número uno británico, una racha que nadie había logrado antes.",
+      "fun_fact_fr": "Le groupe irlandais avait déjà placé sept singles directement à la première place britannique, une série que personne n'avait réussie avant eux.",
+      "fun_fact_nl": "De Ierse groep had al zeven singles rechtstreeks op nummer één in Groot-Brittannië gezet, een reeks die niemand vóór hen had gehaald.",
+      "fun_fact_it": "Il gruppo irlandese aveva già portato sette singoli direttamente al primo posto britannico, una serie che nessuno aveva ottenuto prima."
+    },
+    {
+      "year": 2002,
+      "uri": "spotify:track:6LefIBy3hzTN6Yd1m81gpC",
+      "artist": "Céline Dion",
+      "alt_artists": [
+        "Whitney Houston",
+        "Mariah Carey",
+        "Shania Twain"
+      ],
+      "title": "A New Day Has Come",
+      "isrc": "CAC220100155",
+      "uri_apple_music": "applemusic://track/1481513255",
+      "uri_deezer": "deezer://track/763662102",
+      "fun_fact": "Dion had stopped recording for two years to raise her son, and this was the record that announced she was coming back.",
+      "fun_fact_de": "Dion hatte zwei Jahre nicht aufgenommen, um ihren Sohn großzuziehen, und mit dieser Platte kündigte sie ihre Rückkehr an.",
+      "fun_fact_es": "Dion había dejado de grabar durante dos años para criar a su hijo, y este fue el disco con el que anunció su regreso.",
+      "fun_fact_fr": "Dion avait cessé d'enregistrer pendant deux ans pour élever son fils, et c'est ce disque qui a annoncé son retour.",
+      "fun_fact_nl": "Dion had twee jaar niet opgenomen om haar zoon groot te brengen, en dit was de plaat waarmee ze haar terugkeer aankondigde.",
+      "fun_fact_it": "Dion aveva smesso di incidere per due anni per crescere il figlio, e fu questo il disco che annunciò il suo ritorno."
+    },
+    {
+      "year": 2003,
+      "uri": "spotify:track:4EdOyT1E50Nhnv6dGOmIT4",
+      "artist": "Nelly Furtado",
+      "alt_artists": [
+        "Alanis Morissette",
+        "Dido",
+        "Norah Jones"
+      ],
+      "title": "Powerless (Say What You Want)",
+      "isrc": "USDW10300628",
+      "uri_apple_music": "applemusic://track/1460193857",
+      "uri_deezer": "deezer://track/7574983",
+      "fun_fact": "The banjo running through it belongs to a song about being told to look less Portuguese, which is the argument the title is making.",
+      "fun_fact_de": "Das durchlaufende Banjo gehört zu einem Song darüber, weniger portugiesisch auszusehen — genau das ist die Behauptung des Titels.",
+      "fun_fact_es": "El banjo que la recorre pertenece a una canción sobre que le pidan a uno parecer menos portuguesa, que es justo lo que sostiene el título.",
+      "fun_fact_fr": "Le banjo qui la traverse appartient à une chanson sur le fait qu'on demande de paraître moins portugaise, ce que dit précisément le titre.",
+      "fun_fact_nl": "De banjo die er doorheen loopt hoort bij een lied over het verzoek er minder Portugees uit te zien, precies wat de titel beweert.",
+      "fun_fact_it": "Il banjo che l'attraversa appartiene a una canzone sul sentirsi chiedere di sembrare meno portoghese, che è esattamente ciò che dice il titolo."
+    },
+    {
+      "year": 2004,
+      "uri": "spotify:track:2mTHOerIGzhdTOm1pgW4kf",
+      "artist": "Sarah Connor",
+      "alt_artists": [
+        "Yvonne Catterfeld",
+        "Jeanette Biedermann",
+        "Nena"
+      ],
+      "title": "Living To Love You",
+      "isrc": "DEX570400039",
+      "uri_apple_music": null,
+      "uri_deezer": "deezer://track/1157534",
+      "fun_fact": "Connor sang in English from the start and reached number one in Germany with a ballad most of her listeners could not translate word for word.",
+      "fun_fact_de": "Connor sang von Anfang an auf Englisch und kam in Deutschland mit einer Ballade auf Platz eins, die die meisten ihrer Hörer nicht Wort für Wort übersetzen konnten.",
+      "fun_fact_es": "Connor cantó en inglés desde el principio y llegó al número uno en Alemania con una balada que la mayoría de sus oyentes no podía traducir palabra por palabra.",
+      "fun_fact_fr": "Connor a chanté en anglais dès le début et a atteint la première place en Allemagne avec une ballade que la plupart de ses auditeurs ne pouvaient pas traduire mot à mot.",
+      "fun_fact_nl": "Connor zong vanaf het begin in het Engels en werd in Duitsland nummer één met een ballade die de meeste luisteraars niet woord voor woord konden vertalen.",
+      "fun_fact_it": "Connor cantò in inglese fin dall'inizio e arrivò al primo posto in Germania con una ballata che la maggior parte dei suoi ascoltatori non sapeva tradurre parola per parola."
+    },
+    {
+      "year": 2005,
+      "uri": "spotify:track:0mUyMawtxj1CJ76kn9gIZK",
+      "artist": "Daniel Powter",
+      "alt_artists": [
+        "James Blunt",
+        "Gavin DeGraw",
+        "Jason Mraz"
+      ],
+      "title": "Bad Day",
+      "isrc": "USWB10401971",
+      "uri_apple_music": "applemusic://track/63816165",
+      "uri_deezer": "deezer://track/6685848",
+      "fun_fact": "American Idol used it every week to send home the eliminated contestant, and that weekly slot rather than radio made it the biggest song of its year.",
+      "fun_fact_de": "American Idol spielte den Song jede Woche beim Ausscheiden eines Kandidaten, und dieser wöchentliche Platz statt des Radios machte ihn zum größten Song seines Jahres.",
+      "fun_fact_es": "American Idol lo usaba cada semana para despedir al concursante eliminado, y ese hueco semanal, más que la radio, lo convirtió en la canción del año.",
+      "fun_fact_fr": "American Idol le passait chaque semaine au départ du candidat éliminé, et c'est ce créneau hebdomadaire, plus que la radio, qui en a fait la chanson de l'année.",
+      "fun_fact_nl": "American Idol gebruikte het elke week om de afvaller uit te zwaaien, en die wekelijkse plek maakte het meer dan de radio tot het grootste nummer van dat jaar.",
+      "fun_fact_it": "American Idol lo usava ogni settimana per congedare il concorrente eliminato, e fu quello spazio settimanale, più della radio, a farne la canzone dell'anno."
+    },
+    {
+      "year": 2005,
+      "uri": "spotify:track:0q1uLsz1YBitp0iRj8a4UG",
+      "artist": "Katie Melua",
+      "alt_artists": [
+        "Norah Jones",
+        "Dido",
+        "Amy Macdonald"
+      ],
+      "title": "Nine Million Bicycles",
+      "isrc": "GBDVY0500059",
+      "uri_apple_music": "applemusic://track/1528517557",
+      "uri_deezer": "deezer://track/3786240782",
+      "fun_fact": "A New Scientist columnist publicly objected to the line about the universe being twelve billion years old, and Melua recorded a corrected version in reply.",
+      "fun_fact_de": "Ein Kolumnist des New Scientist beschwerte sich öffentlich über die Zeile vom zwölf Milliarden Jahre alten Universum, und Melua nahm zur Antwort eine korrigierte Fassung auf.",
+      "fun_fact_es": "Un columnista de New Scientist objetó públicamente al verso sobre un universo de doce mil millones de años, y Melua grabó una versión corregida como respuesta.",
+      "fun_fact_fr": "Un chroniqueur de New Scientist a publiquement contesté le vers sur un univers vieux de douze milliards d'années, et Melua a enregistré une version corrigée en réponse.",
+      "fun_fact_nl": "Een columnist van New Scientist maakte publiek bezwaar tegen de regel over een twaalf miljard jaar oud heelal, en Melua nam als antwoord een gecorrigeerde versie op.",
+      "fun_fact_it": "Un editorialista di New Scientist contestò pubblicamente il verso sull'universo di dodici miliardi di anni, e Melua incise per risposta una versione corretta."
+    },
+    {
+      "year": 2006,
+      "uri": "spotify:track:0HyAWcYFr2GfEvwDX2q3a4",
+      "artist": "Mathou",
+      "alt_artists": [
+        "Xavier Naidoo",
+        "Sasha",
+        "Söhne Mannheims"
+      ],
+      "title": "You Never Walk Alone",
+      "isrc": "DEBL60638276",
+      "uri_apple_music": "applemusic://track/188729584",
+      "uri_deezer": "deezer://track/61476518",
+      "fun_fact": "The German singer built a radio hit out of the phrase football crowds sing, and stripped it of the terrace melody entirely.",
+      "fun_fact_de": "Der deutsche Sänger machte aus der Zeile, die Fußballkurven singen, einen Radiohit — und ließ die Stadionmelodie vollständig weg.",
+      "fun_fact_es": "El cantante alemán convirtió en éxito radiofónico la frase que corean las gradas de fútbol, quitándole por completo la melodía del estadio.",
+      "fun_fact_fr": "Le chanteur allemand a fait un tube radio de la phrase que chantent les tribunes de football, en lui retirant entièrement la mélodie des stades.",
+      "fun_fact_nl": "De Duitse zanger maakte een radiohit van de zin die voetbalvakken zingen, en liet de stadionmelodie volledig weg.",
+      "fun_fact_it": "Il cantante tedesco fece un successo radiofonico dalla frase che cantano le curve di calcio, togliendole del tutto la melodia da stadio."
+    },
+    {
+      "year": 2006,
+      "uri": "spotify:track:734t1GgKDg0Nc19tqxlJ0s",
+      "artist": "Take That",
+      "alt_artists": [
+        "Robbie Williams",
+        "Westlife",
+        "Boyzone"
+      ],
+      "title": "Patience",
+      "isrc": "GBUM70604827",
+      "uri_apple_music": "applemusic://track/1440762915",
+      "uri_deezer": "deezer://track/1574788",
+      "fun_fact": "The comeback single arrived eleven years after the band split and without Robbie Williams, and it spent four weeks at number one anyway.",
+      "fun_fact_de": "Die Comeback-Single kam elf Jahre nach der Trennung und ohne Robbie Williams — und stand trotzdem vier Wochen auf Platz eins.",
+      "fun_fact_es": "El sencillo del regreso llegó once años después de la separación y sin Robbie Williams, y aun así pasó cuatro semanas en el número uno.",
+      "fun_fact_fr": "Le single du retour est arrivé onze ans après la séparation et sans Robbie Williams, et il est resté quatre semaines premier malgré tout.",
+      "fun_fact_nl": "De comebacksingle kwam elf jaar na de breuk en zonder Robbie Williams, en stond toch vier weken op nummer één.",
+      "fun_fact_it": "Il singolo del ritorno arrivò undici anni dopo lo scioglimento e senza Robbie Williams, e restò comunque quattro settimane al primo posto."
+    },
+    {
+      "year": 2006,
+      "uri": "spotify:track:6ucR4KfvsBFWCMVFDvyKKl",
+      "artist": "Timbaland",
+      "alt_artists": [
+        "OneRepublic",
+        "Ryan Tedder",
+        "Justin Timberlake"
+      ],
+      "title": "Apologize",
+      "isrc": "USUM70722793",
+      "uri_apple_music": "applemusic://track/1440771632",
+      "uri_deezer": "deezer://track/916841",
+      "fun_fact": "OneRepublic had already released it and been dropped by their label; Timbaland's remix a year later turned the same recording into a worldwide hit.",
+      "fun_fact_de": "OneRepublic hatten den Song bereits veröffentlicht und waren von ihrem Label fallen gelassen worden; Timbalands Remix ein Jahr später machte aus derselben Aufnahme einen Welthit.",
+      "fun_fact_es": "OneRepublic ya la había publicado y su sello los había dejado caer; el remix de Timbaland un año después convirtió la misma grabación en un éxito mundial.",
+      "fun_fact_fr": "OneRepublic l'avait déjà sortie et leur label les avait lâchés ; le remix de Timbaland un an plus tard a fait de ce même enregistrement un tube mondial.",
+      "fun_fact_nl": "OneRepublic had het al uitgebracht en was door hun label gedropt; Timbalands remix een jaar later maakte van dezelfde opname een wereldhit.",
+      "fun_fact_it": "I OneRepublic l'avevano già pubblicata ed erano stati scaricati dall'etichetta; il remix di Timbaland un anno dopo fece della stessa incisione un successo mondiale."
+    },
+    {
+      "year": 2006,
+      "uri": "spotify:track:38LgksKBjt5aes7nlOXPIL",
+      "artist": "Sunrise Avenue",
+      "alt_artists": [
+        "The Rasmus",
+        "HIM",
+        "Negative"
+      ],
+      "title": "Fairytale Gone Bad",
+      "isrc": "FIB3A0600060",
+      "uri_apple_music": "applemusic://track/715844988",
+      "uri_deezer": "deezer://track/3153933",
+      "fun_fact": "The Finnish band broke in Germany first and stayed there, playing to arenas in a country where nobody could place their home town.",
+      "fun_fact_de": "Die finnische Band schaffte den Durchbruch zuerst in Deutschland und blieb dort — Arenen in einem Land, in dem niemand ihre Heimatstadt einordnen konnte.",
+      "fun_fact_es": "El grupo finlandés triunfó primero en Alemania y allí se quedó, llenando pabellones en un país donde nadie sabía situar su ciudad natal.",
+      "fun_fact_fr": "Le groupe finlandais a percé d'abord en Allemagne et y est resté, remplissant des salles dans un pays où personne ne situait leur ville natale.",
+      "fun_fact_nl": "De Finse band brak eerst door in Duitsland en bleef daar, met arena's in een land waar niemand hun woonplaats kon plaatsen.",
+      "fun_fact_it": "Il gruppo finlandese sfondò prima in Germania e lì restò, riempiendo palazzetti in un paese dove nessuno sapeva collocare la loro città."
+    },
+    {
+      "year": 2007,
+      "uri": "spotify:track:4IwOkUNrbkZRGZmYeY7XOO",
+      "artist": "A Fine Frenzy",
+      "alt_artists": [
+        "Regina Spektor",
+        "Sara Bareilles",
+        "Vanessa Carlton"
+      ],
+      "title": "Almost Lover",
+      "isrc": "USVI20700644",
+      "uri_apple_music": "applemusic://track/724597654",
+      "uri_deezer": "deezer://track/3154015",
+      "fun_fact": "Alison Sudol was twenty-two and recorded it with piano and little else; the song reached far more people in Europe than in her own country.",
+      "fun_fact_de": "Alison Sudol war zweiundzwanzig und nahm den Song mit Klavier und wenig sonst auf; er erreichte in Europa weit mehr Menschen als in ihrem eigenen Land.",
+      "fun_fact_es": "Alison Sudol tenía veintidós años y la grabó con piano y poco más; la canción llegó a mucha más gente en Europa que en su propio país.",
+      "fun_fact_fr": "Alison Sudol avait vingt-deux ans et l'a enregistrée au piano et presque rien d'autre ; la chanson a touché bien plus de monde en Europe que dans son pays.",
+      "fun_fact_nl": "Alison Sudol was tweeëntwintig en nam het op met piano en weinig meer; het nummer bereikte in Europa veel meer mensen dan in haar eigen land.",
+      "fun_fact_it": "Alison Sudol aveva ventidue anni e la incise con pianoforte e poco altro; la canzone raggiunse in Europa molte più persone che nel suo paese."
+    },
+    {
+      "year": 2008,
+      "uri": "spotify:track:69sRLJM4Wy2ykLs92f7prG",
+      "artist": "Leona Lewis",
+      "alt_artists": [
+        "Snow Patrol",
+        "Kelly Clarkson",
+        "Alexandra Burke"
+      ],
+      "title": "Run",
+      "isrc": "GBHMU0800023",
+      "uri_apple_music": "applemusic://track/299246218",
+      "uri_deezer": "deezer://track/2485011",
+      "fun_fact": "Snow Patrol had released it twice without a hit; Lewis's version went straight to number one on downloads alone in its first week.",
+      "fun_fact_de": "Snow Patrol hatten den Song zweimal ohne Erfolg veröffentlicht; die Fassung von Lewis ging in der ersten Woche allein über Downloads direkt auf Platz eins.",
+      "fun_fact_es": "Snow Patrol la había publicado dos veces sin éxito; la versión de Lewis llegó directa al número uno solo con descargas en su primera semana.",
+      "fun_fact_fr": "Snow Patrol l'avait sortie deux fois sans succès ; la version de Lewis est allée droit à la première place sur les seuls téléchargements dès la première semaine.",
+      "fun_fact_nl": "Snow Patrol had het twee keer zonder succes uitgebracht; de versie van Lewis ging in de eerste week alleen op downloads rechtstreeks naar nummer één.",
+      "fun_fact_it": "Gli Snow Patrol l'avevano pubblicata due volte senza successo; la versione di Lewis andò dritta al primo posto con i soli download nella prima settimana."
+    },
+    {
+      "year": 2009,
+      "uri": "spotify:track:4N6R6yqkFUTyF3AYOdR0T7",
+      "artist": "Gossip",
+      "alt_artists": [
+        "Yeah Yeah Yeahs",
+        "Scissor Sisters",
+        "Garbage"
+      ],
+      "title": "Heavy Cross",
+      "isrc": "USSM10902231",
+      "uri_apple_music": "applemusic://track/316795262",
+      "uri_deezer": "deezer://track/3056960",
+      "fun_fact": "The song was an American indie record until a German phone advert picked it up, after which it spent most of a year in the German top ten.",
+      "fun_fact_de": "Der Song war eine amerikanische Indieplatte, bis eine deutsche Handywerbung ihn aufgriff — danach stand er fast ein Jahr in den deutschen Top zehn.",
+      "fun_fact_es": "La canción era un disco indie estadounidense hasta que un anuncio de móviles alemán la recogió; después pasó casi un año en el top diez alemán.",
+      "fun_fact_fr": "Le morceau était un disque indé américain jusqu'à ce qu'une publicité allemande pour la téléphonie le reprenne ; il est ensuite resté près d'un an dans le top dix allemand.",
+      "fun_fact_nl": "Het nummer was een Amerikaanse indieplaat tot een Duitse telefoonreclame het oppikte; daarna stond het bijna een jaar in de Duitse top tien.",
+      "fun_fact_it": "Il brano era un disco indie americano finché una pubblicità tedesca di telefonia lo riprese; dopo restò quasi un anno nella top ten tedesca."
+    },
+    {
+      "year": 2009,
+      "uri": "spotify:track:3clsCV1f1E9u1Fge9ntulk",
+      "artist": "Lady Gaga",
+      "alt_artists": [
+        "Madonna",
+        "Kylie Minogue",
+        "Rihanna"
+      ],
+      "title": "Alejandro",
+      "isrc": "USUM70905526",
+      "uri_apple_music": "applemusic://track/1476727671",
+      "uri_deezer": "deezer://track/4709938",
+      "fun_fact": "The horn line quotes ABBA's 'Fernando' closely enough that Gaga has named it as the starting point, and the names in the title follow the same pattern.",
+      "fun_fact_de": "Die Bläserlinie zitiert ABBAs 'Fernando' so deutlich, dass Gaga es selbst als Ausgangspunkt genannt hat, und die Namen im Titel folgen demselben Muster.",
+      "fun_fact_es": "La línea de metales cita 'Fernando' de ABBA de forma tan clara que Gaga la ha señalado como punto de partida, y los nombres del título siguen el mismo patrón.",
+      "fun_fact_fr": "La ligne de cuivres cite « Fernando » d'ABBA d'assez près pour que Gaga l'ait désignée comme point de départ, et les prénoms du titre suivent le même schéma.",
+      "fun_fact_nl": "De blazerslijn citeert ABBA's 'Fernando' zo duidelijk dat Gaga het zelf als uitgangspunt heeft genoemd, en de namen in de titel volgen hetzelfde patroon.",
+      "fun_fact_it": "La linea di fiati cita 'Fernando' degli ABBA così da vicino che Gaga l'ha indicata come punto di partenza, e i nomi nel titolo seguono lo stesso schema."
+    },
+    {
+      "year": 2009,
+      "uri": "spotify:track:7nuBU1HCcOwG5f1orN4ByW",
+      "artist": "Caro Emerald",
+      "alt_artists": [
+        "Postmodern Jukebox",
+        "Nina Simone",
+        "Alice Francis"
+      ],
+      "title": "A Night Like This",
+      "isrc": "NLHR30900011",
+      "uri_apple_music": "applemusic://track/647779610",
+      "uri_deezer": "deezer://track/13551002",
+      "fun_fact": "The Dutch singer sold a forties swing record to a downloading audience, and her debut album kept the Netherlands number one spot for thirty weeks.",
+      "fun_fact_de": "Die niederländische Sängerin verkaufte eine Swingplatte der Vierziger an ein Download-Publikum, und ihr Debütalbum hielt dreißig Wochen Platz eins in den Niederlanden.",
+      "fun_fact_es": "La cantante neerlandesa vendió un disco de swing de los cuarenta a un público de descargas, y su álbum debut mantuvo el número uno neerlandés durante treinta semanas.",
+      "fun_fact_fr": "La chanteuse néerlandaise a vendu un disque de swing des années quarante à un public de téléchargement, et son premier album a tenu trente semaines la première place aux Pays-Bas.",
+      "fun_fact_nl": "De Nederlandse zangeres verkocht een swingplaat uit de jaren veertig aan een downloadpubliek, en haar debuutalbum hield dertig weken de Nederlandse nummer één vast.",
+      "fun_fact_it": "La cantante olandese vendette un disco swing degli anni quaranta a un pubblico da download, e il suo album d'esordio tenne trenta settimane il primo posto nei Paesi Bassi."
+    },
+    {
+      "year": 2009,
+      "uri": "spotify:track:3Cm2bgwzocxsB5sD6g8VSL",
+      "artist": "a-ha",
+      "alt_artists": [
+        "Morten Harket",
+        "Roxette",
+        "Erasure"
+      ],
+      "title": "Foot Of The Mountain",
+      "isrc": "NOUM70900248",
+      "uri_apple_music": "applemusic://track/1443573745",
+      "uri_deezer": "deezer://track/4190292",
+      "fun_fact": "After years of guitars the band went back to the synthesiser sound of their first record, and announced their break-up on the tour that followed.",
+      "fun_fact_de": "Nach Jahren mit Gitarren kehrte die Band zum Synthesizer-Klang ihrer ersten Platte zurück und kündigte auf der folgenden Tournee ihre Trennung an.",
+      "fun_fact_es": "Tras años de guitarras el grupo volvió al sonido de sintetizador de su primer disco, y anunció su separación en la gira que siguió.",
+      "fun_fact_fr": "Après des années de guitares, le groupe est revenu au son de synthétiseur de son premier disque, et a annoncé sa séparation lors de la tournée qui a suivi.",
+      "fun_fact_nl": "Na jaren gitaren keerde de band terug naar het synthesizergeluid van hun eerste plaat, en kondigde tijdens de daaropvolgende tournee hun einde aan.",
+      "fun_fact_it": "Dopo anni di chitarre la band tornò al suono di sintetizzatore del primo disco, e annunciò lo scioglimento nella tournée che seguì."
     }
   ]
 }


### PR DESCRIPTION
Fifth batch from the Bayern 1 expansion (#2374), which is not being added as a playlist of its own.

`2000s-pop-anthems` goes from 181 to 200 songs, version 1.25 to 1.26.

## What is in here

2000 Reamonn · 2001 Shakira, Ozzy Osbourne, Westlife · 2002 Celine Dion · 2003 Nelly Furtado · 2004 Sarah Connor · 2005 Daniel Powter, Katie Melua · 2006 Mathou, Take That, Timbaland, Sunrise Avenue · 2007 A Fine Frenzy · 2008 Leona Lewis · 2009 Gossip, Lady Gaga, Caro Emerald, a-ha

Each carries the original release year, a Spotify URI, Apple and Deezer URIs, an ISRC, alt_artists and fun facts in six languages.

## A pre-existing warning, deliberately not fixed here

The schema gate reports two duplicate URIs in this file: `SexyBack` and `Low` each appear twice on main, once with and once without the feature credit in the title. Both predate this change and both are still there — a data batch is the wrong place to quietly delete songs people have already played. Worth its own issue.

Refs #2374