### PR TITLE
site: 62 playlists and 8,237 songs, in all four places the count appears

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,8 +99,8 @@
 
           <div class="hero-stats">
             <span>488 active installs</span>
-            <span>61 playlists</span>
-            <span>8,211 songs</span>
+            <span>62 playlists</span>
+            <span>8,237 songs</span>
             <span>6 music services</span>
             <span>6 languages</span>
           </div>
@@ -136,7 +136,7 @@
             <div class="step">
               <div class="step-number" aria-hidden="true">2</div>
               <h3>Pick Music</h3>
-              <p>Choose from 59 curated playlists or connect Spotify, Apple Music, YouTube Music, Deezer, Tidal or Amazon Music.</p>
+              <p>Choose from 62 curated playlists or connect Spotify, Apple Music, YouTube Music, Deezer, Tidal or Amazon Music.</p>
             </div>
             <div class="step">
               <div class="step-number" aria-hidden="true">3</div>
@@ -165,7 +165,7 @@
             <div class="feature">
               <div class="feature-icon" aria-hidden="true">🎵</div>
               <h3>Your Music</h3>
-              <p>Spotify, Apple Music, YouTube Music, Deezer, Tidal and Amazon Music. 59 curated playlists included.</p>
+              <p>Spotify, Apple Music, YouTube Music, Deezer, Tidal and Amazon Music. 62 curated playlists included.</p>
             </div>
             <div class="feature">
               <div class="feature-icon" aria-hidden="true">✍️</div>
@@ -265,7 +265,7 @@
               <span class="speaker-check" aria-hidden="true">✅</span>
               <div>
                 <strong>Nothing to buy or reprint</strong>
-                <p>The card decks are playlists. 59 of them ship with Beatify, and you can build your own from any music service or your own library.</p>
+                <p>The card decks are playlists. 62 of them ship with Beatify, and you can build your own from any music service or your own library.</p>
               </div>
             </div>
             <div class="speaker-card">


### PR DESCRIPTION
The catalogue grew to **62 playlists and 8,237 songs** when the Deutschrap Klassiker list landed (#2485). This updates the landing page to match.

## Not just the header

The playlist count appears in four places on the page, and they already disagreed before this change:

| Line | Was | Now |
|---|---|---|
| 102 header | 61 playlists | 62 playlists |
| 103 header | 8,211 songs | 8,237 songs |
| 139 body | 59 curated playlists | 62 |
| 168 body | 59 curated playlists | 62 |
| 268 body | 59 of them ship | 62 |

The last count update touched only the header row, so the three body paragraphs had been two releases out of date. Same lesson as commit 6019598a, whose message is literally "in all five places the number appears".

Both numbers were counted from `origin/main` after the merge, not carried over by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EoSUKDjLvert1VkyyL3RE