### PR TITLE
feat(ui): a favicon on all five pages

### DIFF
--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <link rel="icon" href="/beatify/static/img/icon-256.png">
     <!-- #824: cache-bust the i18n JSON fetches via this version. The SW
          caches /beatify/static/* with a cache-first strategy, so without a
          query-string version, a stale en.json from a prior rc gets served

--- a/custom_components/beatify/www/analytics.html
+++ b/custom_components/beatify/www/analytics.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <link rel="icon" href="/beatify/static/img/icon-256.png">
     <!-- #1098: drives the footer version string + cache-busts i18n JSON.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->
     <meta name="beatify-version" content="{{VERSION}}">

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <link rel="icon" href="/beatify/static/img/icon-256.png">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
     <meta name="beatify-version" content="{{VERSION}}">
     <meta name="beatify-asset-version" content="{{ASSET_VER}}">

--- a/custom_components/beatify/www/launcher.html
+++ b/custom_components/beatify/www/launcher.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" href="/beatify/static/img/icon-256.png">
     <title data-i18n="launcher.title">Beatify</title>
     <style>
         :root {

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <link rel="icon" href="/beatify/static/img/icon-256.png">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
     <meta name="beatify-version" content="{{VERSION}}">
     <meta name="beatify-asset-version" content="{{ASSET_VER}}">


### PR DESCRIPTION
Closes #2476.

## What was missing

None of the five pages had a `rel="icon"` link. `admin.html` carried an `apple-touch-icon`, which Safari uses for the home screen but which Chrome and Firefox do not use for the tab — so every page showed the browser's blank placeholder.

The two that matter most are `player.html` and `dashboard.html`: a guest who switches to another app mid-round comes back to a tab strip of identical grey placeholders, and the television dashboard is equally nameless among other tabs.

## The change

One line per page, after the viewport meta:

```html
<link rel="icon" href="/beatify/static/img/icon-256.png">
```

## Why the project icon and not the emoji

The fork this came from used an inline SVG emoji data URI. That renders in each platform's own emoji font, so the tab looks different on macOS, Windows and Android. `img/icon-256.png` already ships with the integration, so this needs no new asset and shows the same mark everywhere.

The path is the one `player.html` already uses for `styles.min.css`, the vendor scripts and `no-artwork.svg`, and `/beatify/static` is registered without auth — so a guest's browser can fetch it.

## Not in scope

- **`offline.html`** keeps no icon. It is served by the service worker when the network is gone, and the icon would not load then unless it were precached; that is a service-worker change, not a `<head>` change.
- **The home-screen case** — an icon when someone adds the page to their phone's home screen — needs `apple-touch-icon` on the remaining pages plus a web manifest, neither of which exists. Called out in #2476 and left for its own change.