### PR TITLE
chore(playlists): youtube backfill — +93 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/community/salsa-y-merengue.json
+++ b/custom_components/beatify/playlists/community/salsa-y-merengue.json
@@ -1,6 +1,6 @@
 {
   "name": "Salsa y Merengue",
-  "version": "1.19",
+  "version": "1.20",
   "tags": [
     "salsa",
     "merengue",
@@ -6844,7 +6844,8 @@
       "fun_fact_nl": "\"De Qué Manera\" van Mike Bahía, voor het eerst uitgebracht in 2022 op het album \"De Qué Manera\".",
       "uri_deezer": "deezer://track/2069303107",
       "uri_apple_music": "applemusic://track/1659773210",
-      "fun_fact_it": "«De Qué Manera» di Mike Bahía, pubblicata per la prima volta nel 2022 nell'album «De Qué Manera»."
+      "fun_fact_it": "«De Qué Manera» di Mike Bahía, pubblicata per la prima volta nel 2022 nell'album «De Qué Manera».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=y7rg9d1bL9E"
     },
     {
       "year": 2015,
@@ -6859,7 +6860,8 @@
       "fun_fact_nl": "\"No Quería Engañarte\" van Víctor Manuelle, voor het eerst uitgebracht in 2015 op het album \"Que Suenen los Tambores\".",
       "uri_deezer": "deezer://track/97838678",
       "uri_apple_music": "applemusic://track/980041201",
-      "fun_fact_it": "«No Quería Engañarte» di Víctor Manuelle, pubblicata per la prima volta nel 2015 nell'album «Que Suenen los Tambores»."
+      "fun_fact_it": "«No Quería Engañarte» di Víctor Manuelle, pubblicata per la prima volta nel 2015 nell'album «Que Suenen los Tambores».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=CjLJdR6DXZ4"
     },
     {
       "year": 2004,
@@ -6874,7 +6876,8 @@
       "fun_fact_nl": "\"La Pantera Mambo\" van La-33, voor het eerst uitgebracht in 2004 op het album \"La Pantera Mambo\".",
       "uri_deezer": "deezer://track/1853571087",
       "uri_apple_music": "applemusic://track/733395333",
-      "fun_fact_it": "«La Pantera Mambo» di La-33, pubblicata per la prima volta nel 2004 nell'album «La Pantera Mambo»."
+      "fun_fact_it": "«La Pantera Mambo» di La-33, pubblicata per la prima volta nel 2004 nell'album «La Pantera Mambo».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=KLsGFDeiY5I"
     },
     {
       "year": 1992,
@@ -6889,7 +6892,8 @@
       "fun_fact_nl": "\"Salsa Con Coco\" van Pochy Y Su Cocoband, voor het eerst uitgebracht in 1992 op het album \"El Arrollador\".",
       "uri_deezer": "deezer://track/687077312",
       "uri_apple_music": "applemusic://track/1465805506",
-      "fun_fact_it": "«Salsa Con Coco» di Pochy Y Su Cocoband, pubblicata per la prima volta nel 1992 nell'album «El Arrollador»."
+      "fun_fact_it": "«Salsa Con Coco» di Pochy Y Su Cocoband, pubblicata per la prima volta nel 1992 nell'album «El Arrollador».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=S_2ZCG7_63A"
     },
     {
       "year": 1991,
@@ -6904,7 +6908,8 @@
       "fun_fact_nl": "\"Te Propongo\" van Hector Rey, voor het eerst uitgebracht in 1991 op het album \"Al Duro\".",
       "uri_deezer": "deezer://track/63979301",
       "uri_apple_music": "applemusic://track/169538465",
-      "fun_fact_it": "«Te Propongo» di Hector Rey, pubblicata per la prima volta nel 1991 nell'album «Al Duro»."
+      "fun_fact_it": "«Te Propongo» di Hector Rey, pubblicata per la prima volta nel 1991 nell'album «Al Duro».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=r-7YaLaBIQs"
     },
     {
       "year": 2004,
@@ -6919,7 +6924,8 @@
       "fun_fact_nl": "\"Abre Que Voy\" van Miguel Enriquez, voor het eerst uitgebracht in 2004.",
       "uri_deezer": "deezer://track/5216615",
       "uri_apple_music": "applemusic://track/264723691",
-      "fun_fact_it": "«Abre Que Voy» di Miguel Enriquez, pubblicata per la prima volta nel 2004."
+      "fun_fact_it": "«Abre Que Voy» di Miguel Enriquez, pubblicata per la prima volta nel 2004.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Fy5vEYAXmSg"
     },
     {
       "year": 2018,
@@ -6934,7 +6940,8 @@
       "fun_fact_nl": "\"Suma y Resta\" van El Micha, Gilberto Santa Rosa, voor het eerst uitgebracht in 2018 op het album \"Suma y Resta\".",
       "uri_deezer": "deezer://track/1804608407",
       "uri_apple_music": "applemusic://track/1631609821",
-      "fun_fact_it": "«Suma y Resta» di El Micha, Gilberto Santa Rosa, pubblicata per la prima volta nel 2018 nell'album «Suma y Resta»."
+      "fun_fact_it": "«Suma y Resta» di El Micha, Gilberto Santa Rosa, pubblicata per la prima volta nel 2018 nell'album «Suma y Resta».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=3S4lsk6gqeY"
     },
     {
       "year": 2019,
@@ -6949,7 +6956,8 @@
       "fun_fact_nl": "\"Tu Vida en la Mía\" van Marc Anthony, voor het eerst uitgebracht in 2019 op het album \"OPUS\".",
       "uri_deezer": "deezer://track/675919602",
       "uri_apple_music": "applemusic://track/1461181034",
-      "fun_fact_it": "«Tu Vida en la Mía» di Marc Anthony, pubblicata per la prima volta nel 2019 nell'album «OPUS»."
+      "fun_fact_it": "«Tu Vida en la Mía» di Marc Anthony, pubblicata per la prima volta nel 2019 nell'album «OPUS».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BFaRWXEpFrs"
     },
     {
       "year": 2022,
@@ -6964,7 +6972,8 @@
       "fun_fact_nl": "\"Cartas Sobre La Mesa\" van Gilberto Santa Rosa, voor het eerst uitgebracht in 2022 op het album \"Cartas Sobre La Mesa\".",
       "uri_deezer": "deezer://track/1591566102",
       "uri_apple_music": "applemusic://track/1640726284",
-      "fun_fact_it": "«Cartas Sobre La Mesa» di Gilberto Santa Rosa, pubblicata per la prima volta nel 2022 nell'album «Cartas Sobre La Mesa»."
+      "fun_fact_it": "«Cartas Sobre La Mesa» di Gilberto Santa Rosa, pubblicata per la prima volta nel 2022 nell'album «Cartas Sobre La Mesa».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nyTFrpVucUY"
     },
     {
       "year": 1988,
@@ -6979,7 +6988,8 @@
       "fun_fact_nl": "\"Por Retenerte\" van Los Titanes, voor het eerst uitgebracht in 1988 op het album \"La Salsa, Identidad de un Pueblo - Vol. 1 Expresión de Barrio\".",
       "uri_deezer": "deezer://track/131112480",
       "uri_apple_music": "applemusic://track/26107689",
-      "fun_fact_it": "«Por Retenerte» di Los Titanes, pubblicata per la prima volta nel 1988 nell'album «La Salsa, Identidad de un Pueblo - Vol. 1 Expresión de Barrio»."
+      "fun_fact_it": "«Por Retenerte» di Los Titanes, pubblicata per la prima volta nel 1988 nell'album «La Salsa, Identidad de un Pueblo - Vol. 1 Expresión de Barrio».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=AyrmGAS05IQ"
     },
     {
       "year": 2018,
@@ -6994,7 +7004,8 @@
       "fun_fact_nl": "\"Enamórate Bailando\" van Septeto Acarey, Gilberto Santa Rosa, voor het eerst uitgebracht in 2018 op het album \"Enamórate Bailando\".",
       "uri_deezer": "deezer://track/621128942",
       "uri_apple_music": "applemusic://track/1450183023",
-      "fun_fact_it": "«Enamórate Bailando» di Septeto Acarey, Gilberto Santa Rosa, pubblicata per la prima volta nel 2018 nell'album «Enamórate Bailando»."
+      "fun_fact_it": "«Enamórate Bailando» di Septeto Acarey, Gilberto Santa Rosa, pubblicata per la prima volta nel 2018 nell'album «Enamórate Bailando».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FdypRZMRSus"
     },
     {
       "year": 2018,
@@ -7009,7 +7020,8 @@
       "fun_fact_nl": "\"Adiós Amor\" van Daniela Darcourt, voor het eerst uitgebracht in 2018 op het album \"Adiós Amor\".",
       "uri_deezer": "deezer://track/1356751582",
       "uri_apple_music": "applemusic://track/1565039677",
-      "fun_fact_it": "«Adiós Amor» di Daniela Darcourt, pubblicata per la prima volta nel 2018 nell'album «Adiós Amor»."
+      "fun_fact_it": "«Adiós Amor» di Daniela Darcourt, pubblicata per la prima volta nel 2018 nell'album «Adiós Amor».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7ovE33oPcfE"
     },
     {
       "year": 1962,
@@ -7024,7 +7036,8 @@
       "fun_fact_nl": "\"Acuyuye\" van Johnny Pacheco, voor het eerst uitgebracht in 1962 op het album \"Pacheco Y Su Charanga Vol. 3: Que Suene La Flauta\".",
       "uri_deezer": "deezer://track/686114592",
       "uri_apple_music": "applemusic://track/1464289091",
-      "fun_fact_it": "«Acuyuye» di Johnny Pacheco, pubblicata per la prima volta nel 1962 nell'album «Pacheco Y Su Charanga Vol. 3: Que Suene La Flauta»."
+      "fun_fact_it": "«Acuyuye» di Johnny Pacheco, pubblicata per la prima volta nel 1962 nell'album «Pacheco Y Su Charanga Vol. 3: Que Suene La Flauta».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_uBalvHguQk"
     },
     {
       "year": 2018,
@@ -7039,7 +7052,8 @@
       "fun_fact_nl": "\"Probablemente\" van Yiyo Sarante, voor het eerst uitgebracht in 2018 op het album \"Probablemente\".",
       "uri_deezer": "deezer://track/2615626852",
       "uri_apple_music": "applemusic://track/1725171565",
-      "fun_fact_it": "«Probablemente» di Yiyo Sarante, pubblicata per la prima volta nel 2018 nell'album «Probablemente»."
+      "fun_fact_it": "«Probablemente» di Yiyo Sarante, pubblicata per la prima volta nel 2018 nell'album «Probablemente».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rYf1tjlF7gA"
     },
     {
       "year": 2013,
@@ -7054,7 +7068,8 @@
       "fun_fact_nl": "\"Loco Pero Feliz\" van Pirulo y la Tribu, voor het eerst uitgebracht in 2013 op het album \"Calle Linda\".",
       "uri_deezer": "deezer://track/76845877",
       "uri_apple_music": "applemusic://track/1445174742",
-      "fun_fact_it": "«Loco Pero Feliz» di Pirulo y la Tribu, pubblicata per la prima volta nel 2013 nell'album «Calle Linda»."
+      "fun_fact_it": "«Loco Pero Feliz» di Pirulo y la Tribu, pubblicata per la prima volta nel 2013 nell'album «Calle Linda».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1N2HJe6Kqfc"
     },
     {
       "year": 2023,
@@ -7069,7 +7084,8 @@
       "fun_fact_nl": "\"Incomprendido\" van Rawayana, Neutro Shorty, Orestes Gomez, voor het eerst uitgebracht in 2023 op het album \"Incomprendido\".",
       "uri_deezer": "deezer://track/2512990891",
       "uri_apple_music": "applemusic://track/1713427275",
-      "fun_fact_it": "«Incomprendido» di Rawayana, Neutro Shorty, Orestes Gomez, pubblicata per la prima volta nel 2023 nell'album «Incomprendido»."
+      "fun_fact_it": "«Incomprendido» di Rawayana, Neutro Shorty, Orestes Gomez, pubblicata per la prima volta nel 2023 nell'album «Incomprendido».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=aMHDVsHFxN0"
     },
     {
       "year": 2019,
@@ -7084,7 +7100,8 @@
       "fun_fact_nl": "\"Señor Mentira\" van Daniela Darcourt, voor het eerst uitgebracht in 2019 op het album \"Señor Mentira\".",
       "uri_deezer": "deezer://track/1684408737",
       "uri_apple_music": "applemusic://track/1619114602",
-      "fun_fact_it": "«Señor Mentira» di Daniela Darcourt, pubblicata per la prima volta nel 2019 nell'album «Señor Mentira»."
+      "fun_fact_it": "«Señor Mentira» di Daniela Darcourt, pubblicata per la prima volta nel 2019 nell'album «Señor Mentira».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6C4GHCDMAVM"
     },
     {
       "year": 2017,
@@ -7099,7 +7116,8 @@
       "fun_fact_nl": "\"Boogaloo Supreme\" van Víctor Manuelle, Wisin, voor het eerst uitgebracht in 2017 op het album \"Boogaloo Supreme\".",
       "uri_deezer": "deezer://track/889704342",
       "uri_apple_music": "applemusic://track/1500810086",
-      "fun_fact_it": "«Boogaloo Supreme» di Víctor Manuelle, Wisin, pubblicata per la prima volta nel 2017 nell'album «Boogaloo Supreme»."
+      "fun_fact_it": "«Boogaloo Supreme» di Víctor Manuelle, Wisin, pubblicata per la prima volta nel 2017 nell'album «Boogaloo Supreme».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gOXRSxT-wXY"
     },
     {
       "year": 2019,
@@ -7114,7 +7132,8 @@
       "fun_fact_nl": "\"Lo Que Te Di\" van Marc Anthony, voor het eerst uitgebracht in 2019 op het album \"OPUS\".",
       "uri_deezer": "deezer://track/675919642",
       "uri_apple_music": "applemusic://track/1461181860",
-      "fun_fact_it": "«Lo Que Te Di» di Marc Anthony, pubblicata per la prima volta nel 2019 nell'album «OPUS»."
+      "fun_fact_it": "«Lo Que Te Di» di Marc Anthony, pubblicata per la prima volta nel 2019 nell'album «OPUS».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=t-7o7JXENzE"
     },
     {
       "year": 1994,
@@ -7129,7 +7148,8 @@
       "fun_fact_nl": "\"Ven a Medellín\" van Grupo Galé, voor het eerst uitgebracht in 1994 op het album \"Afirmando\".",
       "uri_deezer": "deezer://track/1441560382",
       "uri_apple_music": "applemusic://track/1712790734",
-      "fun_fact_it": "«Ven a Medellín» di Grupo Galé, pubblicata per la prima volta nel 1994 nell'album «Afirmando»."
+      "fun_fact_it": "«Ven a Medellín» di Grupo Galé, pubblicata per la prima volta nel 1994 nell'album «Afirmando».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gw4PZ2ZSSUc"
     },
     {
       "year": 1980,
@@ -7144,7 +7164,8 @@
       "fun_fact_nl": "\"Tu No Sabes Querer\" van Lalo Rodriguez, voor het eerst uitgebracht in 1980 op het album \"Ven Devórame Otra Vez (Baile Total)\".",
       "uri_deezer": "deezer://track/429987982",
       "uri_apple_music": "applemusic://track/1445663992",
-      "fun_fact_it": "«Tu No Sabes Querer» di Lalo Rodriguez, pubblicata per la prima volta nel 1980 nell'album «Ven Devórame Otra Vez (Baile Total)»."
+      "fun_fact_it": "«Tu No Sabes Querer» di Lalo Rodriguez, pubblicata per la prima volta nel 1980 nell'album «Ven Devórame Otra Vez (Baile Total)».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qIo-ZFkv1cU"
     },
     {
       "year": 2022,
@@ -7159,7 +7180,8 @@
       "fun_fact_nl": "\"Mamita Molona\" van Los Yakis, voor het eerst uitgebracht in 2022.",
       "uri_deezer": "deezer://track/3358273931",
       "uri_apple_music": "applemusic://track/1606257468",
-      "fun_fact_it": "«Mamita Molona» di Los Yakis, pubblicata per la prima volta nel 2022."
+      "fun_fact_it": "«Mamita Molona» di Los Yakis, pubblicata per la prima volta nel 2022.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=pfeiWXt4WAA"
     },
     {
       "year": 2019,
@@ -7174,7 +7196,8 @@
       "fun_fact_nl": "\"Un Amor Eterno\" van Marc Anthony, voor het eerst uitgebracht in 2019 op het album \"OPUS\".",
       "uri_deezer": "deezer://track/675919612",
       "uri_apple_music": "applemusic://track/1461181252",
-      "fun_fact_it": "«Un Amor Eterno» di Marc Anthony, pubblicata per la prima volta nel 2019 nell'album «OPUS»."
+      "fun_fact_it": "«Un Amor Eterno» di Marc Anthony, pubblicata per la prima volta nel 2019 nell'album «OPUS».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=bkHhMpPGf0Q"
     },
     {
       "year": 2021,
@@ -7189,7 +7212,8 @@
       "fun_fact_nl": "\"El Combo del Mundo\" van El Gran Combo De Puerto Rico, voor het eerst uitgebracht in 2021 op het album \"El Combo del Mundo\".",
       "uri_deezer": "deezer://track/1250746602",
       "uri_apple_music": "applemusic://track/1554528574",
-      "fun_fact_it": "«El Combo del Mundo» di El Gran Combo De Puerto Rico, pubblicata per la prima volta nel 2021 nell'album «El Combo del Mundo»."
+      "fun_fact_it": "«El Combo del Mundo» di El Gran Combo De Puerto Rico, pubblicata per la prima volta nel 2021 nell'album «El Combo del Mundo».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=MmSACElysig"
     },
     {
       "year": 1969,
@@ -7204,7 +7228,8 @@
       "fun_fact_nl": "\"Te Están Buscando\" van Rubén Blades, Willie Colón, voor het eerst uitgebracht in 1969 op het album \"Canciones Del Solar De Los Aburridos\".",
       "uri_deezer": "deezer://track/687809822",
       "uri_apple_music": "applemusic://track/1763206341",
-      "fun_fact_it": "«Te Están Buscando» di Rubén Blades, Willie Colón, pubblicata per la prima volta nel 1969 nell'album «Canciones Del Solar De Los Aburridos»."
+      "fun_fact_it": "«Te Están Buscando» di Rubén Blades, Willie Colón, pubblicata per la prima volta nel 1969 nell'album «Canciones Del Solar De Los Aburridos».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hfwx2sfhZHY"
     },
     {
       "year": 2020,
@@ -7219,7 +7244,8 @@
       "fun_fact_nl": "\"Acércate\" van Jeremy Bosch, voor het eerst uitgebracht in 2020 op het album \"Acércate\".",
       "uri_deezer": "deezer://track/3231726311",
       "uri_apple_music": "applemusic://track/1796679731",
-      "fun_fact_it": "«Acércate» di Jeremy Bosch, pubblicata per la prima volta nel 2020 nell'album «Acércate»."
+      "fun_fact_it": "«Acércate» di Jeremy Bosch, pubblicata per la prima volta nel 2020 nell'album «Acércate».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-ZhnO_HY91g"
     },
     {
       "year": 2023,
@@ -7234,7 +7260,8 @@
       "fun_fact_nl": "\"Salsa\" van El Micha, voor het eerst uitgebracht in 2023 op het album \"Salsa\".",
       "uri_deezer": "deezer://track/2258652917",
       "uri_apple_music": "applemusic://track/1684952016",
-      "fun_fact_it": "«Salsa» di El Micha, pubblicata per la prima volta nel 2023 nell'album «Salsa»."
+      "fun_fact_it": "«Salsa» di El Micha, pubblicata per la prima volta nel 2023 nell'album «Salsa».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1Ll-KXeuaCg"
     },
     {
       "year": 2001,
@@ -7249,7 +7276,8 @@
       "fun_fact_nl": "\"Virgen\" van Adolescent's Orquesta, voor het eerst uitgebracht in 2001.",
       "uri_deezer": "deezer://track/1385723042",
       "uri_apple_music": "applemusic://track/1582492911",
-      "fun_fact_it": "«Virgen» di Adolescent's Orquesta, pubblicata per la prima volta nel 2001."
+      "fun_fact_it": "«Virgen» di Adolescent's Orquesta, pubblicata per la prima volta nel 2001.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=pz9O3UeM_o0"
     },
     {
       "year": 2007,
@@ -7264,7 +7292,8 @@
       "fun_fact_nl": "\"Bururu Barara Como Estas Miguel\" van Kiko Mendive, voor het eerst uitgebracht in 2007 op het album \"La Sonora Guantanamera de Venezuela\".",
       "uri_deezer": "deezer://track/646076842",
       "uri_apple_music": "applemusic://track/1455491729",
-      "fun_fact_it": "«Bururu Barara Como Estas Miguel» di Kiko Mendive, pubblicata per la prima volta nel 2007 nell'album «La Sonora Guantanamera de Venezuela»."
+      "fun_fact_it": "«Bururu Barara Como Estas Miguel» di Kiko Mendive, pubblicata per la prima volta nel 2007 nell'album «La Sonora Guantanamera de Venezuela».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=e8TwDQs1HPM"
     },
     {
       "year": 1997,
@@ -7278,7 +7307,8 @@
       "fun_fact_fr": "« Ya No Regreso » de Orquesta Inmensidad, parue pour la première fois en 1997.",
       "fun_fact_nl": "\"Ya No Regreso\" van Orquesta Inmensidad, voor het eerst uitgebracht in 1997.",
       "uri_apple_music": "applemusic://track/1797925217",
-      "fun_fact_it": "«Ya No Regreso» di Orquesta Inmensidad, pubblicata per la prima volta nel 1997."
+      "fun_fact_it": "«Ya No Regreso» di Orquesta Inmensidad, pubblicata per la prima volta nel 1997.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Xutsxyd0oqs"
     },
     {
       "year": 2020,
@@ -7293,7 +7323,8 @@
       "fun_fact_nl": "\"Algo Que Se Quede\" van Grupo Niche, voor het eerst uitgebracht in 2020 op het album \"Algo Que Se Quede\".",
       "uri_deezer": "deezer://track/1078473492",
       "uri_apple_music": "applemusic://track/1531533492",
-      "fun_fact_it": "«Algo Que Se Quede» di Grupo Niche, pubblicata per la prima volta nel 2020 nell'album «Algo Que Se Quede»."
+      "fun_fact_it": "«Algo Que Se Quede» di Grupo Niche, pubblicata per la prima volta nel 2020 nell'album «Algo Que Se Quede».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=khB6DUHpR4o"
     },
     {
       "year": 2022,
@@ -7307,7 +7338,8 @@
       "fun_fact_fr": "\"DESPECHÁ\" de ROSALÍA, sortie pour la première fois en 2022 sur l'album \"DESPECHÁ\".",
       "fun_fact_nl": "\"DESPECHÁ\" van ROSALÍA, voor het eerst uitgebracht in 2022 op het album \"DESPECHÁ\".",
       "uri_deezer": "deezer://track/1841999507",
-      "fun_fact_it": "«DESPECHÁ» di ROSALÍA, pubblicata per la prima volta nel 2022 nell'album «DESPECHÁ»."
+      "fun_fact_it": "«DESPECHÁ» di ROSALÍA, pubblicata per la prima volta nel 2022 nell'album «DESPECHÁ».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=5g2hT4GmAGU"
     },
     {
       "year": 1995,
@@ -7322,7 +7354,8 @@
       "fun_fact_nl": "\"Rompecintura\" van Los Hermanos Rosario, voor het eerst uitgebracht in 1995 op het album \"Y Es Fácil!\".",
       "uri_deezer": "deezer://track/1857090737",
       "uri_apple_music": "applemusic://track/1526733635",
-      "fun_fact_it": "«Rompecintura» di Los Hermanos Rosario, pubblicata per la prima volta nel 1995 nell'album «Y Es Fácil!»."
+      "fun_fact_it": "«Rompecintura» di Los Hermanos Rosario, pubblicata per la prima volta nel 1995 nell'album «Y Es Fácil!».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fnqviEoiztg"
     },
     {
       "year": 2002,
@@ -7337,7 +7370,8 @@
       "fun_fact_nl": "\"y entonces\" van Son De Cali, voor het eerst uitgebracht in 2002 op het album \"Estilo Propio\".",
       "uri_deezer": "deezer://track/2357571345",
       "uri_apple_music": "applemusic://track/1443604910",
-      "fun_fact_it": "«y entonces» di Son De Cali, pubblicata per la prima volta nel 2002 nell'album «Estilo Propio»."
+      "fun_fact_it": "«y entonces» di Son De Cali, pubblicata per la prima volta nel 2002 nell'album «Estilo Propio».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gEIy50pn3gQ"
     },
     {
       "year": 1989,
@@ -7352,7 +7386,8 @@
       "fun_fact_nl": "\"Pa'l Bailador\" van Joe Arroyo, La Verdad, voor het eerst uitgebracht in 1989 op het album \"La Salsa: Identidad de un Pueblo, Vol. 5 Expresión Rumbera\".",
       "uri_deezer": "deezer://track/132093106",
       "uri_apple_music": "applemusic://track/203978041",
-      "fun_fact_it": "«Pa'l Bailador» di Joe Arroyo, La Verdad, pubblicata per la prima volta nel 1989 nell'album «La Salsa: Identidad de un Pueblo, Vol. 5 Expresión Rumbera»."
+      "fun_fact_it": "«Pa'l Bailador» di Joe Arroyo, La Verdad, pubblicata per la prima volta nel 1989 nell'album «La Salsa: Identidad de un Pueblo, Vol. 5 Expresión Rumbera».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=LsdSSj90fJI"
     },
     {
       "year": 1973,
@@ -7366,7 +7401,8 @@
       "fun_fact_fr": "« Las Caleñas Son Como las Flores - Remix » de The Latin Brothers, Piper Pimienta Diaz, parue pour la première fois en 1973.",
       "fun_fact_nl": "\"Las Caleñas Son Como las Flores - Remix\" van The Latin Brothers, Piper Pimienta Diaz, voor het eerst uitgebracht in 1973.",
       "uri_apple_music": "applemusic://track/874126077",
-      "fun_fact_it": "«Las Caleñas Son Como las Flores - Remix» di The Latin Brothers, Piper Pimienta Diaz, pubblicata per la prima volta nel 1973."
+      "fun_fact_it": "«Las Caleñas Son Como las Flores - Remix» di The Latin Brothers, Piper Pimienta Diaz, pubblicata per la prima volta nel 1973.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=o99qMU0yTR0"
     },
     {
       "year": 1975,
@@ -7381,7 +7417,8 @@
       "fun_fact_nl": "\"El Preso\" van Fruko Y Sus Tesos, Wilson Saoko, voor het eerst uitgebracht in 1975 op het album \"Fruko el Grande\".",
       "uri_deezer": "deezer://track/451174962",
       "uri_apple_music": "applemusic://track/1046941805",
-      "fun_fact_it": "«El Preso» di Fruko Y Sus Tesos, Wilson Saoko, pubblicata per la prima volta nel 1975 nell'album «Fruko el Grande»."
+      "fun_fact_it": "«El Preso» di Fruko Y Sus Tesos, Wilson Saoko, pubblicata per la prima volta nel 1975 nell'album «Fruko el Grande».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FN5oLBXiNvM"
     },
     {
       "year": 1966,
@@ -7396,7 +7433,8 @@
       "fun_fact_nl": "\"Micaela\" van Pete Rodriguez, voor het eerst uitgebracht in 1966 op het album \"I Like It Like That\".",
       "uri_deezer": "deezer://track/686070082",
       "uri_apple_music": "applemusic://track/1523944952",
-      "fun_fact_it": "«Micaela» di Pete Rodriguez, pubblicata per la prima volta nel 1966 nell'album «I Like It Like That»."
+      "fun_fact_it": "«Micaela» di Pete Rodriguez, pubblicata per la prima volta nel 1966 nell'album «I Like It Like That».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1pVu3qFjFGk"
     },
     {
       "year": 1974,
@@ -7411,7 +7449,8 @@
       "fun_fact_nl": "\"Quimbara - Remastered\" van Celia Cruz, voor het eerst uitgebracht in 1974 op het album \"Celia & Johnny (Remastered 2024)\".",
       "uri_deezer": "deezer://track/3584616581",
       "uri_apple_music": "applemusic://track/1769530331",
-      "fun_fact_it": "«Quimbara - Remastered» di Celia Cruz, pubblicata per la prima volta nel 1974 nell'album «Celia & Johnny (Remastered 2024)»."
+      "fun_fact_it": "«Quimbara - Remastered» di Celia Cruz, pubblicata per la prima volta nel 1974 nell'album «Celia & Johnny (Remastered 2024)».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TxRWQHCSmUg"
     },
     {
       "year": 1990,
@@ -7426,7 +7465,8 @@
       "fun_fact_nl": "\"Cali Aji\" van Grupo Niche, voor het eerst uitgebracht in 1990 op het album \"The Best\".",
       "uri_deezer": "deezer://track/13211923",
       "uri_apple_music": "applemusic://track/321443667",
-      "fun_fact_it": "«Cali Aji» di Grupo Niche, pubblicata per la prima volta nel 1990 nell'album «The Best»."
+      "fun_fact_it": "«Cali Aji» di Grupo Niche, pubblicata per la prima volta nel 1990 nell'album «The Best».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=oWI9Tr-1FBk"
     },
     {
       "year": 1986,
@@ -7441,7 +7481,8 @@
       "fun_fact_nl": "\"Si Algún Día la Ves\" van Sergio Vargas, voor het eerst uitgebracht in 1986 op het album \"Los Años Dorados de Sergio Vargas\".",
       "uri_deezer": "deezer://track/1857060737",
       "uri_apple_music": "applemusic://track/1701636802",
-      "fun_fact_it": "«Si Algún Día la Ves» di Sergio Vargas, pubblicata per la prima volta nel 1986 nell'album «Los Años Dorados de Sergio Vargas»."
+      "fun_fact_it": "«Si Algún Día la Ves» di Sergio Vargas, pubblicata per la prima volta nel 1986 nell'album «Los Años Dorados de Sergio Vargas».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6iRp9l-Pwhs"
     },
     {
       "year": 1997,
@@ -7456,7 +7497,8 @@
       "fun_fact_nl": "\"Fin de Semana\" van Los Hermanos Rosario, voor het eerst uitgebracht in 1997 op het album \"Y Es Fácil!\".",
       "uri_deezer": "deezer://track/1857090667",
       "uri_apple_music": "applemusic://track/1526733346",
-      "fun_fact_it": "«Fin de Semana» di Los Hermanos Rosario, pubblicata per la prima volta nel 1997 nell'album «Y Es Fácil!»."
+      "fun_fact_it": "«Fin de Semana» di Los Hermanos Rosario, pubblicata per la prima volta nel 1997 nell'album «Y Es Fácil!».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=kVGV2sIMzJQ"
     },
     {
       "year": 1993,
@@ -7471,7 +7513,8 @@
       "fun_fact_nl": "\"Morena Ven\" van Los Hermanos Rosario, voor het eerst uitgebracht in 1993.",
       "uri_deezer": "deezer://track/1899381807",
       "uri_apple_music": "applemusic://track/1526584450",
-      "fun_fact_it": "«Morena Ven» di Los Hermanos Rosario, pubblicata per la prima volta nel 1993."
+      "fun_fact_it": "«Morena Ven» di Los Hermanos Rosario, pubblicata per la prima volta nel 1993.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=NakaWu2BXa4"
     },
     {
       "year": 1984,
@@ -7486,7 +7529,8 @@
       "fun_fact_nl": "\"La Asesina\" van Bonny Cepeda, voor het eerst uitgebracht in 1984 op het album \"La Fiesta Esta Buena\".",
       "uri_deezer": "deezer://track/2587509032",
       "uri_apple_music": "applemusic://track/1624844800",
-      "fun_fact_it": "«La Asesina» di Bonny Cepeda, pubblicata per la prima volta nel 1984 nell'album «La Fiesta Esta Buena»."
+      "fun_fact_it": "«La Asesina» di Bonny Cepeda, pubblicata per la prima volta nel 1984 nell'album «La Fiesta Esta Buena».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=V1jnol6o1kQ"
     },
     {
       "year": 1982,
@@ -7501,7 +7545,8 @@
       "fun_fact_nl": "\"El Comejen\" van Wilfrido Vargas, Sandy Reyes, voor het eerst uitgebracht in 1982 op het album \"Wilfrido Vargas & Sandy Reyes\".",
       "uri_deezer": "deezer://track/1857027637",
       "uri_apple_music": "applemusic://track/1526721020",
-      "fun_fact_it": "«El Comejen» di Wilfrido Vargas, Sandy Reyes, pubblicata per la prima volta nel 1982 nell'album «Wilfrido Vargas & Sandy Reyes»."
+      "fun_fact_it": "«El Comejen» di Wilfrido Vargas, Sandy Reyes, pubblicata per la prima volta nel 1982 nell'album «Wilfrido Vargas & Sandy Reyes».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-mB62m7JY7Y"
     },
     {
       "year": 1990,
@@ -7516,7 +7561,8 @@
       "fun_fact_nl": "\"Que Cara Mas Bonita\" van Alex Bueno, voor het eerst uitgebracht in 1990 op het album \"20 Años Despues\".",
       "uri_deezer": "deezer://track/10962833",
       "uri_apple_music": "applemusic://track/1526556594",
-      "fun_fact_it": "«Que Cara Mas Bonita» di Alex Bueno, pubblicata per la prima volta nel 1990 nell'album «20 Años Despues»."
+      "fun_fact_it": "«Que Cara Mas Bonita» di Alex Bueno, pubblicata per la prima volta nel 1990 nell'album «20 Años Despues».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=F4fRUALY2to"
     },
     {
       "year": 1995,
@@ -7531,7 +7577,8 @@
       "fun_fact_nl": "\"La Media María\" van Las Chicas Del Can, voor het eerst uitgebracht in 1995 op het album \"Fuego\".",
       "uri_deezer": "deezer://track/1364338962",
       "uri_apple_music": "applemusic://track/1526720517",
-      "fun_fact_it": "«La Media María» di Las Chicas Del Can, pubblicata per la prima volta nel 1995 nell'album «Fuego»."
+      "fun_fact_it": "«La Media María» di Las Chicas Del Can, pubblicata per la prima volta nel 1995 nell'album «Fuego».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=s99EqS5nfVU"
     },
     {
       "year": 1995,
@@ -7546,7 +7593,8 @@
       "fun_fact_nl": "\"No Hay Pesos\" van Los Cantantes, voor het eerst uitgebracht in 1995 op het album \"El Virao\".",
       "uri_deezer": "deezer://track/2785762742",
       "uri_apple_music": "applemusic://track/1744952406",
-      "fun_fact_it": "«No Hay Pesos» di Los Cantantes, pubblicata per la prima volta nel 1995 nell'album «El Virao»."
+      "fun_fact_it": "«No Hay Pesos» di Los Cantantes, pubblicata per la prima volta nel 1995 nell'album «El Virao».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9185NBpS8Sc"
     },
     {
       "year": 2009,
@@ -7561,7 +7609,8 @@
       "fun_fact_nl": "\"Aguanile\" van Héctor Lavoe, voor het eerst uitgebracht in 2009 op het album \"Aleteo, Cumbia y Guaracha\".",
       "uri_deezer": "deezer://track/3444265241",
       "uri_apple_music": "applemusic://track/1465963965",
-      "fun_fact_it": "«Aguanile» di Héctor Lavoe, pubblicata per la prima volta nel 2009 nell'album «Aleteo, Cumbia y Guaracha»."
+      "fun_fact_it": "«Aguanile» di Héctor Lavoe, pubblicata per la prima volta nel 2009 nell'album «Aleteo, Cumbia y Guaracha».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=5BPYFIWNehg"
     },
     {
       "year": 1995,
@@ -7576,7 +7625,8 @@
       "fun_fact_nl": "\"Richie's Jala Jala\" van Richie Ray, voor het eerst uitgebracht in 1995 op het album \"La Herencia\".",
       "uri_deezer": "deezer://track/686097262",
       "uri_apple_music": "applemusic://track/1562606592",
-      "fun_fact_it": "«Richie's Jala Jala» di Richie Ray, pubblicata per la prima volta nel 1995 nell'album «La Herencia»."
+      "fun_fact_it": "«Richie's Jala Jala» di Richie Ray, pubblicata per la prima volta nel 1995 nell'album «La Herencia».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=2WhSomTUyo8"
     },
     {
       "year": 1991,
@@ -7591,7 +7641,8 @@
       "fun_fact_nl": "\"Sonido Bestial\" van Richie Ray & Bobby Cruz, voor het eerst uitgebracht in 1991 op het album \"A Lifetime of Hits... (Live At Centro de Bellas Artes, San Juan, Puerto Rico.)\".",
       "uri_deezer": "deezer://track/11111575",
       "uri_apple_music": "applemusic://track/1464273298",
-      "fun_fact_it": "«Sonido Bestial» di Richie Ray & Bobby Cruz, pubblicata per la prima volta nel 1991 nell'album «A Lifetime of Hits... (Live At Centro de Bellas Artes, San Juan, Puerto Rico.)»."
+      "fun_fact_it": "«Sonido Bestial» di Richie Ray & Bobby Cruz, pubblicata per la prima volta nel 1991 nell'album «A Lifetime of Hits... (Live At Centro de Bellas Artes, San Juan, Puerto Rico.)».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_eVmOyG6ZZQ"
     },
     {
       "year": 1995,
@@ -7606,7 +7657,8 @@
       "fun_fact_nl": "\"Señora Ley\" van Conjunto Clásico, Tito Nieves, voor het eerst uitgebracht in 1995 op het album \"Ray Castro Presenta...Lo Mejor De Conjunto Clasico Con Tito Nieves\".",
       "uri_deezer": "deezer://track/11174537",
       "uri_apple_music": "applemusic://track/6795463754",
-      "fun_fact_it": "«Señora Ley» di Conjunto Clásico, Tito Nieves, pubblicata per la prima volta nel 1995 nell'album «Ray Castro Presenta...Lo Mejor De Conjunto Clasico Con Tito Nieves»."
+      "fun_fact_it": "«Señora Ley» di Conjunto Clásico, Tito Nieves, pubblicata per la prima volta nel 1995 nell'album «Ray Castro Presenta...Lo Mejor De Conjunto Clasico Con Tito Nieves».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=v_jz7ELZLo0"
     },
     {
       "year": 1958,
@@ -7621,7 +7673,8 @@
       "fun_fact_nl": "\"Fiesta\" van La Sonora Matancera, voor het eerst uitgebracht in 1958 op het album \"Festejando Navidad\".",
       "uri_deezer": "deezer://track/688241822",
       "uri_apple_music": "applemusic://track/1656785398",
-      "fun_fact_it": "«Fiesta» di La Sonora Matancera, pubblicata per la prima volta nel 1958 nell'album «Festejando Navidad»."
+      "fun_fact_it": "«Fiesta» di La Sonora Matancera, pubblicata per la prima volta nel 1958 nell'album «Festejando Navidad».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=MJro6Q_TM88"
     },
     {
       "year": 1978,
@@ -7636,7 +7689,8 @@
       "fun_fact_nl": "\"Mala Mujer\" van La Sonora Matancera, voor het eerst uitgebracht in 1978 op het album \"Cuando Salí de Cuba\".",
       "uri_deezer": "deezer://track/58479081",
       "uri_apple_music": "applemusic://track/1637750135",
-      "fun_fact_it": "«Mala Mujer» di La Sonora Matancera, pubblicata per la prima volta nel 1978 nell'album «Cuando Salí de Cuba»."
+      "fun_fact_it": "«Mala Mujer» di La Sonora Matancera, pubblicata per la prima volta nel 1978 nell'album «Cuando Salí de Cuba».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=yGNaxs10PUs"
     },
     {
       "year": 1986,
@@ -7651,7 +7705,8 @@
       "fun_fact_nl": "\"El Coco\" van Jossie Esteban y La Patrulla 15, voor het eerst uitgebracht in 1986 op het album \"Noches de Copas\".",
       "uri_deezer": "deezer://track/63637511",
       "uri_apple_music": "applemusic://track/294581830",
-      "fun_fact_it": "«El Coco» di Jossie Esteban y La Patrulla 15, pubblicata per la prima volta nel 1986 nell'album «Noches de Copas»."
+      "fun_fact_it": "«El Coco» di Jossie Esteban y La Patrulla 15, pubblicata per la prima volta nel 1986 nell'album «Noches de Copas».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mrOC7iMZuWY"
     },
     {
       "year": 1995,
@@ -7666,7 +7721,8 @@
       "fun_fact_nl": "\"Estamos en Salsa\" van Wayne Gorbea, voor het eerst uitgebracht in 1995 op het album \"La Salsa del Conjunto Salsa\".",
       "uri_deezer": "deezer://track/2992201601",
       "uri_apple_music": "applemusic://track/1768113824",
-      "fun_fact_it": "«Estamos en Salsa» di Wayne Gorbea, pubblicata per la prima volta nel 1995 nell'album «La Salsa del Conjunto Salsa»."
+      "fun_fact_it": "«Estamos en Salsa» di Wayne Gorbea, pubblicata per la prima volta nel 1995 nell'album «La Salsa del Conjunto Salsa».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UUUpSMWB7fk"
     },
     {
       "year": 1973,
@@ -7681,7 +7737,8 @@
       "fun_fact_nl": "\"El Forastero\" van Nelson Y Sus Estrellas, voor het eerst uitgebracht in 1973 op het album \"Ritmo Y Sabor, Vol. 1\".",
       "uri_deezer": "deezer://track/3778530162",
       "uri_apple_music": "applemusic://track/339950382",
-      "fun_fact_it": "«El Forastero» di Nelson Y Sus Estrellas, pubblicata per la prima volta nel 1973 nell'album «Ritmo Y Sabor, Vol. 1»."
+      "fun_fact_it": "«El Forastero» di Nelson Y Sus Estrellas, pubblicata per la prima volta nel 1973 nell'album «Ritmo Y Sabor, Vol. 1».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ShsYmRzWoi8"
     },
     {
       "year": 2009,
@@ -7696,7 +7753,8 @@
       "fun_fact_nl": "\"Apretaito\" van Edgar Gonzalon, voor het eerst uitgebracht in 2009 op het album \"Apretaito (El Negrito de la Salsa)\".",
       "uri_deezer": "deezer://track/2301549945",
       "uri_apple_music": "applemusic://track/1691388516",
-      "fun_fact_it": "«Apretaito» di Edgar Gonzalon, pubblicata per la prima volta nel 2009 nell'album «Apretaito (El Negrito de la Salsa)»."
+      "fun_fact_it": "«Apretaito» di Edgar Gonzalon, pubblicata per la prima volta nel 2009 nell'album «Apretaito (El Negrito de la Salsa)».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YwW3r1hOy6w"
     },
     {
       "year": 2000,
@@ -7711,7 +7769,8 @@
       "fun_fact_nl": "\"Te Voy a Hacer Feliz\" van Mariano Civico, voor het eerst uitgebracht in 2000 op het album \"Costa Brava\".",
       "uri_deezer": "deezer://track/1104813912",
       "uri_apple_music": "applemusic://track/1735824620",
-      "fun_fact_it": "«Te Voy a Hacer Feliz» di Mariano Civico, pubblicata per la prima volta nel 2000 nell'album «Costa Brava»."
+      "fun_fact_it": "«Te Voy a Hacer Feliz» di Mariano Civico, pubblicata per la prima volta nel 2000 nell'album «Costa Brava».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ByUdV31RtaQ"
     },
     {
       "year": 1989,
@@ -7726,7 +7785,8 @@
       "fun_fact_nl": "\"La Flaca\" van Cocoband, voor het eerst uitgebracht in 1989.",
       "uri_deezer": "deezer://track/96359226",
       "uri_apple_music": "applemusic://track/1513631032",
-      "fun_fact_it": "«La Flaca» di Cocoband, pubblicata per la prima volta nel 1989."
+      "fun_fact_it": "«La Flaca» di Cocoband, pubblicata per la prima volta nel 1989.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mdndTRMvPu0"
     },
     {
       "year": 1986,
@@ -7741,7 +7801,8 @@
       "fun_fact_nl": "\"Me Enamoro de Ella\" van Juan Luis Guerra 4.40, voor het eerst uitgebracht in 1986 op het album \"Los Merengues del Año, Vol. 4\".",
       "uri_deezer": "deezer://track/1857194817",
       "uri_apple_music": "applemusic://track/19512273",
-      "fun_fact_it": "«Me Enamoro de Ella» di Juan Luis Guerra 4.40, pubblicata per la prima volta nel 1986 nell'album «Los Merengues del Año, Vol. 4»."
+      "fun_fact_it": "«Me Enamoro de Ella» di Juan Luis Guerra 4.40, pubblicata per la prima volta nel 1986 nell'album «Los Merengues del Año, Vol. 4».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BvYv6DNJlPM"
     },
     {
       "year": 1989,
@@ -7756,7 +7817,8 @@
       "fun_fact_nl": "\"Visa para un Sueno\" van Juan Luis Guerra 4.40, voor het eerst uitgebracht in 1989.",
       "uri_deezer": "deezer://track/1857061897",
       "uri_apple_music": "applemusic://track/19468930",
-      "fun_fact_it": "«Visa para un Sueno» di Juan Luis Guerra 4.40, pubblicata per la prima volta nel 1989."
+      "fun_fact_it": "«Visa para un Sueno» di Juan Luis Guerra 4.40, pubblicata per la prima volta nel 1989.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=py5lONtuw2A"
     },
     {
       "year": 1980,
@@ -7771,7 +7833,8 @@
       "fun_fact_nl": "\"La Medicina\" van Wilfrido Vargas, voor het eerst uitgebracht in 1980.",
       "uri_deezer": "deezer://track/2024070087",
       "uri_apple_music": "applemusic://track/1526599759",
-      "fun_fact_it": "«La Medicina» di Wilfrido Vargas, pubblicata per la prima volta nel 1980."
+      "fun_fact_it": "«La Medicina» di Wilfrido Vargas, pubblicata per la prima volta nel 1980.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_pThCgekT2w"
     },
     {
       "year": 1986,
@@ -7786,7 +7849,8 @@
       "fun_fact_nl": "\"Mary\" van Joe Arroyo, La Verdad, voor het eerst uitgebracht in 1986 op het album \"La Salsa, Identidad de un Pueblo - Vol. 10 Expresión Bacana\".",
       "uri_deezer": "deezer://track/132002198",
       "uri_apple_music": "applemusic://track/455561904",
-      "fun_fact_it": "«Mary» di Joe Arroyo, La Verdad, pubblicata per la prima volta nel 1986 nell'album «La Salsa, Identidad de un Pueblo - Vol. 10 Expresión Bacana»."
+      "fun_fact_it": "«Mary» di Joe Arroyo, La Verdad, pubblicata per la prima volta nel 1986 nell'album «La Salsa, Identidad de un Pueblo - Vol. 10 Expresión Bacana».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0ZZSDXg5xic"
     },
     {
       "year": 2014,
@@ -7800,7 +7864,8 @@
       "fun_fact_fr": "« Checarnaval: La Rama del Tamarindo / La Danza del Garabato / De Qué Me Disfrazaré » de Checo Acosta, parue pour la première fois en 2014 sur l'album « Checo Acosta 30 Aniversario ».",
       "fun_fact_nl": "\"Checarnaval: La Rama del Tamarindo / La Danza del Garabato / De Qué Me Disfrazaré\" van Checo Acosta, voor het eerst uitgebracht in 2014 op het album \"Checo Acosta 30 Aniversario\".",
       "uri_deezer": "deezer://track/3894699911",
-      "fun_fact_it": "«Checarnaval: La Rama del Tamarindo / La Danza del Garabato / De Qué Me Disfrazaré» di Checo Acosta, pubblicata per la prima volta nel 2014 nell'album «Checo Acosta 30 Aniversario»."
+      "fun_fact_it": "«Checarnaval: La Rama del Tamarindo / La Danza del Garabato / De Qué Me Disfrazaré» di Checo Acosta, pubblicata per la prima volta nel 2014 nell'album «Checo Acosta 30 Aniversario».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=t3nDazy6XXA"
     },
     {
       "year": 1972,
@@ -7830,7 +7895,8 @@
       "fun_fact_nl": "\"Una Mirada Tu\" van The Bananas, voor het eerst uitgebracht in 1993 op het album \"30 Mejores\".",
       "uri_deezer": "deezer://track/1441557992",
       "uri_apple_music": "applemusic://track/1712783791",
-      "fun_fact_it": "«Una Mirada Tu» di The Bananas, pubblicata per la prima volta nel 1993 nell'album «30 Mejores»."
+      "fun_fact_it": "«Una Mirada Tu» di The Bananas, pubblicata per la prima volta nel 1993 nell'album «30 Mejores».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=56Nmibtpc4U"
     },
     {
       "year": 1991,
@@ -7845,7 +7911,8 @@
       "fun_fact_nl": "\"No Quiero Tu Amor\" van Alfa 8, voor het eerst uitgebracht in 1991 op het album \"Mas Internacional Que Nunca\".",
       "uri_deezer": "deezer://track/3250717491",
       "uri_apple_music": "applemusic://track/1845906687",
-      "fun_fact_it": "«No Quiero Tu Amor» di Alfa 8, pubblicata per la prima volta nel 1991 nell'album «Mas Internacional Que Nunca»."
+      "fun_fact_it": "«No Quiero Tu Amor» di Alfa 8, pubblicata per la prima volta nel 1991 nell'album «Mas Internacional Que Nunca».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7NH8gtn4TkA"
     },
     {
       "year": 1986,
@@ -7860,7 +7927,8 @@
       "fun_fact_nl": "\"Ay! Mujer\" van Juan Luis Guerra 4.40, voor het eerst uitgebracht in 1986 op het album \"Mientras Más Lo Pienso…Tú\".",
       "uri_deezer": "deezer://track/2698668582",
       "uri_apple_music": "applemusic://track/19512275",
-      "fun_fact_it": "«Ay! Mujer» di Juan Luis Guerra 4.40, pubblicata per la prima volta nel 1986 nell'album «Mientras Más Lo Pienso…Tú»."
+      "fun_fact_it": "«Ay! Mujer» di Juan Luis Guerra 4.40, pubblicata per la prima volta nel 1986 nell'album «Mientras Más Lo Pienso…Tú».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cY8Bwog22xo"
     },
     {
       "year": 2020,
@@ -7874,7 +7942,8 @@
       "fun_fact_fr": "« Mesa Que Mas Aplauda (version - Española » de Grupo Climax, parue pour la première fois en 2020 sur l'album « Mesa Que Mas Aplauda (Versión Española) ».",
       "fun_fact_nl": "\"Mesa Que Mas Aplauda (version - Española\" van Grupo Climax, voor het eerst uitgebracht in 2020 op het album \"Mesa Que Mas Aplauda (Versión Española)\".",
       "uri_deezer": "deezer://track/2818449062",
-      "fun_fact_it": "«Mesa Que Mas Aplauda (version - Española» di Grupo Climax, pubblicata per la prima volta nel 2020 nell'album «Mesa Que Mas Aplauda (Versión Española)»."
+      "fun_fact_it": "«Mesa Que Mas Aplauda (version - Española» di Grupo Climax, pubblicata per la prima volta nel 2020 nell'album «Mesa Que Mas Aplauda (Versión Española)».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=n-OXTG8LiXI"
     },
     {
       "year": 1998,
@@ -7889,7 +7958,8 @@
       "fun_fact_nl": "\"Tuyo\" van Tito Nieves, voor het eerst uitgebracht in 1998 op het album \"Salsa sensual\".",
       "uri_deezer": "deezer://track/900342522",
       "uri_apple_music": "applemusic://track/1825451282",
-      "fun_fact_it": "«Tuyo» di Tito Nieves, pubblicata per la prima volta nel 1998 nell'album «Salsa sensual»."
+      "fun_fact_it": "«Tuyo» di Tito Nieves, pubblicata per la prima volta nel 1998 nell'album «Salsa sensual».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zonc_7XxatQ"
     },
     {
       "year": 2015,
@@ -7904,7 +7974,8 @@
       "fun_fact_nl": "\"Swagga\" van Cali Flow Latino, voor het eerst uitgebracht in 2015 op het album \"Full HD\".",
       "uri_deezer": "deezer://track/122544946",
       "uri_apple_music": "applemusic://track/1758826230",
-      "fun_fact_it": "«Swagga» di Cali Flow Latino, pubblicata per la prima volta nel 2015 nell'album «Full HD»."
+      "fun_fact_it": "«Swagga» di Cali Flow Latino, pubblicata per la prima volta nel 2015 nell'album «Full HD».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FyW6sk75XF0"
     },
     {
       "year": 2013,
@@ -7919,7 +7990,8 @@
       "fun_fact_nl": "\"Menea Tu Chapa\" van Wilo D New, voor het eerst uitgebracht in 2013 op het album \"KlK Llego El Tipo the Album\".",
       "uri_deezer": "deezer://track/75004798",
       "uri_apple_music": "applemusic://track/1364922342",
-      "fun_fact_it": "«Menea Tu Chapa» di Wilo D New, pubblicata per la prima volta nel 2013 nell'album «KlK Llego El Tipo the Album»."
+      "fun_fact_it": "«Menea Tu Chapa» di Wilo D New, pubblicata per la prima volta nel 2013 nell'album «KlK Llego El Tipo the Album».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cOWMByXN33w"
     },
     {
       "year": 2007,
@@ -7934,7 +8006,8 @@
       "fun_fact_nl": "\"La Flaca\" van Pochy Y Su Cocoband, voor het eerst uitgebracht in 2007 op het album \"Coco De Oro\".",
       "uri_deezer": "deezer://track/971476492",
       "uri_apple_music": "applemusic://track/1513631032",
-      "fun_fact_it": "«La Flaca» di Pochy Y Su Cocoband, pubblicata per la prima volta nel 2007 nell'album «Coco De Oro»."
+      "fun_fact_it": "«La Flaca» di Pochy Y Su Cocoband, pubblicata per la prima volta nel 2007 nell'album «Coco De Oro».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mdndTRMvPu0"
     },
     {
       "year": 1970,
@@ -7949,7 +8022,8 @@
       "fun_fact_nl": "\"Mambo Rock\" van Alfredo Linares, voor het eerst uitgebracht in 1970 op het album \"Mambo Rock\".",
       "uri_deezer": "deezer://track/1765270697",
       "uri_apple_music": "applemusic://track/1626128873",
-      "fun_fact_it": "«Mambo Rock» di Alfredo Linares, pubblicata per la prima volta nel 1970 nell'album «Mambo Rock»."
+      "fun_fact_it": "«Mambo Rock» di Alfredo Linares, pubblicata per la prima volta nel 1970 nell'album «Mambo Rock».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_AdTKHAqw0U"
     },
     {
       "year": 2011,
@@ -7964,7 +8038,8 @@
       "fun_fact_nl": "\"Te Invito\" van Herencia de Timbiqui, voor het eerst uitgebracht in 2011 op het album \"Tambó\".",
       "uri_deezer": "deezer://track/3235960331",
       "uri_apple_music": "applemusic://track/1566506511",
-      "fun_fact_it": "«Te Invito» di Herencia de Timbiqui, pubblicata per la prima volta nel 2011 nell'album «Tambó»."
+      "fun_fact_it": "«Te Invito» di Herencia de Timbiqui, pubblicata per la prima volta nel 2011 nell'album «Tambó».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=eaKG17XoQ48"
     },
     {
       "year": 2014,
@@ -7979,7 +8054,8 @@
       "fun_fact_nl": "\"Sabrás\" van Herencia de Timbiqui, voor het eerst uitgebracht in 2014 op het album \"This Is Gozar (Timbiquí Edition)\".",
       "uri_deezer": "deezer://track/3257260471",
       "uri_apple_music": "applemusic://track/1454694029",
-      "fun_fact_it": "«Sabrás» di Herencia de Timbiqui, pubblicata per la prima volta nel 2014 nell'album «This Is Gozar (Timbiquí Edition)»."
+      "fun_fact_it": "«Sabrás» di Herencia de Timbiqui, pubblicata per la prima volta nel 2014 nell'album «This Is Gozar (Timbiquí Edition)».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=srE7nr4xuGI"
     },
     {
       "year": 1983,
@@ -7994,7 +8070,8 @@
       "fun_fact_nl": "\"Gitana\" van Willie Colón, voor het eerst uitgebracht in 1983 op het album \"Tiempo pa' Matar\".",
       "uri_deezer": "deezer://track/688277692",
       "uri_apple_music": "applemusic://track/1466117667",
-      "fun_fact_it": "«Gitana» di Willie Colón, pubblicata per la prima volta nel 1983 nell'album «Tiempo pa' Matar»."
+      "fun_fact_it": "«Gitana» di Willie Colón, pubblicata per la prima volta nel 1983 nell'album «Tiempo pa' Matar».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=eOU5B7sttHw"
     },
     {
       "year": 1973,
@@ -8009,7 +8086,8 @@
       "fun_fact_nl": "\"Tiahuanaco (Puerta Del Sol)\" van Alfredo Linares, voor het eerst uitgebracht in 1973 op het album \"Sensacionales!!!\".",
       "uri_deezer": "deezer://track/1763729667",
       "uri_apple_music": "applemusic://track/1625719963",
-      "fun_fact_it": "«Tiahuanaco (Puerta Del Sol)» di Alfredo Linares, pubblicata per la prima volta nel 1973 nell'album «Sensacionales!!!»."
+      "fun_fact_it": "«Tiahuanaco (Puerta Del Sol)» di Alfredo Linares, pubblicata per la prima volta nel 1973 nell'album «Sensacionales!!!».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ktapVHqPQB8"
     },
     {
       "year": 2002,
@@ -8023,7 +8101,8 @@
       "fun_fact_fr": "« Ganas » de Grupo Niche, parue pour la première fois en 2002 sur l'album « Control Absoluto ».",
       "fun_fact_nl": "\"Ganas\" van Grupo Niche, voor het eerst uitgebracht in 2002 op het album \"Control Absoluto\".",
       "uri_deezer": "deezer://track/1001031902",
-      "fun_fact_it": "«Ganas» di Grupo Niche, pubblicata per la prima volta nel 2002 nell'album «Control Absoluto»."
+      "fun_fact_it": "«Ganas» di Grupo Niche, pubblicata per la prima volta nel 2002 nell'album «Control Absoluto».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=exwWCXZC0zA"
     },
     {
       "year": 1996,
@@ -8038,7 +8117,8 @@
       "fun_fact_nl": "\"La Canoa Ranchaa\" van Grupo Niche, voor het eerst uitgebracht in 1996.",
       "uri_deezer": "deezer://track/13256379",
       "uri_apple_music": "applemusic://track/1862587272",
-      "fun_fact_it": "«La Canoa Ranchaa» di Grupo Niche, pubblicata per la prima volta nel 1996."
+      "fun_fact_it": "«La Canoa Ranchaa» di Grupo Niche, pubblicata per la prima volta nel 1996.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=AbpnWgNdKAs"
     },
     {
       "year": 1992,
@@ -8053,7 +8133,8 @@
       "fun_fact_nl": "\"La Vamo a Tumbar\" van Grupo Saboreo, voor het eerst uitgebracht in 1992 op het album \"Lo Mejor de la Música del Pacifico Colombiano, Vol. 2\".",
       "uri_deezer": "deezer://track/2981328231",
       "uri_apple_music": "applemusic://track/1657043875",
-      "fun_fact_it": "«La Vamo a Tumbar» di Grupo Saboreo, pubblicata per la prima volta nel 1992 nell'album «Lo Mejor de la Música del Pacifico Colombiano, Vol. 2»."
+      "fun_fact_it": "«La Vamo a Tumbar» di Grupo Saboreo, pubblicata per la prima volta nel 1992 nell'album «Lo Mejor de la Música del Pacifico Colombiano, Vol. 2».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Pfsf6jFPpuA"
     },
     {
       "year": 1982,
@@ -8068,7 +8149,8 @@
       "fun_fact_nl": "\"Yambeque\" van Sonora Ponceña, voor het eerst uitgebracht in 1982 op het album \"50 Aniversario, Vol.2\".",
       "uri_deezer": "deezer://track/8552497",
       "uri_apple_music": "applemusic://track/1464284879",
-      "fun_fact_it": "«Yambeque» di Sonora Ponceña, pubblicata per la prima volta nel 1982 nell'album «50 Aniversario, Vol.2»."
+      "fun_fact_it": "«Yambeque» di Sonora Ponceña, pubblicata per la prima volta nel 1982 nell'album «50 Aniversario, Vol.2».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HrSC9fKWAqE"
     },
     {
       "year": 2006,
@@ -8083,7 +8165,8 @@
       "fun_fact_nl": "\"Te Amo\" van Son De Cali, Willy Garcia, voor het eerst uitgebracht in 2006 op het album \"Cambiando La Historia\".",
       "uri_deezer": "deezer://track/2357573455",
       "uri_apple_music": "applemusic://track/1696136226",
-      "fun_fact_it": "«Te Amo» di Son De Cali, Willy Garcia, pubblicata per la prima volta nel 2006 nell'album «Cambiando La Historia»."
+      "fun_fact_it": "«Te Amo» di Son De Cali, Willy Garcia, pubblicata per la prima volta nel 2006 nell'album «Cambiando La Historia».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uQcIdSgm9y0"
     },
     {
       "year": 1974,
@@ -8097,7 +8180,8 @@
       "fun_fact_fr": "« Se Formo la Rumbantela » de Javier Vázquez y Su Salsa, parue pour la première fois en 1974.",
       "fun_fact_nl": "\"Se Formo la Rumbantela\" van Javier Vázquez y Su Salsa, voor het eerst uitgebracht in 1974.",
       "uri_apple_music": "applemusic://track/1464956362",
-      "fun_fact_it": "«Se Formo la Rumbantela» di Javier Vázquez y Su Salsa, pubblicata per la prima volta nel 1974."
+      "fun_fact_it": "«Se Formo la Rumbantela» di Javier Vázquez y Su Salsa, pubblicata per la prima volta nel 1974.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=57QGsapkEcw"
     },
     {
       "year": 2017,
@@ -8112,7 +8196,8 @@
       "fun_fact_nl": "\"Imitadora\" van Romeo Santos, voor het eerst uitgebracht in 2017 op het album \"Golden\".",
       "uri_deezer": "deezer://track/385074601",
       "uri_apple_music": "applemusic://track/1258804105",
-      "fun_fact_it": "«Imitadora» di Romeo Santos, pubblicata per la prima volta nel 2017 nell'album «Golden»."
+      "fun_fact_it": "«Imitadora» di Romeo Santos, pubblicata per la prima volta nel 2017 nell'album «Golden».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mhHqonzsuoA"
     },
     {
       "year": 1980,
@@ -8127,7 +8212,8 @@
       "fun_fact_nl": "\"Sin Negro No Hay Guaguancó\" van Lebrón Brothers, voor het eerst uitgebracht in 1980 op het album \"Criollo\".",
       "uri_deezer": "deezer://track/686140532",
       "uri_apple_music": "applemusic://track/1464273107",
-      "fun_fact_it": "«Sin Negro No Hay Guaguancó» di Lebrón Brothers, pubblicata per la prima volta nel 1980 nell'album «Criollo»."
+      "fun_fact_it": "«Sin Negro No Hay Guaguancó» di Lebrón Brothers, pubblicata per la prima volta nel 1980 nell'album «Criollo».",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-jJNyhjou_w"
     }
   ]
 }

--- a/custom_components/beatify/playlists/movies-100-greatest-themes.json
+++ b/custom_components/beatify/playlists/movies-100-greatest-themes.json
@@ -1,6 +1,6 @@
 {
   "name": "Movie & TV Soundtracks 🎬",
-  "version": "1.32",
+  "version": "1.33",
   "tags": [
     "movies",
     "soundtrack",
@@ -8045,7 +8045,8 @@
       "fun_fact_es": "Zimmer escribió la sintonía para una serie sobre una corona, no sobre una persona, y el tema se comporta en consecuencia: una máquina de metales y cuerdas que gira sin importar quién la lleve.",
       "fun_fact_fr": "Zimmer a écrit le générique d'une série qui parle d'une couronne et non d'une personne, et le thème se comporte en conséquence : une machine de cuivres et de cordes qui tourne, peu importe qui la porte.",
       "fun_fact_nl": "Zimmer schreef de titelmuziek voor een serie over een kroon en niet over een mens, en het thema gedraagt zich navenant: een machine van koper en strijkers die doordraait, wie hem ook draagt.",
-      "fun_fact_it": "Zimmer scrisse la sigla per una serie che parla di una corona e non di una persona, e il tema si comporta di conseguenza: una macchina di ottoni e archi che gira comunque, chiunque la indossi."
+      "fun_fact_it": "Zimmer scrisse la sigla per una serie che parla di una corona e non di una persona, e il tema si comporta di conseguenza: una macchina di ottoni e archi che gira comunque, chiunque la indossi.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=EIEqXWHPf88"
     },
     {
       "artist": "Lady Gaga",
@@ -8064,7 +8065,8 @@
       "fun_fact_es": "Se canta en Ha nacido una estrella en el punto en que el personaje ya ha ganado y la relación ya empieza a perder. Gaga la escribió con tres compositores de Nashville.",
       "fun_fact_fr": "Chantée dans A Star Is Born au moment où le personnage a déjà gagné et où la relation commence déjà à perdre. Gaga l'a écrite avec trois auteurs de Nashville.",
       "fun_fact_nl": "Gezongen in A Star Is Born op het punt waar het personage al gewonnen heeft en de relatie al begint te verliezen. Gaga schreef het met drie songwriters uit Nashville.",
-      "fun_fact_it": "Cantata in A Star Is Born nel punto in cui il personaggio ha già vinto e la relazione comincia già a perdere. Gaga la scrisse con tre autori di Nashville."
+      "fun_fact_it": "Cantata in A Star Is Born nel punto in cui il personaggio ha già vinto e la relazione comincia già a perdere. Gaga la scrisse con tre autori di Nashville.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=5vheNbQlsyU"
     },
     {
       "artist": "Doris Day",
@@ -8083,7 +8085,8 @@
       "fun_fact_es": "Escrita para El hombre que sabía demasiado de Hitchcock, donde Day la canta para que su hijo secuestrado la oiga dos pisos más arriba. Ganó el Óscar y se convirtió en su seña de identidad.",
       "fun_fact_fr": "Écrite pour L'Homme qui en savait trop de Hitchcock, où Day la chante pour être entendue de son fils enlevé, deux étages plus haut. Elle a remporté l'Oscar et est devenue sa signature.",
       "fun_fact_nl": "Geschreven voor Hitchcocks The Man Who Knew Too Much, waarin Day het zingt zodat haar ontvoerde zoon twee verdiepingen hoger haar hoort. Het won de Oscar en werd haar herkenningsmelodie.",
-      "fun_fact_it": "Scritta per L'uomo che sapeva troppo di Hitchcock, dove la Day la canta perché il figlio rapito la senta due piani più su. Vinse l'Oscar e divenne il suo marchio."
+      "fun_fact_it": "Scritta per L'uomo che sapeva troppo di Hitchcock, dove la Day la canta perché il figlio rapito la senta due piani più su. Vinse l'Oscar e divenne il suo marchio.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xZbKHDPPrrc"
     },
     {
       "artist": "The Beatles",
@@ -8102,7 +8105,8 @@
       "fun_fact_es": "Ringo Starr la canta en Revolver, dos años antes de que la película de animación tomara su nombre. Los efectos se construyeron en el estudio con cadenas, campanas y una bañera de hojalata.",
       "fun_fact_fr": "Ringo Starr la chante sur Revolver, deux ans avant que le film d'animation n'en reprenne le titre. Les bruitages ont été fabriqués en studio avec des chaînes, des cloches et une baignoire en fer-blanc.",
       "fun_fact_nl": "Ringo Starr zingt het op Revolver, twee jaar voordat de tekenfilm er zijn naam aan ontleende. De geluidseffecten werden in de studio gemaakt met kettingen, bellen en een blikken teil.",
-      "fun_fact_it": "Ringo Starr la canta in Revolver, due anni prima che il film d'animazione ne prendesse il nome. Gli effetti sonori furono costruiti in studio con catene, campanelli e una tinozza di latta."
+      "fun_fact_it": "Ringo Starr la canta in Revolver, due anni prima che il film d'animazione ne prendesse il nome. Gli effetti sonori furono costruiti in studio con catene, campanelli e una tinozza di latta.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=m2uTFF_3MaA"
     },
     {
       "artist": "Monty Python",
@@ -8121,7 +8125,8 @@
       "fun_fact_es": "Eric Idle la escribió para que se silbara desde una cruz al final de La vida de Brian. Desde entonces se canta en los estadios de fútbol y, con bastante frecuencia, en los funerales.",
       "fun_fact_fr": "Eric Idle l'a écrite pour être sifflée depuis une croix à la fin de La Vie de Brian. Depuis, on la chante dans les stades de football et, assez souvent, aux enterrements.",
       "fun_fact_nl": "Eric Idle schreef het om aan het eind van Life of Brian vanaf een kruis gefloten te worden. Sindsdien wordt het gezongen in voetbalstadions en, vaak genoeg, op begrafenissen.",
-      "fun_fact_it": "Eric Idle la scrisse perché fosse fischiettata da una croce alla fine di Brian di Nazareth. Da allora si canta negli stadi di calcio e, abbastanza spesso, ai funerali."
+      "fun_fact_it": "Eric Idle la scrisse perché fosse fischiettata da una croce alla fine di Brian di Nazareth. Da allora si canta negli stadi di calcio e, abbastanza spesso, ai funerali.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jHPOzQzk9Qo"
     },
     {
       "artist": "Gary Portnoy",
@@ -8140,7 +8145,8 @@
       "fun_fact_es": "Portnoy y Judy Hart Angelo la escribieron después de que rechazaran una canción anterior para la serie. El bar que describe tiene un modelo real en Boston.",
       "fun_fact_fr": "Portnoy et Judy Hart Angelo l'ont écrite après le refus d'une première chanson pour la série. Le bar qu'elle décrit a un modèle réel à Boston.",
       "fun_fact_nl": "Portnoy en Judy Hart Angelo schreven het nadat een eerder lied voor de serie was afgewezen. De kroeg die het beschrijft heeft een echt voorbeeld in Boston.",
-      "fun_fact_it": "Portnoy e Judy Hart Angelo la scrissero dopo che una canzone precedente per la serie era stata rifiutata. Il bar che descrive ha un modello reale a Boston."
+      "fun_fact_it": "Portnoy e Judy Hart Angelo la scrissero dopo che una canzone precedente per la serie era stata rifiutata. Il bar che descrive ha un modello reale a Boston.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=JhVRzh4_j50"
     },
     {
       "artist": "Harold Faltermeyer",
@@ -8159,7 +8165,8 @@
       "fun_fact_es": "El muniqués Faltermeyer construyó el tema de Superdetective en Hollywood con un Roland Jupiter-8 y lo bautizó con el nombre del personaje de Eddie Murphy. Triunfó como instrumental, algo insólito entonces y aún más raro hoy.",
       "fun_fact_fr": "Le Munichois Faltermeyer a bâti le thème du Flic de Beverly Hills sur un Roland Jupiter-8 et l'a nommé d'après le personnage d'Eddie Murphy. Il est devenu un tube en instrumental, chose inhabituelle alors et plus rare encore aujourd'hui.",
       "fun_fact_nl": "De uit München afkomstige Faltermeyer bouwde het thema van Beverly Hills Cop op een Roland Jupiter-8 en noemde het naar het personage van Eddie Murphy. Het werd een hit als instrumentaal, toen ongebruikelijk en nu nog zeldzamer.",
-      "fun_fact_it": "Il monacense Faltermeyer costruì il tema di Beverly Hills Cop su un Roland Jupiter-8 e lo intitolò al personaggio di Eddie Murphy. Divenne un successo da strumentale, cosa insolita allora e ancor più rara oggi."
+      "fun_fact_it": "Il monacense Faltermeyer costruì il tema di Beverly Hills Cop su un Roland Jupiter-8 e lo intitolò al personaggio di Eddie Murphy. Divenne un successo da strumentale, cosa insolita allora e ancor più rara oggi.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Qx2gvHjNhQ0"
     },
     {
       "artist": "John Barry",


### PR DESCRIPTION
A `provider-uri-backfill` run, driven automatically by `com.beatify.youtube-backfill`.

- `salsa-y-merengue` YouTube 177 -> **263**/531
- `movies-100-greatest-themes` YouTube 162 -> **169**/257

**Draft on purpose** — merged only once the maintainer approves.