### PR TITLE
data(playlists): the last five from the Bayern 1 request (#2374)

### DIFF
--- a/custom_components/beatify/playlists/40s-50s-classics.json
+++ b/custom_components/beatify/playlists/40s-50s-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "40s & 50s Classics",
-  "version": "1.18",
+  "version": "1.19",
   "tags": [
     "1940s",
     "1950s",
@@ -3812,6 +3812,46 @@
       "fun_fact_es": "Un clásico de los años 50 (1962).",
       "fun_fact_fr": "Un classique des années 50 (1962).",
       "fun_fact_nl": "Een jaren-50-klassieker (1962)."
+    },
+    {
+      "year": 1955,
+      "uri": "spotify:track:2kKvwBX4Qsn1CpbqjtNyad",
+      "artist": "Frank Sinatra",
+      "alt_artists": [
+        "Dean Martin",
+        "Bing Crosby",
+        "Sammy Davis Jr."
+      ],
+      "title": "Love And Marriage",
+      "isrc": "USCA20902785",
+      "uri_apple_music": "applemusic://track/1804913753",
+      "uri_deezer": "deezer://track/97327612",
+      "fun_fact": "Written for a television production of Our Town, it won an Emmy and thirty years later became the theme of a sitcom about a deeply unhappy marriage.",
+      "fun_fact_de": "Für eine Fernsehfassung von Our Town geschrieben, gewann der Song einen Emmy und wurde dreißig Jahre später zum Titellied einer Sitcom über eine zutiefst unglückliche Ehe.",
+      "fun_fact_es": "Escrita para una versión televisiva de Our Town, ganó un Emmy y treinta años después se convirtió en la sintonía de una comedia sobre un matrimonio profundamente infeliz.",
+      "fun_fact_fr": "Écrite pour une adaptation télévisée d'Our Town, elle a remporté un Emmy et, trente ans plus tard, est devenue le générique d'une sitcom sur un mariage profondément malheureux.",
+      "fun_fact_nl": "Geschreven voor een televisieversie van Our Town, won het een Emmy en werd het dertig jaar later de tune van een sitcom over een diep ongelukkig huwelijk.",
+      "fun_fact_it": "Scritta per una versione televisiva di Our Town, vinse un Emmy e trent'anni dopo divenne la sigla di una sitcom su un matrimonio profondamente infelice."
+    },
+    {
+      "year": 1956,
+      "uri": "spotify:track:01u6AEzGbGbQyYVdxajxqk",
+      "artist": "Elvis Presley",
+      "alt_artists": [
+        "Carl Perkins",
+        "Jerry Lee Lewis",
+        "Buddy Holly"
+      ],
+      "title": "Don't Be Cruel",
+      "isrc": "USRC10200073",
+      "uri_apple_music": "applemusic://track/388127877",
+      "uri_deezer": "deezer://track/7675086",
+      "fun_fact": "Otis Blackwell sold the song outright for twenty-five dollars, then had to hand Presley half the writing credit as a condition of the recording.",
+      "fun_fact_de": "Otis Blackwell verkaufte den Song für fünfundzwanzig Dollar und musste Presley dann als Bedingung für die Aufnahme die halbe Autorenschaft überlassen.",
+      "fun_fact_es": "Otis Blackwell vendió la canción en firme por veinticinco dólares y luego tuvo que ceder a Presley la mitad de la autoría como condición para grabarla.",
+      "fun_fact_fr": "Otis Blackwell a vendu la chanson pour vingt-cinq dollars, puis a dû céder à Presley la moitié des droits d'auteur comme condition de l'enregistrement.",
+      "fun_fact_nl": "Otis Blackwell verkocht het nummer voor vijfentwintig dollar en moest Presley daarna de helft van het auteurschap afstaan als voorwaarde voor de opname.",
+      "fun_fact_it": "Otis Blackwell vendette la canzone per venticinque dollari e poi dovette cedere a Presley metà dei diritti d'autore come condizione per l'incisione."
     }
   ]
 }

--- a/custom_components/beatify/playlists/community/musica-italiana.json
+++ b/custom_components/beatify/playlists/community/musica-italiana.json
@@ -1,7 +1,7 @@
 {
   "name": "Musica Italiana 🇮🇹",
   "description": "Italian classics from the 1960s to the 2000s — cantautori, Sanremo winners and the songs every Italian party sings along to. Merged from playlist requests #2228 and #2229.",
-  "version": "0.13",
+  "version": "0.14",
   "songs": [
     {
       "year": 1962,
@@ -2213,6 +2213,26 @@
       "fun_fact_it": "Gianni Nazzaro - \"Quando L'Amore Diventa Poesía\" (2007), dal canone del pop italiano.",
       "isrc": null,
       "uri_apple_music": "applemusic://track/1780787742"
+    },
+    {
+      "year": 1990,
+      "uri": "spotify:track:7dp45uA0Ws4TadWaMwdIRw",
+      "artist": "Eros Ramazzotti",
+      "alt_artists": [
+        "Laura Pausini",
+        "Zucchero",
+        "Andrea Bocelli"
+      ],
+      "title": "Se bastasse una canzone",
+      "isrc": "ITB009700365",
+      "uri_apple_music": "applemusic://track/254549432",
+      "uri_deezer": "deezer://track/604862",
+      "fun_fact": "Ramazzotti wrote it for a Milan charity concert and sang it with an audience of forty thousand carrying the chorus back at him.",
+      "fun_fact_de": "Ramazzotti schrieb den Song für ein Benefizkonzert in Mailand und sang ihn vor vierzigtausend Menschen, die ihm den Refrain zurücktrugen.",
+      "fun_fact_es": "Ramazzotti la escribió para un concierto benéfico en Milán y la cantó ante cuarenta mil personas que le devolvían el estribillo.",
+      "fun_fact_fr": "Ramazzotti l'a écrite pour un concert caritatif à Milan et l'a chantée devant quarante mille personnes qui lui renvoyaient le refrain.",
+      "fun_fact_nl": "Ramazzotti schreef het voor een benefietconcert in Milaan en zong het voor veertigduizend mensen die het refrein terugzongen.",
+      "fun_fact_it": "Ramazzotti la scrisse per un concerto di beneficenza a Milano e la cantò davanti a quarantamila persone che gli rimandavano il ritornello."
     }
   ],
   "tags": [

--- a/custom_components/beatify/playlists/community/schlager-klassiker.json
+++ b/custom_components/beatify/playlists/community/schlager-klassiker.json
@@ -1,6 +1,6 @@
 {
   "name": "Schlager Classics 🇩🇪",
-  "version": "1.22",
+  "version": "1.23",
   "tags": [
     "german",
     "schlager",
@@ -4696,6 +4696,46 @@
       "fun_fact_es": "Jordi ganó el Grand Prix der Volksmusik en 1998 y representó a Suiza en Eurovisión en 2002. Entre ambos hitos pasó de la música folclórica al Schlager mayoritario.",
       "fun_fact_fr": "Jordi a remporté le Grand Prix der Volksmusik en 1998 et a représenté la Suisse à l'Eurovision en 2002. Entre les deux, elle est passée de la musique folklorique au Schlager grand public.",
       "fun_fact_nl": "Jordi won in 1998 de Grand Prix der Volksmusik en vertegenwoordigde Zwitserland in 2002 op het Eurovisiesongfestival. Daartussen stapte ze van volksmuziek over naar de brede Schlager."
+    },
+    {
+      "year": 1983,
+      "uri": "spotify:track:5OsHWD22P4lg2wP58C6mCw",
+      "artist": "Nickerbocker & Biene",
+      "alt_artists": [
+        "Rainhard Fendrich",
+        "Wolfgang Ambros",
+        "EAV"
+      ],
+      "title": "Hallo Klaus (I wü zruck zu Dir)",
+      "isrc": "ATT238200120",
+      "uri_apple_music": "applemusic://track/309569089",
+      "uri_deezer": "deezer://track/15306741",
+      "fun_fact": "The record exists in two versions, one sung from the man's side and one from the woman's; this is the 1983 female original.",
+      "fun_fact_de": "Die Platte gibt es in zwei Fassungen, einer aus Sicht des Mannes und einer aus Sicht der Frau; dies ist das weibliche Original von 1983.",
+      "fun_fact_es": "El disco existe en dos versiones, una cantada desde el punto de vista del hombre y otra desde el de la mujer; esta es la original femenina de 1983.",
+      "fun_fact_fr": "Le disque existe en deux versions, l'une chantée du point de vue de l'homme, l'autre de celui de la femme ; voici l'original féminin de 1983.",
+      "fun_fact_nl": "De plaat bestaat in twee versies, één vanuit de man en één vanuit de vrouw gezongen; dit is het vrouwelijke origineel uit 1983.",
+      "fun_fact_it": "Il disco esiste in due versioni, una cantata dal punto di vista dell'uomo e una da quello della donna; questa è l'originale femminile del 1983."
+    },
+    {
+      "year": 2015,
+      "uri": "spotify:track:2Bh1bOO728itHij0vMBeHL",
+      "artist": "Seiler und Speer",
+      "alt_artists": [
+        "Rainhard Fendrich",
+        "Wanda",
+        "Bilderbuch"
+      ],
+      "title": "Ham kummst",
+      "isrc": "ATCF31503102",
+      "uri_apple_music": "applemusic://track/1783779165",
+      "uri_deezer": "deezer://track/3130198181",
+      "fun_fact": "The two Austrians put it on the internet as a joke, and within weeks it had spent months at number one and started a run on Viennese dialect pop.",
+      "fun_fact_de": "Die beiden Österreicher stellten das Lied als Scherz ins Internet, und binnen Wochen stand es monatelang auf Platz eins und löste einen Ansturm auf Wiener Dialektpop aus.",
+      "fun_fact_es": "Los dos austriacos la subieron a internet como broma, y en semanas llevaba meses en el número uno y había desatado una fiebre por el pop en dialecto vienés.",
+      "fun_fact_fr": "Les deux Autrichiens l'ont mise sur internet pour plaisanter, et en quelques semaines elle occupait la première place depuis des mois et lançait une vague de pop en dialecte viennois.",
+      "fun_fact_nl": "De twee Oostenrijkers zetten het als grap op internet, en binnen weken stond het maandenlang op nummer één en begon een golf van Weense dialectpop.",
+      "fun_fact_it": "I due austriaci la misero in rete per scherzo, e in poche settimane era da mesi al primo posto e aveva avviato una corsa al pop in dialetto viennese."
     }
   ]
 }


### PR DESCRIPTION
Final batch from the Bayern 1 expansion (#2374). Three files, five songs — too few per playlist to be worth a PR each.

| Playlist | Change | Songs |
|---|---|---|
| `40s-50s-classics` | 152 → 154, v1.18 → 1.19 | Frank Sinatra 1955, Elvis Presley 1956 |
| `community/schlager-klassiker` | 152 → 154, v1.22 → 1.23 | Nickerbocker & Biene 1983, Seiler und Speer 2015 |
| `community/musica-italiana` | 114 → 115, v0.13 → 0.14 | Eros Ramazzotti 1990 |

## On the two Austrian records

Neither is schlager in the strict sense — both are Viennese dialect pop. The catalogue holds no Austrian playlist, and `schlager-klassiker` is the closest existing home. If an Austrian playlist ever gets built they belong there instead.

## One more year against the signal

`Se bastasse una canzone` comes back from the provider as 1987. That is the year of a different Ramazzotti record; this one is 1990.

Refs #2374