### PR TITLE
fix(game): grant sabotage tokens and enforce the player floor on the real start paths

### DIFF
--- a/custom_components/beatify/game/state_lifecycle.py
+++ b/custom_components/beatify/game/state_lifecycle.py
@@ -134,17 +134,29 @@ class RoundLifecycleMixin:
 
         self._set_phase(GamePhase.PLAYING)
 
-        # Issue #1665: hand every player their single sabotage token. Unlike the
-        # steal (unlocked by a streak), the sabotage token exists from round 1 —
-        # a token you have to earn first would rarely be spent in a short game.
-        # No-op when the setting is off, so default games are unchanged.
-        if self.sabotage_enabled:
-            for player in self.players.values():
-                player.unlock_sabotage()
+        self._grant_sabotage_tokens()
 
         # Round and song selection will be implemented in Epic 4
         _LOGGER.info("Game started: %d players", len(self.players))
         return True, None
+
+    def _grant_sabotage_tokens(self) -> None:
+        """Hand every player their single sabotage token (#1665).
+
+        Unlike the steal (unlocked by a streak), the sabotage token exists from
+        round 1 — a token you have to earn first would rarely be spent in a
+        short game. No-op when the setting is off, so default games are
+        unchanged, and idempotent, so being called twice cannot hand out two.
+
+        #2497: this used to live inline in ``start_game()``, which no
+        production path calls — both real start paths go straight to
+        ``start_round()``. It is called from the LOBBY transition there as well
+        now, and lives in its own method so the two callers cannot drift.
+        """
+        if not self.sabotage_enabled:
+            return
+        for player in self.players.values():
+            player.unlock_sabotage()
 
     def _get_round_start_lock(self) -> asyncio.Lock:
         """Get (lazily creating) the #1697 round-start serialization lock.
@@ -227,6 +239,16 @@ class RoundLifecycleMixin:
         # that view entirely — hooking the view fixed one path and left the
         # other broken. Fires once; a hook failure must never block a game, so
         # the worst case is the room keeping its creation-time songs.
+        # #2497: the sabotage grant belongs to the LOBBY -> first-round
+        # transition, and this is the only place both start paths pass through.
+        # It used to sit in start_game(), which nothing in production calls: the
+        # websocket admin handler and the REST start view both call start_round()
+        # directly and the phase flip happens inside _initialize_round. Same
+        # reasoning as the pre-start hook below, which is here for exactly that
+        # reason.
+        if self.phase == GamePhase.LOBBY and _retry_count == 0:
+            self._grant_sabotage_tokens()
+
         hook = getattr(self, "pre_start_hook", None)
         if hook is not None and self.phase == GamePhase.LOBBY and _retry_count == 0:
             self.pre_start_hook = None

--- a/custom_components/beatify/server/game_views.py
+++ b/custom_components/beatify/server/game_views.py
@@ -23,6 +23,7 @@ from custom_components.beatify.const import (
     ERR_MEDIA_PLAYER_UNAVAILABLE,
     ERR_NO_PLAYABLE_SONGS,
     ERR_NO_PLAYLISTS_SELECTED,
+    MIN_PLAYERS,
     PROVIDER_AMAZON_MUSIC,
     PROVIDER_APPLE_MUSIC,
     PROVIDER_DEEZER,
@@ -1211,6 +1212,18 @@ class StartGameplayView(BeatifyAdminView):
 
         if game_state.phase != GamePhase.LOBBY:
             return _json_error("Game already started", 409, code="INVALID_PHASE")
+
+        # #2497: the minimum-player floor. It used to live in
+        # GameState.start_game(), which no production path calls, so a game
+        # could be started alone. Enforced at the two places a *user* starts a
+        # game — here and in the websocket admin handler — rather than inside
+        # start_round(), which runs for every round of every game.
+        if len(game_state.players) < MIN_PLAYERS:
+            return _json_error(
+                f"Need at least {MIN_PLAYERS} players to start",
+                409,
+                code="NOT_ENOUGH_PLAYERS",
+            )
 
         # Issue #827: Sudden Death requires >=3 players. Players join the LOBBY
         # *after* create_game (which clears sessions), so the floor can only be

--- a/custom_components/beatify/server/ws_handlers/admin.py
+++ b/custom_components/beatify/server/ws_handlers/admin.py
@@ -20,6 +20,7 @@ from custom_components.beatify.const import (
     ERR_NO_SONGS_REMAINING,
     ERR_NOT_ADMIN,
     ERR_UNAUTHORIZED,
+    MIN_PLAYERS,
 )
 from custom_components.beatify.game.state import GamePhase, GameState
 from custom_components.beatify.server.serializers import build_state_message
@@ -129,6 +130,21 @@ async def admin_start_game(
                 "type": "error",
                 "code": ERR_INVALID_ACTION,
                 "message": "Game already started",
+            }
+        )
+        return
+
+    # #2497: the minimum-player check used to live in GameState.start_game(),
+    # which no production path calls — so a game could be started with a single
+    # player. It belongs here rather than inside start_round(): start_round runs
+    # for every round of every game, while this is a property of *starting* one,
+    # and only here is there a socket to tell the host why nothing happened.
+    if len(game_state.players) < MIN_PLAYERS:
+        await ws.send_json(
+            {
+                "type": "error",
+                "code": ERR_GAME_NOT_STARTED,
+                "message": f"Need at least {MIN_PLAYERS} players to start",
             }
         )
         return

--- a/tests/unit/test_sabotage_start_path_2497.py
+++ b/tests/unit/test_sabotage_start_path_2497.py
@@ -1,0 +1,131 @@
+"""#2497 — the sabotage grant and the minimum-player floor on the real paths.
+
+Both used to live in ``GameState.start_game()``, which no production code
+calls: the websocket admin handler and the REST start view both call
+``start_round()`` directly, and the LOBBY -> PLAYING flip happens inside
+``_initialize_round``. So sabotage tokens were never handed out in a real game
+and a game could be started with a single player, while the unit tests that
+drove ``start_game()`` directly kept passing.
+
+These tests deliberately drive the paths a host actually uses.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.beatify.const import DOMAIN, MIN_PLAYERS
+from custom_components.beatify.game.state import GamePhase
+from tests.conftest import make_game_state, make_songs
+
+from custom_components.beatify.server.websocket import (  # isort: skip
+    BeatifyWebSocketHandler,
+)
+
+
+def _stub_media_service() -> MagicMock:
+    svc = MagicMock()
+    svc.is_available.return_value = True
+    svc.play_song = AsyncMock(return_value=True)
+    svc.verify_responsive = AsyncMock(return_value=(True, None))
+    return svc
+
+
+def _handler_game(**create_kwargs):
+    mock_hass = MagicMock()
+    gs = make_game_state()
+    gs.create_game(
+        playlists=["t.json"],
+        songs=make_songs(5),
+        media_player="media_player.x",
+        base_url="http://h",
+        **create_kwargs,
+    )
+    gs._media_player_service = _stub_media_service()
+    gs.platform = "music_assistant"
+    mock_hass.data = {DOMAIN: {"game": gs}}
+    handler = BeatifyWebSocketHandler(mock_hass)
+    handler.broadcast_state = AsyncMock()
+    handler.broadcast = AsyncMock()
+    handler.debounced_broadcast_state = AsyncMock()
+    return handler, gs
+
+
+def _ws() -> AsyncMock:
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+    ws.closed = False
+    ws.close = AsyncMock()
+    return ws
+
+
+def _join(gs, names):
+    sockets = {}
+    for name in names:
+        ws = _ws()
+        gs.add_player(name, ws)
+        gs.get_player(name).connected = True
+        sockets[name] = ws
+    return sockets
+
+
+class TestSabotageGrantOnTheRealStartPath:
+    async def test_start_round_hands_out_tokens(self):
+        """The path the host actually takes must grant the tokens."""
+        _, gs = _handler_game(sabotage_enabled=True)
+        _join(gs, ["Alice", "Bob"])
+        assert gs.get_player("Alice").sabotage_available is False
+
+        await gs.start_round()
+
+        assert gs.phase == GamePhase.PLAYING
+        assert gs.get_player("Alice").sabotage_available is True
+        assert gs.get_player("Bob").sabotage_available is True
+
+    async def test_no_tokens_when_the_setting_is_off(self):
+        _, gs = _handler_game(sabotage_enabled=False)
+        _join(gs, ["Alice", "Bob"])
+
+        await gs.start_round()
+
+        assert gs.get_player("Alice").sabotage_available is False
+        assert gs.get_player("Bob").sabotage_available is False
+
+    async def test_a_spent_token_is_not_handed_back_next_round(self):
+        """The grant belongs to the LOBBY transition, not to every round."""
+        _, gs = _handler_game(sabotage_enabled=True)
+        _join(gs, ["Alice", "Bob"])
+        await gs.start_round()
+
+        gs.get_player("Alice").sabotage_available = False  # as if spent
+        await gs.end_round()
+        await gs.start_round()
+
+        assert gs.get_player("Alice").sabotage_available is False
+        assert gs.get_player("Bob").sabotage_available is True
+
+
+class TestMinimumPlayersOnTheRealStartPath:
+    async def test_websocket_start_refuses_a_single_player(self):
+        handler, gs = _handler_game()
+        sockets = _join(gs, ["Alice"])
+        ws = sockets["Alice"]
+        gs.set_admin("Alice")
+        ws.send_json.reset_mock()
+
+        await handler._handle_message(ws, {"type": "admin", "action": "start_game"})
+
+        sent = [c.args[0] for c in ws.send_json.call_args_list]
+        assert any(m.get("type") == "error" for m in sent), sent
+        assert gs.phase == GamePhase.LOBBY
+
+    async def test_websocket_start_allows_the_minimum(self):
+        handler, gs = _handler_game()
+        names = [f"P{i}" for i in range(MIN_PLAYERS)]
+        sockets = _join(gs, names)
+        gs.set_admin(names[0])
+        ws = sockets[names[0]]
+
+        await handler._handle_message(ws, {"type": "admin", "action": "start_game"})
+
+        assert gs.phase == GamePhase.PLAYING


### PR DESCRIPTION
`GameState.start_game()` holds two things — the sabotage grant and the minimum-player floor — and **nothing in production calls it**. Both real start paths go straight to `start_round()`, and the LOBBY → PLAYING flip happens inside `_initialize_round`:

```
server/ws_handlers/admin.py:144    admin_start_game  -> start_round()
server/game_views.py:1246          StartGameplayView -> start_round()
```

`grep -rn "start_game(" custom_components/` returns only the definition. The only callers are unit tests, which is why the suite stayed green while the sabotage power-up from #1822 did nothing in a real game and a game could be started alone.

## Where each piece went, and why not to the same place

**The sabotage grant → `_start_round_locked`, on the LOBBY transition.** That is the one point both start paths pass through. It sits right next to the pre-start hook, which is already there for exactly this reason — its comment says so:

> This lives here rather than in the REST start view because the websocket admin handler calls start_round() directly and bypasses that view entirely — hooking the view fixed one path and left the other broken.

It moved into `_grant_sabotage_tokens()` so `start_game()` and the round path cannot drift apart, and it is idempotent, so being reached twice cannot hand out two tokens.

**The minimum-player floor → the two start paths, not `start_round()`.** This is deliberate and the two are not symmetric. `start_round()` runs for every round of every game, and roughly two thousand existing tests drive it with a single player; putting a floor there would be wrong in substance as well as disruptive — it is a property of *starting* a game, not of starting a round. It also needs somewhere to report the refusal, and only the two entry points have a socket or a response to report it on.

So the websocket handler answers with an error, and the REST view returns 409 `NOT_ENOUGH_PLAYERS`.

## Tests

`tests/unit/test_sabotage_start_path_2497.py`, five tests that deliberately drive the paths a host uses rather than `start_game()`:

- `start_round()` hands out the tokens, and does not when the setting is off.
- **A spent token is not handed back next round** — the grant belongs to the LOBBY transition, not to every round. This is the test that would catch a fix applied one level too high.
- The websocket start refuses a single player and leaves the phase at LOBBY.
- It allows exactly `MIN_PLAYERS`.

## Checks

- `pytest tests/unit` — **2138 passed** (5 new)
- `ruff check` and `ruff format --check` — clean

Closes #2497

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EoSUKDjLvert1VkyyL3RE
