### PR TITLE
fix: keep the Cloudflare worker source pure ASCII (#2526)

### DIFF
--- a/cf-workers/beatify-api.js
+++ b/cf-workers/beatify-api.js
@@ -1,3 +1,19 @@
+// Beatify Cloudflare Worker (#2526: keep this file pure ASCII).
+//
+// This worker is deployed by copying the file into the Cloudflare dashboard.
+// That copy path has been round-tripped through a terminal-style buffer at
+// least once, which read the UTF-8 bytes as Latin-1 and then wrote the
+// resulting control characters back out in caret notation. Every non-ASCII
+// literal in the source was destroyed by it, so the issues this worker files
+// arrived titled "data: wrong year reported \xc3\xa2^@^T ..." instead of
+// carrying an em dash.
+//
+// The fix is structural: no byte in this file may be >= 0x80. Characters that
+// have to reach GitHub (em dash, en dash, the zero-width spaces that break
+// @mentions, emoji) are written as \u escapes, which are themselves ASCII and
+// therefore survive any such round trip untouched. The runtime output is
+// unchanged. tests/unit/test_worker_ascii_only_2526.py enforces the rule.
+
 async function handleReportData(request, env, corsHeaders) {
   let body;
   try {
@@ -9,11 +25,11 @@ async function handleReportData(request, env, corsHeaders) {
   if (!artist || !title) {
     return Response.json({ success: false, error: 'MISSING_FIELDS' }, { status: 400, headers: corsHeaders });
   }
-  const issueTitle = `data: wrong year reported — ${artist} – ${title}`;
+  const issueTitle = `data: wrong year reported \u2014 ${artist} \u2013 ${title}`;
   const issueBody = [
     '## Wrong Year Report', '', 'A player flagged incorrect data during a game.', '',
     '| Field | Value |', '|-------|-------|',
-    `| **Song** | ${artist} – ${title} |`,
+    `| **Song** | ${artist} \u2013 ${title} |`,
     `| **Year in playlist** | ${year ?? '?'} |`,
     `| **Playlist file** | \`${playlist_file}\` |`,
     `| **Reported by** | ${reporter} |`, '',
@@ -43,12 +59,12 @@ async function handleReportData(request, env, corsHeaders) {
 
 
 // ===========================================================================
-// Quizify community-pack submission (additive — Beatify logic above/below is
+// Quizify community-pack submission (additive - Beatify logic above/below is
 // untouched). Mounted on any path starting with `/quizify` (e.g.
 // `/quizify/submit-pack`). Self-contained: own secret gate, own GitHub repo,
 // own (no-)CORS policy. Ported from the standalone quizify-api worker so both
 // HA integrations can share one deployed Worker.
-//   Secrets:  SHARED_SECRET        (REQUIRED — fail-closed gate, #292/#316)
+//   Secrets:  SHARED_SECRET        (REQUIRED - fail-closed gate, #292/#316)
 //             QUIZIFY_GITHUB_PAT   (Issues R+W on mholzi/quizify; falls back to
 //                                   GITHUB_PAT if that token also covers quizify)
 // ===========================================================================
@@ -77,7 +93,7 @@ function qzTimingSafeEqualStr(a, b) {
   return crypto.subtle.timingSafeEqual(bufA, bufB);
 }
 
-/** Validate the pack against the #179 schema — mirrors
+/** Validate the pack against the #179 schema - mirrors
  *  server/pack_submission.py::validate_pack exactly. */
 function qzValidatePack(pack) {
   if (!pack || typeof pack !== 'object' || Array.isArray(pack)) return 'Top-level JSON must be an object.';
@@ -118,14 +134,14 @@ function qzEsc(s) {
     .replace(/[\r\n]+/g, ' ')
     .replace(/[`|\\]/g, '\\$&')
     .replace(/[[\]()!]/g, '\\$&')
-    .replace(/@/g, '@​')
-    .replace(/#(?=\d)/g, '#​')
+    .replace(/@/g, '@\u200B')
+    .replace(/#(?=\d)/g, '#\u200B')
     .slice(0, 500);
 }
 
 function qzBuildIssue(pack) {
   const qs = pack.questions || [];
-  const title = `pack: ${qzEsc(pack.name)} (${qzEsc(pack.language || 'de')}) — ${qs.length} questions`;
+  const title = `pack: ${qzEsc(pack.name)} (${qzEsc(pack.language || 'de')}) \u2014 ${qs.length} questions`;
   const lines = [
     '## Community pack submission', '',
     'A host submitted a community question pack from the in-app composer.', '',
@@ -138,7 +154,7 @@ function qzBuildIssue(pack) {
   qs.forEach((q, i) => {
     lines.push(`**${i + 1}. ${qzEsc(q.question)}**`);
     (q.answers || []).forEach((a) => {
-      lines.push(`- ${a && a.correct === true ? '✅ ' : ''}${qzEsc(a && a.text)}`);
+      lines.push(`- ${a && a.correct === true ? '\u2705 ' : ''}${qzEsc(a && a.text)}`);
     });
     lines.push('');
   });
@@ -151,7 +167,7 @@ async function handleQuizifySubmit(request, env) {
   if (!pat) {
     return qzJsonError('GITHUB_ERROR', 'Worker is missing its GitHub PAT secret.', 500);
   }
-  // Shared-secret gate — FAIL CLOSED (#292/#316): reject 401 if SHARED_SECRET is
+  // Shared-secret gate - FAIL CLOSED (#292/#316): reject 401 if SHARED_SECRET is
   // unset OR the X-Quizify-Secret header is missing / doesn't match. The worker
   // must never be an open, unauthenticated proxy that files issues with the PAT.
   if (!env.SHARED_SECRET) {
@@ -195,8 +211,8 @@ async function handleQuizifySubmit(request, env) {
 
 export default {
   async fetch(request, env) {
-    // Quizify community-pack route (additive). Fully self-contained — owns its
-    // method guard, secret gate and (no-)CORS — so every non-/quizify request
+    // Quizify community-pack route (additive). Fully self-contained - owns its
+    // method guard, secret gate and (no-)CORS - so every non-/quizify request
     // falls through to the Beatify handling below byte-for-byte as before.
     const qzUrl = new URL(request.url);
     if (qzUrl.pathname.startsWith('/quizify')) {
@@ -275,7 +291,7 @@ export default {
       }
 
       // Create GitHub issue
-      const issueBody = `## 🎵 Playlist Request
+      const issueBody = `## \u{1F3B5} Playlist Request
 
 **Playlist:** ${playlist_name}
 **Spotify URL:** ${spotify_url}
@@ -307,7 +323,7 @@ ${thumbnail_url ? `![Playlist Cover](${thumbnail_url})` : ''}
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          title: `🎵 Playlist Request: ${playlist_name}`,
+          title: `\u{1F3B5} Playlist Request: ${playlist_name}`,
           body: issueBody,
           labels: ['playlist-request'],
         }),

--- a/tests/unit/test_worker_ascii_only_2526.py
+++ b/tests/unit/test_worker_ascii_only_2526.py
@@ -1,0 +1,56 @@
+"""The Cloudflare worker source must stay pure ASCII (#2526).
+
+``cf-workers/beatify-api.js`` is deployed by copying the file into the
+Cloudflare dashboard rather than from a checkout. That copy path was at some
+point round-tripped through a terminal-style buffer: the UTF-8 bytes were read
+as Latin-1 and the resulting control characters written back in caret notation.
+Every non-ASCII literal in the deployed worker was destroyed by it, so the
+issues the worker files landed as
+``data: wrong year reported \xc3\xa2^@^T Kendrick Lamar ...`` instead of
+carrying an em dash -- a garbled, unsearchable public issue list.
+
+Escaping the characters (``\\u2014`` instead of a literal em dash) makes the
+source immune: the escape itself is ASCII, so no Latin-1 round trip can touch
+it, while the runtime output is byte-identical. These tests keep the file that
+way.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+WORKER = Path(__file__).resolve().parents[2] / "cf-workers" / "beatify-api.js"
+
+
+def test_worker_source_exists() -> None:
+    assert WORKER.is_file(), f"worker source missing at {WORKER}"
+
+
+def test_worker_source_is_pure_ascii() -> None:
+    """No byte >= 0x80 anywhere in the worker source.
+
+    Use ``\\uXXXX`` / ``\\u{XXXXX}`` escapes for characters that must reach
+    GitHub, and plain ASCII punctuation in comments.
+    """
+    data = WORKER.read_bytes()
+    offenders = [
+        (line_no, line.decode("utf-8", "replace"))
+        for line_no, line in enumerate(data.split(b"\n"), start=1)
+        if any(byte >= 0x80 for byte in line)
+    ]
+    assert not offenders, (
+        "non-ASCII bytes in cf-workers/beatify-api.js -- the deploy copy path "
+        "mangles them (#2526). Write them as \\u escapes instead:\n"
+        + "\n".join(f"  line {n}: {text}" for n, text in offenders)
+    )
+
+
+def test_generated_issue_titles_keep_their_escaped_characters() -> None:
+    """The auto-filed title templates still carry their dashes/emoji, escaped."""
+    src = WORKER.read_text(encoding="ascii")
+    assert "`data: wrong year reported \\u2014 ${artist} \\u2013 ${title}`" in src, (
+        "the wrong-year title lost its escaped em/en dash"
+    )
+    assert "title: `\\u{1F3B5} Playlist Request: ${playlist_name}`" in src, (
+        "the playlist-request title lost its escaped music note"
+    )


### PR DESCRIPTION
Closes #2526

## What was wrong

Every issue filed by the in-game data reporter and by the playlist-request button carried a mangled title: `data: wrong year reported â^@^T Kendrick Lamar â^@^S Alright` instead of an em dash, and a garbled music note on the playlist funnel.

The repo source was clean UTF-8, so the damage is in the deploy path. `cf-workers/beatify-api.js` is copied into the Cloudflare dashboard by hand rather than deployed from a checkout, and that copy was round-tripped through a terminal-style buffer: the UTF-8 bytes were read as Latin-1 (`e2 80 94` → `â` + U+0080 + U+0094) and the resulting control characters were then written back in **caret notation** as the literal ASCII characters `^@` and `^T` — which is why the stored title contains `5e 40`, not a control byte.

Only literals in the source file are affected. `artist` and `title` come from the request body at runtime and arrive intact, which is exactly why the dashes are the only mangled part of those titles.

## The fix

Structural rather than a repair pass: **no byte in the worker source may be `>= 0x80` any more.** Every character that has to reach GitHub is written as a `\u` escape — em dash, en dash, the two zero-width spaces that break `@mentions`/`#refs` in `qzEsc`, the check mark, and the music note. The escapes are themselves ASCII, so no Latin-1 round trip can touch them. Em dashes inside comments become plain hyphens.

`tests/unit/test_worker_ascii_only_2526.py` enforces the invariant so the next edit cannot silently reintroduce a raw non-ASCII literal.

## Readiness assessment
- [x] Ready to merge
- [ ] Borderline — see notes
- [ ] Not ready — needs human review

**Honest summary:** The runtime output is byte-identical — each changed string-literal line was resolved back and compared against `origin/main`, all eight match exactly. Nothing about the request handling, the secret gate or the GitHub calls changed. What this PR cannot do is fix the *deployed* worker: merging it does not redeploy anything, so the titles keep coming out mangled until the worker is redeployed from this file.

## Test plan
- `pytest tests/unit/ tests/integration/` → 2169 passed, 2 skipped (includes the 3 new guardrail tests)
- `ruff check .` and `ruff format --check .` → clean
- `npm run lint` → 0 errors, `npm run build:check` → all 18 artifacts match, `npm test` → 708 passed
- `node --check cf-workers/beatify-api.js` → parses
- Manual, after deploy: redeploy the worker from this file, then file one wrong-year report for a song whose artist or title contains a dash and confirm the created issue title shows a real em/en dash. Same for one playlist request (music-note prefix).

## Risk assessment
- **Blast radius:** `cf-workers/beatify-api.js` only (string literals + comments), plus one new test file. No Python, no frontend, no `custom_components/beatify/www/**` — the min.js / `?v=` / `sw.js CACHE_VERSION` guardrail does not apply here.
- **What could go wrong:** `\u{1F3B5}` is an ES6 code-point escape; it parses under the Workers V8 runtime and under `node --check`, but an older bundler would reject it. The `qzEsc` zero-width spaces are a security control (mention-breaking, #305) — they are unchanged in value, but they now depend on the escape being correct rather than on an invisible character being preserved, which is the safer of the two.
- **What I did NOT test:** anything against the live Cloudflare deployment — no deploy was performed and no real issue was filed. The six already-mangled titles (#2388, #2398, #2401, #2404, #2480, #2525) are left untouched.

🤖 Auto-generated by issue-triage routine