### PR TITLE
data(deutschrap-klassiker): chart peaks and certifications where they are documented

### DIFF
--- a/custom_components/beatify/playlists/community/deutschrap-klassiker.json
+++ b/custom_components/beatify/playlists/community/deutschrap-klassiker.json
@@ -78,6 +78,13 @@
         "D-Flame"
       ],
       "title": "Weck mich auf",
+      "chart_info": {
+        "german_peak": 4,
+        "weeks_on_chart": 14
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
       "fun_fact": "Released as an EP in September 2001, it reached number four in the German singles chart and remains his best-known political song.",
       "fun_fact_de": "Im September 2001 als EP erschienen, erreichte der Song Platz vier der deutschen Singlecharts und ist bis heute sein bekanntester politischer Titel.",
       "fun_fact_es": "Publicado como EP en septiembre de 2001, alcanzo el numero cuatro en las listas alemanas y sigue siendo su cancion politica mas conocida.",
@@ -129,6 +136,10 @@
         "Fettes Brot"
       ],
       "title": "Monsta",
+      "chart_info": {
+        "german_peak": 3,
+        "weeks_on_chart": 63
+      },
       "fun_fact": "The Berlin group sings in German, English, Spanish and Jamaican Patois — Monsta is the track that carried that mix into the summer charts.",
       "fun_fact_de": "Die Berliner Gruppe singt auf Deutsch, Englisch, Spanisch und jamaikanischem Patois — Monsta ist der Titel, der diese Mischung in die Sommercharts trug.",
       "fun_fact_es": "El grupo berlines canta en aleman, ingles, espanol y patois jamaicano; Monsta es el tema que llevo esa mezcla a las listas de verano.",
@@ -163,6 +174,15 @@
         "Kraftklub"
       ],
       "title": "Easy",
+      "chart_info": {
+        "german_peak": 2,
+        "weeks_on_chart": 51
+      },
+      "certifications": [
+        "3x Platinum (DE)",
+        "Platinum (AT)",
+        "Platinum (CH)"
+      ],
       "fun_fact": "The panda mask kept the rapper's face unknown while the song was everywhere — deliberate anonymity at the moment of his breakthrough.",
       "fun_fact_de": "Die Pandamaske hielt das Gesicht des Rappers unbekannt, waehrend der Song ueberall lief — gewollte Anonymitaet im Moment des Durchbruchs.",
       "fun_fact_es": "La mascara de panda mantuvo oculto el rostro del rapero mientras la cancion sonaba en todas partes: anonimato deliberado en pleno exito.",
@@ -180,6 +200,14 @@
         "K.I.Z."
       ],
       "title": "Leider geil",
+      "chart_info": {
+        "german_peak": 6,
+        "weeks_on_chart": 26
+      },
+      "certifications": [
+        "Gold (DE)",
+        "Gold (AT)"
+      ],
       "fun_fact": "The whole song is one confession: it lists things the singer knows are wrong and enjoys anyway, and the title says so in two words.",
       "fun_fact_de": "Der ganze Song ist ein Gestaendnis — er zaehlt Dinge auf, die der Saenger falsch findet und trotzdem geniesst, und der Titel sagt das in zwei Worten.",
       "fun_fact_es": "Toda la cancion es una confesion: enumera cosas que el cantante sabe que estan mal y disfruta igualmente, y el titulo lo resume en dos palabras.",
@@ -197,6 +225,10 @@
         "Cro"
       ],
       "title": "Wolke 7",
+      "chart_info": {
+        "german_peak": 6,
+        "weeks_on_chart": 33
+      },
       "fun_fact": "Max Herre had already written A-N-N-A with Freundeskreis fifteen years earlier — the same voice, two eras of German rap apart.",
       "fun_fact_de": "Max Herre hatte A-N-N-A mit Freundeskreis schon fuenfzehn Jahre frueher geschrieben — dieselbe Stimme, zwei Epochen des Deutschraps auseinander.",
       "fun_fact_es": "Max Herre ya habia escrito A-N-N-A con Freundeskreis quince anos antes: la misma voz, a dos epocas de distancia del rap aleman.",
@@ -214,6 +246,13 @@
         "Xatar"
       ],
       "title": "Chabos wissen wer der Babo ist",
+      "chart_info": {
+        "german_peak": 10,
+        "weeks_on_chart": 17
+      },
+      "certifications": [
+        "Gold (DE)"
+      ],
       "fun_fact": "Babo was voted Germany's youth word of the year in 2013, straight out of this song — a rap line that entered the dictionary.",
       "fun_fact_de": "Babo wurde 2013 zum Jugendwort des Jahres gewaehlt, direkt aus diesem Song — eine Rapzeile, die es ins Woerterbuch schaffte.",
       "fun_fact_es": "Babo fue elegida palabra juvenil del ano 2013 en Alemania, directamente de esta cancion: un verso de rap que llego al diccionario.",
@@ -231,6 +270,13 @@
         "Kitty Kat"
       ],
       "title": "Liebe",
+      "chart_info": {
+        "german_peak": 13,
+        "weeks_on_chart": 36
+      },
+      "certifications": [
+        "Platinum (DE)"
+      ],
       "fun_fact": "From 30-11-80, the album Sido named after his own date of birth.",
       "fun_fact_de": "Vom Album 30-11-80, das Sido nach seinem eigenen Geburtsdatum benannt hat.",
       "fun_fact_es": "Del album 30-11-80, que Sido bautizo con su propia fecha de nacimiento.",
@@ -248,6 +294,13 @@
         "Ufo361"
       ],
       "title": "Ohne mein Team",
+      "chart_info": {
+        "german_peak": 7,
+        "weeks_on_chart": 90
+      },
+      "certifications": [
+        "4x Platinum (DE)"
+      ],
       "fun_fact": "From Palmen aus Plastik, the joint album with RAF Camora that pulled dancehall into German rap and stayed in the charts for years.",
       "fun_fact_de": "Vom Gemeinschaftsalbum Palmen aus Plastik mit RAF Camora, das Dancehall in den Deutschrap holte und jahrelang in den Charts blieb.",
       "fun_fact_es": "Del album conjunto Palmen aus Plastik con RAF Camora, que trajo el dancehall al rap aleman y permanecio anos en las listas.",
@@ -367,6 +420,10 @@
         "Nimo"
       ],
       "title": "Airwaves",
+      "chart_info": {
+        "german_peak": 2,
+        "weeks_on_chart": 32
+      },
       "fun_fact": "Berlin street rap named after a chewing gum — part of a wave that took its images from everyday brands rather than luxury ones.",
       "fun_fact_de": "Berliner Strassenrap, benannt nach einem Kaugummi — Teil einer Welle, die ihre Bilder aus Alltagsmarken zog statt aus Luxusmarken.",
       "fun_fact_es": "Rap callejero berlines que toma su nombre de un chicle, parte de una ola que sacaba sus imagenes de marcas cotidianas y no de lujo.",


### PR DESCRIPTION
Fills in `chart_info` and `certifications` for the Deutschrap Klassiker list, for the tracks where a source actually says so.

## What landed

| Track | DE peak | Weeks | Certification |
|---|---|---|---|
| Pashanim — Airwaves | 2 | 32 | — |
| Cro — Easy | 2 | 51 | 3x Platinum (DE), Platinum (AT), Platinum (CH) |
| Culcha Candela — Monsta | 3 | 63 | — |
| Samy Deluxe — Weck mich auf | 4 | 14 | Gold (DE) |
| Max Herre — Wolke 7 | 6 | 33 | — |
| Deichkind — Leider geil | 6 | 26 | Gold (DE), Gold (AT) |
| Bonez MC — Ohne mein Team | 7 | 90 | 4x Platinum (DE) |
| Haftbefehl — Chabos wissen wer der Babo ist | 10 | 17 | Gold (DE) |
| Sido — Liebe | 13 | 36 | Platinum (DE) |

**9 of 26.** The other 17 keep no `chart_info` — a street-rap single that never entered the top 100, or never got an article, has no number to carry.

## Source and the two traps in it

The German Wikipedia chart template, which cites offiziellecharts.de.

**The template exists in two forms.** Newer articles use `{{Charts|DEU-S|peak|weeks}}`, older ones `{{Charts|DE|peak|date|weeks}}` inside the infobox. A parser that knows only the first reports "no chart data" for Sido's *Liebe* and Max Herre's *Wolke 7*, both of which have it.

**Title search alone picks wrong records.** Searching for Capital Bra's *Cherry Lady* returns Modern Talking's *Cheri, Cheri Lady*, a number 2 hit. Every page is now checked for the artist's name before its numbers are used — that one would have shipped a 1985 Schlager chart position as a 2019 rap statistic.

**Certifications are prose, not a template field**, so they were read rather than pattern-matched. *Airwaves* and *Monsta* are deliberately left without one: both articles give a total across Germany, Austria and Switzerland ("einmal Gold sowie vier Platin im deutschsprachigen Raum"), which cannot be split into a German figure.

## One thing for a separate PR

The catalogue spells this field three ways: `german_peak` (202 songs), `de_peak` (30) and `germany_peak` (4). This PR uses `german_peak`, the majority spelling. The other 34 entries are a cleanup of their own.

## Test plan

- [x] `scripts/validate_playlists.py` passes
- [ ] Play a round and confirm the chart line renders for the enriched tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EoSUKDjLvert1VkyyL3RE