### PR TITLE
fix(ws): one Title & Artist attempt per player per round

### DIFF
--- a/custom_components/beatify/server/ws_handlers/guessing.py
+++ b/custom_components/beatify/server/ws_handlers/guessing.py
@@ -771,6 +771,24 @@ async def handle_title_artist_guess(
         )
         return
 
+    # One title/artist attempt per player per round (#2498). Without this the
+    # handler overwrites the stored guess and answers every attempt with its
+    # classification (``exact`` / ``fuzzy`` / ``near_miss`` / ``skipped``), so a
+    # player can probe the answer and have the converged guess scored as a
+    # first try — the resubmission also pushes ``submission_time`` later, which
+    # feeds the speed bonus. This mirrors the artist-challenge guard added for
+    # the same reason in #1660; the flag was already being set here, only never
+    # read.
+    if player.has_title_artist_guess:
+        await ws.send_json(
+            {
+                "type": "error",
+                "code": ERR_INVALID_ACTION,
+                "message": "Title & artist already guessed this round",
+            }
+        )
+        return
+
     if not game_state.title_artist_challenge:
         await ws.send_json(
             {

--- a/tests/unit/test_ws_title_artist_guess.py
+++ b/tests/unit/test_ws_title_artist_guess.py
@@ -210,3 +210,83 @@ class TestGuessTruncatedAtIngest:
         assert data["artist"] == "short"
 
         gs._cancel_auto_advance()
+
+
+class TestTitleArtistOneAttemptPerRound:
+    """#2498: one title/artist attempt per player per round.
+
+    The handler answers each attempt with its classification, so without a
+    guard a player can probe the answer and have the converged guess scored as
+    a first try. Mirrors the artist-challenge guard from #1660.
+    """
+
+    async def test_second_guess_is_rejected_and_does_not_overwrite(self):
+        handler, gs = _make_handler_game()
+        ws = _ws()
+        gs.add_player("Alice", ws)
+        gs.get_player("Alice").connected = True
+        await gs.start_round()
+        assert gs.phase == GamePhase.PLAYING
+
+        truth_title = gs.current_song["title"]
+        truth_artist = gs.current_song["artist"]
+
+        # First attempt: deliberately wrong, so a successful overwrite would be
+        # visible as a score change rather than a no-op.
+        await handler._handle_message(
+            ws,
+            {"type": "title_artist_guess", "title": "nope", "artist": "nope"},
+        )
+        player = gs.get_player("Alice")
+        assert player.has_title_artist_guess is True
+        first_time = player.submission_time
+
+        ws.send_json.reset_mock()
+
+        # Second attempt: the correct answer. Must be refused.
+        await handler._handle_message(
+            ws,
+            {
+                "type": "title_artist_guess",
+                "title": truth_title,
+                "artist": truth_artist,
+            },
+        )
+
+        sent = [c.args[0] for c in ws.send_json.call_args_list]
+        assert any(m.get("type") == "error" for m in sent), sent
+        # No acknowledgement, so no classification leaks back for attempt two.
+        assert not any(m.get("type") == "title_artist_guess_ack" for m in sent), sent
+
+        # The stored guess is still the first one, and the speed bonus does not
+        # get a later timestamp handed to it.
+        stored = gs.title_artist_challenge.guesses["Alice"]
+        assert stored["title"] == "nope"
+        assert stored["artist"] == "nope"
+        assert player.submission_time == first_time
+
+    async def test_flag_is_cleared_between_rounds(self):
+        """The lock is per round — round two must accept a guess again."""
+        handler, gs = _make_handler_game()
+        ws = _ws()
+        gs.add_player("Alice", ws)
+        gs.get_player("Alice").connected = True
+        await gs.start_round()
+
+        await handler._handle_message(
+            ws,
+            {"type": "title_artist_guess", "title": "a", "artist": "b"},
+        )
+        assert gs.get_player("Alice").has_title_artist_guess is True
+
+        await gs.end_round()
+        await gs.start_round()
+
+        assert gs.get_player("Alice").has_title_artist_guess is False
+        ws.send_json.reset_mock()
+        await handler._handle_message(
+            ws,
+            {"type": "title_artist_guess", "title": "c", "artist": "d"},
+        )
+        sent = [c.args[0] for c in ws.send_json.call_args_list]
+        assert any(m.get("type") == "title_artist_guess_ack" for m in sent), sent


### PR DESCRIPTION
`handle_title_artist_guess` set `player.has_title_artist_guess` and never read it, so a guess could be resubmitted without limit.

That would be harmless on its own. What makes it exploitable is the acknowledgement: every attempt is answered with its classification — `exact`, `fuzzy`, `near_miss` or `skipped` — during PLAYING. Probe, read how close you were, converge, and the final guess is scored as a first try. Each resubmission also pushed `submission_time` later, which is what the speed bonus reads.

## The same guard already exists next door

The artist challenge carries it, added in #1660 with a comment describing exactly this attack:

> One artist attempt per player per round. The artist challenge is multiple-choice and the options are broadcast, so without this guard a player could submit each option in turn and is guaranteed to hit the correct one (brute-force the bonus).

Title & Artist arrived later, in #1180, and never got the same treatment. This adds it in the same position, after the eliminated check.

## Tests

Two, both driving the real handler rather than the state object:

- **A second attempt is refused.** The first guess is deliberately wrong so that a successful overwrite would show up as a changed score rather than a no-op. Asserts the error, asserts that *no* acknowledgement is sent (so no classification leaks back for attempt two), and asserts the stored guess and `submission_time` are unchanged.
- **The flag clears between rounds.** The lock is per round, so round two must accept a guess again.

## Checks

- `pytest tests/unit` — **2133 passed**
- `ruff format --check` — clean

Closes #2498

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EoSUKDjLvert1VkyyL3RE
