### PR TITLE
chore(release): v4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [4.4.0] - 2026-09-01
+
+Released as **4.4.0** rather than 4.3.1: the work shipped as the `v4.3.1-rc1`, `v4.3.1-rc2` and
+`v4.4.0-rc1`…`rc4` release candidates, but a patch number promises bug fixes and this carries a
+new game mechanic, a provider that needs no paid subscription, three new playlists and 1,069
+more songs. Everything in those candidates is included.
+
+### Changed
+- **The catalogue reached 61 playlists and 8,211 songs**, from 58 and 7,142 at 4.3.0. Around a
+  thousand of those songs came from four requests filed through the in-app button — a Schlager
+  party list (#2372), a radio station's playlist (#2374), a guilty-pleasures list (#2373) and a
+  soundtracks list (#2377). None became a playlist of its own: each overlapped the catalogue by a
+  fifth to two thirds, so the usable songs were sorted into the decade, Schlager, Deutschpop and
+  film playlists instead.
+- **A soundtrack is dated by its work, not by its pressing (#2450).** The three signals behind a
+  song's year describe the same reissue when all three are read off the linked track, so they
+  agreed on a year decades off the work — the Seinfeld theme dated 2021 against a 1989 work. The
+  rule now takes the earliest recording credited to that artist, with the work's own year as a
+  ceiling where the artist is the composer of the film or series named in the title. A cover by
+  different performers keeps its own recording's year, unchanged from the rule of 2026-08-20.
+- **The catalogue figure in the README** now says 61 playlists and 8,211 songs. The landing page
+  is served from the `gh-pages` branch and still says 59 and 7,671.
+
+### Fixed
+- **The final standings reach the players when the host ends a game (#2442, #2443).**
+  `EndGameView` tore the game down before finalizing, so the podium never went out.
+- **The YouTube backfill budget counts on the Pacific day (#2452, #2453)** and the playlist
+  version is raised once per run rather than once per track (#2447).
+
 ## [4.4.0-rc4] - 2026-08-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ Playlists are displayed on the main Beatify admin screen:
 
 ### Included Playlists
 
-Beatify comes with 7,671 songs across 59 curated playlists:
+Beatify comes with 8,211 songs across 61 curated playlists:
 
 - 🎬 **100 Greatest Movie Themes** — 162 iconic film soundtracks
 - 🎸 **100 Greatest Rock Songs** — 122 rock essentials spanning 1964–2026

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -20,5 +20,5 @@
     "num2words==0.5.14"
   ],
   "single_config_entry": true,
-  "version": "4.4.0-rc4"
+  "version": "4.4.0"
 }

--- a/docs/release-notes-v4.4.0.md
+++ b/docs/release-notes-v4.4.0.md
@@ -1,0 +1,37 @@
+## Beatify v4.4.0 — "Keep What You Catch"
+
+### 🎴 Keep what you catch
+
+Guess a year close enough and the song pins to a row you keep for the rest of the game. It appears in the final standings and on the share card.
+
+### 🆓 A music service that costs nothing
+
+Beatify can now play through `ytmusic_free`, which streams YouTube Music without a Premium account — every service before this needed a paid plan. It has to be installed in Music Assistant first, and the wizard says so. Asked for by **@ipalomo**.
+
+### 🎚️ Decade marks on the year slider
+
+Labelled ticks along the rail, and the ends follow the playlists you picked instead of a fixed range.
+
+### ⏱️ Ten rounds means ten rounds
+
+The round cap did nothing once more than one playlist was selected. It holds now.
+
+### 📺 The end screen fits, and it arrives
+
+The winner's name, the award values and a two-player podium stay inside their cards. Ending a game from the host screen shows the final standings — the teardown used to run first. Reported by **@boardnick0815**.
+
+### 🔧 Also fixed
+
+- The last round announces itself again, including after an unavailable track.
+- A wobbly connection, a slow submit or a page reload no longer costs you your answer.
+- A round waits for the speaker to actually change tracks.
+- Steal and sabotage respect the round deadline, and the status endpoint no longer exposes the running answer.
+
+### 🎧 Playlists
+
+**58 playlists and 7,142 songs became 61 and 8,211.**
+
+- **Salsa y Merengue**, 531 songs — the second-largest playlist in the catalogue. Latin America had fifty songs before this.
+- **Clásicos Disney (Castellano)** and **Disney Latino**, 118 songs between them. Two lists rather than one: the same film is often a different recording, singer and lyric in the two regions.
+- **Around a thousand songs went into playlists that already existed**, from four requests that came in through the in-app button. Not one became a playlist of its own — each overlapped the catalogue too heavily, so the songs were sorted into the decade, Schlager, Deutschpop and film lists instead.
+- **The decade playlists contain only their decade.** Nineteen songs sat outside their range.


### PR DESCRIPTION
Cuts the stable **v4.4.0**.

## Why 4.4.0 and not 4.3.1

The work shipped as `v4.3.1-rc1`, `v4.3.1-rc2` and `v4.4.0-rc1`…`rc4`. A patch number promises bug fixes, and this carries a new game mechanic (the collected row), a provider that needs no paid subscription, three new playlists and 1,069 more songs. Everything in those candidates is included.

## What is in the commit

- `manifest.json` **4.4.0-rc4 → 4.4.0**
- A `[4.4.0]` section in `CHANGELOG.md` covering the candidates plus the merges landed after rc4 — the final standings reaching the players when the host ends a game (#2443), the YouTube backfill budget counting on the Pacific day (#2453), the soundtrack year rule (#2450), and the catalogue growth
- `docs/release-notes-v4.4.0.md`, **force-added** because `docs/` is gitignored — the trap that lost the rc4 notes on their first attempt
- The README catalogue figure, **7,671 songs across 59 playlists → 8,211 across 61**

## Counted, not copied

Both figures come from `git ls-tree` against the tags rather than from the rc notes: `v4.3.0` holds **58 playlists / 7,142 songs**, `main` holds **61 / 8,211**. The rc4 notes gave 55/6,079 as their baseline, which is not the state of the last stable release.

## Two things deliberately left alone

- **The landing page** still says 59 playlists and 7,671 songs. It is served from the `gh-pages` branch, not from `docs/` on `main`, so it is not this commit's to change.
- **The per-playlist list in the README** has drifted further than a release cut should absorb: 54 rows for 61 playlists, and four of them name a playlist that has since been renamed (*100 Greatest Movie Themes* is now *Movie & TV Soundtracks*, at 257 songs rather than 162). Worth its own pass.