### PR TITLE
fix: add emoji favicon to player.html and dashboard.html

### DIFF
--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🎶</text></svg>">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>▶️</text></svg>">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->


### PR DESCRIPTION
## Summary

- `player.html` and `dashboard.html` were missing `<link rel="icon">` entries, leaving a blank tab icon on the two pages guests and the TV screen sit on
- Adds inline SVG emoji favicons (▶️ for player, 🎶 for dashboard) using the same data URI pattern already in `admin.html`, `analytics.html`, and `launcher.html`
- No extra files added, no network requests -- works correctly on a local Home Assistant instance

Closes #2476

## Test plan

- [ ] Open player.html in browser -- tab shows ▶️ icon
- [ ] Open dashboard.html in browser -- tab shows 🎶 icon
- [ ] Confirm admin.html, analytics.html, launcher.html icons unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012q4pqz2KN7Zo8DhmAvympJ