### PR TITLE
site: 64 playlists and 8,330 songs

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,8 +99,8 @@
 
           <div class="hero-stats">
             <span>488 active installs</span>
-            <span>63 playlists</span>
-            <span>8,294 songs</span>
+            <span>64 playlists</span>
+            <span>8,330 songs</span>
             <span>6 music services</span>
             <span>6 languages</span>
           </div>
@@ -136,7 +136,7 @@
             <div class="step">
               <div class="step-number" aria-hidden="true">2</div>
               <h3>Pick Music</h3>
-              <p>Choose from 63 curated playlists or connect Spotify, Apple Music, YouTube Music, Deezer, Tidal or Amazon Music.</p>
+              <p>Choose from 64 curated playlists or connect Spotify, Apple Music, YouTube Music, Deezer, Tidal or Amazon Music.</p>
             </div>
             <div class="step">
               <div class="step-number" aria-hidden="true">3</div>
@@ -165,7 +165,7 @@
             <div class="feature">
               <div class="feature-icon" aria-hidden="true">🎵</div>
               <h3>Your Music</h3>
-              <p>Spotify, Apple Music, YouTube Music, Deezer, Tidal and Amazon Music. 63 curated playlists included.</p>
+              <p>Spotify, Apple Music, YouTube Music, Deezer, Tidal and Amazon Music. 64 curated playlists included.</p>
             </div>
             <div class="feature">
               <div class="feature-icon" aria-hidden="true">✍️</div>
@@ -265,7 +265,7 @@
               <span class="speaker-check" aria-hidden="true">✅</span>
               <div>
                 <strong>Nothing to buy or reprint</strong>
-                <p>The card decks are playlists. 63 of them ship with Beatify, and you can build your own from any music service or your own library.</p>
+                <p>The card decks are playlists. 64 of them ship with Beatify, and you can build your own from any music service or your own library.</p>
               </div>
             </div>
             <div class="speaker-card">


### PR DESCRIPTION
Rock Rioplatense (#2495) took the catalogue to **64 playlists and 8,330 songs** — the third playlist added today. Same five places as the last two count updates, counted from `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EoSUKDjLvert1VkyyL3RE