### PR TITLE
fix: answer NO_PLAYABLE_SONGS instead of a bare 500 (#2530)

### DIFF
--- a/custom_components/beatify/game/state_setup.py
+++ b/custom_components/beatify/game/state_setup.py
@@ -93,6 +93,21 @@ from .playlist import PlaylistManager
 _LOGGER = logging.getLogger(__name__)
 
 
+class NoPlayableSongsError(ValueError):
+    """The chosen provider has no playable song in the selected playlist(s).
+
+    #2530: ``create_game`` raises ``ValueError`` for two unrelated reasons — an
+    out-of-range round duration and this one. The HTTP layer has a distinct
+    error code for each (``INVALID_REQUEST`` / ``NO_PLAYABLE_SONGS``) and cannot
+    tell them apart from a bare ``ValueError`` without matching on the message
+    text, which a translation or a reword would silently break.
+
+    It subclasses ``ValueError`` deliberately: every existing caller and test
+    that expects a ``ValueError`` from ``create_game`` keeps working, so this
+    adds a distinction without changing the contract.
+    """
+
+
 class GameSetupMixin:
     """Game-setup (create / reset / end / rematch) behavior for :class:`GameState`.
 
@@ -202,7 +217,7 @@ class GameSetupMixin:
         # #709: if the chosen provider has zero playable songs, fail fast with
         # a clear error rather than silently starting a game that will stall.
         if not playlist_manager.has_playable_songs():
-            raise ValueError(
+            raise NoPlayableSongsError(
                 f"No playable songs for provider '{provider}' in the selected "
                 f"playlist(s). Pick a different playlist or provider."
             )

--- a/custom_components/beatify/server/game_views.py
+++ b/custom_components/beatify/server/game_views.py
@@ -40,6 +40,7 @@ from custom_components.beatify.game.playlist import (
     async_discover_playlists_detailed,
 )
 from custom_components.beatify.game.state import GamePhase, GameState
+from custom_components.beatify.game.state_setup import NoPlayableSongsError
 from custom_components.beatify.server.ws_handlers._helpers import finalize_and_end
 from custom_components.beatify.server.base import (
     BeatifyAdminView,
@@ -483,7 +484,24 @@ class StartGameView(RateLimitMixin, HomeAssistantView):
             body.get("round_duration"),
         )
 
-        result = game_state.create_game(**create_kwargs)
+        # #2530: create_game validates before it mutates (#1378) and signals a
+        # rejection by raising. Uncaught, that ValueError left aiohttp to answer
+        # with a bare 500 "Server got itself in trouble" — a response carrying no
+        # code at all, which defeats the whole point of #2294 (every create-game
+        # rejection gets its own code so the client can say WHICH one fired) and
+        # sends the i18n lookup in errors.<CODE> looking for nothing.
+        try:
+            result = game_state.create_game(**create_kwargs)
+        except NoPlayableSongsError as err:
+            return _json_error(str(err), 400, code=ERR_NO_PLAYABLE_SONGS)
+        except ValueError as err:
+            # The only other raise in create_game is the round-duration range
+            # check, which the block above already rejects with its own code —
+            # so this arm is a backstop for a future validation, not dead code.
+            # It must not borrow NO_PLAYABLE_SONGS: a wrong code is worse than a
+            # generic one, because the client renders it as a specific sentence.
+            _LOGGER.warning("create_game rejected the request: %s", err)
+            return _json_error(str(err), 400, code="INVALID_REQUEST")
 
         # Crate Digger: install the pre-start hook so the songs
         # are regenerated from the CURRENT settings on the LOBBY -> first

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+from custom_components.beatify.const import DOMAIN
 from custom_components.beatify.game.player import PlayerSession
 from custom_components.beatify.game.state import GameState
+from custom_components.beatify.server.views import StartGameView
 
 
 def make_player(name: str = "Alice", score: int = 0, **kwargs) -> PlayerSession:
@@ -30,3 +36,102 @@ def make_songs(n: int = 5) -> list[dict]:
         }
         for i in range(n)
     ]
+
+
+# ---------------------------------------------------------------------------
+# start-game harness (#2530): moved here from test_start_game_view.py so more
+# than one module can drive a real create_game. Importing a fixture across test
+# modules works but reads as a redefinition to the linter, and the repo's own
+# convention for shared test scaffolding is conftest (see make_game_state /
+# make_songs in tests/conftest.py). Behaviour is unchanged.
+# ---------------------------------------------------------------------------
+VALID_START_GAME_PLAYLIST = json.dumps(
+    {
+        "songs": [
+            {
+                "year": 1985,
+                "title": "Song One",
+                "artist": "Artist One",
+                "uri": "spotify:track:0000000000000000000001",
+            },
+            {
+                "year": 1990,
+                "title": "Song Two",
+                "artist": "Artist Two",
+                "uri": "spotify:track:0000000000000000000002",
+            },
+        ]
+    }
+)
+
+
+def make_start_game_request(hass: MagicMock, body: dict) -> MagicMock:
+    """Build a mock request returning ``body`` from ``.json()`` (#1180)."""
+    request = MagicMock()
+    request.remote = "1.2.3.4"
+    request.json = AsyncMock(return_value=body)
+    request.url = SimpleNamespace(scheme="http", host="localhost", port=8123)
+    return request
+
+
+@pytest.fixture
+def start_game_env():
+    """A StartGameView + real GameState + a valid playlist mocked on disk.
+
+    Returns ``(view, hass, body)`` where the body is a minimal-but-complete
+    start-game payload. The playlist file read and platform capabilities are
+    mocked so ``create_game`` runs and writes the body flags onto the
+    real ``GameState`` stored in ``hass.data[DOMAIN]["game"]``.
+    """
+    game_state = GameState()
+    hass = MagicMock()
+    hass.data = {DOMAIN: {"game": game_state}}
+
+    # Media player entity exists and is available.
+    media_state = MagicMock()
+    media_state.state = "playing"
+    hass.states.get.return_value = media_state
+
+    hass.config.path.return_value = "/tmp/beatify/playlists"
+
+    # Playlist file read runs in an executor; return the valid content.
+    async def _executor(func, *args):
+        return VALID_START_GAME_PLAYLIST
+
+    hass.async_add_executor_job = AsyncMock(side_effect=_executor)
+
+    body = {
+        "playlists": ["test.json"],
+        "media_player": "media_player.test",
+    }
+
+    with (
+        patch(
+            "custom_components.beatify.server.game_views.is_authorized_http",
+            new=MagicMock(return_value=True),
+        ),
+        patch("custom_components.beatify.server.game_views.Path") as mock_path_cls,
+        patch(
+            "custom_components.beatify.server.game_views.er.async_get"
+        ) as mock_async_get,
+        patch(
+            "custom_components.beatify.server.game_views.get_platform_capabilities",
+            return_value={"supported": True},
+        ),
+    ):
+        # Make path-traversal + existence checks pass for any playlist path.
+        mock_path = MagicMock()
+        full_path = MagicMock()
+        full_path.resolve.return_value = full_path
+        full_path.is_relative_to.return_value = True
+        full_path.exists.return_value = True
+        mock_path.resolve.return_value = mock_path
+        mock_path.__truediv__.return_value = full_path
+        mock_path_cls.return_value = mock_path
+
+        entity_entry = MagicMock()
+        entity_entry.platform = "music_assistant"
+        mock_async_get.return_value.async_get.return_value = entity_entry
+
+        view = StartGameView(hass)
+        yield view, hass, body

--- a/tests/unit/test_no_playable_songs_500_2530.py
+++ b/tests/unit/test_no_playable_songs_500_2530.py
@@ -1,0 +1,163 @@
+"""start-game must answer NO_PLAYABLE_SONGS, not a bare 500 (#2530).
+
+Picking a playlist that has no URI for the chosen provider used to escape
+``StartGameView.post`` as an uncaught ``ValueError``, which aiohttp turned into
+``500 Internal Server Error`` — a response carrying no ``code`` at all. That
+defeats #2294 (every create-game rejection gets its own code so the client can
+say WHICH one fired) and leaves the ``errors.<CODE>`` i18n lookup with nothing
+to look up, so the host saw a crash page instead of "this playlist has nothing
+playable on that provider".
+
+Every assertion here checks the **status code and the error code together**. A
+test that only asserts "not 200" would have passed on the broken build — a 500
+is also not 200.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.beatify.const import DOMAIN, ERR_NO_PLAYABLE_SONGS
+from custom_components.beatify.game.state_setup import NoPlayableSongsError
+
+from .conftest import make_start_game_request
+
+
+def _apple_capable():
+    """Let the speaker-capability gate pass for Apple Music.
+
+    The shared fixture stubs ``get_platform_capabilities`` with
+    ``{"supported": True}`` only, which the earlier per-provider gate
+    (``game_views.py``, PROVIDER_NOT_SUPPORTED) rejects before ``create_game``
+    is ever reached. Without this the test would assert the wrong rejection and
+    pass on a build that still 500s.
+    """
+    return patch(
+        "custom_components.beatify.server.game_views.get_platform_capabilities",
+        return_value={"supported": True, "apple_music": True},
+    )
+
+
+class TestNoPlayableSongsResponse:
+    """The provider-with-no-URIs rejection reaches the client as a 400 + code."""
+
+    async def test_provider_without_uris_returns_400_no_playable_songs(
+        self, start_game_env
+    ):
+        # The fixture's playlist carries Spotify URIs only. Asking for Apple
+        # Music is exactly the real-world case from the v4.4.1-rc1 live test:
+        # songs load, none of them is playable on the chosen provider.
+        view, hass, body = start_game_env
+        body["provider"] = "apple_music"
+
+        with _apple_capable():
+            resp = await view.post(make_start_game_request(hass, body))
+
+        assert resp.status == 400, (
+            f"expected 400, got {resp.status} — a 500 here is the #2530 regression"
+        )
+        payload = json.loads(resp.body)
+        assert payload["code"] == ERR_NO_PLAYABLE_SONGS
+        # The message must still name the provider; it is what tells the host
+        # which of their two choices to change.
+        assert "apple_music" in payload["message"]
+
+    async def test_the_game_is_not_left_half_created(self, start_game_env):
+        # #1378 validates before mutating. The new except-arm must not undo
+        # that: after a rejection the state has to be as untouched as before.
+        view, hass, body = start_game_env
+        body["provider"] = "apple_music"
+
+        with _apple_capable():
+            await view.post(make_start_game_request(hass, body))
+
+        game_state = hass.data[DOMAIN]["game"]
+        assert game_state.game_id is None
+        assert game_state.players == {}
+
+    async def test_a_playable_provider_still_starts(self, start_game_env):
+        # Guard against over-catching: the happy path must be untouched.
+        view, hass, body = start_game_env
+        body["provider"] = "spotify"
+
+        resp = await view.post(make_start_game_request(hass, body))
+
+        assert resp.status == 200
+        assert hass.data[DOMAIN]["game"].game_id is not None
+
+
+class TestOtherValueErrorsKeepTheirOwnCode:
+    """A different rejection must not borrow NO_PLAYABLE_SONGS."""
+
+    async def test_unrelated_value_error_maps_to_invalid_request(self, start_game_env):
+        # A wrong code is worse than a generic one: the client renders it as a
+        # specific sentence, so mapping every ValueError onto NO_PLAYABLE_SONGS
+        # would tell the host to change their playlist over an unrelated fault.
+        view, hass, body = start_game_env
+        game_state = hass.data[DOMAIN]["game"]
+
+        with patch.object(
+            game_state,
+            "create_game",
+            side_effect=ValueError("Round duration must be between 15 and 60 seconds"),
+        ):
+            resp = await view.post(make_start_game_request(hass, body))
+
+        assert resp.status == 400
+        payload = json.loads(resp.body)
+        assert payload["code"] == "INVALID_REQUEST"
+        assert payload["code"] != ERR_NO_PLAYABLE_SONGS
+
+
+class TestExceptionContract:
+    """The new exception narrows the signal without changing the contract."""
+
+    def test_is_a_value_error(self):
+        # Subclassing ValueError is what keeps every existing caller and test
+        # that expects `pytest.raises(ValueError)` from create_game working.
+        assert issubclass(NoPlayableSongsError, ValueError)
+
+    def test_create_game_still_raises_for_a_dead_provider(self):
+        from custom_components.beatify.game.state import GameState
+
+        game_state = GameState()
+        songs = [
+            {
+                "year": 1985,
+                "title": "Song One",
+                "artist": "Artist One",
+                "uri": "spotify:track:0000000000000000000001",
+            }
+        ]
+        with pytest.raises(NoPlayableSongsError):
+            game_state.create_game(
+                playlists=["test.json"],
+                songs=songs,
+                media_player="media_player.test",
+                base_url="http://localhost:8123",
+                provider="apple_music",
+            )
+
+    def test_caller_catching_plain_value_error_still_sees_it(self):
+        from custom_components.beatify.game.state import GameState
+
+        game_state = GameState()
+        songs = [
+            {
+                "year": 1985,
+                "title": "Song One",
+                "artist": "Artist One",
+                "uri": "spotify:track:0000000000000000000001",
+            }
+        ]
+        with pytest.raises(ValueError):  # noqa: PT011
+            game_state.create_game(
+                playlists=["test.json"],
+                songs=songs,
+                media_player="media_player.test",
+                base_url="http://localhost:8123",
+                provider="apple_music",
+            )

--- a/tests/unit/test_start_game_view.py
+++ b/tests/unit/test_start_game_view.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 import json
 import logging
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 
 from custom_components.beatify.const import DEFAULT_ROUND_DURATION, DOMAIN
 from custom_components.beatify.game.state import GamePhase, GameState
 from custom_components.beatify.server.views import StartGameView
+
+from .conftest import VALID_START_GAME_PLAYLIST, make_start_game_request
 
 
 def _hass_with_game(phase: GamePhase) -> MagicMock:
@@ -60,97 +60,6 @@ class TestStartGameExistingGameGuard:
 # Happy-path start-game: body flags reach game_state (#1180)
 # ---------------------------------------------------------------------------
 
-_VALID_PLAYLIST = json.dumps(
-    {
-        "songs": [
-            {
-                "year": 1985,
-                "title": "Song One",
-                "artist": "Artist One",
-                "uri": "spotify:track:0000000000000000000001",
-            },
-            {
-                "year": 1990,
-                "title": "Song Two",
-                "artist": "Artist Two",
-                "uri": "spotify:track:0000000000000000000002",
-            },
-        ]
-    }
-)
-
-
-def _make_request(hass: MagicMock, body: dict) -> MagicMock:
-    """Build a mock request returning ``body`` from ``.json()`` (#1180)."""
-    request = MagicMock()
-    request.remote = "1.2.3.4"
-    request.json = AsyncMock(return_value=body)
-    request.url = SimpleNamespace(scheme="http", host="localhost", port=8123)
-    return request
-
-
-@pytest.fixture
-def start_game_env():
-    """A StartGameView + real GameState + a valid playlist mocked on disk.
-
-    Returns ``(view, hass, body)`` where the body is a minimal-but-complete
-    start-game payload. The playlist file read and platform capabilities are
-    mocked so ``create_game`` runs and writes the body flags onto the
-    real ``GameState`` stored in ``hass.data[DOMAIN]["game"]``.
-    """
-    game_state = GameState()
-    hass = MagicMock()
-    hass.data = {DOMAIN: {"game": game_state}}
-
-    # Media player entity exists and is available.
-    media_state = MagicMock()
-    media_state.state = "playing"
-    hass.states.get.return_value = media_state
-
-    hass.config.path.return_value = "/tmp/beatify/playlists"
-
-    # Playlist file read runs in an executor; return the valid content.
-    async def _executor(func, *args):
-        return _VALID_PLAYLIST
-
-    hass.async_add_executor_job = AsyncMock(side_effect=_executor)
-
-    body = {
-        "playlists": ["test.json"],
-        "media_player": "media_player.test",
-    }
-
-    with (
-        patch(
-            "custom_components.beatify.server.game_views.is_authorized_http",
-            new=MagicMock(return_value=True),
-        ),
-        patch("custom_components.beatify.server.game_views.Path") as mock_path_cls,
-        patch(
-            "custom_components.beatify.server.game_views.er.async_get"
-        ) as mock_async_get,
-        patch(
-            "custom_components.beatify.server.game_views.get_platform_capabilities",
-            return_value={"supported": True},
-        ),
-    ):
-        # Make path-traversal + existence checks pass for any playlist path.
-        mock_path = MagicMock()
-        full_path = MagicMock()
-        full_path.resolve.return_value = full_path
-        full_path.is_relative_to.return_value = True
-        full_path.exists.return_value = True
-        mock_path.resolve.return_value = mock_path
-        mock_path.__truediv__.return_value = full_path
-        mock_path_cls.return_value = mock_path
-
-        entity_entry = MagicMock()
-        entity_entry.platform = "music_assistant"
-        mock_async_get.return_value.async_get.return_value = entity_entry
-
-        view = StartGameView(hass)
-        yield view, hass, body
-
 
 class TestTitleArtistModeStartFlag:
     """StartGameView forwards title_artist_mode into create_game (#1180)."""
@@ -159,7 +68,7 @@ class TestTitleArtistModeStartFlag:
         view, hass, body = start_game_env
         body["title_artist_mode"] = True
 
-        resp = await view.post(_make_request(hass, body))
+        resp = await view.post(make_start_game_request(hass, body))
         assert resp.status == 200
 
         game_state = hass.data[DOMAIN]["game"]
@@ -169,7 +78,7 @@ class TestTitleArtistModeStartFlag:
         view, hass, body = start_game_env
         body.pop("title_artist_mode", None)
 
-        resp = await view.post(_make_request(hass, body))
+        resp = await view.post(make_start_game_request(hass, body))
         assert resp.status == 200
 
         game_state = hass.data[DOMAIN]["game"]
@@ -213,7 +122,7 @@ def _twin_start_game_env(media_player: str, entries: list[MagicMock]):
     hass.config.path.return_value = "/tmp/beatify/playlists"
 
     async def _executor(func, *args):
-        return _VALID_PLAYLIST
+        return VALID_START_GAME_PLAYLIST
 
     hass.async_add_executor_job = AsyncMock(side_effect=_executor)
 
@@ -265,7 +174,7 @@ class TestNativeTwinRemapAtStart:
             mock_path_cls.return_value = mock_path
 
             view = StartGameView(hass)
-            resp = await view.post(_make_request(hass, body))
+            resp = await view.post(make_start_game_request(hass, body))
 
         assert resp.status == 200
         # The stale native twin was healed to the MA twin before create_game.
@@ -308,7 +217,7 @@ class TestNativeTwinRemapAtStart:
             mock_path_cls.return_value = mock_path
 
             view = StartGameView(hass)
-            resp = await view.post(_make_request(hass, body))
+            resp = await view.post(make_start_game_request(hass, body))
 
         assert resp.status == 200
         # A normal (non-twin) MA entity_id is used as-is.
@@ -385,7 +294,7 @@ class TestStartGameReusesDiscoveryParse:
             mock_async_get.return_value.async_get.return_value = entity_entry
 
             view = StartGameView(hass)
-            resp = await view.post(_make_request(hass, body))
+            resp = await view.post(make_start_game_request(hass, body))
 
         assert resp.status == 200
         hass.async_add_executor_job.assert_not_awaited()
@@ -407,7 +316,7 @@ class TestRoundDurationProvenanceLog:
         body["round_duration"] = 30
 
         with caplog.at_level(logging.INFO):
-            resp = await view.post(_make_request(hass, body))
+            resp = await view.post(make_start_game_request(hass, body))
         assert resp.status == 200
 
         line = next(
@@ -425,7 +334,7 @@ class TestRoundDurationProvenanceLog:
         body.pop("round_duration", None)
 
         with caplog.at_level(logging.INFO):
-            resp = await view.post(_make_request(hass, body))
+            resp = await view.post(make_start_game_request(hass, body))
         assert resp.status == 200
 
         line = next(


### PR DESCRIPTION
Closes #2530.

Picking a playlist that has no URI for the chosen provider answered the host with a bare `500 Internal Server Error` instead of the `NO_PLAYABLE_SONGS` code the project already defines. Found in the live test of v4.4.1-rc1 and reproduced five times.

## What was wrong

`StartGameView.post` called `create_game` without a `try`/`except`, and `create_game` signals the #709 "this provider has nothing playable" rejection by raising. The `ValueError` escaped into aiohttp, which turned it into a generic 500.

The interesting part is not the missing `except` — it is that **the right code already existed and was already used in the same file**. `ERR_NO_PLAYABLE_SONGS` fires at `game_views.py:366` for "no songs loaded at all"; it never covered "songs loaded, none of them playable on this provider", which `state_setup.py:205` catches a hundred lines later. So one variant of an empty playlist produced a helpful sentence and the other produced a crash page.

That also silently undid #2294 for this path: a 500 carries no `code`, so the client cannot say which rejection fired and the `errors.<CODE>` i18n lookup has nothing to resolve. A German or Spanish host got an English browser error page.

## What changed

**`NoPlayableSongsError`**, a `ValueError` subclass, is raised at the #709 site. `create_game` raises `ValueError` for two unrelated reasons — an out-of-range round duration and this one — and the HTTP layer has a different code for each. Telling them apart from a bare `ValueError` would mean matching on the message text, which a reword or a translation breaks silently.

Subclassing is deliberate: every existing caller and test that expects a `ValueError` from `create_game` keeps working, so this adds a distinction without changing the contract. Two tests in the new file pin exactly that.

**The view maps each arm to its own code.** `NoPlayableSongsError` → 400 `NO_PLAYABLE_SONGS`; any other `ValueError` → 400 `INVALID_REQUEST` plus a log line. The second arm is a backstop for a future validation rather than dead code, and it deliberately does not borrow `NO_PLAYABLE_SONGS` — a wrong code is worse than a generic one, because the client renders it as a specific instruction ("change your playlist") for a fault that has nothing to do with the playlist.

## Tests

`tests/unit/test_no_playable_songs_500_2530.py`, 7 cases. Every one asserts the **status and the error code together**: a test that only checked "not 200" would have passed on the broken build, because a 500 is also not 200.

Verified the tests actually catch the regression — with the source fix reverted and only the new exception left in place, three of the seven fail, including the response test with `expected 400, got 500`.

Covered: the rejection returns 400 + `NO_PLAYABLE_SONGS` with the provider named in the message; the game is not left half-created (#1378's validate-before-mutate still holds through the new except arm); a playable provider still starts, so the fix cannot over-catch; an unrelated `ValueError` keeps `INVALID_REQUEST`; and the exception contract.

## One thing worth flagging in review

The start-game harness (`_VALID_PLAYLIST`, `_make_request`, the `start_game_env` fixture) moved from `test_start_game_view.py` into `tests/unit/conftest.py` so more than one module can drive a real `create_game`. That is most of the diff. Importing the fixture across test modules works at runtime but reads as a redefinition to the linter, and `conftest` is what this repo already does for shared test scaffolding (`make_game_state`, `make_songs`). Behaviour is unchanged; both test modules pass.

## Checks

- pytest **2173 passed**, 2 skipped
- vitest **708 passed** (73 files)
- ruff check clean, ruff format clean (187 files)
- eslint 0 errors
- `npm run build:check` — 18/18 artifacts match source

No frontend files touched, so no bundle rebuild was needed.

## Not in this PR

The trigger is a separate gap: the five playlists added in v4.4.1-rc1 carry **zero** Apple Music URIs (Spotify on all five, Deezer on four, `deutschrap-klassiker` is Spotify-only). That is a content problem and belongs in its own issue. This PR is only about the answer the server gives when it happens.
