### PR TITLE
fix(security): close the name-based takeover of a disconnected host's session

### DIFF
--- a/custom_components/beatify/game/player_registry.py
+++ b/custom_components/beatify/game/player_registry.py
@@ -11,6 +11,7 @@ from ..const import (
     ERR_GAME_FULL,
     ERR_NAME_INVALID,
     ERR_NAME_TAKEN,
+    ERR_UNAUTHORIZED,
     MAX_NAME_LENGTH,
     MAX_PLAYERS,
     MIN_NAME_LENGTH,
@@ -99,6 +100,7 @@ class PlayerRegistry:
         phase: GamePhase,
         average_score_fn: Callable[[], int],
         current_round: int = 0,
+        admin_claim_authenticated: bool = False,
     ) -> tuple[bool, str | None]:
         """
         Add a player to the game.
@@ -114,6 +116,9 @@ class PlayerRegistry:
             current_round: The round in progress (#1752). Recorded as
                 ``joined_round`` for late joiners so Sudden Death can grant them
                 one grace round (excluded from that round's elimination pool).
+            admin_claim_authenticated: True only when the caller has already
+                verified an HA login for this join (#2501). Required to re-attach
+                to a session whose ``is_admin`` is set — see the fallback below.
 
         Returns:
             (success, error_code) - error_code is None on success
@@ -142,6 +147,22 @@ class PlayerRegistry:
         existing_id = self._name_index.get(name.lower())
         existing_player = self.players.get(existing_id) if existing_id else None
         if existing_player is not None:
+            # #2501 (security): the fallback above matches on a display name,
+            # and the host's name is on the TV for the whole room to read. For
+            # an ordinary player that is a cosmetic risk; for the host it hands
+            # over the ``is_admin`` flag that every admin action is gated on,
+            # and the #998 token check never runs because nothing was declared.
+            # So the fallback stays open for players and closes for a host
+            # session: regaining the host role always goes through HA login,
+            # either as an authenticated ``is_admin`` join or via the
+            # session_id reconnect path, which needs the secret from join_ack.
+            if existing_player.is_admin and not admin_claim_authenticated:
+                _LOGGER.warning(
+                    "Refused name-based reconnect to the host session for %s "
+                    "— no verified Home Assistant login (#2501)",
+                    existing_player.name,
+                )
+                return False, ERR_UNAUTHORIZED
             if not existing_player.connected:
                 existing_player.ws = ws
                 existing_player.connected = True

--- a/custom_components/beatify/game/state_player.py
+++ b/custom_components/beatify/game/state_player.py
@@ -109,11 +109,23 @@ class PlayerLifecycleMixin:
         return self._player_registry.get_average_score()
 
     def add_player(
-        self, name: str, ws: web.WebSocketResponse
+        self,
+        name: str,
+        ws: web.WebSocketResponse,
+        admin_claim_authenticated: bool = False,
     ) -> tuple[bool, str | None]:
-        """Add a player to the game. Delegates to PlayerRegistry."""
+        """Add a player to the game. Delegates to PlayerRegistry.
+
+        ``admin_claim_authenticated`` (#2501) must be True to re-attach to a
+        session that holds the host role; the default refuses it.
+        """
         return self._player_registry.add_player(
-            name, ws, self.phase, self.get_average_score, self.round
+            name,
+            ws,
+            self.phase,
+            self.get_average_score,
+            self.round,
+            admin_claim_authenticated=admin_claim_authenticated,
         )
 
     def get_player(self, name: str) -> PlayerSession | None:

--- a/custom_components/beatify/server/ws_handlers/lifecycle.py
+++ b/custom_components/beatify/server/ws_handlers/lifecycle.py
@@ -91,7 +91,17 @@ async def handle_join(
     # add_player() will take its reconnection path.
     was_existing_player = game_state.get_player(name) is not None
 
-    success, error_code = game_state.add_player(name, ws)
+    # #998: claiming the host role requires a logged-in HA user. The check runs
+    # here, before add_player, because add_player needs the answer too: #2501
+    # closed the hole where a join *without* the flag could re-attach to the
+    # host's session by name and inherit is_admin without ever being asked for
+    # a login. Called once — it logs, and the rejection reasons are diagnostics
+    # for the #1120/#1131 Companion saga, not something to duplicate.
+    authed = _is_ha_authenticated(handler, data, ws) if is_admin else False
+
+    success, error_code = game_state.add_player(
+        name, ws, admin_claim_authenticated=authed
+    )
     _LOGGER.debug(
         "[WS-Debug] join add_player name=%r success=%s error_code=%s was_existing=%s",
         name,
@@ -104,10 +114,8 @@ async def handle_join(
         player = game_state.get_player(name)
 
         if is_admin:
-            # #998: claiming the host role requires a logged-in HA user.
             # Normal players join with no auth — only the admin claim is
             # gated. add_player() already ran, so undo it on rejection.
-            authed = _is_ha_authenticated(handler, data, ws)
             _LOGGER.debug(
                 "[WS-Debug] join is_admin=True _is_ha_authenticated=%s",
                 authed,
@@ -248,6 +256,7 @@ async def handle_join(
             ERR_NAME_INVALID: "Please enter a name",
             ERR_GAME_FULL: "Game is full",
             ERR_GAME_ENDED: "This game has ended",
+            ERR_UNAUTHORIZED: "Home Assistant login required to rejoin as host",
         }
         await ws.send_json(
             {

--- a/tests/unit/test_admin_takeover_2501.py
+++ b/tests/unit/test_admin_takeover_2501.py
@@ -1,0 +1,165 @@
+"""#2501 (security) — the host's session must not be reachable by name.
+
+``add_player`` keeps a deprecated case-insensitive name-based reconnect
+fallback for clients that rejoin without a valid session_id. It re-attaches a
+new socket to the existing ``PlayerSession`` and keeps its ``is_admin`` flag,
+and every admin action is gated on exactly that flag. So a join that carried
+the host's display name — which is on the TV for the whole room to read — and
+*no* ``is_admin`` field inherited the host role without ever meeting the #998
+token check, because nothing was declared for the check to guard.
+
+The fallback stays open for ordinary players and closes for a host session.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.beatify.const import DOMAIN, ERR_UNAUTHORIZED
+from custom_components.beatify.game.state import GameState
+from custom_components.beatify.server.websocket import BeatifyWebSocketHandler
+from tests.conftest import make_game_state, make_songs
+
+_AUTH = "custom_components.beatify.server.ws_handlers.lifecycle._is_ha_authenticated"
+
+
+def _ws() -> AsyncMock:
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+    ws.closed = False
+    ws.close = AsyncMock()
+    return ws
+
+
+def _handler_and_game() -> tuple[BeatifyWebSocketHandler, GameState]:
+    mock_hass = MagicMock()
+    game_state = make_game_state()
+    game_state.create_game(
+        playlists=["test.json"],
+        songs=make_songs(5),
+        media_player="media_player.test",
+        base_url="http://localhost:8123",
+    )
+    mock_hass.data = {DOMAIN: {"game": game_state}}
+    handler = BeatifyWebSocketHandler(mock_hass)
+    handler.debounced_broadcast_state = AsyncMock()
+    handler.broadcast_state = AsyncMock()
+    handler.broadcast = AsyncMock()
+    return handler, game_state
+
+
+def _seat_host(game_state: GameState, name: str = "Host") -> None:
+    """Seat a host and drop their connection, as a network blip would."""
+    game_state.add_player(name, _ws())
+    game_state.set_admin(name)
+    player = game_state.get_player(name)
+    player.connected = False
+    player.ws = None
+
+
+class TestNameBasedTakeoverIsRefused:
+    async def test_join_by_host_name_without_the_flag_is_refused(self):
+        handler, game_state = _handler_and_game()
+        _seat_host(game_state)
+        host_session_id = game_state.get_player("Host").session_id
+
+        attacker = _ws()
+        await handler._handle_message(attacker, {"type": "join", "name": "Host"})
+
+        msg = attacker.send_json.call_args[0][0]
+        assert msg["type"] == "error"
+        assert msg["code"] == ERR_UNAUTHORIZED
+
+        # The attacker holds neither the socket nor the session secret.
+        host = game_state.get_player("Host")
+        assert host.is_admin is True
+        assert host.connected is False
+        assert host.ws is None
+        assert host.session_id == host_session_id
+        assert game_state.get_player_by_ws(attacker) is None
+
+    async def test_a_stale_socket_does_not_open_the_door_either(self):
+        """#646 lets a rejoin through when the old socket is closed but the
+        connected flag has not been cleared yet. That branch is downstream of
+        the guard, so it must not become the way around it."""
+        handler, game_state = _handler_and_game()
+        game_state.add_player("Host", _ws())
+        game_state.set_admin("Host")
+        game_state.get_player("Host").ws.closed = True  # connected still True
+
+        attacker = _ws()
+        await handler._handle_message(attacker, {"type": "join", "name": "Host"})
+
+        assert attacker.send_json.call_args[0][0]["code"] == ERR_UNAUTHORIZED
+        assert game_state.get_player_by_ws(attacker) is None
+
+    async def test_an_unauthenticated_admin_claim_is_still_refused(self):
+        """The declared claim was already gated by #998 — it stays gated, and
+        the refusal must not cost the host their record (#1696)."""
+        handler, game_state = _handler_and_game()
+        _seat_host(game_state)
+        game_state.get_player("Host").score = 4200
+
+        attacker = _ws()
+        await handler._handle_message(
+            attacker, {"type": "join", "name": "Host", "is_admin": True}
+        )
+
+        assert attacker.send_json.call_args[0][0]["code"] == ERR_UNAUTHORIZED
+        assert game_state.get_player("Host").score == 4200
+        assert game_state.get_player("Host").is_admin is True
+
+
+class TestTheDoorsThatMustStayOpen:
+    async def test_an_ordinary_player_still_reconnects_by_name(self):
+        """The fallback exists for old cookies and cleared storage. Closing it
+        for everyone would strand players mid-game."""
+        handler, game_state = _handler_and_game()
+        game_state.add_player("Alice", _ws())
+        alice = game_state.get_player("Alice")
+        alice.score = 1500
+        alice.connected = False
+        alice.ws = None
+
+        rejoin = _ws()
+        await handler._handle_message(rejoin, {"type": "join", "name": "Alice"})
+
+        sent = [c.args[0] for c in rejoin.send_json.call_args_list]
+        assert not [m for m in sent if m.get("type") == "error"], sent
+        assert game_state.get_player("Alice").connected is True
+        assert game_state.get_player("Alice").score == 1500
+
+    async def test_the_real_host_reclaims_with_a_verified_login(self):
+        """With an HA login the name path is open again — that is the whole
+        point: regaining the host role goes through the token check."""
+        handler, game_state = _handler_and_game()
+        _seat_host(game_state)
+
+        host_again = _ws()
+        with patch(_AUTH, return_value=True):
+            await handler._handle_message(
+                host_again,
+                {"type": "join", "name": "Host", "is_admin": True, "ha_token": "t"},
+            )
+
+        sent = [c.args[0] for c in host_again.send_json.call_args_list]
+        assert any(m.get("type") == "join_ack" for m in sent), sent
+        host = game_state.get_player("Host")
+        assert host.is_admin is True
+        assert host.connected is True
+        assert host.ws is host_again
+
+    async def test_the_host_can_still_reconnect_by_session_id(self):
+        """The authoritative path needs the secret from join_ack, so it is
+        unaffected — and it is what a host's own browser actually uses."""
+        handler, game_state = _handler_and_game()
+        _seat_host(game_state)
+        session_id = game_state.get_player("Host").session_id
+
+        host_again = _ws()
+        await handler._handle_message(
+            host_again, {"type": "reconnect", "session_id": session_id}
+        )
+
+        assert game_state.get_player("Host").connected is True
+        assert game_state.get_player("Host").is_admin is True


### PR DESCRIPTION
The deprecated name-based reconnect fallback in `add_player` re-attaches a new socket to an existing `PlayerSession` and keeps its `is_admin` flag. Every admin action is gated on that flag. So `{join, name: "<host>"}` — the host's display name, which is on the TV for the whole room to read, and **no** `is_admin` field — inherited the host role, and the #998 token check never ran, because nothing was declared for it to guard.

## The fix

The fallback exists for old cookies and cleared storage, so closing it outright would strand ordinary players mid-game. It now stays open for players and closes for a host session:

```python
if existing_player.is_admin and not admin_claim_authenticated:
    return False, ERR_UNAUTHORIZED
```

`admin_claim_authenticated` is threaded from `handle_join`, which had to move one thing: `_is_ha_authenticated` used to run *after* `add_player`, so the check that guards the host role ran after the seat had already been taken. It now runs first, once, and both the guard and the existing admin-claim branch read the same answer. Calling it once also matters because it logs its rejection reasons — those are the #1120/#1131 Companion diagnostics, not something to emit twice per join.

That leaves exactly two ways back into the host role, both of which prove something the room cannot read off the TV:

- an `is_admin` join with a verified HA login (#998), or
- the session_id reconnect path, which needs the secret handed out in `join_ack`.

The generic "Join failed" for `UNAUTHORIZED` is replaced with a message that says what to do.

## Tests

`tests/unit/test_admin_takeover_2501.py`, six tests split into the door that closes and the doors that must stay open:

- A join under the host's name without the flag is refused; the host keeps `is_admin`, their socket, session_id and disconnected state, and the attacker's socket maps to no player.
- The #646 stale-socket branch is not a way around the guard — it sits downstream of it.
- An unauthenticated *declared* claim is still refused without costing the host their score (#1696).
- An ordinary player still reconnects by name, score intact.
- The real host reclaims by name with a verified login.
- The host still reconnects by session_id.

Two of these fail on `main` (verified by stashing the fix); the rest are the guards that the fallback did not get closed too far.

## Checks

- `pytest tests/unit` — **2139 passed** (6 new)
- `ruff check` and `ruff format --check` — clean

Closes #2501

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EoSUKDjLvert1VkyyL3RE
