### PR TITLE
data(2010s/2020s): fifteen additions from the Bayern 1 request (#2374)

### DIFF
--- a/custom_components/beatify/playlists/hits-2010s-2020s.json
+++ b/custom_components/beatify/playlists/hits-2010s-2020s.json
@@ -1,6 +1,6 @@
 {
   "name": "2010s & 2020s Hits",
-  "version": "1.15",
+  "version": "1.16",
   "tags": [
     "pop",
     "charts",
@@ -1958,6 +1958,306 @@
         "nl": "applemusic://track/1744523906",
         "it": "applemusic://track/1744523906"
       }
+    },
+    {
+      "year": 2011,
+      "uri": "spotify:track:4bCOAuhvjsxbVBM5MM8oik",
+      "artist": "Nickelback",
+      "alt_artists": [
+        "Daughtry",
+        "Theory of a Deadman",
+        "Shinedown"
+      ],
+      "title": "When We Stand Together",
+      "isrc": "NLA321191798",
+      "uri_apple_music": "applemusic://track/469259206",
+      "uri_deezer": "deezer://track/14500181",
+      "fun_fact": "The band recorded a protest song on their most commercial album, and the video was shot in the mountains of British Columbia where they grew up.",
+      "fun_fact_de": "Die Band nahm auf ihrem kommerziellsten Album einen Protestsong auf, und das Video entstand in den Bergen von British Columbia, wo sie aufgewachsen sind.",
+      "fun_fact_es": "El grupo grabó una canción protesta en su disco más comercial, y el vídeo se rodó en las montañas de la Columbia Británica donde crecieron.",
+      "fun_fact_fr": "Le groupe a enregistré une chanson de protestation sur son album le plus commercial, et le clip a été tourné dans les montagnes de Colombie-Britannique où ils ont grandi.",
+      "fun_fact_nl": "De band nam een protestlied op op hun meest commerciële album, en de video werd opgenomen in de bergen van Brits-Columbia waar ze opgroeiden.",
+      "fun_fact_it": "La band incise una canzone di protesta nell'album più commerciale, e il video fu girato tra le montagne della Columbia Britannica dove sono cresciuti."
+    },
+    {
+      "year": 2012,
+      "uri": "spotify:track:6O20JhBJPePEkBdrB5sqRx",
+      "artist": "Rihanna",
+      "alt_artists": [
+        "Sia",
+        "Beyoncé",
+        "Katy Perry"
+      ],
+      "title": "Diamonds",
+      "isrc": "USUM71211793",
+      "uri_apple_music": "applemusic://track/1444321282",
+      "uri_deezer": "deezer://track/60978718",
+      "fun_fact": "Sia wrote the words in fourteen minutes, and Rihanna has said she took the song on the spot because it was the least aggressive thing she had been offered in years.",
+      "fun_fact_de": "Sia schrieb den Text in vierzehn Minuten, und Rihanna sagte, sie habe den Song sofort genommen, weil er das am wenigsten aggressive Angebot seit Jahren war.",
+      "fun_fact_es": "Sia escribió la letra en catorce minutos, y Rihanna ha dicho que aceptó la canción en el acto porque era lo menos agresivo que le habían ofrecido en años.",
+      "fun_fact_fr": "Sia a écrit le texte en quatorze minutes, et Rihanna a dit avoir pris la chanson sur-le-champ car c'était la proposition la moins agressive depuis des années.",
+      "fun_fact_nl": "Sia schreef de tekst in veertien minuten, en Rihanna heeft gezegd dat ze het nummer meteen nam omdat het het minst agressieve was dat haar in jaren was aangeboden.",
+      "fun_fact_it": "Sia scrisse il testo in quattordici minuti, e Rihanna ha detto di aver preso la canzone all'istante perché era la cosa meno aggressiva che le fosse stata offerta da anni."
+    },
+    {
+      "year": 2012,
+      "uri": "spotify:track:4bzBPrGYD3fQfAadLgIiwT",
+      "artist": "Passenger",
+      "alt_artists": [
+        "Ed Sheeran",
+        "James Bay",
+        "George Ezra"
+      ],
+      "title": "Let Her Go",
+      "isrc": "GBMQN1100004",
+      "uri_apple_music": "applemusic://track/694621758",
+      "uri_deezer": "deezer://track/64482460",
+      "fun_fact": "Michael Rosenberg had been busking in Australia when he recorded it, and the song went to number one in nineteen countries before he stopped playing streets.",
+      "fun_fact_de": "Michael Rosenberg spielte in Australien auf der Straße, als er den Song aufnahm, und der Titel kam in neunzehn Ländern auf Platz eins, bevor er das Straßenspielen aufgab.",
+      "fun_fact_es": "Michael Rosenberg tocaba en la calle en Australia cuando la grabó, y la canción llegó al número uno en diecinueve países antes de que dejara las calles.",
+      "fun_fact_fr": "Michael Rosenberg jouait dans la rue en Australie quand il l'a enregistrée, et le morceau a atteint la première place dans dix-neuf pays avant qu'il n'arrête la rue.",
+      "fun_fact_nl": "Michael Rosenberg speelde op straat in Australië toen hij het opnam, en het nummer werd in negentien landen nummer één voordat hij met straatmuziek stopte.",
+      "fun_fact_it": "Michael Rosenberg suonava per strada in Australia quando la incise, e il brano arrivò al primo posto in diciannove paesi prima che lasciasse la strada."
+    },
+    {
+      "year": 2013,
+      "uri": "spotify:track:27tNWlhdAryQY04Gb2ZhUI",
+      "artist": "Katy Perry",
+      "alt_artists": [
+        "Sara Bareilles",
+        "Kelly Clarkson",
+        "Taylor Swift"
+      ],
+      "title": "Roar",
+      "isrc": "USUM71308669",
+      "uri_apple_music": "applemusic://track/1440818897",
+      "uri_deezer": "deezer://track/71645431",
+      "fun_fact": "The song drew immediate comparisons to Sara Bareilles's 'Brave', released two months earlier; both writers have publicly waved the argument away.",
+      "fun_fact_de": "Der Song wurde sofort mit 'Brave' von Sara Bareilles verglichen, das zwei Monate früher erschien; beide Autorinnen haben den Streit öffentlich abgetan.",
+      "fun_fact_es": "La canción se comparó de inmediato con 'Brave' de Sara Bareilles, publicada dos meses antes; ambas autoras han restado importancia al asunto en público.",
+      "fun_fact_fr": "Le morceau a aussitôt été comparé à « Brave » de Sara Bareilles, sorti deux mois plus tôt ; les deux autrices ont publiquement balayé la polémique.",
+      "fun_fact_nl": "Het nummer werd meteen vergeleken met 'Brave' van Sara Bareilles, twee maanden eerder uitgebracht; beide schrijfsters hebben de discussie publiekelijk weggewuifd.",
+      "fun_fact_it": "Il brano fu subito paragonato a 'Brave' di Sara Bareilles, uscito due mesi prima; entrambe le autrici hanno pubblicamente liquidato la polemica."
+    },
+    {
+      "year": 2014,
+      "uri": "spotify:track:1HNkqx9Ahdgi1Ixy2xkKkL",
+      "artist": "Ed Sheeran",
+      "alt_artists": [
+        "Passenger",
+        "James Blunt",
+        "Lewis Capaldi"
+      ],
+      "title": "Photograph",
+      "isrc": "GBAHS1400094",
+      "uri_apple_music": "applemusic://track/858512630",
+      "uri_deezer": "deezer://track/79875054",
+      "fun_fact": "Sheeran wrote it on a tour bus with Snow Patrol's Johnny McDaid, and the video is built from his own childhood home footage.",
+      "fun_fact_de": "Sheeran schrieb den Song im Tourbus mit Johnny McDaid von Snow Patrol, und das Video besteht aus seinen eigenen Kindheitsaufnahmen.",
+      "fun_fact_es": "Sheeran la escribió en un autobús de gira con Johnny McDaid de Snow Patrol, y el vídeo está hecho con grabaciones caseras de su propia infancia.",
+      "fun_fact_fr": "Sheeran l'a écrite dans un bus de tournée avec Johnny McDaid de Snow Patrol, et le clip est monté à partir de ses propres films d'enfance.",
+      "fun_fact_nl": "Sheeran schreef het in een tourbus met Johnny McDaid van Snow Patrol, en de video bestaat uit zijn eigen jeugdopnames.",
+      "fun_fact_it": "Sheeran la scrisse su un tour bus con Johnny McDaid degli Snow Patrol, e il video è montato con i filmati della sua infanzia."
+    },
+    {
+      "year": 2015,
+      "uri": "spotify:track:0eZBeB2xFIS65jQHerispi",
+      "artist": "Disturbed",
+      "alt_artists": [
+        "Simon & Garfunkel",
+        "Nine Inch Nails",
+        "Evanescence"
+      ],
+      "title": "The Sound of Silence",
+      "isrc": "USRE11500180",
+      "uri_apple_music": "applemusic://track/1006937459",
+      "uri_deezer": "deezer://track/105765234",
+      "fun_fact": "Paul Simon wrote to the band after hearing it, and the metal group's straight reading of a 1964 folk song outsold every original they had released.",
+      "fun_fact_de": "Paul Simon schrieb der Band, nachdem er die Fassung gehört hatte, und die ernst gemeinte Lesart eines Folksongs von 1964 verkaufte sich besser als jedes eigene Stück der Metalband.",
+      "fun_fact_es": "Paul Simon escribió al grupo tras oírla, y la lectura seria de una canción folk de 1964 vendió más que cualquier tema propio de la banda de metal.",
+      "fun_fact_fr": "Paul Simon a écrit au groupe après l'avoir entendue, et cette lecture sérieuse d'une chanson folk de 1964 s'est mieux vendue que tous leurs morceaux originaux.",
+      "fun_fact_nl": "Paul Simon schreef de band na het horen ervan, en de serieuze lezing van een folksong uit 1964 verkocht beter dan elk eigen nummer van de metalband.",
+      "fun_fact_it": "Paul Simon scrisse alla band dopo averla ascoltata, e quella lettura seria di un brano folk del 1964 vendette più di ogni pezzo originale del gruppo metal."
+    },
+    {
+      "year": 2016,
+      "uri": "spotify:track:5LLRo6dCGxg4PZmtSqNzrZ",
+      "artist": "Rag'n'Bone Man",
+      "alt_artists": [
+        "Hozier",
+        "Michael Kiwanuka",
+        "James Arthur"
+      ],
+      "title": "Human",
+      "isrc": "GBARL1600665",
+      "uri_apple_music": "applemusic://track/1303447606",
+      "uri_deezer": "deezer://track/128878464",
+      "fun_fact": "Rory Graham had spent years in drum and bass before this; the record went platinum in Germany faster than in his own country.",
+      "fun_fact_de": "Rory Graham hatte davor Jahre im Drum and Bass verbracht; die Platte wurde in Deutschland schneller Platin als in seiner Heimat.",
+      "fun_fact_es": "Rory Graham había pasado años en el drum and bass antes de esto; el disco fue platino en Alemania antes que en su propio país.",
+      "fun_fact_fr": "Rory Graham avait passé des années dans le drum and bass avant cela ; le disque a été disque de platine en Allemagne plus vite que chez lui.",
+      "fun_fact_nl": "Rory Graham had daarvoor jaren in de drum-and-bass gezeten; de plaat werd in Duitsland sneller platina dan in zijn eigen land.",
+      "fun_fact_it": "Rory Graham aveva passato anni nel drum and bass prima di questo; il disco fu platino in Germania prima che in patria."
+    },
+    {
+      "year": 2017,
+      "uri": "spotify:track:5Ohxk2dO5COHF1krpoPigN",
+      "artist": "Harry Styles",
+      "alt_artists": [
+        "One Direction",
+        "Zayn",
+        "Sam Smith"
+      ],
+      "title": "Sign of the Times",
+      "isrc": "USSM11703595",
+      "uri_apple_music": "applemusic://track/1226034393",
+      "uri_deezer": "deezer://track/360301951",
+      "fun_fact": "Styles left a boy band and opened his solo career with a six-minute piano ballad, which record companies generally advise against.",
+      "fun_fact_de": "Styles verließ eine Boyband und eröffnete seine Solokarriere mit einer sechsminütigen Klavierballade — wovon Plattenfirmen üblicherweise abraten.",
+      "fun_fact_es": "Styles dejó una boy band y abrió su carrera en solitario con una balada de piano de seis minutos, algo que las discográficas suelen desaconsejar.",
+      "fun_fact_fr": "Styles a quitté un boys band et a ouvert sa carrière solo avec une ballade au piano de six minutes, ce que les maisons de disques déconseillent en général.",
+      "fun_fact_nl": "Styles verliet een boyband en opende zijn solocarrière met een pianoballade van zes minuten, iets wat platenmaatschappijen doorgaans afraden.",
+      "fun_fact_it": "Styles lasciò una boy band e aprì la carriera solista con una ballata al pianoforte di sei minuti, cosa che le case discografiche di solito sconsigliano."
+    },
+    {
+      "year": 2018,
+      "uri": "spotify:track:7DnAm9FOTWE3cUvso43HhI",
+      "artist": "Ava Max",
+      "alt_artists": [
+        "Bebe Rexha",
+        "Dua Lipa",
+        "Sia"
+      ],
+      "title": "Sweet but Psycho",
+      "isrc": "USAT21802011",
+      "uri_apple_music": "applemusic://track/1386719031",
+      "uri_deezer": "deezer://track/539562302",
+      "fun_fact": "The single reached number one in twenty-two countries and stayed on the German chart for over a year, which no debut had managed in a decade.",
+      "fun_fact_de": "Die Single kam in zweiundzwanzig Ländern auf Platz eins und hielt sich über ein Jahr in den deutschen Charts — das hatte seit einem Jahrzehnt kein Debüt geschafft.",
+      "fun_fact_es": "El sencillo llegó al número uno en veintidós países y se mantuvo más de un año en la lista alemana, algo que ningún debut había logrado en una década.",
+      "fun_fact_fr": "Le single a atteint la première place dans vingt-deux pays et est resté plus d'un an dans le classement allemand, ce qu'aucun premier titre n'avait réussi depuis dix ans.",
+      "fun_fact_nl": "De single werd in tweeëntwintig landen nummer één en stond ruim een jaar in de Duitse lijst, wat geen debuut in tien jaar was gelukt.",
+      "fun_fact_it": "Il singolo arrivò al primo posto in ventidue paesi e restò oltre un anno nella classifica tedesca, cosa che nessun esordio aveva ottenuto in un decennio."
+    },
+    {
+      "year": 2018,
+      "uri": "spotify:track:27rdGxbavYJeBphck5MZAF",
+      "artist": "Mark Ronson",
+      "alt_artists": [
+        "Miley Cyrus",
+        "Dua Lipa",
+        "Lady Gaga"
+      ],
+      "title": "Nothing Breaks Like a Heart",
+      "isrc": "GBARL1801571",
+      "uri_apple_music": "applemusic://track/1459276883",
+      "uri_deezer": "deezer://track/595074062",
+      "fun_fact": "Ronson set a country fiddle line against a dance beat, and Miley Cyrus recorded the vocal days after her Malibu house burned down.",
+      "fun_fact_de": "Ronson setzte eine Country-Fiedel gegen einen Dance-Beat, und Miley Cyrus nahm den Gesang wenige Tage nach dem Abbrennen ihres Hauses in Malibu auf.",
+      "fun_fact_es": "Ronson enfrentó un violín country a un ritmo de baile, y Miley Cyrus grabó la voz días después de que se quemara su casa en Malibú.",
+      "fun_fact_fr": "Ronson a opposé un violon country à un beat dance, et Miley Cyrus a enregistré le chant quelques jours après l'incendie de sa maison de Malibu.",
+      "fun_fact_nl": "Ronson zette een countryviool tegen een dancebeat, en Miley Cyrus nam de zang op enkele dagen nadat haar huis in Malibu was afgebrand.",
+      "fun_fact_it": "Ronson mise un violino country contro un ritmo dance, e Miley Cyrus incise la voce pochi giorni dopo l'incendio della sua casa a Malibu."
+    },
+    {
+      "year": 2019,
+      "uri": "spotify:track:4cktbXiXOapiLBMprHFErI",
+      "artist": "Maroon 5",
+      "alt_artists": [
+        "OneRepublic",
+        "Coldplay",
+        "Ed Sheeran"
+      ],
+      "title": "Memories",
+      "isrc": "USUM71913350",
+      "uri_apple_music": "applemusic://track/1479600902",
+      "uri_deezer": "deezer://track/1400843202",
+      "fun_fact": "The chord sequence is Pachelbel's Canon, note for note, which puts a 1680s piece of chamber music at the top of the 2019 charts.",
+      "fun_fact_de": "Die Akkordfolge ist Pachelbels Kanon, Note für Note — damit stand ein Kammermusikstück aus den 1680er Jahren an der Spitze der Charts von 2019.",
+      "fun_fact_es": "La secuencia de acordes es el Canon de Pachelbel, nota por nota, lo que colocó una pieza de cámara de la década de 1680 en lo alto de las listas de 2019.",
+      "fun_fact_fr": "La suite d'accords est le Canon de Pachelbel, note pour note, ce qui a placé une pièce de chambre des années 1680 en tête des classements de 2019.",
+      "fun_fact_nl": "De akkoordenreeks is Pachelbels Canon, noot voor noot, waarmee een kamermuziekstuk uit de jaren 1680 boven aan de lijsten van 2019 stond.",
+      "fun_fact_it": "La sequenza di accordi è il Canone di Pachelbel, nota per nota, il che portò un pezzo da camera degli anni 1680 in cima alle classifiche del 2019."
+    },
+    {
+      "year": 2020,
+      "uri": "spotify:track:4tfLFDGypUWad5AT6772If",
+      "artist": "Michael Patrick Kelly",
+      "alt_artists": [
+        "Kelly Family",
+        "Rea Garvey",
+        "Johannes Oerding"
+      ],
+      "title": "Beautiful Madness",
+      "isrc": "DEE862000669",
+      "uri_apple_music": "applemusic://track/1508890055",
+      "uri_deezer": "deezer://track/935958362",
+      "fun_fact": "Kelly spent six years in a monastery between the family band and this record, and it became his first solo number one in Germany.",
+      "fun_fact_de": "Kelly verbrachte zwischen der Familienband und dieser Platte sechs Jahre in einem Kloster, und sie wurde seine erste Solo-Nummer-eins in Deutschland.",
+      "fun_fact_es": "Kelly pasó seis años en un monasterio entre la banda familiar y este disco, que se convirtió en su primer número uno en solitario en Alemania.",
+      "fun_fact_fr": "Kelly a passé six ans dans un monastère entre le groupe familial et ce disque, qui est devenu son premier numéro un solo en Allemagne.",
+      "fun_fact_nl": "Kelly zat tussen de familieband en deze plaat zes jaar in een klooster, en het werd zijn eerste solonummer één in Duitsland.",
+      "fun_fact_it": "Kelly trascorse sei anni in un monastero tra la band di famiglia e questo disco, che divenne il suo primo numero uno da solista in Germania."
+    },
+    {
+      "year": 2021,
+      "uri": "spotify:track:0939D7aT18uBDS2MTjWzct",
+      "artist": "Coldplay",
+      "alt_artists": [
+        "Imagine Dragons",
+        "The Killers",
+        "Muse"
+      ],
+      "title": "Higher Power",
+      "isrc": "GBAYE2100379",
+      "uri_apple_music": "applemusic://track/1564099110",
+      "uri_deezer": "deezer://track/1518077822",
+      "fun_fact": "The band premiered it by beaming a hologram to the International Space Station, where Thomas Pesquet played it back to Earth.",
+      "fun_fact_de": "Die Band stellte den Song vor, indem sie ein Hologramm zur Internationalen Raumstation sendete, von wo Thomas Pesquet ihn zurück zur Erde spielte.",
+      "fun_fact_es": "El grupo lo estrenó enviando un holograma a la Estación Espacial Internacional, desde donde Thomas Pesquet lo reprodujo hacia la Tierra.",
+      "fun_fact_fr": "Le groupe l'a présenté en envoyant un hologramme à la Station spatiale internationale, d'où Thomas Pesquet l'a rejoué vers la Terre.",
+      "fun_fact_nl": "De band presenteerde het door een hologram naar het internationale ruimtestation te sturen, waar Thomas Pesquet het terug naar de aarde speelde.",
+      "fun_fact_it": "Il gruppo lo presentò inviando un ologramma alla Stazione Spaziale Internazionale, da dove Thomas Pesquet lo rimandò verso la Terra."
+    },
+    {
+      "year": 2022,
+      "uri": "spotify:track:0V3wPSX9ygBnCm8psDIegu",
+      "artist": "Taylor Swift",
+      "alt_artists": [
+        "Olivia Rodrigo",
+        "Lorde",
+        "Billie Eilish"
+      ],
+      "title": "Anti-Hero",
+      "isrc": null,
+      "uri_apple_music": "applemusic://track/1645937758",
+      "uri_deezer": null,
+      "fun_fact": "Swift called it one of her favourite songs she has written, and it opened the week in which she held all ten places at the top of the American chart.",
+      "fun_fact_de": "Swift nannte den Song einen ihrer liebsten eigenen, und er eröffnete die Woche, in der sie alle zehn Spitzenplätze der amerikanischen Charts belegte.",
+      "fun_fact_es": "Swift la llamó una de sus canciones favoritas propias, y abrió la semana en la que ocupó los diez primeros puestos de la lista estadounidense.",
+      "fun_fact_fr": "Swift l'a désignée comme l'une de ses chansons préférées parmi les siennes, et elle a ouvert la semaine où elle occupait les dix premières places du classement américain.",
+      "fun_fact_nl": "Swift noemde het een van haar favoriete eigen nummers, en het opende de week waarin ze alle tien de toppositie van de Amerikaanse lijst bezette.",
+      "fun_fact_it": "Swift l'ha definita una delle sue canzoni preferite tra le proprie, e aprì la settimana in cui occupò tutti e dieci i primi posti della classifica americana."
+    },
+    {
+      "year": 2023,
+      "uri": "spotify:track:0daHbdrLvUmkh81rnolMcG",
+      "artist": "The Rolling Stones",
+      "alt_artists": [
+        "Keith Richards",
+        "Mick Jagger",
+        "The Who"
+      ],
+      "title": "Angry",
+      "isrc": "GBUM72302314",
+      "uri_apple_music": "applemusic://track/1704374028",
+      "uri_deezer": "deezer://track/2503446951",
+      "fun_fact": "The first single from the band's first album of new songs in eighteen years, recorded after Charlie Watts had died and with him on two other tracks.",
+      "fun_fact_de": "Die erste Single vom ersten Album mit neuen Songs seit achtzehn Jahren, aufgenommen nach Charlie Watts' Tod — auf zwei anderen Stücken ist er noch zu hören.",
+      "fun_fact_es": "El primer sencillo del primer disco de canciones nuevas en dieciocho años, grabado tras la muerte de Charlie Watts, que aún aparece en otros dos temas.",
+      "fun_fact_fr": "Le premier single du premier album de chansons inédites en dix-huit ans, enregistré après la mort de Charlie Watts, qui figure encore sur deux autres titres.",
+      "fun_fact_nl": "De eerste single van het eerste album met nieuwe nummers in achttien jaar, opgenomen na de dood van Charlie Watts, die nog op twee andere tracks te horen is.",
+      "fun_fact_it": "Il primo singolo del primo album di brani nuovi in diciotto anni, inciso dopo la morte di Charlie Watts, che compare ancora in altri due pezzi."
     }
   ]
 }


### PR DESCRIPTION
Sixth batch from the Bayern 1 expansion (#2374), which is not being added as a playlist of its own.

`hits-2010s-2020s` goes from 71 to 86 songs, version 1.15 to 1.16.

## What is in here

2011 Nickelback · 2012 Rihanna, Passenger · 2013 Katy Perry · 2014 Ed Sheeran · 2015 Disturbed · 2016 Rag'n'Bone Man · 2017 Harry Styles · 2018 Ava Max, Mark Ronson · 2019 Maroon 5 · 2020 Michael Patrick Kelly · 2021 Coldplay · 2022 Taylor Swift · 2023 The Rolling Stones

Each carries the original release year, a Spotify URI, Apple and Deezer URIs, an ISRC, alt_artists and fun facts in six languages.

## One track dropped

`Alice Merton — No Roots` is in the source list as the Live from Spotify Berlin recording. Its URI plays a concert take while the answer would be the 2016 studio single, which is exactly the mismatch described in #2272. Left out rather than entered against a recording nobody would recognise as the hit.

Refs #2374