### PR TITLE
chore(playlists): youtube backfill — +14 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/community/disney-latino.json
+++ b/custom_components/beatify/playlists/community/disney-latino.json
@@ -1,6 +1,6 @@
 {
   "name": "Disney Latino",
-  "version": "0.3",
+  "version": "0.4",
   "tags": [
     "disney",
     "movies",
@@ -909,7 +909,8 @@
         "Carlos Vives",
         "Eduardo Tejedo"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (1994)."
+      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (1994).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=5qYjzNv-WoA"
     },
     {
       "year": 2016,

--- a/custom_components/beatify/playlists/movies-100-greatest-themes.json
+++ b/custom_components/beatify/playlists/movies-100-greatest-themes.json
@@ -1,6 +1,6 @@
 {
   "name": "Movie & TV Soundtracks 🎬",
-  "version": "1.33",
+  "version": "1.34",
   "tags": [
     "movies",
     "soundtrack",
@@ -8108,7 +8108,8 @@
       "fun_fact_es": "Barry ya había escrito cinco bandas sonoras de Bond cuando compuso esta, que le valió su cuarto Óscar. El tema toma su título de la primera frase hablada de la película.",
       "fun_fact_fr": "Barry avait déjà écrit cinq partitions de Bond quand il a composé celle-ci, qui lui a valu son quatrième Oscar. Le thème tire son titre de la première réplique du film.",
       "fun_fact_nl": "Barry had al vijf Bond-partituren geschreven toen hij deze componeerde, die hem zijn vierde Oscar opleverde. Het thema ontleent zijn titel aan de eerste gesproken zin van de film.",
-      "fun_fact_it": "Barry aveva già scritto cinque partiture di Bond quando compose questa, che gli valse il quarto Oscar. Il tema prende il titolo dalla prima battuta del film."
+      "fun_fact_it": "Barry aveva già scritto cinque partiture di Bond quando compose questa, che gli valse il quarto Oscar. Il tema prende il titolo dalla prima battuta del film.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=OCaIFh9oJCU"
     },
     {
       "artist": "Berlin",
@@ -8127,7 +8128,8 @@
       "fun_fact_es": "Giorgio Moroder y Tom Whitlock escribieron el tema de amor de Top Gun, y ganó el Óscar por delante de Danger Zone de Kenny Loggins, de la misma película.",
       "fun_fact_fr": "Giorgio Moroder et Tom Whitlock ont écrit le thème d'amour de Top Gun, qui a remporté l'Oscar devant Danger Zone de Kenny Loggins, tiré du même film.",
       "fun_fact_nl": "Giorgio Moroder en Tom Whitlock schreven het liefdesthema voor Top Gun, en het won de Oscar vóór Danger Zone van Kenny Loggins uit dezelfde film.",
-      "fun_fact_it": "Giorgio Moroder e Tom Whitlock scrissero il tema d'amore di Top Gun, che vinse l'Oscar davanti a Danger Zone di Kenny Loggins, dallo stesso film."
+      "fun_fact_it": "Giorgio Moroder e Tom Whitlock scrissero il tema d'amore di Top Gun, che vinse l'Oscar davanti a Danger Zone di Kenny Loggins, dallo stesso film.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Bx51eegLTY8"
     },
     {
       "artist": "Queen",
@@ -8146,7 +8148,8 @@
       "fun_fact_es": "Escrita para Los inmortales, una película cuya música Queen firmó casi por completo. La frase sobre que solo puede quedar uno viene del filme y le ha sobrevivido como dicho.",
       "fun_fact_fr": "Écrite pour Highlander, un film dont Queen a signé presque toute la musique. La réplique disant qu'il ne peut en rester qu'un vient du film et lui a survécu comme expression.",
       "fun_fact_nl": "Geschreven voor Highlander, een film die Queen bijna volledig van muziek voorzag. De regel dat er maar één kan zijn komt uit de film en heeft hem als gezegde overleefd.",
-      "fun_fact_it": "Scritta per Highlander, film che i Queen musicarono quasi per intero. La battuta secondo cui ne può restare soltanto uno viene dal film e gli è sopravvissuta come modo di dire."
+      "fun_fact_it": "Scritta per Highlander, film che i Queen musicarono quasi per intero. La battuta secondo cui ne può restare soltanto uno viene dal film e gli è sopravvissuta come modo di dire.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VEJ8lpCQbyw"
     },
     {
       "artist": "Danny Elfman",
@@ -8165,7 +8168,8 @@
       "fun_fact_es": "La marcha de Elfman para el Batman de Tim Burton pasó directamente a la serie animada posterior, por lo que toda una generación la conoce por televisión y no por el cine.",
       "fun_fact_fr": "La marche d'Elfman pour le Batman de Tim Burton est passée telle quelle dans la série animée qui a suivi, ce qui fait que toute une génération la connaît par la télévision et non par le cinéma.",
       "fun_fact_nl": "Elfmans mars voor Tim Burtons Batman ging rechtstreeks over in de daaropvolgende tekenfilmserie, waardoor een hele generatie hem van televisie kent en niet uit de bioscoop.",
-      "fun_fact_it": "La marcia di Elfman per il Batman di Tim Burton passò direttamente nella serie animata successiva, ed è per questo che un'intera generazione la conosce dalla televisione e non dal cinema."
+      "fun_fact_it": "La marcia di Elfman per il Batman di Tim Burton passò direttamente nella serie animata successiva, ed è per questo che un'intera generazione la conosce dalla televisione e non dal cinema.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YoaU3kRFvLg"
     },
     {
       "artist": "DJ Jazzy Jeff & The Fresh Prince",
@@ -8184,7 +8188,8 @@
       "fun_fact_es": "La sintonía cuenta la premisa de la serie en menos de un minuto, y esa era la idea: unos créditos iniciales que son también la exposición. Will Smith rapea su propia historia previa.",
       "fun_fact_fr": "Le générique raconte le principe de la série en moins d'une minute, et c'était l'intention : un générique qui fait aussi office d'exposition. Will Smith rappe sa propre histoire.",
       "fun_fact_nl": "De tune vertelt de premisse van de serie in minder dan een minuut, en dat was de bedoeling: een titelsequentie die tegelijk de voorgeschiedenis is. Will Smith rapt zijn eigen verhaal.",
-      "fun_fact_it": "La sigla racconta la premessa della serie in meno di un minuto, ed era proprio l'intento: titoli di testa che sono anche l'antefatto. Will Smith rappa il proprio passato."
+      "fun_fact_it": "La sigla racconta la premessa della serie in meno di un minuto, ed era proprio l'intento: titoli di testa che sono anche l'antefatto. Will Smith rappa il proprio passato.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Kr0tTbTbmVA"
     },
     {
       "artist": "Angelo Badalamenti",
@@ -8241,7 +8246,8 @@
       "fun_fact_es": "Piovani ganó el Óscar por una partitura que ha de ser lo bastante ligera para el juego de un padre y lo bastante grave para lo que ese juego esconde.",
       "fun_fact_fr": "Piovani a remporté l'Oscar pour une partition qui doit être assez légère pour le jeu d'un père et assez lourde pour ce que ce jeu dissimule.",
       "fun_fact_nl": "Piovani won de Oscar voor muziek die licht genoeg moet zijn voor het spel van een vader en zwaar genoeg voor wat dat spel verbergt.",
-      "fun_fact_it": "Piovani vinse l'Oscar per una partitura che deve essere abbastanza leggera per il gioco di un padre e abbastanza grave per ciò che quel gioco nasconde."
+      "fun_fact_it": "Piovani vinse l'Oscar per una partitura che deve essere abbastanza leggera per il gioco di un padre e abbastanza grave per ciò che quel gioco nasconde.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jV3im7nkIFs"
     },
     {
       "artist": "Hans Zimmer",
@@ -8260,7 +8266,8 @@
       "fun_fact_es": "Lisa Gerrard canta la pieza final de Gladiator en ningún idioma: sílabas elegidas por su sonido y no por su significado, un método que llevaba años usando con Dead Can Dance.",
       "fun_fact_fr": "Lisa Gerrard chante le morceau final de Gladiator dans aucune langue — des syllabes choisies pour leur son et non leur sens, une méthode qu'elle pratiquait depuis des années avec Dead Can Dance.",
       "fun_fact_nl": "Lisa Gerrard zingt het slotstuk van Gladiator in geen enkele taal — lettergrepen gekozen om hun klank en niet om hun betekenis, een methode die ze jarenlang bij Dead Can Dance gebruikte.",
-      "fun_fact_it": "Lisa Gerrard canta il brano finale del Gladiatore in nessuna lingua: sillabe scelte per il suono e non per il significato, un metodo che usava da anni con i Dead Can Dance."
+      "fun_fact_it": "Lisa Gerrard canta il brano finale del Gladiatore in nessuna lingua: sillabe scelte per il suono e non per il significato, un metodo che usava da anni con i Dead Can Dance.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mQQKZ5cgybU"
     },
     {
       "artist": "Kyle Dixon & Michael Stein",
@@ -8279,7 +8286,8 @@
       "fun_fact_es": "Los dos tocaban en una banda de sintetizadores en Austin cuando los hermanos Duffer les pidieron una cabecera. El arpegio es un eco deliberado de las partituras de John Carpenter de principios de los ochenta.",
       "fun_fact_fr": "Tous deux jouaient dans un groupe de synthétiseurs à Austin quand les frères Duffer leur ont demandé un générique. L'arpège est un écho délibéré des partitions de John Carpenter du début des années quatre-vingt.",
       "fun_fact_nl": "De twee speelden in een synthesizerband in Austin toen de gebroeders Duffer hun om een titelsequentie vroegen. Het arpeggio is een bewuste echo van John Carpenters muziek uit de vroege jaren tachtig.",
-      "fun_fact_it": "I due suonavano in una band di sintetizzatori ad Austin quando i fratelli Duffer chiesero loro una sigla. L'arpeggio è un'eco voluta delle partiture di John Carpenter dei primi anni Ottanta."
+      "fun_fact_it": "I due suonavano in una band di sintetizzatori ad Austin quando i fratelli Duffer chiesero loro una sigla. L'arpeggio è un'eco voluta delle partiture di John Carpenter dei primi anni Ottanta.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Ha2OcL_0gtM"
     },
     {
       "artist": "Kendrick Lamar",
@@ -8317,7 +8325,8 @@
       "fun_fact_es": "Una melodía popular griega tocada en una Fender a una velocidad que nadie había intentado. Tarantino la puso bajo los títulos de Pulp Fiction tres décadas después y le dio una segunda vida.",
       "fun_fact_fr": "Une mélodie populaire grecque jouée sur une Fender à une vitesse que personne n'avait tentée. Trente ans plus tard, Tarantino l'a placée sur le générique de Pulp Fiction et lui a offert une seconde vie.",
       "fun_fact_nl": "Een Griekse volksmelodie op een Fender gespeeld in een tempo dat niemand eerder had geprobeerd. Tarantino zette hem drie decennia later onder de titels van Pulp Fiction en gaf hem een tweede leven.",
-      "fun_fact_it": "Una melodia popolare greca suonata su una Fender a una velocità che nessuno aveva tentato. Tarantino la mise sotto i titoli di testa di Pulp Fiction trent'anni dopo, dandole una seconda vita."
+      "fun_fact_it": "Una melodia popolare greca suonata su una Fender a una velocità che nessuno aveva tentato. Tarantino la mise sotto i titoli di testa di Pulp Fiction trent'anni dopo, dandole una seconda vita.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ZIU0RMV_II8"
     },
     {
       "artist": "Ennio Morricone",
@@ -8507,7 +8516,8 @@
       "fun_fact_es": "Escrita por una banda jamaicana de reggae años antes de que la serie documental estadounidense Cops la adoptara. La pregunta del estribillo es hoy inseparable de unas imágenes ajenas a la banda y a la canción.",
       "fun_fact_fr": "Écrite par un groupe de reggae jamaïcain des années avant que la série documentaire américaine Cops ne l'adopte. La question du refrain est aujourd'hui indissociable d'images étrangères au groupe comme à la chanson.",
       "fun_fact_nl": "Geschreven door een Jamaicaanse reggaeband, jaren voordat de Amerikaanse documentaireserie Cops het overnam. De vraag in het refrein is nu onlosmakelijk verbonden met beelden waar band noch lied iets mee te maken had.",
-      "fun_fact_it": "Scritta da una band reggae giamaicana anni prima che la serie documentaria americana Cops la adottasse. La domanda del ritornello è oggi inseparabile da immagini estranee sia al gruppo sia alla canzone."
+      "fun_fact_it": "Scritta da una band reggae giamaicana anni prima che la serie documentaria americana Cops la adottasse. La domanda del ritornello è oggi inseparabile da immagini estranee sia al gruppo sia alla canzone.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Zd68AthoNIw"
     },
     {
       "artist": "Madonna",
@@ -8640,7 +8650,8 @@
       "fun_fact_es": "Quién la escribió se discutió en los tribunales: el crédito es de Monty Norman, John Barry hizo el arreglo que todos conocen, y Vic Flick tocó la línea de guitarra por seis libras de caché.",
       "fun_fact_fr": "La paternité s'est réglée au tribunal : le crédit revient à Monty Norman, John Barry a signé l'arrangement que tout le monde connaît, et Vic Flick a joué la ligne de guitare pour six livres de cachet.",
       "fun_fact_nl": "Wie het schreef is voor de rechter uitgevochten: Monty Norman heeft de credit, John Barry maakte het arrangement dat iedereen kent, en Vic Flick speelde de gitaarlijn voor zes pond sessiegeld.",
-      "fun_fact_it": "Chi l'abbia scritta si è discusso in tribunale: il credito è di Monty Norman, John Barry firmò l'arrangiamento che tutti conoscono, e Vic Flick suonò la linea di chitarra per sei sterline di cachet."
+      "fun_fact_it": "Chi l'abbia scritta si è discusso in tribunale: il credito è di Monty Norman, John Barry firmò l'arrangiamento che tutti conoscono, e Vic Flick suonò la linea di chitarra per sei sterline di cachet.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=tCr5BhPqUjk"
     },
     {
       "artist": "Jimi Jamison",
@@ -8849,7 +8860,8 @@
       "fun_fact_es": "Delerue compuso la música original de la película de Oliver Stone, aunque la que casi todos recuerdan es prestada: el Adagio para cuerdas de Samuel Barber, escrito medio siglo antes. Delerue llevaba ya dos décadas poniendo música a la Nouvelle Vague de Truffaut y Godard.",
       "fun_fact_fr": "Delerue a composé la musique originale du film d'Oliver Stone, alors que celle dont tout le monde se souvient est empruntée : l'Adagio pour cordes de Samuel Barber, écrit un demi-siècle plus tôt. Delerue avait déjà passé vingt ans à mettre la Nouvelle Vague en musique pour Truffaut et Godard.",
       "fun_fact_nl": "Delerue schreef de originele muziek voor de film van Oliver Stone, terwijl de muziek die de meesten zich herinneren geleend is: Samuel Barbers Adagio for Strings, een halve eeuw ouder. Delerue had toen al twintig jaar de Nouvelle Vague getoonzet voor Truffaut en Godard.",
-      "fun_fact_it": "Delerue scrisse la musica originale del film di Oliver Stone, anche se quella che quasi tutti ricordano è presa a prestito: l'Adagio per archi di Samuel Barber, di mezzo secolo prima. Delerue aveva già alle spalle vent'anni di musiche per la Nouvelle Vague di Truffaut e Godard."
+      "fun_fact_it": "Delerue scrisse la musica originale del film di Oliver Stone, anche se quella che quasi tutti ricordano è presa a prestito: l'Adagio per archi di Samuel Barber, di mezzo secolo prima. Delerue aveva già alle spalle vent'anni di musiche per la Nouvelle Vague di Truffaut e Godard.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=m_BJlyfIGf0"
     },
     {
       "artist": "Ramin Djawadi",
@@ -8984,7 +8996,8 @@
       "fun_fact_es": "Swayze escribió la canción años antes de Dirty Dancing para otra película, la cantó él mismo y fue el único éxito de su carrera como actor.",
       "fun_fact_fr": "Swayze a écrit la chanson des années avant Dirty Dancing pour un autre film, l'a chantée lui-même, et ce fut l'unique tube de sa carrière d'acteur.",
       "fun_fact_nl": "Swayze schreef het nummer jaren voor Dirty Dancing voor een andere film, zong het zelf, en het bleef de enige hit van zijn acteercarrière.",
-      "fun_fact_it": "Swayze scrisse la canzone anni prima di Dirty Dancing per un altro film, la cantò lui stesso, e restò l'unico successo della sua carriera di attore."
+      "fun_fact_it": "Swayze scrisse la canzone anni prima di Dirty Dancing per un altro film, la cantò lui stesso, e restò l'unico successo della sua carriera di attore.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lU9p1WRfA9w"
     },
     {
       "year": 1982,


### PR DESCRIPTION
A `provider-uri-backfill` run, driven automatically by `com.beatify.youtube-backfill`.

- `disney-latino` YouTube 0 -> **1**/54
- `movies-100-greatest-themes` YouTube 169 -> **182**/257

**Draft on purpose** — merged only once the maintainer approves.