### PR TITLE
playlist(deutschrap-klassiker): 26 German rap tracks from 1995 to 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ Playlists are displayed on the main Beatify admin screen:
 
 ### Included Playlists
 
-Beatify comes with 8,211 songs across 61 curated playlists:
+Beatify comes with 8,237 songs across 62 curated playlists:
 
 - 🎸 **100 Greatest Rock Songs** — 122 rock essentials spanning 1964–2026
 - ☀️ **100 Summer Anthems** — 112 feel-good tracks from 1957–2020
@@ -452,6 +452,7 @@ Beatify comes with 8,211 songs across 61 curated playlists:
 - 🏰 **Clásicos Disney (Castellano)** — 64 Disney songs in the Spanish of Spain
 - 🎭 **Cologne Carnival** — 290 German carnival favorites
 - 🇩🇪 **Deutschpop Klassiker** — 118 German pop classics, incl. the 90s / NDW canon
+- 🇩🇪 **Deutschrap Klassiker** — 26 German rap tracks from 1995 to 2024, Freundeskreis and Beginner through Sido and Haftbefehl to Pashanim and Ski Aggu
 - 🇩🇪 **Deutschrock - Best Of** — 100 modern German rock tracks, from Böhse Onkelz to Die Toten Hosen
 - 🕺 **Disco & Funk Classics** — 98 essential disco and funk tracks from the 70s and 80s
 - 🏰 **Disney Classics** — 69 soundtrack singalongs from the Disney canon

--- a/custom_components/beatify/playlists/community/deutschrap-klassiker.json
+++ b/custom_components/beatify/playlists/community/deutschrap-klassiker.json
@@ -1,0 +1,462 @@
+{
+  "name": "Deutschrap Klassiker",
+  "version": "1.0",
+  "tags": [
+    "deutschrap",
+    "hip-hop",
+    "rap",
+    "german",
+    "90s",
+    "2000s",
+    "2010s",
+    "2020s"
+  ],
+  "language": "de",
+  "author": "Beatify Team",
+  "added_date": "2026-09-02",
+  "description": "German-language rap from Freundeskreis and Beginner through Sido and Haftbefehl to Pashanim and Ski Aggu — three decades of Deutschrap in one round.",
+  "songs": [
+    {
+      "year": 1995,
+      "uri": "spotify:track:0CbiLoqWTQG4TiyCizsxXd",
+      "artist": "Schwester S.",
+      "alt_artists": [
+        "Cora E.",
+        "Sabrina Setlur",
+        "Lady Bitch Ray",
+        "Nina MC"
+      ],
+      "title": "Ja klar",
+      "fun_fact": "Schwester S. was the early stage name of Sabrina Setlur, who later charted under her own first name — the same artist behind two names.",
+      "fun_fact_de": "Schwester S. war der fruehe Kuenstlername von Sabrina Setlur, die spaeter unter ihrem Vornamen in die Charts kam — dieselbe Kuenstlerin hinter zwei Namen.",
+      "fun_fact_es": "Schwester S. fue el primer nombre artistico de Sabrina Setlur, que mas tarde entro en las listas con su propio nombre: la misma artista tras dos nombres.",
+      "fun_fact_fr": "Schwester S. etait le premier nom de scene de Sabrina Setlur, entree ensuite dans les charts sous son prenom : la meme artiste sous deux noms.",
+      "fun_fact_nl": "Schwester S. was de vroege artiestennaam van Sabrina Setlur, die later onder haar eigen voornaam in de hitlijsten kwam — dezelfde artieste met twee namen."
+    },
+    {
+      "year": 1997,
+      "uri": "spotify:track:6EWtkdeKmVtRjmydTfIR0S",
+      "artist": "Freundeskreis",
+      "alt_artists": [
+        "Die Fantastischen Vier",
+        "Absolute Beginner",
+        "Fettes Brot",
+        "Blumentopf"
+      ],
+      "title": "A-N-N-A",
+      "fun_fact": "The title is a palindrome and the hook plays on it: the chorus spells the name out because it reads the same in both directions.",
+      "fun_fact_de": "Der Titel ist ein Palindrom, und der Refrain spielt genau damit — der Name wird buchstabiert, weil er vorwaerts wie rueckwaerts gleich gelesen wird.",
+      "fun_fact_es": "El titulo es un palindromo y el estribillo juega con ello: deletrea el nombre porque se lee igual en ambos sentidos.",
+      "fun_fact_fr": "Le titre est un palindrome et le refrain joue dessus : le prenom est epele parce qu'il se lit pareil dans les deux sens.",
+      "fun_fact_nl": "De titel is een palindroom en het refrein speelt daarmee: de naam wordt gespeld omdat hij in beide richtingen hetzelfde leest."
+    },
+    {
+      "year": 1998,
+      "uri": "spotify:track:6YzYyeMV5MY7wHOGskZdzf",
+      "artist": "Beginner",
+      "alt_artists": [
+        "Fettes Brot",
+        "Dynamite Deluxe",
+        "Deichkind",
+        "Fischmob"
+      ],
+      "title": "Liebes Lied",
+      "fun_fact": "It comes from Bambule, the Hamburg album that made German-language rap a chart format rather than a scene affair.",
+      "fun_fact_de": "Der Song stammt von Bambule, dem Hamburger Album, das deutschsprachigen Rap von einer Szene-Sache zu einem Chart-Format machte.",
+      "fun_fact_es": "Procede de Bambule, el album de Hamburgo que convirtio el rap en aleman en un formato de listas y no solo en cosa de escena.",
+      "fun_fact_fr": "Le morceau vient de Bambule, l'album hambourgeois qui a fait du rap en allemand un format de charts et plus seulement une affaire de scene.",
+      "fun_fact_nl": "Het komt van Bambule, het Hamburgse album dat Duitstalige rap van scene-zaak tot hitlijstformaat maakte."
+    },
+    {
+      "year": 2001,
+      "uri": "spotify:track:47VRtROAdociHgtuVZNoBL",
+      "artist": "Samy Deluxe",
+      "alt_artists": [
+        "Afrob",
+        "Curse",
+        "Torch",
+        "D-Flame"
+      ],
+      "title": "Weck mich auf",
+      "fun_fact": "Released as an EP in September 2001, it reached number four in the German singles chart and remains his best-known political song.",
+      "fun_fact_de": "Im September 2001 als EP erschienen, erreichte der Song Platz vier der deutschen Singlecharts und ist bis heute sein bekanntester politischer Titel.",
+      "fun_fact_es": "Publicado como EP en septiembre de 2001, alcanzo el numero cuatro en las listas alemanas y sigue siendo su cancion politica mas conocida.",
+      "fun_fact_fr": "Sorti en EP en septembre 2001, il a atteint la quatrieme place des charts allemands et reste sa chanson politique la plus connue.",
+      "fun_fact_nl": "In september 2001 als ep verschenen, haalde het nummer vier in de Duitse hitlijst en blijft zijn bekendste politieke song."
+    },
+    {
+      "year": 2007,
+      "uri": "spotify:track:1mC06CRaWGhsWhdX99GJqL",
+      "artist": "AZAD",
+      "alt_artists": [
+        "Kool Savas",
+        "Curse",
+        "Chakuza",
+        "Massiv"
+      ],
+      "title": "Prison Break Anthem (Ich glaub an Dich)",
+      "fun_fact": "Built on the theme of the television series Prison Break, with Adel Tawil singing the hook years before Ich + Ich became a household name.",
+      "fun_fact_de": "Gebaut auf dem Titelthema der Serie Prison Break, mit Adel Tawil auf dem Refrain — Jahre bevor Ich + Ich jeder kannte.",
+      "fun_fact_es": "Construida sobre el tema de la serie Prison Break, con Adel Tawil en el estribillo anos antes de que Ich + Ich fuera conocido por todos.",
+      "fun_fact_fr": "Construit sur le theme de la serie Prison Break, avec Adel Tawil au refrain, des annees avant qu'Ich + Ich ne soit connu de tous.",
+      "fun_fact_nl": "Gebouwd op het thema van de serie Prison Break, met Adel Tawil op het refrein, jaren voordat Ich + Ich een begrip werd."
+    },
+    {
+      "year": 2008,
+      "uri": "spotify:track:3tv1DRqL9KRuIUawu6eYG0",
+      "artist": "Bushido",
+      "alt_artists": [
+        "Sido",
+        "Fler",
+        "Kool Savas",
+        "Massiv"
+      ],
+      "title": "Für immer jung",
+      "fun_fact": "A rap version of Alphaville's Forever Young, sung by Karel Gott — a pairing of German rap and Schlager that nobody had tried before.",
+      "fun_fact_de": "Eine Rap-Fassung von Alphavilles Forever Young, gesungen von Karel Gott — eine Paarung aus Deutschrap und Schlager, die vorher niemand versucht hatte.",
+      "fun_fact_es": "Una version rap de Forever Young de Alphaville, cantada por Karel Gott: una union de rap aleman y Schlager que nadie habia intentado antes.",
+      "fun_fact_fr": "Une version rap de Forever Young d'Alphaville, chantee par Karel Gott : un melange de rap allemand et de Schlager que personne n'avait tente avant.",
+      "fun_fact_nl": "Een rapversie van Forever Young van Alphaville, gezongen door Karel Gott — een combinatie van Duitse rap en Schlager die niemand eerder probeerde."
+    },
+    {
+      "year": 2009,
+      "uri": "spotify:track:3RM5RpRDDdST1njqOMG141",
+      "artist": "Culcha Candela",
+      "alt_artists": [
+        "Seeed",
+        "Peter Fox",
+        "Jan Delay",
+        "Fettes Brot"
+      ],
+      "title": "Monsta",
+      "fun_fact": "The Berlin group sings in German, English, Spanish and Jamaican Patois — Monsta is the track that carried that mix into the summer charts.",
+      "fun_fact_de": "Die Berliner Gruppe singt auf Deutsch, Englisch, Spanisch und jamaikanischem Patois — Monsta ist der Titel, der diese Mischung in die Sommercharts trug.",
+      "fun_fact_es": "El grupo berlines canta en aleman, ingles, espanol y patois jamaicano; Monsta es el tema que llevo esa mezcla a las listas de verano.",
+      "fun_fact_fr": "Le groupe berlinois chante en allemand, anglais, espagnol et patois jamaicain : Monsta est le titre qui a porte ce melange dans les charts d'ete.",
+      "fun_fact_nl": "De Berlijnse groep zingt in het Duits, Engels, Spaans en Jamaicaans Patois — Monsta bracht die mix naar de zomerhitlijsten."
+    },
+    {
+      "year": 2010,
+      "uri": "spotify:track:02ywbmwM0tICk8EOhYIwpw",
+      "artist": "Marteria",
+      "alt_artists": [
+        "Casper",
+        "Prinz Pi",
+        "Cro",
+        "Kraftklub"
+      ],
+      "title": "Endboss",
+      "fun_fact": "From Zum Glueck in die Zukunft, the album on which the Rostock rapper dropped his earlier English-language alias Marsimoto's twin persona for good.",
+      "fun_fact_de": "Vom Album Zum Glueck in die Zukunft, mit dem der Rostocker Rapper seine fruehere englischsprachige Laufbahn endgueltig hinter sich liess.",
+      "fun_fact_es": "Del album Zum Glueck in die Zukunft, con el que el rapero de Rostock dejo definitivamente atras su etapa en ingles.",
+      "fun_fact_fr": "Extrait de Zum Glueck in die Zukunft, l'album avec lequel le rappeur de Rostock a definitivement laisse derriere lui sa periode anglophone.",
+      "fun_fact_nl": "Van het album Zum Glueck in die Zukunft, waarmee de rapper uit Rostock zijn eerdere Engelstalige fase definitief achter zich liet."
+    },
+    {
+      "year": 2012,
+      "uri": "spotify:track:3FwxpJdlexIR6MeTT56HAm",
+      "artist": "CRO",
+      "alt_artists": [
+        "Casper",
+        "Marteria",
+        "Prinz Pi",
+        "Kraftklub"
+      ],
+      "title": "Easy",
+      "fun_fact": "The panda mask kept the rapper's face unknown while the song was everywhere — deliberate anonymity at the moment of his breakthrough.",
+      "fun_fact_de": "Die Pandamaske hielt das Gesicht des Rappers unbekannt, waehrend der Song ueberall lief — gewollte Anonymitaet im Moment des Durchbruchs.",
+      "fun_fact_es": "La mascara de panda mantuvo oculto el rostro del rapero mientras la cancion sonaba en todas partes: anonimato deliberado en pleno exito.",
+      "fun_fact_fr": "Le masque de panda a garde le visage du rappeur inconnu alors que le morceau passait partout : un anonymat voulu au moment de la percee.",
+      "fun_fact_nl": "Het pandamasker hield het gezicht van de rapper onbekend terwijl het nummer overal klonk — bewuste anonimiteit op het moment van de doorbraak."
+    },
+    {
+      "year": 2012,
+      "uri": "spotify:track:3gmxpKRiDdCe6ub96LvKx5",
+      "artist": "Deichkind",
+      "alt_artists": [
+        "Die Antwoord",
+        "Marteria",
+        "Jan Delay",
+        "K.I.Z."
+      ],
+      "title": "Leider geil",
+      "fun_fact": "The whole song is one confession: it lists things the singer knows are wrong and enjoys anyway, and the title says so in two words.",
+      "fun_fact_de": "Der ganze Song ist ein Gestaendnis — er zaehlt Dinge auf, die der Saenger falsch findet und trotzdem geniesst, und der Titel sagt das in zwei Worten.",
+      "fun_fact_es": "Toda la cancion es una confesion: enumera cosas que el cantante sabe que estan mal y disfruta igualmente, y el titulo lo resume en dos palabras.",
+      "fun_fact_fr": "Toute la chanson est un aveu : elle enumere des choses que le chanteur juge mauvaises et apprecie quand meme, et le titre le dit en deux mots.",
+      "fun_fact_nl": "Het hele nummer is een bekentenis: het somt dingen op die de zanger fout vindt en toch geniet, en de titel zegt dat in twee woorden."
+    },
+    {
+      "year": 2012,
+      "uri": "spotify:track:2Jcx6qkJTt7mFRiIAXX3uc",
+      "artist": "Max Herre",
+      "alt_artists": [
+        "Clueso",
+        "Joy Denalane",
+        "Xavier Naidoo",
+        "Cro"
+      ],
+      "title": "Wolke 7",
+      "fun_fact": "Max Herre had already written A-N-N-A with Freundeskreis fifteen years earlier — the same voice, two eras of German rap apart.",
+      "fun_fact_de": "Max Herre hatte A-N-N-A mit Freundeskreis schon fuenfzehn Jahre frueher geschrieben — dieselbe Stimme, zwei Epochen des Deutschraps auseinander.",
+      "fun_fact_es": "Max Herre ya habia escrito A-N-N-A con Freundeskreis quince anos antes: la misma voz, a dos epocas de distancia del rap aleman.",
+      "fun_fact_fr": "Max Herre avait deja ecrit A-N-N-A avec Freundeskreis quinze ans plus tot : la meme voix, a deux epoques d'ecart du rap allemand.",
+      "fun_fact_nl": "Max Herre schreef A-N-N-A met Freundeskreis al vijftien jaar eerder — dezelfde stem, twee tijdperken Duitse rap uit elkaar."
+    },
+    {
+      "year": 2012,
+      "uri": "spotify:track:6kjBafSuYC8gClzfYu7T1t",
+      "artist": "Haftbefehl",
+      "alt_artists": [
+        "Celo & Abdi",
+        "Kollegah",
+        "Farid Bang",
+        "Xatar"
+      ],
+      "title": "Chabos wissen wer der Babo ist",
+      "fun_fact": "Babo was voted Germany's youth word of the year in 2013, straight out of this song — a rap line that entered the dictionary.",
+      "fun_fact_de": "Babo wurde 2013 zum Jugendwort des Jahres gewaehlt, direkt aus diesem Song — eine Rapzeile, die es ins Woerterbuch schaffte.",
+      "fun_fact_es": "Babo fue elegida palabra juvenil del ano 2013 en Alemania, directamente de esta cancion: un verso de rap que llego al diccionario.",
+      "fun_fact_fr": "Babo a ete elu mot de l'annee des jeunes en 2013 en Allemagne, directement issu de ce morceau : une punchline entree au dictionnaire.",
+      "fun_fact_nl": "Babo werd in 2013 in Duitsland tot jeugdwoord van het jaar gekozen, rechtstreeks uit dit nummer — een raprijm dat het woordenboek haalde."
+    },
+    {
+      "year": 2013,
+      "uri": "spotify:track:5cBx2v7XJSErfesDmgNtr2",
+      "artist": "Sido",
+      "alt_artists": [
+        "Bushido",
+        "Fler",
+        "B-Tight",
+        "Kitty Kat"
+      ],
+      "title": "Liebe",
+      "fun_fact": "From 30-11-80, the album Sido named after his own date of birth.",
+      "fun_fact_de": "Vom Album 30-11-80, das Sido nach seinem eigenen Geburtsdatum benannt hat.",
+      "fun_fact_es": "Del album 30-11-80, que Sido bautizo con su propia fecha de nacimiento.",
+      "fun_fact_fr": "Extrait de 30-11-80, l'album que Sido a nomme d'apres sa propre date de naissance.",
+      "fun_fact_nl": "Van het album 30-11-80, dat Sido naar zijn eigen geboortedatum noemde."
+    },
+    {
+      "year": 2016,
+      "uri": "spotify:track:05Mp2UJulSttxQ4E6hQPH3",
+      "artist": "Bonez MC",
+      "alt_artists": [
+        "Gzuz",
+        "187 Strassenbande",
+        "Capital Bra",
+        "Ufo361"
+      ],
+      "title": "Ohne mein Team",
+      "fun_fact": "From Palmen aus Plastik, the joint album with RAF Camora that pulled dancehall into German rap and stayed in the charts for years.",
+      "fun_fact_de": "Vom Gemeinschaftsalbum Palmen aus Plastik mit RAF Camora, das Dancehall in den Deutschrap holte und jahrelang in den Charts blieb.",
+      "fun_fact_es": "Del album conjunto Palmen aus Plastik con RAF Camora, que trajo el dancehall al rap aleman y permanecio anos en las listas.",
+      "fun_fact_fr": "Extrait de l'album commun Palmen aus Plastik avec RAF Camora, qui a amene le dancehall dans le rap allemand et est reste des annees dans les charts.",
+      "fun_fact_nl": "Van het gezamenlijke album Palmen aus Plastik met RAF Camora, dat dancehall naar de Duitse rap bracht en jarenlang in de lijsten bleef."
+    },
+    {
+      "year": 2017,
+      "uri": "spotify:track:7fUWZUNj5qbEuoL6K9947g",
+      "artist": "Nimo",
+      "alt_artists": [
+        "Hanybal",
+        "Celo & Abdi",
+        "Olexesh",
+        "Azzi Memo"
+      ],
+      "title": "Heute mit mir",
+      "fun_fact": "Nimo raps in the Frankfurt dialect of the Offenbach scene around Haftbefehl, the city that gave German rap its own accent.",
+      "fun_fact_de": "Nimo rappt im Frankfurter Zungenschlag der Offenbacher Szene um Haftbefehl — der Stadt, die dem Deutschrap einen eigenen Akzent gab.",
+      "fun_fact_es": "Nimo rapea con el acento de Francfort de la escena de Offenbach en torno a Haftbefehl, la ciudad que dio al rap aleman su propio tono.",
+      "fun_fact_fr": "Nimo rappe avec l'accent francfortois de la scene d'Offenbach autour de Haftbefehl, la ville qui a donne au rap allemand son propre accent.",
+      "fun_fact_nl": "Nimo rapt met het Frankfurtse accent van de Offenbach-scene rond Haftbefehl, de stad die de Duitse rap een eigen klank gaf."
+    },
+    {
+      "year": 2018,
+      "uri": "spotify:track:6WusSsncC0Oo9sFHKwQii6",
+      "artist": "RIN",
+      "alt_artists": [
+        "Yung Hurn",
+        "Ufo361",
+        "LGoony",
+        "Money Boy"
+      ],
+      "title": "Dior 2001",
+      "fun_fact": "The title dates a fashion collection: RIN raps about the Dior line of 2001, not about the year the track came out.",
+      "fun_fact_de": "Der Titel datiert eine Modekollektion — RIN rappt ueber die Dior-Linie von 2001, nicht ueber das Erscheinungsjahr des Songs.",
+      "fun_fact_es": "El titulo data una coleccion de moda: RIN rapea sobre la linea Dior de 2001, no sobre el ano de publicacion del tema.",
+      "fun_fact_fr": "Le titre date une collection de mode : RIN rappe sur la ligne Dior de 2001, pas sur l'annee de sortie du morceau.",
+      "fun_fact_nl": "De titel dateert een modecollectie: RIN rapt over de Dior-lijn van 2001, niet over het jaar waarin het nummer uitkwam."
+    },
+    {
+      "year": 2018,
+      "uri": "spotify:track:2eRq2jwsZtb0uGH4qUsvT1",
+      "artist": "Summer Cem",
+      "alt_artists": [
+        "Farid Bang",
+        "Kollegah",
+        "Eko Fresh",
+        "Bausa"
+      ],
+      "title": "Tamam Tamam",
+      "fun_fact": "The hook is Turkish — tamam means okay — and it carried the song beyond Germany into Turkish charts and clubs.",
+      "fun_fact_de": "Der Refrain ist tuerkisch — tamam heisst okay — und trug den Song ueber Deutschland hinaus in tuerkische Charts und Clubs.",
+      "fun_fact_es": "El estribillo es turco: tamam significa vale, y llevo la cancion mas alla de Alemania, a listas y clubes turcos.",
+      "fun_fact_fr": "Le refrain est en turc : tamam signifie d'accord, ce qui a porte le morceau au-dela de l'Allemagne, jusqu'aux charts turcs.",
+      "fun_fact_nl": "Het refrein is Turks — tamam betekent oke — en bracht het nummer tot buiten Duitsland, tot in Turkse hitlijsten."
+    },
+    {
+      "year": 2019,
+      "uri": "spotify:track:2u8AXJyk8pICzj2wyPBL0b",
+      "artist": "Sido",
+      "alt_artists": [
+        "Bushido",
+        "Kool Savas",
+        "Fler",
+        "Marteria"
+      ],
+      "title": "2002",
+      "fun_fact": "Sido looks back at his own beginnings and hands the second half to Apache 207, who was two years old in the year of the title.",
+      "fun_fact_de": "Sido blickt auf seine eigenen Anfaenge zurueck und uebergibt die zweite Haelfte an Apache 207, der im Jahr des Titels zwei Jahre alt war.",
+      "fun_fact_es": "Sido mira atras a sus propios comienzos y cede la segunda mitad a Apache 207, que tenia dos anos en el ano del titulo.",
+      "fun_fact_fr": "Sido revient sur ses debuts et laisse la seconde moitie a Apache 207, qui avait deux ans l'annee du titre.",
+      "fun_fact_nl": "Sido kijkt terug op zijn eigen begin en geeft de tweede helft aan Apache 207, die in het jaar van de titel twee was."
+    },
+    {
+      "year": 2019,
+      "uri": "spotify:track:4j5WelE5mkf9A2jmts729h",
+      "artist": "Capital Bra",
+      "alt_artists": [
+        "Ufo361",
+        "Samra",
+        "AK Ausserkontrolle",
+        "Bonez MC"
+      ],
+      "title": "Cherry Lady",
+      "fun_fact": "It appeared in the year Capital Bra set a German chart record with a run of number-one singles released one after another.",
+      "fun_fact_de": "Der Song erschien in dem Jahr, in dem Capital Bra mit einer Serie von Nummer-eins-Singles einen deutschen Chartrekord aufstellte.",
+      "fun_fact_es": "Aparecio el ano en que Capital Bra establecio un record en las listas alemanas con una serie de sencillos numero uno.",
+      "fun_fact_fr": "Il est paru l'annee ou Capital Bra a etabli un record des charts allemands avec une serie de singles numero un.",
+      "fun_fact_nl": "Het verscheen in het jaar waarin Capital Bra een Duits hitlijstrecord vestigde met een reeks nummer-1-singles."
+    },
+    {
+      "year": 2020,
+      "uri": "spotify:track:1hoLUVBx0ixX3kn0EX0P5n",
+      "artist": "Juju",
+      "alt_artists": [
+        "Loredana",
+        "Shirin David",
+        "Nura",
+        "Haiyti"
+      ],
+      "title": "Kein Wort",
+      "fun_fact": "Two of the best-known women in German rap on one track, produced by Miksu and Macloud, who shaped much of the sound of that year.",
+      "fun_fact_de": "Zwei der bekanntesten Frauen des Deutschraps auf einem Track, produziert von Miksu und Macloud, die den Sound jenes Jahres mitpraegten.",
+      "fun_fact_es": "Dos de las mujeres mas conocidas del rap aleman en un mismo tema, producido por Miksu y Macloud, que marcaron el sonido de ese ano.",
+      "fun_fact_fr": "Deux des femmes les plus connues du rap allemand sur un meme morceau, produit par Miksu et Macloud, qui ont marque le son de cette annee.",
+      "fun_fact_nl": "Twee van de bekendste vrouwen in de Duitse rap op een nummer, geproduceerd door Miksu en Macloud, die de sound van dat jaar mee bepaalden."
+    },
+    {
+      "year": 2020,
+      "uri": "spotify:track:5CqkgDH8QZjSqqI3HmYxDD",
+      "artist": "Pashanim",
+      "alt_artists": [
+        "Symba",
+        "Ski Aggu",
+        "Makko",
+        "Nimo"
+      ],
+      "title": "Airwaves",
+      "fun_fact": "Berlin street rap named after a chewing gum — part of a wave that took its images from everyday brands rather than luxury ones.",
+      "fun_fact_de": "Berliner Strassenrap, benannt nach einem Kaugummi — Teil einer Welle, die ihre Bilder aus Alltagsmarken zog statt aus Luxusmarken.",
+      "fun_fact_es": "Rap callejero berlines que toma su nombre de un chicle, parte de una ola que sacaba sus imagenes de marcas cotidianas y no de lujo.",
+      "fun_fact_fr": "Rap de rue berlinois nomme d'apres un chewing-gum, dans une vague qui puisait ses images dans les marques du quotidien plutot que dans le luxe.",
+      "fun_fact_nl": "Berlijnse straatrap vernoemd naar een kauwgom — deel van een golf die beelden ontleende aan alledaagse merken in plaats van luxemerken."
+    },
+    {
+      "year": 2021,
+      "uri": "spotify:track:1BHgWnOYgtAHhMZU73co1D",
+      "artist": "KASIMIR1441",
+      "alt_artists": [
+        "badmomzjay",
+        "Ski Aggu",
+        "Symba",
+        "Pashanim"
+      ],
+      "title": "Ohne Dich",
+      "fun_fact": "Released in January 2021, produced by the WILDBWOYS duo whose name is credited on the track itself.",
+      "fun_fact_de": "Im Januar 2021 erschienen, produziert vom Duo WILDBWOYS, dessen Name direkt auf dem Track steht.",
+      "fun_fact_es": "Publicada en enero de 2021, producida por el duo WILDBWOYS, cuyo nombre figura en el propio tema.",
+      "fun_fact_fr": "Sorti en janvier 2021, produit par le duo WILDBWOYS, dont le nom figure sur le morceau lui-meme.",
+      "fun_fact_nl": "Verschenen in januari 2021, geproduceerd door het duo WILDBWOYS, wiens naam op het nummer zelf staat."
+    },
+    {
+      "year": 2021,
+      "uri": "spotify:track:2H7jZg2HliuQhZjfBblLrZ",
+      "artist": "Pashanim",
+      "alt_artists": [
+        "Symba",
+        "Ski Aggu",
+        "Makko",
+        "Yung Kafa"
+      ],
+      "title": "Sommergewitter",
+      "fun_fact": "The second Pashanim track on this list, one year after Airwaves — the same summer-in-Berlin tone, a year further on.",
+      "fun_fact_de": "Der zweite Pashanim-Titel dieser Liste, ein Jahr nach Airwaves — derselbe Berliner Sommerton, ein Jahr weiter.",
+      "fun_fact_es": "El segundo tema de Pashanim en esta lista, un ano despues de Airwaves: el mismo tono de verano berlines, un ano mas tarde.",
+      "fun_fact_fr": "Le deuxieme titre de Pashanim de cette liste, un an apres Airwaves : le meme ton d'ete berlinois, un an plus tard.",
+      "fun_fact_nl": "Het tweede Pashanim-nummer op deze lijst, een jaar na Airwaves — dezelfde Berlijnse zomertoon, een jaar later."
+    },
+    {
+      "year": 2022,
+      "uri": "spotify:track:5xX2LYdXyx0Boa61rZOjq5",
+      "artist": "Luciano",
+      "alt_artists": [
+        "Ufo361",
+        "Nimo",
+        "Samra",
+        "Bausa"
+      ],
+      "title": "Beautiful Girl",
+      "fun_fact": "Luciano was born in Chile and grew up in Berlin — his melodic rap carries both, and this is one of its softest examples.",
+      "fun_fact_de": "Luciano wurde in Chile geboren und wuchs in Berlin auf — sein melodischer Rap traegt beides, und dies ist eines seiner sanftesten Beispiele.",
+      "fun_fact_es": "Luciano nacio en Chile y crecio en Berlin; su rap melodico lleva ambas cosas, y este es uno de sus ejemplos mas suaves.",
+      "fun_fact_fr": "Luciano est ne au Chili et a grandi a Berlin : son rap melodique porte les deux, et voici l'un de ses exemples les plus doux.",
+      "fun_fact_nl": "Luciano werd geboren in Chili en groeide op in Berlijn — zijn melodische rap draagt beide, en dit is een van zijn zachtste voorbeelden."
+    },
+    {
+      "year": 2022,
+      "uri": "spotify:track:0s8AvyGCRVZ0waM9aJdAHI",
+      "artist": "BHZ",
+      "alt_artists": [
+        "Ski Aggu",
+        "Symba",
+        "Pashanim",
+        "Genetikk"
+      ],
+      "title": "Powerade",
+      "fun_fact": "BHZ stands for Berlin's Schoeneberg neighbourhood — the collective takes its name from the district it comes from.",
+      "fun_fact_de": "BHZ steht fuer das Berliner Schoeneberg — das Kollektiv traegt den Namen des Viertels, aus dem es kommt.",
+      "fun_fact_es": "BHZ alude al barrio berlines de Schoeneberg: el colectivo lleva el nombre del distrito del que procede.",
+      "fun_fact_fr": "BHZ renvoie au quartier berlinois de Schoeneberg : le collectif porte le nom du quartier dont il vient.",
+      "fun_fact_nl": "BHZ verwijst naar de Berlijnse wijk Schoeneberg — het collectief draagt de naam van de buurt waar het vandaan komt."
+    },
+    {
+      "year": 2024,
+      "uri": "spotify:track:4P2Sdu2zPhm2XN2W9Z8e1X",
+      "artist": "Ski Aggu",
+      "alt_artists": [
+        "Pashanim",
+        "Symba",
+        "Makko",
+        "domiinoo"
+      ],
+      "title": "IMMER",
+      "fun_fact": "Ski Aggu performs in ski goggles, so his face stays hidden the way Cro's did behind the panda mask a decade earlier.",
+      "fun_fact_de": "Ski Aggu tritt mit Skibrille auf, sein Gesicht bleibt also verdeckt — so wie Cros ein Jahrzehnt frueher hinter der Pandamaske.",
+      "fun_fact_es": "Ski Aggu actua con gafas de esqui, asi que su rostro queda oculto igual que el de Cro tras la mascara de panda una decada antes.",
+      "fun_fact_fr": "Ski Aggu se produit avec un masque de ski : son visage reste cache, comme celui de Cro derriere le masque de panda dix ans plus tot.",
+      "fun_fact_nl": "Ski Aggu treedt op met een skibril, zodat zijn gezicht verborgen blijft zoals dat van Cro tien jaar eerder achter het pandamasker."
+    }
+  ]
+}


### PR DESCRIPTION
Adds a German rap playlist. The catalogue did not have one.

## Why a new list rather than an addition to an existing one

`90s & 2000s Hip Hop Bangers` is 40 songs from 1990 to 2008 and its description names the US golden era. `Deutschpop Klassiker` and `Deutschrock - Best Of` cover German pop and rock. German rap fell between all three, so these tracks had nowhere to go.

## Where the tracks come from

The German-language block of the HITSTER Hip Hop request in #2376. That request was measured against the whole catalogue twice — by Spotify ID and by normalised artist/title pair — and 78 of its tracks were not already present. 26 of those are Deutschrap, and none of the 26 appears anywhere else in the catalogue.

The span is 1995 to 2024: Schwester S., Freundeskreis, Beginner and Samy Deluxe at one end, Pashanim, Luciano, BHZ and Ski Aggu at the other.

## On the years

Every year is individually sourced, because the iTunes minimum is wrong often enough here that it cannot be taken on trust:

- **Samy Deluxe — Weck mich auf**: iTunes dates it 2010 from a live album. The EP is September 2001.
- **Bushido — Für immer jung**: iTunes returns 2001, five years before the song existed. It is from *Heavy Metal Payback* (2008).
- **Summer Cem — Tamam Tamam**: iTunes matched a different artist's song of the same name. The track is 2018.
- **Pashanim — Sommergewitter**: iTunes returns 2016 for an unrelated track of that name. Pashanim's is 2021.
- **Haftbefehl, KASIMIR1441, BHZ**: no iTunes match at all; confirmed as 2012, 2021 and 2022.

## What is deliberately absent

No `chart_info`, `certifications` or `awards`. Those are factual claims about a record, the schema does not require them, and for these 26 they would have to be invented. An invented gold certification appears in front of players as fact.

## Test plan

- [x] `scripts/validate_playlists.py` — all 62 playlist files pass the schema gate
- [x] No duplicate Spotify URI against any other playlist in the catalogue
- [x] `ruff format --check` clean
- [ ] Play a round on the new list and confirm the fun facts render in all five languages

Note for the reviewer: the validator reports 10 pre-existing duplicate-URI warnings in five other playlists. They are untouched by this change and non-blocking.

Related: #2376

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EoSUKDjLvert1VkyyL3RE