### PR TITLE
chore(release): v4.4.1-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [4.4.1-rc1] - 2026-09-02
+
+A patch number, and it holds: no new mechanic, no new provider. Six defects from a full review of
+the running app, two locale repairs, and five new playlists.
+
+### Fixed
+- **Sabotage tokens were never handed out (#2497).** The grant lived in `GameState.start_game()`,
+  which no production path calls — both the websocket admin handler and the REST start view go
+  straight to `start_round()`. The power-up had been inert since it shipped. The grant moved to the
+  LOBBY-to-first-round transition, the one point both paths pass through. The minimum-player floor
+  travelled the same dead path and now sits in the two entry points, which are the only places that
+  can report the refusal.
+- **A disconnected host's session could be taken over by name (#2501).** The deprecated name-based
+  reconnect fallback re-attached a socket to an existing player and kept its `is_admin` flag, so a
+  join carrying the host's display name — which is on the TV — inherited the host role without ever
+  meeting the token check, because nothing was declared. The fallback stays open for players and
+  now requires a verified Home Assistant login for a host session.
+- **A mid-game reload could reset a player's score (#2508).** Two connection paths start on page
+  load and nothing coordinated them: while the session reconnect was open but unacknowledged,
+  `state.playerName` was null, so the name path tore the socket down with a `leave` — which removes
+  the player server-side — and rejoined from scratch on the room average. The connect decision now
+  has one owner and stands down if the session path already holds a socket.
+- **One Title & Artist attempt per player per round (#2498).** Second attempts were accepted.
+- **The Join button stayed dead after leaving a game (#2506).** Only the join-timeout path ever
+  restored it; leaving, a session takeover, a failed reconnect and an unknown session all returned
+  to the join view and left a disabled button reading "Joining…". The reset now happens where the
+  view is shown, and re-derives the disabled state from the name in the box rather than simply
+  enabling it.
+- **A refused join is shown on the join view (#2499).** `escapeHtml` also escapes quotes, so
+  attribute context is safe (#2505).
+- **The onboarding tour counted "Step 5 of 4" (#2500).** The fifth card arrived with Title & Artist
+  mode; the six `stepOf` strings did not. The number now comes from the card count at render time
+  and the strings carry only the connecting word.
+- **Eight translation keys did not exist (#2507).** `t()` returns the key itself on a miss and never
+  a falsy value, so `t(key) || 'fallback'` is dead code: the steal modal's aria-label ended in
+  `leaderboard.leader` and the admin toast read `admin.alreadyJoined`. Four more left hard-coded
+  English on a German TV. A check now cross-references every literal `data-i18n` and `t('…')`
+  against `en.json`.
+- **The Spanish locale said "ano" where it means "año" in 14 strings (#2519)**, including the
+  reveal screen after every round, and had dropped accents in 118 more.
+
+### Changed
+- **The catalogue reached 66 playlists and 8,403 songs.** Deutschrap Klassiker, Clásicos del Rock
+  en Español, Rock Rioplatense, Vallenato Clásico and Música Colombiana Alegre.
+- **Latin repertoire needs three sources for a release year.** Streaming catalogues and MusicBrainz
+  agreed on 17 of 47 vallenato candidates, and every error ran late, because compilations and
+  reissues dominate. The ISRC registration year is now a third signal, the year at least two agree
+  on wins, and the agreement of two catalogue copies of one reissue is not evidence — two sources
+  dated a Diomedes Díaz and Juancho Rois recording to 2006, twelve years after Rois died.
+
 ## [4.4.0] - 2026-09-01
 
 Released as **4.4.0** rather than 4.3.1: the work shipped as the `v4.3.1-rc1`, `v4.3.1-rc2` and

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -20,5 +20,5 @@
     "num2words==0.5.14"
   ],
   "single_config_entry": true,
-  "version": "4.4.0"
+  "version": "4.4.1-rc1"
 }

--- a/docs/release-notes-v4.4.1-rc1.md
+++ b/docs/release-notes-v4.4.1-rc1.md
@@ -1,0 +1,35 @@
+## 4.4.1-rc1 — Nothing Lost
+
+A round of fixes aimed at the moments where Beatify used to quietly take something away from you — your points, your turn, your way back into the game. Plus five new playlists, all of them Spanish-language.
+
+### 🎭 The sabotage token actually arrives
+
+Turn sabotage on and every player now gets their one token at the start of the game. Until now the setting was there, the button was there, and the token never reached anybody.
+
+### 🔄 A reload no longer costs you your score
+
+If your phone reloaded in the middle of a game, you could come back as a brand-new player on the room average with your points gone, while the room watched your name drop to the bottom. Your seat is now held by one place only, and you come back as yourself.
+
+### 🚪 Leaving, and getting back in
+
+The Join button used to stay greyed out on "Joining…" after you left a game — the only way back was to change a letter of your own name. It works now. And when the game turns a join down, because the name is taken or the room is full, it says so on the join screen instead of leaving you watching a spinner.
+
+Three smaller ones in the same corner: Title & Artist now takes one guess per player per round, a game needs two players before it will start, and only the host can take the host role back.
+
+### 🖥️ Screens that read right
+
+The onboarding tour counted "Step 5 of 4". A German or Spanish party found a few stubbornly English labels on the TV. Spanish had lost its accents in a hundred places — including the word for *year*, which appears after every single round. All corrected. Every Beatify page now shows the same icon in the browser tab too, thanks to **@slmingol**.
+
+### 🎉 Five new playlists
+
+**Deutschrap Klassiker** · **Clásicos del Rock en Español** · **Rock Rioplatense** · **Vallenato Clásico** · **Música Colombiana Alegre** — German rap from 1995 on, and four lists that take the catalogue across Spain, Argentina, Uruguay and the Colombian coast.
+
+### 🙏 Thank you
+
+**@slmingol** for the favicons, and for the nudge to finish the job on every page.
+
+---
+
+**66 playlists · 8,403 songs · 5 music platforms · 5 languages**
+
+[Report a Bug](https://github.com/mholzi/beatify/issues) · [Discussions](https://github.com/mholzi/beatify/discussions) · [Full Changelog](https://github.com/mholzi/beatify/blob/main/CHANGELOG.md)


### PR DESCRIPTION
Nothing Lost.

A patch number, and it holds: no new mechanic, no new provider. Six defects from a full review of the running app, two locale repairs, and five new playlists.

Version bump, changelog section, and the release notes under `docs/` — force-added, because `docs/` is gitignored and only the release notes are tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EoSUKDjLvert1VkyyL3RE