### PR TITLE
chore(playlists): deezer backfill — +42 deezer uris

### DIFF
--- a/custom_components/beatify/playlists/community/deutschrap-klassiker.json
+++ b/custom_components/beatify/playlists/community/deutschrap-klassiker.json
@@ -1,6 +1,6 @@
 {
   "name": "Deutschrap Klassiker",
-  "version": "1.0",
+  "version": "1.1",
   "tags": [
     "deutschrap",
     "hip-hop",
@@ -31,7 +31,8 @@
       "fun_fact_de": "Schwester S. war der fruehe Kuenstlername von Sabrina Setlur, die spaeter unter ihrem Vornamen in die Charts kam — dieselbe Kuenstlerin hinter zwei Namen.",
       "fun_fact_es": "Schwester S. fue el primer nombre artistico de Sabrina Setlur, que mas tarde entro en las listas con su propio nombre: la misma artista tras dos nombres.",
       "fun_fact_fr": "Schwester S. etait le premier nom de scene de Sabrina Setlur, entree ensuite dans les charts sous son prenom : la meme artiste sous deux noms.",
-      "fun_fact_nl": "Schwester S. was de vroege artiestennaam van Sabrina Setlur, die later onder haar eigen voornaam in de hitlijsten kwam — dezelfde artieste met twee namen."
+      "fun_fact_nl": "Schwester S. was de vroege artiestennaam van Sabrina Setlur, die later onder haar eigen voornaam in de hitlijsten kwam — dezelfde artieste met twee namen.",
+      "uri_deezer": "deezer://track/124641868"
     },
     {
       "year": 1997,
@@ -48,7 +49,9 @@
       "fun_fact_de": "Der Titel ist ein Palindrom, und der Refrain spielt genau damit — der Name wird buchstabiert, weil er vorwaerts wie rueckwaerts gleich gelesen wird.",
       "fun_fact_es": "El titulo es un palindromo y el estribillo juega con ello: deletrea el nombre porque se lee igual en ambos sentidos.",
       "fun_fact_fr": "Le titre est un palindrome et le refrain joue dessus : le prenom est epele parce qu'il se lit pareil dans les deux sens.",
-      "fun_fact_nl": "De titel is een palindroom en het refrein speelt daarmee: de naam wordt gespeld omdat hij in beide richtingen hetzelfde leest."
+      "fun_fact_nl": "De titel is een palindroom en het refrein speelt daarmee: de naam wordt gespeld omdat hij in beide richtingen hetzelfde leest.",
+      "uri_apple_music": "applemusic://track/298144521",
+      "uri_deezer": "deezer://track/15644778"
     },
     {
       "year": 1998,
@@ -65,7 +68,9 @@
       "fun_fact_de": "Der Song stammt von Bambule, dem Hamburger Album, das deutschsprachigen Rap von einer Szene-Sache zu einem Chart-Format machte.",
       "fun_fact_es": "Procede de Bambule, el album de Hamburgo que convirtio el rap en aleman en un formato de listas y no solo en cosa de escena.",
       "fun_fact_fr": "Le morceau vient de Bambule, l'album hambourgeois qui a fait du rap en allemand un format de charts et plus seulement une affaire de scene.",
-      "fun_fact_nl": "Het komt van Bambule, het Hamburgse album dat Duitstalige rap van scene-zaak tot hitlijstformaat maakte."
+      "fun_fact_nl": "Het komt van Bambule, het Hamburgse album dat Duitstalige rap van scene-zaak tot hitlijstformaat maakte.",
+      "uri_apple_music": "applemusic://track/1440731825",
+      "uri_deezer": "deezer://track/2176668"
     },
     {
       "year": 2001,
@@ -89,7 +94,8 @@
       "fun_fact_de": "Im September 2001 als EP erschienen, erreichte der Song Platz vier der deutschen Singlecharts und ist bis heute sein bekanntester politischer Titel.",
       "fun_fact_es": "Publicado como EP en septiembre de 2001, alcanzo el numero cuatro en las listas alemanas y sigue siendo su cancion politica mas conocida.",
       "fun_fact_fr": "Sorti en EP en septembre 2001, il a atteint la quatrieme place des charts allemands et reste sa chanson politique la plus connue.",
-      "fun_fact_nl": "In september 2001 als ep verschenen, haalde het nummer vier in de Duitse hitlijst en blijft zijn bekendste politieke song."
+      "fun_fact_nl": "In september 2001 als ep verschenen, haalde het nummer vier in de Duitse hitlijst en blijft zijn bekendste politieke song.",
+      "uri_deezer": "deezer://track/3283333"
     },
     {
       "year": 2007,
@@ -106,7 +112,8 @@
       "fun_fact_de": "Gebaut auf dem Titelthema der Serie Prison Break, mit Adel Tawil auf dem Refrain — Jahre bevor Ich + Ich jeder kannte.",
       "fun_fact_es": "Construida sobre el tema de la serie Prison Break, con Adel Tawil en el estribillo anos antes de que Ich + Ich fuera conocido por todos.",
       "fun_fact_fr": "Construit sur le theme de la serie Prison Break, avec Adel Tawil au refrain, des annees avant qu'Ich + Ich ne soit connu de tous.",
-      "fun_fact_nl": "Gebouwd op het thema van de serie Prison Break, met Adel Tawil op het refrein, jaren voordat Ich + Ich een begrip werd."
+      "fun_fact_nl": "Gebouwd op het thema van de serie Prison Break, met Adel Tawil op het refrein, jaren voordat Ich + Ich een begrip werd.",
+      "uri_deezer": "deezer://track/1163878"
     },
     {
       "year": 2008,
@@ -123,7 +130,9 @@
       "fun_fact_de": "Eine Rap-Fassung von Alphavilles Forever Young, gesungen von Karel Gott — eine Paarung aus Deutschrap und Schlager, die vorher niemand versucht hatte.",
       "fun_fact_es": "Una version rap de Forever Young de Alphaville, cantada por Karel Gott: una union de rap aleman y Schlager que nadie habia intentado antes.",
       "fun_fact_fr": "Une version rap de Forever Young d'Alphaville, chantee par Karel Gott : un melange de rap allemand et de Schlager que personne n'avait tente avant.",
-      "fun_fact_nl": "Een rapversie van Forever Young van Alphaville, gezongen door Karel Gott — een combinatie van Duitse rap en Schlager die niemand eerder probeerde."
+      "fun_fact_nl": "Een rapversie van Forever Young van Alphaville, gezongen door Karel Gott — een combinatie van Duitse rap en Schlager die niemand eerder probeerde.",
+      "uri_apple_music": "applemusic://track/1555448874",
+      "uri_deezer": "deezer://track/1256158602"
     },
     {
       "year": 2009,
@@ -144,7 +153,9 @@
       "fun_fact_de": "Die Berliner Gruppe singt auf Deutsch, Englisch, Spanisch und jamaikanischem Patois — Monsta ist der Titel, der diese Mischung in die Sommercharts trug.",
       "fun_fact_es": "El grupo berlines canta en aleman, ingles, espanol y patois jamaicano; Monsta es el tema que llevo esa mezcla a las listas de verano.",
       "fun_fact_fr": "Le groupe berlinois chante en allemand, anglais, espagnol et patois jamaicain : Monsta est le titre qui a porte ce melange dans les charts d'ete.",
-      "fun_fact_nl": "De Berlijnse groep zingt in het Duits, Engels, Spaans en Jamaicaans Patois — Monsta bracht die mix naar de zomerhitlijsten."
+      "fun_fact_nl": "De Berlijnse groep zingt in het Duits, Engels, Spaans en Jamaicaans Patois — Monsta bracht die mix naar de zomerhitlijsten.",
+      "uri_apple_music": "applemusic://track/1593834204",
+      "uri_deezer": "deezer://track/1543798462"
     },
     {
       "year": 2010,
@@ -161,7 +172,9 @@
       "fun_fact_de": "Vom Album Zum Glueck in die Zukunft, mit dem der Rostocker Rapper seine fruehere englischsprachige Laufbahn endgueltig hinter sich liess.",
       "fun_fact_es": "Del album Zum Glueck in die Zukunft, con el que el rapero de Rostock dejo definitivamente atras su etapa en ingles.",
       "fun_fact_fr": "Extrait de Zum Glueck in die Zukunft, l'album avec lequel le rappeur de Rostock a definitivement laisse derriere lui sa periode anglophone.",
-      "fun_fact_nl": "Van het album Zum Glueck in die Zukunft, waarmee de rapper uit Rostock zijn eerdere Engelstalige fase definitief achter zich liet."
+      "fun_fact_nl": "Van het album Zum Glueck in die Zukunft, waarmee de rapper uit Rostock zijn eerdere Engelstalige fase definitief achter zich liet.",
+      "uri_apple_music": "applemusic://track/1625550159",
+      "uri_deezer": "deezer://track/1761910157"
     },
     {
       "year": 2012,
@@ -187,7 +200,8 @@
       "fun_fact_de": "Die Pandamaske hielt das Gesicht des Rappers unbekannt, waehrend der Song ueberall lief — gewollte Anonymitaet im Moment des Durchbruchs.",
       "fun_fact_es": "La mascara de panda mantuvo oculto el rostro del rapero mientras la cancion sonaba en todas partes: anonimato deliberado en pleno exito.",
       "fun_fact_fr": "Le masque de panda a garde le visage du rappeur inconnu alors que le morceau passait partout : un anonymat voulu au moment de la percee.",
-      "fun_fact_nl": "Het pandamasker hield het gezicht van de rapper onbekend terwijl het nummer overal klonk — bewuste anonimiteit op het moment van de doorbraak."
+      "fun_fact_nl": "Het pandamasker hield het gezicht van de rapper onbekend terwijl het nummer overal klonk — bewuste anonimiteit op het moment van de doorbraak.",
+      "uri_deezer": "deezer://track/3786097162"
     },
     {
       "year": 2012,
@@ -212,7 +226,9 @@
       "fun_fact_de": "Der ganze Song ist ein Gestaendnis — er zaehlt Dinge auf, die der Saenger falsch findet und trotzdem geniesst, und der Titel sagt das in zwei Worten.",
       "fun_fact_es": "Toda la cancion es una confesion: enumera cosas que el cantante sabe que estan mal y disfruta igualmente, y el titulo lo resume en dos palabras.",
       "fun_fact_fr": "Toute la chanson est un aveu : elle enumere des choses que le chanteur juge mauvaises et apprecie quand meme, et le titre le dit en deux mots.",
-      "fun_fact_nl": "Het hele nummer is een bekentenis: het somt dingen op die de zanger fout vindt en toch geniet, en de titel zegt dat in twee woorden."
+      "fun_fact_nl": "Het hele nummer is een bekentenis: het somt dingen op die de zanger fout vindt en toch geniet, en de titel zegt dat in twee woorden.",
+      "uri_apple_music": "applemusic://track/1562123058",
+      "uri_deezer": "deezer://track/82120542"
     },
     {
       "year": 2012,
@@ -233,7 +249,9 @@
       "fun_fact_de": "Max Herre hatte A-N-N-A mit Freundeskreis schon fuenfzehn Jahre frueher geschrieben — dieselbe Stimme, zwei Epochen des Deutschraps auseinander.",
       "fun_fact_es": "Max Herre ya habia escrito A-N-N-A con Freundeskreis quince anos antes: la misma voz, a dos epocas de distancia del rap aleman.",
       "fun_fact_fr": "Max Herre avait deja ecrit A-N-N-A avec Freundeskreis quinze ans plus tot : la meme voix, a deux epoques d'ecart du rap allemand.",
-      "fun_fact_nl": "Max Herre schreef A-N-N-A met Freundeskreis al vijftien jaar eerder — dezelfde stem, twee tijdperken Duitse rap uit elkaar."
+      "fun_fact_nl": "Max Herre schreef A-N-N-A met Freundeskreis al vijftien jaar eerder — dezelfde stem, twee tijdperken Duitse rap uit elkaar.",
+      "uri_apple_music": "applemusic://track/1440865655",
+      "uri_deezer": "deezer://track/46425761"
     },
     {
       "year": 2012,
@@ -257,7 +275,8 @@
       "fun_fact_de": "Babo wurde 2013 zum Jugendwort des Jahres gewaehlt, direkt aus diesem Song — eine Rapzeile, die es ins Woerterbuch schaffte.",
       "fun_fact_es": "Babo fue elegida palabra juvenil del ano 2013 en Alemania, directamente de esta cancion: un verso de rap que llego al diccionario.",
       "fun_fact_fr": "Babo a ete elu mot de l'annee des jeunes en 2013 en Allemagne, directement issu de ce morceau : une punchline entree au dictionnaire.",
-      "fun_fact_nl": "Babo werd in 2013 in Duitsland tot jeugdwoord van het jaar gekozen, rechtstreeks uit dit nummer — een raprijm dat het woordenboek haalde."
+      "fun_fact_nl": "Babo werd in 2013 in Duitsland tot jeugdwoord van het jaar gekozen, rechtstreeks uit dit nummer — een raprijm dat het woordenboek haalde.",
+      "uri_deezer": "deezer://track/463173312"
     },
     {
       "year": 2013,
@@ -281,7 +300,9 @@
       "fun_fact_de": "Vom Album 30-11-80, das Sido nach seinem eigenen Geburtsdatum benannt hat.",
       "fun_fact_es": "Del album 30-11-80, que Sido bautizo con su propia fecha de nacimiento.",
       "fun_fact_fr": "Extrait de 30-11-80, l'album que Sido a nomme d'apres sa propre date de naissance.",
-      "fun_fact_nl": "Van het album 30-11-80, dat Sido naar zijn eigen geboortedatum noemde."
+      "fun_fact_nl": "Van het album 30-11-80, dat Sido naar zijn eigen geboortedatum noemde.",
+      "uri_apple_music": "applemusic://track/1443107793",
+      "uri_deezer": "deezer://track/72370901"
     },
     {
       "year": 2016,
@@ -305,7 +326,8 @@
       "fun_fact_de": "Vom Gemeinschaftsalbum Palmen aus Plastik mit RAF Camora, das Dancehall in den Deutschrap holte und jahrelang in den Charts blieb.",
       "fun_fact_es": "Del album conjunto Palmen aus Plastik con RAF Camora, que trajo el dancehall al rap aleman y permanecio anos en las listas.",
       "fun_fact_fr": "Extrait de l'album commun Palmen aus Plastik avec RAF Camora, qui a amene le dancehall dans le rap allemand et est reste des annees dans les charts.",
-      "fun_fact_nl": "Van het gezamenlijke album Palmen aus Plastik met RAF Camora, dat dancehall naar de Duitse rap bracht en jarenlang in de lijsten bleef."
+      "fun_fact_nl": "Van het gezamenlijke album Palmen aus Plastik met RAF Camora, dat dancehall naar de Duitse rap bracht en jarenlang in de lijsten bleef.",
+      "uri_deezer": "deezer://track/138394775"
     },
     {
       "year": 2017,
@@ -322,7 +344,8 @@
       "fun_fact_de": "Nimo rappt im Frankfurter Zungenschlag der Offenbacher Szene um Haftbefehl — der Stadt, die dem Deutschrap einen eigenen Akzent gab.",
       "fun_fact_es": "Nimo rapea con el acento de Francfort de la escena de Offenbach en torno a Haftbefehl, la ciudad que dio al rap aleman su propio tono.",
       "fun_fact_fr": "Nimo rappe avec l'accent francfortois de la scene d'Offenbach autour de Haftbefehl, la ville qui a donne au rap allemand son propre accent.",
-      "fun_fact_nl": "Nimo rapt met het Frankfurtse accent van de Offenbach-scene rond Haftbefehl, de stad die de Duitse rap een eigen klank gaf."
+      "fun_fact_nl": "Nimo rapt met het Frankfurtse accent van de Offenbach-scene rond Haftbefehl, de stad die de Duitse rap een eigen klank gaf.",
+      "uri_deezer": "deezer://track/371619861"
     },
     {
       "year": 2018,
@@ -339,7 +362,9 @@
       "fun_fact_de": "Der Titel datiert eine Modekollektion — RIN rappt ueber die Dior-Linie von 2001, nicht ueber das Erscheinungsjahr des Songs.",
       "fun_fact_es": "El titulo data una coleccion de moda: RIN rapea sobre la linea Dior de 2001, no sobre el ano de publicacion del tema.",
       "fun_fact_fr": "Le titre date une collection de mode : RIN rappe sur la ligne Dior de 2001, pas sur l'annee de sortie du morceau.",
-      "fun_fact_nl": "De titel dateert een modecollectie: RIN rapt over de Dior-lijn van 2001, niet over het jaar waarin het nummer uitkwam."
+      "fun_fact_nl": "De titel dateert een modecollectie: RIN rapt over de Dior-lijn van 2001, niet over het jaar waarin het nummer uitkwam.",
+      "uri_apple_music": "applemusic://track/1473865026",
+      "uri_deezer": "deezer://track/717156672"
     },
     {
       "year": 2018,
@@ -356,7 +381,8 @@
       "fun_fact_de": "Der Refrain ist tuerkisch — tamam heisst okay — und trug den Song ueber Deutschland hinaus in tuerkische Charts und Clubs.",
       "fun_fact_es": "El estribillo es turco: tamam significa vale, y llevo la cancion mas alla de Alemania, a listas y clubes turcos.",
       "fun_fact_fr": "Le refrain est en turc : tamam signifie d'accord, ce qui a porte le morceau au-dela de l'Allemagne, jusqu'aux charts turcs.",
-      "fun_fact_nl": "Het refrein is Turks — tamam betekent oke — en bracht het nummer tot buiten Duitsland, tot in Turkse hitlijsten."
+      "fun_fact_nl": "Het refrein is Turks — tamam betekent oke — en bracht het nummer tot buiten Duitsland, tot in Turkse hitlijsten.",
+      "uri_deezer": "deezer://track/531941511"
     },
     {
       "year": 2019,
@@ -373,7 +399,9 @@
       "fun_fact_de": "Sido blickt auf seine eigenen Anfaenge zurueck und uebergibt die zweite Haelfte an Apache 207, der im Jahr des Titels zwei Jahre alt war.",
       "fun_fact_es": "Sido mira atras a sus propios comienzos y cede la segunda mitad a Apache 207, que tenia dos anos en el ano del titulo.",
       "fun_fact_fr": "Sido revient sur ses debuts et laisse la seconde moitie a Apache 207, qui avait deux ans l'annee du titre.",
-      "fun_fact_nl": "Sido kijkt terug op zijn eigen begin en geeft de tweede helft aan Apache 207, die in het jaar van de titel twee was."
+      "fun_fact_nl": "Sido kijkt terug op zijn eigen begin en geeft de tweede helft aan Apache 207, die in het jaar van de titel twee was.",
+      "uri_apple_music": "applemusic://track/1462078882",
+      "uri_deezer": "deezer://track/760466952"
     },
     {
       "year": 2019,
@@ -390,7 +418,9 @@
       "fun_fact_de": "Der Song erschien in dem Jahr, in dem Capital Bra mit einer Serie von Nummer-eins-Singles einen deutschen Chartrekord aufstellte.",
       "fun_fact_es": "Aparecio el ano en que Capital Bra establecio un record en las listas alemanas con una serie de sencillos numero uno.",
       "fun_fact_fr": "Il est paru l'annee ou Capital Bra a etabli un record des charts allemands avec une serie de singles numero un.",
-      "fun_fact_nl": "Het verscheen in het jaar waarin Capital Bra een Duits hitlijstrecord vestigde met een reeks nummer-1-singles."
+      "fun_fact_nl": "Het verscheen in het jaar waarin Capital Bra een Duits hitlijstrecord vestigde met een reeks nummer-1-singles.",
+      "uri_apple_music": "applemusic://track/1460798637",
+      "uri_deezer": "deezer://track/672190002"
     },
     {
       "year": 2020,
@@ -407,7 +437,9 @@
       "fun_fact_de": "Zwei der bekanntesten Frauen des Deutschraps auf einem Track, produziert von Miksu und Macloud, die den Sound jenes Jahres mitpraegten.",
       "fun_fact_es": "Dos de las mujeres mas conocidas del rap aleman en un mismo tema, producido por Miksu y Macloud, que marcaron el sonido de ese ano.",
       "fun_fact_fr": "Deux des femmes les plus connues du rap allemand sur un meme morceau, produit par Miksu et Macloud, qui ont marque le son de cette annee.",
-      "fun_fact_nl": "Twee van de bekendste vrouwen in de Duitse rap op een nummer, geproduceerd door Miksu en Macloud, die de sound van dat jaar mee bepaalden."
+      "fun_fact_nl": "Twee van de bekendste vrouwen in de Duitse rap op een nummer, geproduceerd door Miksu en Macloud, die de sound van dat jaar mee bepaalden.",
+      "uri_apple_music": "applemusic://track/1494301748",
+      "uri_deezer": "deezer://track/851311772"
     },
     {
       "year": 2020,
@@ -428,7 +460,9 @@
       "fun_fact_de": "Berliner Strassenrap, benannt nach einem Kaugummi — Teil einer Welle, die ihre Bilder aus Alltagsmarken zog statt aus Luxusmarken.",
       "fun_fact_es": "Rap callejero berlines que toma su nombre de un chicle, parte de una ola que sacaba sus imagenes de marcas cotidianas y no de lujo.",
       "fun_fact_fr": "Rap de rue berlinois nomme d'apres un chewing-gum, dans une vague qui puisait ses images dans les marques du quotidien plutot que dans le luxe.",
-      "fun_fact_nl": "Berlijnse straatrap vernoemd naar een kauwgom — deel van een golf die beelden ontleende aan alledaagse merken in plaats van luxemerken."
+      "fun_fact_nl": "Berlijnse straatrap vernoemd naar een kauwgom — deel van een golf die beelden ontleende aan alledaagse merken in plaats van luxemerken.",
+      "uri_apple_music": "applemusic://track/1512773990",
+      "uri_deezer": "deezer://track/957653672"
     },
     {
       "year": 2021,
@@ -445,7 +479,8 @@
       "fun_fact_de": "Im Januar 2021 erschienen, produziert vom Duo WILDBWOYS, dessen Name direkt auf dem Track steht.",
       "fun_fact_es": "Publicada en enero de 2021, producida por el duo WILDBWOYS, cuyo nombre figura en el propio tema.",
       "fun_fact_fr": "Sorti en janvier 2021, produit par le duo WILDBWOYS, dont le nom figure sur le morceau lui-meme.",
-      "fun_fact_nl": "Verschenen in januari 2021, geproduceerd door het duo WILDBWOYS, wiens naam op het nummer zelf staat."
+      "fun_fact_nl": "Verschenen in januari 2021, geproduceerd door het duo WILDBWOYS, wiens naam op het nummer zelf staat.",
+      "uri_deezer": "deezer://track/1199814512"
     },
     {
       "year": 2021,
@@ -462,7 +497,9 @@
       "fun_fact_de": "Der zweite Pashanim-Titel dieser Liste, ein Jahr nach Airwaves — derselbe Berliner Sommerton, ein Jahr weiter.",
       "fun_fact_es": "El segundo tema de Pashanim en esta lista, un ano despues de Airwaves: el mismo tono de verano berlines, un ano mas tarde.",
       "fun_fact_fr": "Le deuxieme titre de Pashanim de cette liste, un an apres Airwaves : le meme ton d'ete berlinois, un an plus tard.",
-      "fun_fact_nl": "Het tweede Pashanim-nummer op deze lijst, een jaar na Airwaves — dezelfde Berlijnse zomertoon, een jaar later."
+      "fun_fact_nl": "Het tweede Pashanim-nummer op deze lijst, een jaar na Airwaves — dezelfde Berlijnse zomertoon, een jaar later.",
+      "uri_apple_music": "applemusic://track/1572443408",
+      "uri_deezer": "deezer://track/1408516272"
     },
     {
       "year": 2022,
@@ -479,7 +516,9 @@
       "fun_fact_de": "Luciano wurde in Chile geboren und wuchs in Berlin auf — sein melodischer Rap traegt beides, und dies ist eines seiner sanftesten Beispiele.",
       "fun_fact_es": "Luciano nacio en Chile y crecio en Berlin; su rap melodico lleva ambas cosas, y este es uno de sus ejemplos mas suaves.",
       "fun_fact_fr": "Luciano est ne au Chili et a grandi a Berlin : son rap melodique porte les deux, et voici l'un de ses exemples les plus doux.",
-      "fun_fact_nl": "Luciano werd geboren in Chili en groeide op in Berlijn — zijn melodische rap draagt beide, en dit is een van zijn zachtste voorbeelden."
+      "fun_fact_nl": "Luciano werd geboren in Chili en groeide op in Berlijn — zijn melodische rap draagt beide, en dit is een van zijn zachtste voorbeelden.",
+      "uri_apple_music": "applemusic://track/1647178504",
+      "uri_deezer": "deezer://track/1730583477"
     },
     {
       "year": 2022,
@@ -496,7 +535,8 @@
       "fun_fact_de": "BHZ steht fuer das Berliner Schoeneberg — das Kollektiv traegt den Namen des Viertels, aus dem es kommt.",
       "fun_fact_es": "BHZ alude al barrio berlines de Schoeneberg: el colectivo lleva el nombre del distrito del que procede.",
       "fun_fact_fr": "BHZ renvoie au quartier berlinois de Schoeneberg : le collectif porte le nom du quartier dont il vient.",
-      "fun_fact_nl": "BHZ verwijst naar de Berlijnse wijk Schoeneberg — het collectief draagt de naam van de buurt waar het vandaan komt."
+      "fun_fact_nl": "BHZ verwijst naar de Berlijnse wijk Schoeneberg — het collectief draagt de naam van de buurt waar het vandaan komt.",
+      "uri_deezer": "deezer://track/2849923752"
     },
     {
       "year": 2024,
@@ -513,7 +553,8 @@
       "fun_fact_de": "Ski Aggu tritt mit Skibrille auf, sein Gesicht bleibt also verdeckt — so wie Cros ein Jahrzehnt frueher hinter der Pandamaske.",
       "fun_fact_es": "Ski Aggu actua con gafas de esqui, asi que su rostro queda oculto igual que el de Cro tras la mascara de panda una decada antes.",
       "fun_fact_fr": "Ski Aggu se produit avec un masque de ski : son visage reste cache, comme celui de Cro derriere le masque de panda dix ans plus tot.",
-      "fun_fact_nl": "Ski Aggu treedt op met een skibril, zodat zijn gezicht verborgen blijft zoals dat van Cro tien jaar eerder achter het pandamasker."
+      "fun_fact_nl": "Ski Aggu treedt op met een skibril, zodat zijn gezicht verborgen blijft zoals dat van Cro tien jaar eerder achter het pandamasker.",
+      "uri_deezer": "deezer://track/3272152801"
     }
   ]
 }

--- a/custom_components/beatify/playlists/community/schlager-klassiker.json
+++ b/custom_components/beatify/playlists/community/schlager-klassiker.json
@@ -1,6 +1,6 @@
 {
   "name": "Schlager Classics 🇩🇪",
-  "version": "1.25",
+  "version": "1.26",
   "tags": [
     "german",
     "schlager",
@@ -2598,7 +2598,7 @@
       "certifications": [],
       "awards": [],
       "awards_nl": [],
-      "uri_apple_music": null,
+      "uri_apple_music": "applemusic://track/317319297",
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1136244151",
         "de": "applemusic://track/634870720",
@@ -4953,7 +4953,7 @@
       "title": "Nachts, wenn alles schläft",
       "isrc": null,
       "uri_apple_music": "applemusic://track/724312432",
-      "uri_deezer": null,
+      "uri_deezer": "deezer://track/116941940",
       "fun_fact": "Carpendale is South African and learned German as an adult, which is why his early records carry an accent that German audiences came to like.",
       "fun_fact_de": "Carpendale ist Südafrikaner und lernte Deutsch erst als Erwachsener — daher der Akzent auf seinen frühen Platten, den das deutsche Publikum liebgewann.",
       "fun_fact_es": "Carpendale es sudafricano y aprendió alemán de adulto; de ahí el acento de sus primeros discos, que al público alemán acabó gustándole.",
@@ -5136,7 +5136,9 @@
       "fun_fact_de": "Mario Jordan ist ein Künstlername — der Sänger heißt Mario Lehner, und der Text stammt von Michael Kunze, der auch für Udo Jürgens schrieb.",
       "fun_fact_es": "Mario Jordan es un nombre artístico: el cantante se llama Mario Lehner, y la letra es de Michael Kunze, que también escribió para Udo Jürgens.",
       "fun_fact_fr": "Mario Jordan est un nom de scène : le chanteur s'appelle Mario Lehner, et le texte est signé Michael Kunze, qui a aussi écrit pour Udo Jürgens.",
-      "fun_fact_nl": "Mario Jordan is een artiestennaam — de zanger heet Mario Lehner, en de tekst komt van Michael Kunze, die ook voor Udo Jürgens schreef."
+      "fun_fact_nl": "Mario Jordan is een artiestennaam — de zanger heet Mario Lehner, en de tekst komt van Michael Kunze, die ook voor Udo Jürgens schreef.",
+      "uri_apple_music": "applemusic://track/313132976",
+      "uri_deezer": "deezer://track/3801813892"
     },
     {
       "year": 1994,
@@ -5153,7 +5155,8 @@
       "fun_fact_de": "Die österreichische Band musste sich aus rechtlichen Gründen in Caraboo umbenennen — dieselbe Gruppe steht also unter zwei Namen im Plattenregal.",
       "fun_fact_es": "La banda austriaca tuvo que cambiar su nombre a Caraboo por motivos legales, así que el mismo grupo aparece con dos nombres.",
       "fun_fact_fr": "Le groupe autrichien a dû se rebaptiser Caraboo pour des raisons juridiques : la même formation existe donc sous deux noms.",
-      "fun_fact_nl": "De Oostenrijkse band moest zich om juridische redenen Caraboo gaan noemen, dus dezelfde groep staat onder twee namen in de rekken."
+      "fun_fact_nl": "De Oostenrijkse band moest zich om juridische redenen Caraboo gaan noemen, dus dezelfde groep staat onder twee namen in de rekken.",
+      "uri_deezer": "deezer://track/2267596"
     },
     {
       "year": 1996,
@@ -5170,7 +5173,9 @@
       "fun_fact_de": "Die Debütsingle der österreichischen Sängerin, die zuerst Malerin war, bevor sie überhaupt etwas aufnahm.",
       "fun_fact_es": "El sencillo debut de la cantante austriaca, que antes de grabar nada se formó como pintora.",
       "fun_fact_fr": "Le premier single de la chanteuse autrichienne, peintre de formation avant d'enregistrer quoi que ce soit.",
-      "fun_fact_nl": "De debuutsingle van de Oostenrijkse zangeres, die schilderes was voordat ze ook maar iets opnam."
+      "fun_fact_nl": "De debuutsingle van de Oostenrijkse zangeres, die schilderes was voordat ze ook maar iets opnam.",
+      "uri_apple_music": "applemusic://track/1822469931",
+      "uri_deezer": "deezer://track/10495720"
     },
     {
       "year": 2000,
@@ -5187,7 +5192,9 @@
       "fun_fact_de": "Der Titel stammt von Ibos letztem Album — der Discofox-Sänger starb im selben Jahr mit 44, und das Lied überlebte ihn als Partyklassiker.",
       "fun_fact_es": "Procede del último álbum de Ibo: el cantante de discofox murió ese mismo año con 44 años, y la canción le sobrevivió como clásico de fiesta.",
       "fun_fact_fr": "Le titre vient du dernier album d'Ibo : le chanteur de discofox est mort la même année à 44 ans, et la chanson lui a survécu comme classique de fête.",
-      "fun_fact_nl": "Het nummer komt van Ibo's laatste album — de discofoxzanger stierf datzelfde jaar op zijn 44e, en het lied overleefde hem als partyklassieker."
+      "fun_fact_nl": "Het nummer komt van Ibo's laatste album — de discofoxzanger stierf datzelfde jaar op zijn 44e, en het lied overleefde hem als partyklassieker.",
+      "uri_apple_music": "applemusic://track/311136341",
+      "uri_deezer": "deezer://track/2759281"
     },
     {
       "year": 2001,
@@ -5204,7 +5211,8 @@
       "fun_fact_de": "Simone ist die Österreicherin Simone Stelzer, und das hier ist der Titelsong des Albums, auf dessen Cover nur ihr Vorname steht.",
       "fun_fact_es": "Simone es la austriaca Simone Stelzer, y esta es la canción que da título al álbum que lleva solo su nombre de pila en la portada.",
       "fun_fact_fr": "Simone, c'est l'Autrichienne Simone Stelzer, et voici la chanson-titre de l'album qui ne porte que son prénom en couverture.",
-      "fun_fact_nl": "Simone is de Oostenrijkse Simone Stelzer, en dit is het titelnummer van het album dat alleen haar voornaam op de hoes draagt."
+      "fun_fact_nl": "Simone is de Oostenrijkse Simone Stelzer, en dit is het titelnummer van het album dat alleen haar voornaam op de hoes draagt.",
+      "uri_deezer": "deezer://track/2488095"
     },
     {
       "year": 2002,
@@ -5221,7 +5229,9 @@
       "fun_fact_de": "Sandy Wagner ist ein Mann — Stefan Dietmar Wagner, Fernsehmoderator, der diesen Titel selbst geschrieben, gesungen und produziert hat.",
       "fun_fact_es": "Sandy Wagner es un hombre: Stefan Dietmar Wagner, presentador de televisión que escribió, cantó y produjo él mismo esta canción.",
       "fun_fact_fr": "Sandy Wagner est un homme : Stefan Dietmar Wagner, animateur de télévision, qui a écrit, chanté et produit lui-même ce titre.",
-      "fun_fact_nl": "Sandy Wagner is een man — Stefan Dietmar Wagner, tv-presentator, die dit nummer zelf schreef, zong en produceerde."
+      "fun_fact_nl": "Sandy Wagner is een man — Stefan Dietmar Wagner, tv-presentator, die dit nummer zelf schreef, zong en produceerde.",
+      "uri_apple_music": "applemusic://track/311150929",
+      "uri_deezer": "deezer://track/2195346"
     },
     {
       "year": 2004,
@@ -5238,7 +5248,8 @@
       "fun_fact_de": "Hilbert schrieb eine Reihe deutscher Top-Ten-Singles für andere und saß bei Popstars in der Jury — als Autor war er bekannter denn als Sänger.",
       "fun_fact_es": "Hilbert escribió varios sencillos alemanes de top ten para otros artistas y fue jurado en Popstars: se le conocía más como autor que como cantante.",
       "fun_fact_fr": "Hilbert a écrit plusieurs singles allemands du top dix pour d'autres et a siégé au jury de Popstars : il était plus connu comme auteur que comme chanteur.",
-      "fun_fact_nl": "Hilbert schreef een reeks Duitse toptienhits voor anderen en zat in de jury van Popstars — als auteur was hij bekender dan als zanger."
+      "fun_fact_nl": "Hilbert schreef een reeks Duitse toptienhits voor anderen en zat in de jury van Popstars — als auteur was hij bekender dan als zanger.",
+      "uri_deezer": "deezer://track/776910"
     },
     {
       "year": 2006,
@@ -5255,7 +5266,9 @@
       "fun_fact_de": "Discofox mit 132 Schlägen pro Minute — schnell genug, dass die Tanzfläche das Tempo vorgibt und nicht das Lied.",
       "fun_fact_es": "Discofox a 132 pulsaciones por minuto: lo bastante rápido para que el ritmo lo marque la pista y no la canción.",
       "fun_fact_fr": "Du discofox à 132 battements par minute : assez rapide pour que ce soit la piste qui donne le tempo, pas la chanson.",
-      "fun_fact_nl": "Discofox op 132 slagen per minuut — snel genoeg dat de dansvloer het tempo bepaalt en niet het nummer."
+      "fun_fact_nl": "Discofox op 132 slagen per minuut — snel genoeg dat de dansvloer het tempo bepaalt en niet het nummer.",
+      "uri_apple_music": "applemusic://track/375149661",
+      "uri_deezer": "deezer://track/40137411"
     },
     {
       "year": 2007,
@@ -5272,7 +5285,8 @@
       "fun_fact_de": "Die Single erschien mit Stadl-Mix, Rock-Mix und DJ-Mix — ein Lied in drei Fassungen für drei verschiedene Säle.",
       "fun_fact_es": "El sencillo salió con un mix Stadl, uno de rock y uno de DJ: una canción en tres versiones para tres salas distintas.",
       "fun_fact_fr": "Le single est sorti avec un mix Stadl, un mix rock et un mix DJ : une chanson en trois versions pour trois salles différentes.",
-      "fun_fact_nl": "De single verscheen met een Stadl-mix, een rockmix en een dj-mix — één lied in drie versies voor drie verschillende zalen."
+      "fun_fact_nl": "De single verscheen met een Stadl-mix, een rockmix en een dj-mix — één lied in drie versies voor drie verschillende zalen.",
+      "uri_deezer": "deezer://track/3303554"
     },
     {
       "year": 2014,
@@ -5289,7 +5303,8 @@
       "fun_fact_de": "Fünf Wochen in Folge auf Platz eins der deutschen Airplay-Charts — damit war es in dem Jahr der meistgespielte Titel im Schlagerradio.",
       "fun_fact_es": "Cinco semanas seguidas en el número uno de las listas de radiodifusión alemanas, la canción más pinchada en la radio schlager de ese año.",
       "fun_fact_fr": "Cinq semaines d'affilée en tête des classements radio allemands : le titre le plus diffusé de l'année sur les radios schlager.",
-      "fun_fact_nl": "Vijf weken op rij op nummer één in de Duitse airplaylijsten — daarmee het meest gedraaide nummer op schlagerradio dat jaar."
+      "fun_fact_nl": "Vijf weken op rij op nummer één in de Duitse airplaylijsten — daarmee het meest gedraaide nummer op schlagerradio dat jaar.",
+      "uri_deezer": "deezer://track/2044258827"
     },
     {
       "year": 2018,
@@ -5306,7 +5321,9 @@
       "fun_fact_de": "Jordi gewann 1998 den Grand Prix der Volksmusik und sang 2002 für die Schweiz beim Eurovision Song Contest — auf Französisch, nicht auf Deutsch.",
       "fun_fact_es": "Jordi ganó el Grand Prix der Volksmusik en 1998 y cantó por Suiza en Eurovisión en 2002, en francés y no en alemán.",
       "fun_fact_fr": "Jordi a gagné le Grand Prix der Volksmusik en 1998 et a chanté pour la Suisse à l'Eurovision en 2002 — en français, pas en allemand.",
-      "fun_fact_nl": "Jordi won in 1998 de Grand Prix der Volksmusik en zong in 2002 voor Zwitserland op het Eurovisiesongfestival — in het Frans, niet in het Duits."
+      "fun_fact_nl": "Jordi won in 1998 de Grand Prix der Volksmusik en zong in 2002 voor Zwitserland op het Eurovisiesongfestival — in het Frans, niet in het Duits.",
+      "uri_apple_music": "applemusic://track/1436587677",
+      "uri_deezer": "deezer://track/546259292"
     },
     {
       "year": 2019,
@@ -5323,7 +5340,8 @@
       "fun_fact_de": "Die Duettpartnerin ist die österreichische Sängerin Allessa, und der Titel folgt auf ihr gemeinsames Der Einzige.",
       "fun_fact_es": "La compañera de dueto es la cantante austriaca Allessa, y el tema sigue a Der Einzige, que grabaron juntos antes.",
       "fun_fact_fr": "La partenaire de duo est la chanteuse autrichienne Allessa, et le titre fait suite à leur précédent, Der Einzige.",
-      "fun_fact_nl": "De duetpartner is de Oostenrijkse zangeres Allessa, en het nummer volgt op hun eerdere Der Einzige."
+      "fun_fact_nl": "De duetpartner is de Oostenrijkse zangeres Allessa, en het nummer volgt op hun eerdere Der Einzige.",
+      "uri_apple_music": "applemusic://track/1822532767"
     },
     {
       "year": 2020,
@@ -5340,7 +5358,9 @@
       "fun_fact_de": "Der Titelsong ihres Debütalbums und erst ihre zweite Single — ihr Herz hängt an Country und Rock, daher die Gitarren.",
       "fun_fact_es": "La canción que da título a su álbum debut y apenas su segundo sencillo: su corazón está en el country y el rock, de ahí las guitarras.",
       "fun_fact_fr": "La chanson-titre de son premier album et seulement son deuxième single — son cœur penche vers le country et le rock, d'où les guitares.",
-      "fun_fact_nl": "Het titelnummer van haar debuutalbum en pas haar tweede single — haar hart ligt bij country en rock, vandaar de gitaren."
+      "fun_fact_nl": "Het titelnummer van haar debuutalbum en pas haar tweede single — haar hart ligt bij country en rock, vandaar de gitaren.",
+      "uri_apple_music": "applemusic://track/1512422192",
+      "uri_deezer": "deezer://track/1015644662"
     },
     {
       "year": 2020,
@@ -5357,7 +5377,9 @@
       "fun_fact_de": "Grosch stand im Finale der dritten DSDS-Staffel und verlor gegen Tobias Regner — dieser Titel war vierzehn Jahre später sein Comeback.",
       "fun_fact_es": "Grosch llegó a la final de la tercera edición de Deutschland sucht den Superstar y perdió ante Tobias Regner; este tema fue su regreso, catorce años después.",
       "fun_fact_fr": "Grosch a atteint la finale de la troisième saison de Deutschland sucht den Superstar et a perdu face à Tobias Regner ; ce titre marque son retour, quatorze ans plus tard.",
-      "fun_fact_nl": "Grosch haalde de finale van het derde seizoen van Deutschland sucht den Superstar en verloor van Tobias Regner; dit nummer was veertien jaar later zijn comeback."
+      "fun_fact_nl": "Grosch haalde de finale van het derde seizoen van Deutschland sucht den Superstar en verloor van Tobias Regner; dit nummer was veertien jaar later zijn comeback.",
+      "uri_apple_music": "applemusic://track/1530420079",
+      "uri_deezer": "deezer://track/1294955122"
     },
     {
       "year": 2021,
@@ -5374,7 +5396,8 @@
       "fun_fact_de": "Eine Neuaufnahme von Roger Whittakers Hit von 1982 — und Whittaker singt ihn fast vierzig Jahre später selbst noch einmal.",
       "fun_fact_es": "Una nueva grabación del éxito de Roger Whittaker de 1982, con el propio Whittaker cantándolo de nuevo casi cuarenta años después.",
       "fun_fact_fr": "Un nouvel enregistrement du tube de Roger Whittaker de 1982 — avec Whittaker lui-même qui le rechante près de quarante ans plus tard.",
-      "fun_fact_nl": "Een nieuwe opname van Roger Whittakers hit uit 1982 — met Whittaker die hem bijna veertig jaar later zelf opnieuw zingt."
+      "fun_fact_nl": "Een nieuwe opname van Roger Whittakers hit uit 1982 — met Whittaker die hem bijna veertig jaar later zelf opnieuw zingt.",
+      "uri_apple_music": "applemusic://track/1562335293"
     },
     {
       "year": 2022,
@@ -5391,7 +5414,9 @@
       "fun_fact_de": "Die Band spielt Andrea Berg und Udo Jürgens auf Kontrabass und E-Gitarre und nennt das Ergebnis Schlagerbilly.",
       "fun_fact_es": "La banda toca a Andrea Berg y Udo Jürgens con contrabajo y guitarra eléctrica, y llama al resultado Schlagerbilly.",
       "fun_fact_fr": "Le groupe joue Andrea Berg et Udo Jürgens à la contrebasse et à la guitare électrique, et appelle ça du Schlagerbilly.",
-      "fun_fact_nl": "De band speelt Andrea Berg en Udo Jürgens op contrabas en elektrische gitaar en noemt het resultaat Schlagerbilly."
+      "fun_fact_nl": "De band speelt Andrea Berg en Udo Jürgens op contrabas en elektrische gitaar en noemt het resultaat Schlagerbilly.",
+      "uri_apple_music": "applemusic://track/1822479497",
+      "uri_deezer": "deezer://track/3783462492"
     },
     {
       "year": 2026,
@@ -5408,7 +5433,8 @@
       "fun_fact_de": "Zur Karnevalszeit erschienen und direkt in den Mallorca-Sommer getragen — einer der beiden Julian-Sommer-Titel, auf denen das Opening 2026 aufbaute.",
       "fun_fact_es": "Publicada en carnaval y llevada directamente al verano mallorquín: uno de los dos temas de Julian Sommer sobre los que se construyó la apertura de 2026.",
       "fun_fact_fr": "Sorti pendant le carnaval et porté directement dans l'été majorquin — l'un des deux titres de Julian Sommer sur lesquels reposait l'ouverture 2026.",
-      "fun_fact_nl": "Uitgebracht in het carnavalsseizoen en meteen doorgedragen naar de Mallorca-zomer — een van de twee Julian Sommer-nummers waarop de opening van 2026 leunde."
+      "fun_fact_nl": "Uitgebracht in het carnavalsseizoen en meteen doorgedragen naar de Mallorca-zomer — een van de twee Julian Sommer-nummers waarop de opening van 2026 leunde.",
+      "uri_apple_music": "applemusic://track/6805916976"
     },
     {
       "year": 2026,
@@ -5425,7 +5451,9 @@
       "fun_fact_de": "Der Text stammt von Tobias Reitz, der auch für Helene Fischer und Vanessa Mai schreibt — ein Autor, den man weit öfter hört als nennt.",
       "fun_fact_es": "La letra es de Tobias Reitz, que también escribe para Helene Fischer y Vanessa Mai: un autor al que se escucha mucho más de lo que se le nombra.",
       "fun_fact_fr": "Le texte est de Tobias Reitz, qui écrit aussi pour Helene Fischer et Vanessa Mai — un auteur qu'on entend bien plus souvent qu'on ne le nomme.",
-      "fun_fact_nl": "De tekst is van Tobias Reitz, die ook voor Helene Fischer en Vanessa Mai schrijft — een auteur die je veel vaker hoort dan noemt."
+      "fun_fact_nl": "De tekst is van Tobias Reitz, die ook voor Helene Fischer en Vanessa Mai schrijft — een auteur die je veel vaker hoort dan noemt.",
+      "uri_apple_music": "applemusic://track/1891981430",
+      "uri_deezer": "deezer://track/3952473041"
     }
   ]
 }


### PR DESCRIPTION
A `provider-uri-backfill` run focused on Deezer, driven automatically by `com.beatify.deezer-backfill`.

- `deutschrap-klassiker` Deezer 0 -> **26**/26
- `schlager-klassiker` Deezer 174 -> **190**/193

Filled in along the way, because Odesli answers with every provider at once: apple +29.

**The run stopped at its cap rather than finishing** (`reached --max-minutes 34`). The remaining tracks of the playlist are untouched and are not a catalogue gap.

**Draft on purpose** — merged only once the maintainer approves. This agent has deliberately NO auto-merge.