### PR TITLE
fix(ui): one favicon on all five pages

### DIFF
--- a/custom_components/beatify/www/admin.html
+++ b/custom_components/beatify/www/admin.html
@@ -49,6 +49,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="Beatify">
+    <link rel="icon" href="/beatify/static/img/icon-256.png">
     <link rel="apple-touch-icon" href="/beatify/static/img/icon-256.png">
     <meta name="mobile-web-app-capable" content="yes">
     <!-- Preconnect for faster font loading (Story 9.8) -->

--- a/custom_components/beatify/www/analytics.html
+++ b/custom_components/beatify/www/analytics.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link rel="icon" href="/beatify/static/img/icon-256.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #1098: drives the footer version string + cache-busts i18n JSON.
          Bumped each rc alongside manifest.json + sw.js CACHE_VERSION. -->

--- a/custom_components/beatify/www/dashboard.html
+++ b/custom_components/beatify/www/dashboard.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🎶</text></svg>">
     <meta charset="UTF-8">
+    <link rel="icon" href="/beatify/static/img/icon-256.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
     <meta name="beatify-version" content="{{VERSION}}">

--- a/custom_components/beatify/www/launcher.html
+++ b/custom_components/beatify/www/launcher.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link rel="icon" href="/beatify/static/img/icon-256.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title data-i18n="launcher.title">Beatify</title>
     <style>

--- a/custom_components/beatify/www/player.html
+++ b/custom_components/beatify/www/player.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>▶️</text></svg>">
     <meta charset="UTF-8">
+    <link rel="icon" href="/beatify/static/img/icon-256.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <!-- #824: cache-bust i18n JSON fetches. See admin.html for rationale. -->
     <meta name="beatify-version" content="{{VERSION}}">


### PR DESCRIPTION
Finishes what #2479 started.

## What was missing

#2479 gave `player.html` and `dashboard.html` an inline SVG emoji favicon and closed #2476 through its merge keyword. Three pages were still uncovered:

- `admin.html` — only `<link rel="apple-touch-icon">`. Safari uses that for the home screen; Chrome and Firefox do not use it for the tab.
- `analytics.html` — no icon link
- `launcher.html` — no icon link

## What this does

All five pages now point at the bundled `img/icon-256.png`. That replaces the two emoji data URIs as well, so every page shows the same mark. Emoji are drawn by the OS font and differ between platforms — leaving the split in place would have meant three different icons across the five pages.

No new file and no service worker change is needed: `icon-256.png` already ships in the repository, `admin.html` already references it for `apple-touch-icon`, and it is already in the `sw.js` precache list, so the icon is available offline too.

## Test plan

- [ ] Open each of admin, analytics, launcher, player and dashboard — the tab shows the Beatify icon
- [ ] Same icon in Chrome, Firefox and Safari
- [ ] Home screen install on iOS still uses `apple-touch-icon` from `admin.html`

## Out of scope

- `offline.html` — noted on #2476, left as it is
- Home screen install beyond `admin.html` — needs a web manifest

Closes #2482

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EoSUKDjLvert1VkyyL3RE