### PR TITLE
chore(playlists): deezer backfill — +2 deezer uris

### DIFF
--- a/custom_components/beatify/playlists/community/salsa-y-merengue.json
+++ b/custom_components/beatify/playlists/community/salsa-y-merengue.json
@@ -1,6 +1,6 @@
 {
   "name": "Salsa y Merengue",
-  "version": "1.18",
+  "version": "1.19",
   "tags": [
     "salsa",
     "merengue",
@@ -5254,7 +5254,8 @@
       "fun_fact_es": "\"Calambre\" de Conjunto Barbacoa, publicada por primera vez en 2000 en el álbum \"Händel: Serse - The Sony Opera House\".",
       "fun_fact_fr": "« Calambre » de Conjunto Barbacoa, parue pour la première fois en 2000 sur l'album « Händel: Serse - The Sony Opera House ».",
       "fun_fact_nl": "\"Calambre\" van Conjunto Barbacoa, voor het eerst uitgebracht in 2000 op het album \"Händel: Serse - The Sony Opera House\".",
-      "fun_fact_it": "«Calambre» di Conjunto Barbacoa, pubblicata per la prima volta nel 2000 nell'album «Händel: Serse - The Sony Opera House»."
+      "fun_fact_it": "«Calambre» di Conjunto Barbacoa, pubblicata per la prima volta nel 2000 nell'album «Händel: Serse - The Sony Opera House».",
+      "uri_deezer": "deezer://track/71884899"
     },
     {
       "year": 1993,
@@ -6610,7 +6611,8 @@
       "fun_fact_es": "\"Alo Alo\" de Wayne Gorbea, publicada por primera vez en 2007 en el álbum \"Introducing Wayne Gorbea's Salsa Picante\".",
       "fun_fact_fr": "« Alo Alo » de Wayne Gorbea, parue pour la première fois en 2007 sur l'album « Introducing Wayne Gorbea's Salsa Picante ».",
       "fun_fact_nl": "\"Alo Alo\" van Wayne Gorbea, voor het eerst uitgebracht in 2007 op het album \"Introducing Wayne Gorbea's Salsa Picante\".",
-      "fun_fact_it": "«Alo Alo» di Wayne Gorbea, pubblicata per la prima volta nel 2007 nell'album «Introducing Wayne Gorbea's Salsa Picante»."
+      "fun_fact_it": "«Alo Alo» di Wayne Gorbea, pubblicata per la prima volta nel 2007 nell'album «Introducing Wayne Gorbea's Salsa Picante».",
+      "uri_deezer": "deezer://track/10973342"
     },
     {
       "year": 1981,


### PR DESCRIPTION
A `provider-uri-backfill` run focused on Deezer, driven automatically by `com.beatify.deezer-backfill`.

- `salsa-y-merengue` Deezer 517 -> **519**/531

**The run stopped at its cap rather than finishing** (`reached --max-minutes 50`). The remaining tracks of the playlist are untouched and are not a catalogue gap.

**Draft on purpose** — merged only once the maintainer approves. This agent has deliberately NO auto-merge.