### PR TITLE
chore(playlists): youtube backfill — +16 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/community/clasicos-disney-castellano.json
+++ b/custom_components/beatify/playlists/community/clasicos-disney-castellano.json
@@ -1,6 +1,6 @@
 {
   "name": "Clásicos Disney (Castellano)",
-  "version": "0.4",
+  "version": "0.5",
   "tags": [
     "disney",
     "movies",
@@ -884,7 +884,8 @@
         "Geraldine Larrosa",
         "Yolanda de las Heras"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Coco» della Disney (2017)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Coco» della Disney (2017).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ZZkVaNWvatM"
     },
     {
       "year": 1997,
@@ -902,7 +903,8 @@
         "Marta Martorell",
         "Sleeping Beauty"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Hércules» della Disney (1997)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Hércules» della Disney (1997).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ItyNru6j0CY"
     },
     {
       "year": 1998,
@@ -921,7 +923,8 @@
         "Armando Pita",
         "Susan Martín"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Mulán» della Disney (1998)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Mulán» della Disney (1998).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=b7EfMXGdeqM"
     },
     {
       "year": 1999,
@@ -940,7 +943,8 @@
         "Flavio",
         "Lupita Pérez"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Tarzán» della Disney (1999)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Tarzán» della Disney (1999).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=5k8NySrpplY"
     },
     {
       "year": 1953,
@@ -958,7 +962,8 @@
         "Jordi Doncos",
         "Sleeping Beauty"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Peter Pan» della Disney (1953)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Peter Pan» della Disney (1953).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=H-BtICAhebk"
     },
     {
       "year": 1996,
@@ -977,7 +982,8 @@
         "Alex Ubago",
         "Chila Lynn"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «El Jorobado de Notre Dame» della Disney (1996)."
+      "fun_fact_it": "Dalla versione in spagnolo di «El Jorobado de Notre Dame» della Disney (1996).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=_6t2g06U2wo"
     },
     {
       "year": 2003,
@@ -993,7 +999,8 @@
         "Geraldine Larrosa",
         "Lupita Pérez"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Tierra de Osos» della Disney (2003)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Tierra de Osos» della Disney (2003).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vrjis75CBmw"
     },
     {
       "year": 1937,
@@ -1009,7 +1016,8 @@
         "Josema Yuste",
         "Miguel Morant"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Blancanieves» della Disney (1937)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Blancanieves» della Disney (1937).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mix2vXsFKcc"
     },
     {
       "year": 1995,
@@ -1028,7 +1036,8 @@
         "Josema Yuste",
         "Susan Martín"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Pocahontas» della Disney (1995)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Pocahontas» della Disney (1995).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hl61cQcSu9Y"
     },
     {
       "year": 1996,
@@ -1044,7 +1053,8 @@
         "Gipsy Kings",
         "Jim Sutherland"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «El Jorobado de Notre Dame» della Disney (1996)."
+      "fun_fact_it": "Dalla versione in spagnolo di «El Jorobado de Notre Dame» della Disney (1996).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cwkDAsrFVfY"
     },
     {
       "year": 1991,
@@ -1061,7 +1071,8 @@
         "Josema Yuste",
         "Naima Barroso"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (1991)."
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (1991).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=a93jxmsrimo"
     },
     {
       "year": 1995,
@@ -1078,7 +1089,8 @@
         "Anolita Domínguez",
         "Jesús Aguirre"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Pocahontas» della Disney (1995)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Pocahontas» della Disney (1995).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=p2z-Xv_ScDg"
     },
     {
       "year": 1991,
@@ -1095,7 +1107,8 @@
         "AD Santos",
         "Josema Yuste"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (1991)."
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (1991).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mSZ1sSSgL4E"
     },
     {
       "year": 1992,
@@ -1114,7 +1127,8 @@
         "Jordi Doncos",
         "Ricky Martin"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Aladdín» della Disney (1992)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Aladdín» della Disney (1992).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=tzXxK2e_AQY"
     },
     {
       "year": 1992,
@@ -1133,7 +1147,8 @@
         "Malú",
         "Sol Pilas"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Aladdín» della Disney (1992)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Aladdín» della Disney (1992).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YbQHMw5DJaY"
     },
     {
       "year": 1991,
@@ -1152,7 +1167,8 @@
         "Angélica Valle",
         "Malú"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (1991)."
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (1991).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=yE6J-_TjlkM"
     }
   ]
 }


### PR DESCRIPTION
A `provider-uri-backfill` run, driven automatically by `com.beatify.youtube-backfill`.

- `clasicos-disney-castellano` YouTube 0 -> **16**/64

**Draft on purpose** — merged only once the maintainer approves.