### PR TITLE
data(playlists): backfill 138 Apple Music URIs across the five v4.4.1-rc1 playlists

### DIFF
--- a/custom_components/beatify/playlists/community/clasicos-rock-en-espanol.json
+++ b/custom_components/beatify/playlists/community/clasicos-rock-en-espanol.json
@@ -1,6 +1,6 @@
 {
   "name": "Clásicos del Rock en Español",
-  "version": "1.0",
+  "version": "1.1",
   "tags": [
     "rock",
     "spanish",
@@ -31,7 +31,8 @@
       "fun_fact_fr": "Tout le monde la connaît par la phrase que le public hurle en retour, sufre mamón, et pas par son vrai titre.",
       "fun_fact_nl": "Iedereen kent het door de zin die het publiek terugbrult — sufre mamón — en niet door de echte titel.",
       "isrc": "ES5018572005",
-      "uri_deezer": "deezer://track/14932729"
+      "uri_deezer": "deezer://track/14932729",
+      "uri_apple_music": "applemusic://track/979321016"
     },
     {
       "year": 1986,
@@ -50,7 +51,8 @@
       "fun_fact_fr": "De l'album nommé d'après Burt Lancaster, La cagaste... Burt Lancaster, tiré d'une réplique de doublage et non de sa filmographie.",
       "fun_fact_nl": "Van het album vernoemd naar Burt Lancaster — La cagaste... Burt Lancaster — naar een zin uit een nasynchronisatie, niet naar zijn werk.",
       "isrc": "ES5018672005",
-      "uri_deezer": "deezer://track/814665"
+      "uri_deezer": "deezer://track/814665",
+      "uri_apple_music": "applemusic://track/131367623"
     },
     {
       "year": 1988,
@@ -69,7 +71,8 @@
       "fun_fact_fr": "Le groupe a tourné un film du même nom, et voici sa chanson-titre : la pop espagnole des années quatre-vingt dans sa version la plus commerciale.",
       "fun_fact_nl": "De band maakte een gelijknamige film, en dit is het titelnummer — Spaanse jarentachtigpop op zijn commercieelst.",
       "isrc": "ES5018872005",
-      "uri_deezer": "deezer://track/814803"
+      "uri_deezer": "deezer://track/814803",
+      "uri_apple_music": "applemusic://track/80836759"
     },
     {
       "year": 1985,
@@ -88,7 +91,8 @@
       "fun_fact_fr": "Du même premier album de 1985 que Devuélveme a mi chica, enregistré quand le groupe sortait à peine de l'adolescence.",
       "fun_fact_nl": "Van hetzelfde debuutalbum uit 1985 als Devuélveme a mi chica, opgenomen toen de band net de tienerjaren ontgroeid was.",
       "isrc": "ES5018572000",
-      "uri_deezer": "deezer://track/3918195"
+      "uri_deezer": "deezer://track/3918195",
+      "uri_apple_music": "applemusic://track/979321011"
     },
     {
       "year": 1986,
@@ -107,7 +111,8 @@
       "fun_fact_fr": "Une chanson entière bâtie sur le déni d'un prénom : la blague, c'est que le déni répète sans cesse le prénom qu'il nie.",
       "fun_fact_nl": "Een heel nummer gebouwd op het ontkennen van een naam — de grap is dat de ontkenning die naam blijft herhalen.",
       "isrc": "ES5028600142",
-      "uri_deezer": "deezer://track/93888288"
+      "uri_deezer": "deezer://track/93888288",
+      "uri_apple_music": "applemusic://track/964104304"
     },
     {
       "year": 1987,
@@ -126,7 +131,8 @@
       "fun_fact_fr": "Extrait de El grito del tiempo, l'album qui a fait sortir le trio basque du circuit indépendant vers les radios nationales.",
       "fun_fact_nl": "Van El grito del tiempo, het album dat het Baskische trio uit het indiecircuit naar de landelijke radio bracht.",
       "isrc": "ES5018760000",
-      "uri_deezer": "deezer://track/674813"
+      "uri_deezer": "deezer://track/674813",
+      "uri_apple_music": "applemusic://track/101291785"
     },
     {
       "year": 1994,
@@ -145,7 +151,8 @@
       "fun_fact_fr": "Extrait de Piedras, enregistré des années après l'apogée des années quatre-vingt et dernier single largement diffusé.",
       "fun_fact_nl": "Van Piedras, jaren na het hoogtepunt in de jaren tachtig opgenomen en hun laatste breed gehoorde single.",
       "isrc": "ES5019460010",
-      "uri_deezer": "deezer://track/3894270"
+      "uri_deezer": "deezer://track/3894270",
+      "uri_apple_music": "applemusic://track/81256859"
     },
     {
       "year": 1984,
@@ -164,7 +171,8 @@
       "fun_fact_fr": "Le premier single du premier album, et son loup-garou vient d'une nouvelle de Boris Vian, pas d'un film d'horreur.",
       "fun_fact_nl": "De eerste single van het eerste album, en de weerwolf komt uit een kort verhaal van Boris Vian, niet uit een horrorfilm.",
       "isrc": "ES5159401001",
-      "uri_deezer": "deezer://track/3899862"
+      "uri_deezer": "deezer://track/3899862",
+      "uri_apple_music": "applemusic://track/256662823"
     },
     {
       "year": 1996,
@@ -183,7 +191,8 @@
       "fun_fact_fr": "Pau Donés l'a écrite après un voyage à Cuba ; ce premier single a donné son nom à l'album et sa direction à toute la carrière.",
       "fun_fact_nl": "Pau Donés schreef het na een reis naar Cuba; de debuutsingle gaf het album zijn naam en de hele carrière zijn richting.",
       "isrc": "ES5039600004",
-      "uri_deezer": "deezer://track/3092625"
+      "uri_deezer": "deezer://track/3092625",
+      "uri_apple_music": "applemusic://track/696616314"
     },
     {
       "year": 1990,
@@ -278,7 +287,8 @@
       "fun_fact_fr": "Il a remporté un MTV Video Award en 1994 et parle de l'assassinat de l'écrivain et militant argentin Rodolfo Walsh.",
       "fun_fact_nl": "Het won in 1994 een MTV Video Award en gaat over de moord op de Argentijnse schrijver en activist Rodolfo Walsh.",
       "isrc": "ARFSB0800334",
-      "uri_deezer": "deezer://track/6686670"
+      "uri_deezer": "deezer://track/6686670",
+      "uri_apple_music": "applemusic://track/1555328828"
     },
     {
       "year": 1993,
@@ -297,7 +307,8 @@
       "fun_fact_fr": "Un duo avec Celia Cruz, enregistré quand la chanteuse cubaine frôlait les soixante-dix ans et le groupe à peine trente.",
       "fun_fact_nl": "Een duet met Celia Cruz, opgenomen toen de Cubaanse salsazangeres bijna zeventig was en de band nauwelijks dertig.",
       "isrc": "ARF100100531",
-      "uri_deezer": "deezer://track/6686072"
+      "uri_deezer": "deezer://track/6686072",
+      "uri_apple_music": "applemusic://track/1555328435"
     },
     {
       "year": 1995,
@@ -316,7 +327,8 @@
       "fun_fact_fr": "Rey Azúcar a été produit par Tina Weymouth et Chris Frantz de Talking Heads, d'où le groove plus serré de l'album.",
       "fun_fact_nl": "Rey Azúcar werd geproduceerd door Tina Weymouth en Chris Frantz van Talking Heads — vandaar de strakkere groove.",
       "isrc": "ARFSB0800352",
-      "uri_deezer": "deezer://track/6686599"
+      "uri_deezer": "deezer://track/6686599",
+      "uri_apple_music": "applemusic://track/298978638"
     },
     {
       "year": 1992,
@@ -335,7 +347,8 @@
       "fun_fact_fr": "Extrait de El León, l'album où le ska du groupe est devenu plus lent et plus lourd.",
       "fun_fact_nl": "Van El León, het album waarop de ska van de band trager en zwaarder werd.",
       "isrc": "ARFSB0800319",
-      "uri_deezer": "deezer://track/6686677"
+      "uri_deezer": "deezer://track/6686677",
+      "uri_apple_music": "applemusic://track/297762618"
     },
     {
       "year": 1994,
@@ -354,7 +367,8 @@
       "fun_fact_fr": "Big Bang a porté le groupe hors d'Argentine à travers tout le continent ; c'est cette chanson qui l'a porté.",
       "fun_fact_nl": "Big Bang bracht de band buiten Argentinië over het hele continent — en dit is het nummer dat dat deed.",
       "isrc": "ARF049400245",
-      "uri_deezer": "deezer://track/3538068"
+      "uri_deezer": "deezer://track/3538068",
+      "uri_apple_music": "applemusic://track/721632344"
     },
     {
       "year": 1986,
@@ -373,7 +387,8 @@
       "fun_fact_fr": "Extrait de Contrarreloj, le deuxième album, enregistré à Mendoza bien avant que le groupe soit connu hors d'Argentine.",
       "fun_fact_nl": "Van Contrarreloj, het tweede album, opgenomen in Mendoza lang voordat de band buiten Argentinië bekend was.",
       "isrc": "ARF109400173",
-      "uri_deezer": "deezer://track/6080021"
+      "uri_deezer": "deezer://track/6080021",
+      "uri_apple_music": "applemusic://track/187443614"
     },
     {
       "year": 1994,
@@ -392,7 +407,8 @@
       "fun_fact_fr": "Du même album de 1994 que Lamento Boliviano, et les deux singles ont couru les classements presque côte à côte.",
       "fun_fact_nl": "Van hetzelfde album uit 1994 als Lamento Boliviano; beide singles liepen bijna gelijktijdig in de hitlijsten.",
       "isrc": "ARF049400340",
-      "uri_deezer": "deezer://track/3538021"
+      "uri_deezer": "deezer://track/3538021",
+      "uri_apple_music": "applemusic://track/721632554"
     },
     {
       "year": 1987,
@@ -411,7 +427,8 @@
       "fun_fact_fr": "Extrait de Habitaciones Extrañas : l'étranger aux cheveux longs du titre était déjà une image bien usée du rock argentin.",
       "fun_fact_nl": "Van Habitaciones Extrañas — de langharige vreemdeling uit de titel was toen al een vertrouwd beeld in de Argentijnse rock.",
       "isrc": "ARF109400172",
-      "uri_deezer": "deezer://track/13233546"
+      "uri_deezer": "deezer://track/13233546",
+      "uri_apple_music": "applemusic://track/187443606"
     },
     {
       "year": 1986,
@@ -430,7 +447,8 @@
       "fun_fact_fr": "Une chanson sur les enfants que l'école laisse de côté, écrite en 1986 et reprise dans les rues chiliennes des décennies plus tard.",
       "fun_fact_nl": "Een lied over de kinderen die school achterlaat, geschreven in 1986 en decennia later opnieuw gezongen op straat in Chili.",
       "isrc": "CLBB28600013",
-      "uri_deezer": "deezer://track/52849281"
+      "uri_deezer": "deezer://track/52849281",
+      "uri_apple_music": "applemusic://track/714026688"
     },
     {
       "year": 1990,
@@ -468,7 +486,8 @@
       "fun_fact_fr": "La chanson-titre du premier album, faite par trois camarades de lycée de San Miguel et enregistrée alors que le Chili était encore sous Pinochet.",
       "fun_fact_nl": "Het titelnummer van het debuut, gemaakt door drie schoolvrienden uit San Miguel en opgenomen toen Chili nog onder Pinochet stond.",
       "isrc": "CLAC28400001",
-      "uri_deezer": "deezer://track/3234660331"
+      "uri_deezer": "deezer://track/3234660331",
+      "uri_apple_music": "applemusic://track/933144890"
     },
     {
       "year": 1984,
@@ -487,7 +506,8 @@
       "fun_fact_fr": "Également extrait du premier album de 1984 : la question du titre est posée sans jamais recevoir de réponse.",
       "fun_fact_nl": "Ook van het debuut uit 1984 — de vraag in de titel wordt gesteld en nooit beantwoord.",
       "isrc": "CLAC28400006",
-      "uri_deezer": "deezer://track/3234660381"
+      "uri_deezer": "deezer://track/3234660381",
+      "uri_apple_music": "applemusic://track/933144905"
     },
     {
       "year": 1995,
@@ -506,7 +526,8 @@
       "fun_fact_fr": "Extrait de El Dorado, le disque qui a fait un boléro du punk de Bogotá et fait du duo le visage du rock colombien.",
       "fun_fact_nl": "Van El Dorado, de plaat die van Bogotá-punk een bolero maakte en het duo tot gezicht van de Colombiaanse rock.",
       "isrc": "USBL10100446",
-      "uri_deezer": "deezer://track/13235072"
+      "uri_deezer": "deezer://track/13235072",
+      "uri_apple_music": "applemusic://track/254793125"
     },
     {
       "year": 1995,
@@ -525,7 +546,8 @@
       "fun_fact_fr": "Également extrait de El Dorado, la chanson qui a porté la voix d'Andrea Echeverri sur les radios de tout le continent.",
       "fun_fact_nl": "Ook van El Dorado, en het nummer dat Andrea Echeverri's stem op radio's over het hele continent bracht.",
       "isrc": "USBL10100445",
-      "uri_deezer": "deezer://track/13186104"
+      "uri_deezer": "deezer://track/13186104",
+      "uri_apple_music": "applemusic://track/254793001"
     },
     {
       "year": 1998,
@@ -544,7 +566,8 @@
       "fun_fact_fr": "Extrait de Caribe Atómico, l'album où le duo a troqué les guitares contre l'électronique : la querelle qui a divisé son public.",
       "fun_fact_nl": "Van Caribe Atómico, het album waarop het duo gitaren inruilde voor elektronica — de discussie die het publiek splitste.",
       "isrc": "USBL10100431",
-      "uri_deezer": "deezer://track/599362"
+      "uri_deezer": "deezer://track/599362",
+      "uri_apple_music": "applemusic://track/268462708"
     },
     {
       "year": 1996,
@@ -563,7 +586,8 @@
       "fun_fact_fr": "Extrait de La Pipa de la Paz, produit par Phil Manzanera de Roxy Music : un guitariste anglais d'art rock sur un disque colombien.",
       "fun_fact_nl": "Van La Pipa de la Paz, geproduceerd door Phil Manzanera van Roxy Music — een Engelse artrockgitarist op een Colombiaanse plaat.",
       "isrc": "USBL10100434",
-      "uri_deezer": "deezer://track/13188346"
+      "uri_deezer": "deezer://track/13188346",
+      "uri_apple_music": "applemusic://track/254839122"
     },
     {
       "year": 1997,
@@ -582,7 +606,8 @@
       "fun_fact_fr": "En 1997, le groupe de Medellín était passé du thrash metal à la ballade rock : cette chanson se situe dans ce virage.",
       "fun_fact_nl": "Tegen 1997 was de band uit Medellín van thrashmetal naar rockballades geschoven — in die omslag zit dit nummer.",
       "isrc": "USFI29702425",
-      "uri_deezer": "deezer://track/15518792"
+      "uri_deezer": "deezer://track/15518792",
+      "uri_apple_music": "applemusic://track/1443545608"
     },
     {
       "year": 1994,
@@ -601,7 +626,8 @@
       "fun_fact_fr": "Ekhymosis, c'était le groupe de Juanes : il y a chanté et joué de la guitare pendant une décennie avant que quiconque connaisse son prénom.",
       "fun_fact_nl": "Ekhymosis was de band van Juanes — hij zong en speelde er tien jaar gitaar voordat iemand zijn voornaam kende.",
       "isrc": "COC019421873",
-      "uri_deezer": "deezer://track/11112815"
+      "uri_deezer": "deezer://track/11112815",
+      "uri_apple_music": "applemusic://track/1712535821"
     },
     {
       "year": 1994,
@@ -620,7 +646,8 @@
       "fun_fact_fr": "Extrait de El nervio del volcán, quatrième et dernier album : le groupe s'est séparé l'année suivante.",
       "fun_fact_nl": "Van El nervio del volcán, het vierde en laatste album — de band ging het jaar erna uit elkaar.",
       "isrc": "MXF019400341",
-      "uri_deezer": "deezer://track/13272449"
+      "uri_deezer": "deezer://track/13272449",
+      "uri_apple_music": "applemusic://track/205385055"
     },
     {
       "year": 1989,
@@ -658,7 +685,8 @@
       "fun_fact_fr": "El Silencio a été produit par Adrian Belew, guitariste de King Crimson et du groupe de David Bowie.",
       "fun_fact_nl": "El Silencio werd geproduceerd door Adrian Belew, gitarist van King Crimson en van David Bowies band.",
       "isrc": "MXF019701449",
-      "uri_deezer": "deezer://track/13302028"
+      "uri_deezer": "deezer://track/13302028",
+      "uri_apple_music": "applemusic://track/322133795"
     },
     {
       "year": 1994,
@@ -677,7 +705,8 @@
       "fun_fact_fr": "Également du dernier album, enregistré alors que la rupture entre le chanteur et le guitariste était déjà entamée.",
       "fun_fact_nl": "Ook van het laatste album, opgenomen terwijl de breuk tussen zanger en gitarist al gaande was.",
       "isrc": "MXF019700411",
-      "uri_deezer": "deezer://track/13272450"
+      "uri_deezer": "deezer://track/13272450",
+      "uri_apple_music": "applemusic://track/205385095"
     },
     {
       "year": 1992,
@@ -696,7 +725,8 @@
       "fun_fact_fr": "Extrait de ¿Dónde jugarán los niños?, vendu à plus de dix millions d'exemplaires et toujours l'album de rock hispanophone le plus vendu.",
       "fun_fact_nl": "Van ¿Dónde jugarán los niños?, dat meer dan tien miljoen keer verkocht en nog altijd het bestverkochte Spaanstalige rockalbum is.",
       "isrc": "MXF159200061",
-      "uri_deezer": "deezer://track/7505025"
+      "uri_deezer": "deezer://track/7505025",
+      "uri_apple_music": "applemusic://track/358349018"
     },
     {
       "year": 1992,
@@ -715,7 +745,8 @@
       "fun_fact_fr": "Le neuvième et dernier single tiré de ce même album, un disque qui a continué à donner des tubes des années après sa sortie.",
       "fun_fact_nl": "De negende en laatste single van datzelfde album — een plaat die nog jaren na verschijnen hits bleef opleveren.",
       "isrc": "MXF150900236",
-      "uri_deezer": "deezer://track/3081259"
+      "uri_deezer": "deezer://track/3081259",
+      "uri_apple_music": "applemusic://track/358349025"
     },
     {
       "year": 1992,
@@ -734,7 +765,8 @@
       "fun_fact_fr": "Du même album de 1992, et le morceau où le côté reggae du groupe est le plus difficile à manquer.",
       "fun_fact_nl": "Van hetzelfde album uit 1992, en het nummer waarop de reggaekant van de band het minst te missen is.",
       "isrc": "MXF159200071",
-      "uri_deezer": "deezer://track/7505035"
+      "uri_deezer": "deezer://track/7505035",
+      "uri_apple_music": "applemusic://track/358349041"
     },
     {
       "year": 1992,
@@ -753,7 +785,8 @@
       "fun_fact_fr": "Également de ¿Dónde jugarán los niños? : le titre de l'album pose une question écologique que le groupe n'a cessé de reposer.",
       "fun_fact_nl": "Ook van ¿Dónde jugarán los niños? — de albumtitel stelt een milieuvraag die de band decennialang bleef stellen.",
       "isrc": "MXF159200065",
-      "uri_deezer": "deezer://track/7505029"
+      "uri_deezer": "deezer://track/7505029",
+      "uri_apple_music": "applemusic://track/358349033"
     }
   ]
 }

--- a/custom_components/beatify/playlists/community/deutschrap-klassiker.json
+++ b/custom_components/beatify/playlists/community/deutschrap-klassiker.json
@@ -1,6 +1,6 @@
 {
   "name": "Deutschrap Klassiker",
-  "version": "1.1",
+  "version": "1.2",
   "tags": [
     "deutschrap",
     "hip-hop",
@@ -32,7 +32,8 @@
       "fun_fact_es": "Schwester S. fue el primer nombre artistico de Sabrina Setlur, que mas tarde entro en las listas con su propio nombre: la misma artista tras dos nombres.",
       "fun_fact_fr": "Schwester S. etait le premier nom de scene de Sabrina Setlur, entree ensuite dans les charts sous son prenom : la meme artiste sous deux noms.",
       "fun_fact_nl": "Schwester S. was de vroege artiestennaam van Sabrina Setlur, die later onder haar eigen voornaam in de hitlijsten kwam — dezelfde artieste met twee namen.",
-      "uri_deezer": "deezer://track/124641868"
+      "uri_deezer": "deezer://track/124641868",
+      "uri_apple_music": "applemusic://track/1119306834"
     },
     {
       "year": 1997,
@@ -113,7 +114,8 @@
       "fun_fact_es": "Construida sobre el tema de la serie Prison Break, con Adel Tawil en el estribillo anos antes de que Ich + Ich fuera conocido por todos.",
       "fun_fact_fr": "Construit sur le theme de la serie Prison Break, avec Adel Tawil au refrain, des annees avant qu'Ich + Ich ne soit connu de tous.",
       "fun_fact_nl": "Gebouwd op het thema van de serie Prison Break, met Adel Tawil op het refrein, jaren voordat Ich + Ich een begrip werd.",
-      "uri_deezer": "deezer://track/1163878"
+      "uri_deezer": "deezer://track/1163878",
+      "uri_apple_music": "applemusic://track/1444292071"
     },
     {
       "year": 2008,

--- a/custom_components/beatify/playlists/community/musica-colombiana-alegre.json
+++ b/custom_components/beatify/playlists/community/musica-colombiana-alegre.json
@@ -1,6 +1,6 @@
 {
   "name": "Música Colombiana Alegre",
-  "version": "0.1",
+  "version": "0.2",
   "tags": [
     "latin",
     "spanish",
@@ -31,7 +31,8 @@
       "fun_fact_fr": "Otto Serge et l'accordéoniste Rafael Ricardo incarnaient le versant lisse et radiophonique du vallenato des années 80.",
       "fun_fact_nl": "Otto Serge en accordeonist Rafael Ricardo stonden voor de gladde, radiovriendelijke kant van de jaren-tachtigvallenato.",
       "isrc": "COC018315793",
-      "uri_deezer": "deezer://track/1700971297"
+      "uri_deezer": "deezer://track/1700971297",
+      "uri_apple_music": "applemusic://track/1712902085"
     },
     {
       "year": 1991,
@@ -50,7 +51,8 @@
       "fun_fact_fr": "L'un des derniers disques de Binomio de Oro avec Rafael Orozco, assassiné l'année suivante.",
       "fun_fact_nl": "Een van de laatste platen die Binomio de Oro met Rafael Orozco maakte; hij werd het jaar daarop vermoord.",
       "isrc": "COC019121031",
-      "uri_deezer": "deezer://track/37800681"
+      "uri_deezer": "deezer://track/37800681",
+      "uri_apple_music": "applemusic://track/1711865709"
     },
     {
       "year": 1993,
@@ -69,7 +71,8 @@
       "fun_fact_fr": "Extrait de Clásicos de la Provincia, l'album où Carlos Vives a placé un groupe de rock derrière les standards vallenato.",
       "fun_fact_nl": "Van Clásicos de la Provincia, het album waarop Carlos Vives een rockband achter vallenatostandards zette.",
       "isrc": "COSO11300340",
-      "uri_deezer": "deezer://track/1170737072"
+      "uri_deezer": "deezer://track/1170737072",
+      "uri_apple_music": "applemusic://track/1543992400"
     },
     {
       "year": 1993,
@@ -88,7 +91,8 @@
       "fun_fact_fr": "Juancho Polo Valencia a écrit Alicia Adorada après la mort de sa femme, alors qu'il jouait loin de chez lui.",
       "fun_fact_nl": "Juancho Polo Valencia schreef Alicia Adorada nadat zijn vrouw stierf terwijl hij ver van huis speelde.",
       "isrc": "COSO11300338",
-      "uri_deezer": "deezer://track/1170737052"
+      "uri_deezer": "deezer://track/1170737052",
+      "uri_apple_music": "applemusic://track/1543992223"
     },
     {
       "year": 1994,
@@ -107,7 +111,8 @@
       "fun_fact_fr": "Morales était l'une des deux voix lancées par Los Inquietos avant que les deux chanteurs ne partent chacun de leur côté.",
       "fun_fact_nl": "Morales was een van de twee stemmen die Los Inquietos voortbracht voordat beide zangers hun eigen weg gingen.",
       "isrc": "COC019422073",
-      "uri_deezer": "deezer://track/12479030"
+      "uri_deezer": "deezer://track/12479030",
+      "uri_apple_music": "applemusic://track/1713457398"
     },
     {
       "year": 1995,
@@ -126,7 +131,8 @@
       "fun_fact_fr": "La chanson-titre de l'album qui a fait entrer la musique d'accordéon dans le rock colombien, et ressortir en pop.",
       "fun_fact_nl": "Het titelnummer van het album dat accordeonmuziek de Colombiaanse rock in trok en er als pop weer uit.",
       "isrc": "QMDA62527660",
-      "uri_deezer": "deezer://track/3484258841"
+      "uri_deezer": "deezer://track/3484258841",
+      "uri_apple_music": "applemusic://track/1543817535"
     },
     {
       "year": 1995,
@@ -145,7 +151,8 @@
       "fun_fact_fr": "Trente ans après, c'est toujours le morceau qu'on met quand une fête colombienne a besoin de repartir.",
       "fun_fact_nl": "Dertig jaar later is dit nog steeds het nummer dat opstaat als een Colombiaans feest opnieuw moet aanslaan.",
       "isrc": "COSO11300351",
-      "uri_deezer": "deezer://track/1169356972"
+      "uri_deezer": "deezer://track/1169356972",
+      "uri_apple_music": "applemusic://track/1543817006"
     },
     {
       "year": 1995,
@@ -164,7 +171,8 @@
       "fun_fact_fr": "Donato et Estéfano formaient un duo colombien qui a ensuite écrit des tubes pour la moitié de la pop latine.",
       "fun_fact_nl": "Donato en Estéfano waren een Colombiaans duo dat later hits schreef voor de halve latinpop.",
       "isrc": "NLB639550001",
-      "uri_deezer": "deezer://track/15213957"
+      "uri_deezer": "deezer://track/15213957",
+      "uri_apple_music": "applemusic://track/404413505"
     },
     {
       "year": 1996,
@@ -183,7 +191,8 @@
       "fun_fact_fr": "Après l'assassinat d'Orozco, le groupe a ajouté « de América » et continué avec un nouveau chanteur.",
       "fun_fact_nl": "Na de moord op Orozco voegde de groep 'de América' toe en ging verder met een nieuwe zanger.",
       "isrc": "COC019622909",
-      "uri_deezer": "deezer://track/1963806"
+      "uri_deezer": "deezer://track/1963806",
+      "uri_apple_music": "applemusic://track/1711870034"
     },
     {
       "year": 1997,
@@ -202,7 +211,8 @@
       "fun_fact_fr": "Los Diablitos ont passé les années 90 comme le groupe auquel on mesurait toutes les autres formations vallenato.",
       "fun_fact_nl": "Los Diablitos waren in de jaren negentig de groep waaraan elke andere vallenatoband werd afgemeten.",
       "isrc": "COC019723289",
-      "uri_deezer": "deezer://track/1401641"
+      "uri_deezer": "deezer://track/1401641",
+      "uri_apple_music": "applemusic://track/1714010379"
     },
     {
       "year": 1998,
@@ -221,7 +231,8 @@
       "fun_fact_fr": "Une berceuse déguisée en chanson d'amour, et l'un des morceaux les plus demandés du groupe aux mariages.",
       "fun_fact_nl": "Een wiegelied vermomd als liefdeslied, en een van de meest gevraagde nummers van de groep op bruiloften.",
       "isrc": "COC019823618",
-      "uri_deezer": "deezer://track/1963860"
+      "uri_deezer": "deezer://track/1963860",
+      "uri_apple_music": "applemusic://track/1711885404"
     },
     {
       "year": 2000,
@@ -240,7 +251,8 @@
       "fun_fact_fr": "Bacilos, c'était un chanteur colombien et deux Brésiliens rencontrés à Miami, qui chantaient quand même en espagnol.",
       "fun_fact_nl": "Bacilos waren een Colombiaanse zanger en twee Brazilianen die elkaar in Miami troffen en toch in het Spaans zongen.",
       "isrc": "USWL10000454",
-      "uri_deezer": "deezer://track/3588703"
+      "uri_deezer": "deezer://track/3588703",
+      "uri_apple_music": "applemusic://track/73297348"
     },
     {
       "year": 2001,
@@ -259,7 +271,8 @@
       "fun_fact_fr": "Celedón et l'accordéoniste Jimmy Zambrano formaient un duo fixe, ce qui au vallenato vaut mariage.",
       "fun_fact_nl": "Celedón en accordeonist Jimmy Zambrano vormden een vast duo, wat in de vallenato als huwelijk telt.",
       "isrc": "COS010100093",
-      "uri_deezer": "deezer://track/13256477"
+      "uri_deezer": "deezer://track/13256477",
+      "uri_apple_music": "applemusic://track/487291493"
     },
     {
       "year": 2002,
@@ -278,7 +291,8 @@
       "fun_fact_fr": "La chanson-titre de l'album qui a valu à Bacilos un Latin Grammy l'année suivante.",
       "fun_fact_nl": "Het titelnummer van het album waarmee Bacilos het jaar daarop een Latin Grammy won.",
       "isrc": "USWL10200073",
-      "uri_deezer": "deezer://track/3588702"
+      "uri_deezer": "deezer://track/3588702",
+      "uri_apple_music": "applemusic://track/280875718"
     },
     {
       "year": 2004,
@@ -297,7 +311,8 @@
       "fun_fact_fr": "Deux ans avant que le duo ne remporte un Latin Grammy et n'amène le genre à la cérémonie pour la première fois.",
       "fun_fact_nl": "Twee jaar voordat het duo een Latin Grammy won en het genre voor het eerst naar de ceremonie bracht.",
       "isrc": "COS010400083",
-      "uri_deezer": "deezer://track/13256481"
+      "uri_deezer": "deezer://track/13256481",
+      "uri_apple_music": "applemusic://track/478753995"
     },
     {
       "year": 2004,
@@ -316,7 +331,8 @@
       "fun_fact_fr": "Lucas Arnau venait de la scène pop de Medellín, qui rivalisait alors avec la côte pour les classements.",
       "fun_fact_nl": "Lucas Arnau kwam uit de popscene van Medellín, die toen met de kust om de hitlijsten streed.",
       "isrc": "COS010400073",
-      "uri_deezer": "deezer://track/1279459542"
+      "uri_deezer": "deezer://track/1279459542",
+      "uri_apple_music": "applemusic://track/1559025955"
     },
     {
       "year": 2005,
@@ -335,7 +351,8 @@
       "fun_fact_fr": "Fanny Lu a fait des études d'ingénieur et travaillé à la télévision avant que ceci n'en fasse une chanteuse à plein temps.",
       "fun_fact_nl": "Fanny Lu studeerde techniek en werkte bij de televisie voordat dit haar fulltime zangeres maakte.",
       "isrc": "COUM70500081",
-      "uri_deezer": "deezer://track/1677541027"
+      "uri_deezer": "deezer://track/1677541027",
+      "uri_apple_music": "applemusic://track/1613183593"
     },
     {
       "year": 2005,
@@ -354,7 +371,8 @@
       "fun_fact_fr": "La percée de Fonseca, le disque qui a prouvé que les rythmes vallenato pouvaient porter une ballade pop.",
       "fun_fact_nl": "Fonseca's doorbraak, en de plaat die bewees dat vallenatoritmes een rechttoe rechtaan popballade kunnen dragen.",
       "isrc": "COH010500153",
-      "uri_deezer": "deezer://track/3462875"
+      "uri_deezer": "deezer://track/3462875",
+      "uri_apple_music": "applemusic://track/714689838"
     },
     {
       "year": 2006,
@@ -373,7 +391,8 @@
       "fun_fact_fr": "Que bonita es esta vida a remporté le Latin Grammy du meilleur album vallenato et est devenu la carte de visite du genre.",
       "fun_fact_nl": "Que bonita es esta vida won de Latin Grammy voor beste vallenato-album en werd het visitekaartje van het genre.",
       "isrc": "COSO10600390",
-      "uri_deezer": "deezer://track/13322048"
+      "uri_deezer": "deezer://track/13322048",
+      "uri_apple_music": "applemusic://track/270219850"
     },
     {
       "year": 2007,
@@ -392,7 +411,8 @@
       "fun_fact_fr": "Israel Romero joue de l'accordéon dans ce groupe depuis qu'il l'a fondé en 1976.",
       "fun_fact_nl": "Israel Romero speelt accordeon in deze groep sinds hij haar in 1976 oprichtte.",
       "isrc": "USALH0702002",
-      "uri_deezer": "deezer://track/63269551"
+      "uri_deezer": "deezer://track/63269551",
+      "uri_apple_music": "applemusic://track/317304235"
     },
     {
       "year": 2008,
@@ -411,7 +431,8 @@
       "fun_fact_fr": "Cabas a bâti son son sur la cumbia plutôt que le vallenato, qui sur la côte sont deux familles distinctes.",
       "fun_fact_nl": "Cabas bouwde zijn geluid op cumbia in plaats van vallenato, aan de kust twee heel verschillende families.",
       "isrc": "ES5080700484",
-      "uri_deezer": "deezer://track/3407308"
+      "uri_deezer": "deezer://track/3407308",
+      "uri_apple_music": "applemusic://track/693078190"
     },
     {
       "year": 2008,
@@ -430,7 +451,8 @@
       "fun_fact_fr": "Emiliano Zuleta est ici en invité ; ce nom appartient à l'une des familles fondatrices du vallenato.",
       "fun_fact_nl": "Emiliano Zuleta is hier te gast; die achternaam hoort bij een van de stichtende families van de vallenato.",
       "isrc": "COC010827434",
-      "uri_deezer": "deezer://track/16341871"
+      "uri_deezer": "deezer://track/16341871",
+      "uri_apple_music": "applemusic://track/1884065840"
     },
     {
       "year": 2009,
@@ -449,7 +471,8 @@
       "fun_fact_fr": "Los Inquietos se sont reformés plus d'une fois ; chaque formation soutient être la bonne.",
       "fun_fact_nl": "Los Inquietos hervormden zich meer dan eens; elke bezetting houdt vol dé bezetting te zijn.",
       "isrc": "ES7511027507",
-      "uri_deezer": "deezer://track/1255474312"
+      "uri_deezer": "deezer://track/1255474312",
+      "uri_apple_music": "applemusic://track/1770525074"
     },
     {
       "year": 2009,
@@ -468,7 +491,8 @@
       "fun_fact_fr": "Manjarrés est présenté comme le Caballero del Vallenato, un titre que la côte décerne avec parcimonie.",
       "fun_fact_nl": "Manjarrés wordt aangekondigd als de Caballero del Vallenato, een titel die de kust spaarzaam uitdeelt.",
       "isrc": "COC010927769",
-      "uri_deezer": "deezer://track/4839674"
+      "uri_deezer": "deezer://track/4839674",
+      "uri_apple_music": "applemusic://track/1713205438"
     },
     {
       "year": 2012,
@@ -487,7 +511,8 @@
       "fun_fact_fr": "Maía a fait les chœurs sur les disques des autres pendant des années avant que ce titre porte son nom.",
       "fun_fact_nl": "Maía zong jarenlang achtergrondvocalen op andermans platen voordat dit nummer haar eigen naam droeg.",
       "isrc": "COS010200637",
-      "uri_deezer": "deezer://track/19778021"
+      "uri_deezer": "deezer://track/19778021",
+      "uri_apple_music": "applemusic://track/520237042"
     },
     {
       "year": 2013,
@@ -506,7 +531,8 @@
       "fun_fact_fr": "Vives est revenu après des années loin de la musique, et ce disque le disait haut et fort.",
       "fun_fact_nl": "Vives keerde terug na jaren zonder muziek, en deze plaat zei dat hardop.",
       "isrc": "USSD11300003",
-      "uri_deezer": "deezer://track/64029983"
+      "uri_deezer": "deezer://track/64029983",
+      "uri_apple_music": "applemusic://track/596889801"
     },
     {
       "year": 2014,
@@ -525,7 +551,8 @@
       "fun_fact_fr": "ChocQuibTown viennent de la côte pacifique, une tout autre Colombie que celle de l'accordéon.",
       "fun_fact_nl": "ChocQuibTown komt van de Pacifische kust, een heel ander Colombia dan dat van het accordeon.",
       "isrc": "USSD11400026",
-      "uri_deezer": "deezer://track/78068431"
+      "uri_deezer": "deezer://track/78068431",
+      "uri_apple_music": "applemusic://track/867644927"
     },
     {
       "year": 2014,
@@ -544,7 +571,8 @@
       "fun_fact_fr": "Un Colombien et un New-Yorkais d'origine portoricaine, chantant sur une figure d'accordéon.",
       "fun_fact_nl": "Een Colombiaan en een New Yorker van Puerto Ricaanse afkomst, zingend over een accordeonfiguur.",
       "isrc": "USSD11400075",
-      "uri_deezer": "deezer://track/78068432"
+      "uri_deezer": "deezer://track/78068432",
+      "uri_apple_music": "applemusic://track/903284901"
     },
     {
       "year": 2015,
@@ -563,7 +591,8 @@
       "fun_fact_fr": "Cocha Molina est accordéoniste issu d'une dynastie d'accordéonistes, la façon dont l'instrument voyage sur la côte.",
       "fun_fact_nl": "Cocha Molina is accordeonist uit een dynastie van accordeonisten; zo reist het instrument aan de kust.",
       "isrc": "QM9F81500022",
-      "uri_deezer": "deezer://track/107970536"
+      "uri_deezer": "deezer://track/107970536",
+      "uri_apple_music": "applemusic://track/1042386379"
     },
     {
       "year": 2016,
@@ -582,7 +611,8 @@
       "fun_fact_fr": "Deux personnes de la même côte caraïbe, à quarante kilomètres l'une de l'autre, qui ont dû devenir célèbres d'abord.",
       "fun_fact_nl": "Twee mensen van dezelfde Caribische kust, veertig kilometer uit elkaar, die eerst beroemd moesten worden.",
       "isrc": "USSD11600112",
-      "uri_deezer": "deezer://track/420364332"
+      "uri_deezer": "deezer://track/420364332",
+      "uri_apple_music": "applemusic://track/1299332776"
     },
     {
       "year": 2016,
@@ -601,7 +631,8 @@
       "fun_fact_fr": "Piso 21 viennent de Medellín et se sont nommés d'après l'appartement où ils ont commencé à répéter.",
       "fun_fact_nl": "Piso 21 komt uit Medellín en noemde zich naar het appartement waar ze begonnen te repeteren.",
       "isrc": "MXF151600405",
-      "uri_deezer": "deezer://track/137209148"
+      "uri_deezer": "deezer://track/137209148",
+      "uri_apple_music": "applemusic://track/1373680440"
     },
     {
       "year": 2018,
@@ -620,7 +651,8 @@
       "fun_fact_fr": "Le vallenato face au reggaeton : l'accordéon reste, le beat vient de tout autre part.",
       "fun_fact_nl": "Vallenato botst frontaal op reggaeton: het accordeon blijft, de beat komt ergens heel anders vandaan.",
       "isrc": "USSD11700403",
-      "uri_deezer": "deezer://track/406447452"
+      "uri_deezer": "deezer://track/406447452",
+      "uri_apple_music": "applemusic://track/1282633918"
     }
   ]
 }

--- a/custom_components/beatify/playlists/community/rock-rioplatense.json
+++ b/custom_components/beatify/playlists/community/rock-rioplatense.json
@@ -1,6 +1,6 @@
 {
   "name": "Rock Rioplatense",
-  "version": "1.0",
+  "version": "1.1",
   "tags": [
     "rock",
     "spanish",
@@ -31,7 +31,8 @@
       "fun_fact_fr": "Le groupe de Montevideo a passé vingt ans comme formation comique avant que cet album n'en fasse les paroliers les plus cités de la région.",
       "fun_fact_nl": "De band uit Montevideo was twintig jaar een grappenband voordat dit album hen tot de meest geciteerde tekstschrijvers van de regio maakte.",
       "isrc": "UYB141602506",
-      "uri_deezer": "deezer://track/3257569121"
+      "uri_deezer": "deezer://track/3257569121",
+      "uri_apple_music": "applemusic://track/1573663046"
     },
     {
       "year": 2006,
@@ -50,7 +51,8 @@
       "fun_fact_fr": "Quatre minutes d'un homme qui se convainc puis se dédit en allant chez un ami, et n'arrive jamais.",
       "fun_fact_nl": "Vier minuten waarin een man zichzelf onderweg naar een vriend een besluit in- en uitpraat, en nooit aankomt.",
       "isrc": "UYB141602504",
-      "uri_deezer": "deezer://track/3257569101"
+      "uri_deezer": "deezer://track/3257569101",
+      "uri_apple_music": "applemusic://track/1573663034"
     },
     {
       "year": 2009,
@@ -88,7 +90,8 @@
       "fun_fact_fr": "Également de l'album de 2012 : le titre n'est qu'une heure, et la chanson parle de ce qui, à cette heure-là, n'arrive pas.",
       "fun_fact_nl": "Ook van het album uit 2012 — de titel is slechts een tijdstip, en het nummer gaat over wat er dan níét gebeurt.",
       "isrc": "UYH121900007",
-      "uri_deezer": "deezer://track/661625492"
+      "uri_deezer": "deezer://track/661625492",
+      "uri_apple_music": "applemusic://track/1442408689"
     },
     {
       "year": 2012,
@@ -107,7 +110,8 @@
       "fun_fact_fr": "Extrait de El Calor del Pleno Invierno, réalisé après la perte de leur saxophoniste, la section de cuivres étant malgré tout conservée.",
       "fun_fact_nl": "Van El Calor del Pleno Invierno, gemaakt nadat de band zijn saxofonist verloor en de blazerssectie toch behield.",
       "isrc": "UYH121200025",
-      "uri_deezer": "deezer://track/588479072"
+      "uri_deezer": "deezer://track/588479072",
+      "uri_apple_music": "applemusic://track/1442408692"
     },
     {
       "year": 2004,
@@ -126,7 +130,8 @@
       "fun_fact_fr": "La chanson-titre de l'album que le groupe défendait quand l'incendie de Cromañón a tué 194 personnes lors d'un de ses concerts.",
       "fun_fact_nl": "Het titelnummer van het album waarmee de band toerde toen de brand in Cromañón bij een van hun concerten 194 mensen doodde.",
       "isrc": "ARF841700043",
-      "uri_deezer": "deezer://track/395890422"
+      "uri_deezer": "deezer://track/395890422",
+      "uri_apple_music": "applemusic://track/1043375433"
     },
     {
       "year": 2004,
@@ -145,7 +150,8 @@
       "fun_fact_fr": "Du même album de 2004 : le groupe a continué des années sous un autre nom, devant un public divisé.",
       "fun_fact_nl": "Van hetzelfde album uit 2004 — de band speelde daarna nog jaren onder een andere naam en voor een verdeeld publiek.",
       "isrc": "ARF840400142",
-      "uri_deezer": "deezer://track/109383418"
+      "uri_deezer": "deezer://track/109383418",
+      "uri_apple_music": "applemusic://track/1043375136"
     },
     {
       "year": 2006,
@@ -183,7 +189,8 @@
       "fun_fact_fr": "Zafar, c'est de l'argot du Río de la Plata pour s'en tirer : le mot n'a pas de traduction propre, et c'est un peu le sujet.",
       "fun_fact_nl": "Zafar is Río-de-la-Plata-slang voor ergens onderuit komen — het woord laat zich niet netjes vertalen, en dat hoort erbij.",
       "isrc": "ARF140400100",
-      "uri_deezer": "deezer://track/1566896"
+      "uri_deezer": "deezer://track/1566896",
+      "uri_apple_music": "applemusic://track/1444074881"
     },
     {
       "year": 2004,
@@ -202,7 +209,8 @@
       "fun_fact_fr": "Extrait de A Contraluz, le disque qui a mené le groupe de Montevideo de l'autre côté du fleuve, jusqu'aux festivals argentins.",
       "fun_fact_nl": "Van A Contraluz, de plaat die de band van Montevideo over de rivier naar de Argentijnse festivals bracht.",
       "isrc": "ARF140400097",
-      "uri_deezer": "deezer://track/1566891"
+      "uri_deezer": "deezer://track/1566891",
+      "uri_apple_music": "applemusic://track/1444074692"
     },
     {
       "year": 2001,
@@ -221,7 +229,8 @@
       "fun_fact_fr": "Extrait de De Bichos y Flores : le groupe de Montevideo joue un rock avec cuivres, ce qui le fait sonner uruguayen et non argentin.",
       "fun_fact_nl": "Van De Bichos y Flores — de band uit Montevideo speelt rock met blazers, en juist dat maakt hun klank Uruguayaans in plaats van Argentijns.",
       "isrc": "ARF140100186",
-      "uri_deezer": "deezer://track/7337794"
+      "uri_deezer": "deezer://track/7337794",
+      "uri_apple_music": "applemusic://track/1444106633"
     },
     {
       "year": 2000,
@@ -240,7 +249,8 @@
       "fun_fact_fr": "Extrait de La Esquina del Infinito : le groupe sort tout sur son propre label et refuse les contrats majors depuis trente ans.",
       "fun_fact_nl": "Van La Esquina del Infinito — de band brengt alles op zijn eigen label uit en wijst al dertig jaar majordeals af.",
       "isrc": "ARF140100136",
-      "uri_deezer": "deezer://track/812044772"
+      "uri_deezer": "deezer://track/812044772",
+      "uri_apple_music": "applemusic://track/1443620090"
     },
     {
       "year": 2003,
@@ -259,7 +269,8 @@
       "fun_fact_fr": "Extrait de Detonador de Sueños, enregistré alors que le groupe remplissait des stades sans le moindre single radio.",
       "fun_fact_nl": "Van Detonador de Sueños, opgenomen toen de band stadions vulde zonder ooit een radiosingle te hebben gehad.",
       "isrc": "ARA140300104",
-      "uri_deezer": "deezer://track/3874514201"
+      "uri_deezer": "deezer://track/3874514201",
+      "uri_apple_music": "applemusic://track/1881332777"
     },
     {
       "year": 2004,
@@ -278,7 +289,8 @@
       "fun_fact_fr": "Extrait de El Número Imperfecto, dernier album avant l'accident de voiture qui a empêché le bassiste, frère du chanteur, de jouer.",
       "fun_fact_nl": "Van El Número Imperfecto, het laatste album voor het auto-ongeluk waardoor de bassist, de broer van de zanger, niet meer kon optreden.",
       "isrc": "ARF040400453",
-      "uri_deezer": "deezer://track/3411903"
+      "uri_deezer": "deezer://track/3411903",
+      "uri_apple_music": "applemusic://track/722225923"
     },
     {
       "year": 2000,
@@ -297,7 +309,8 @@
       "fun_fact_fr": "Extrait de Cuentos decapitados, l'album qui a fait sortir le groupe du circuit des clubs de Buenos Aires.",
       "fun_fact_nl": "Van Cuentos decapitados, het album dat de band uit het clubcircuit van Buenos Aires haalde.",
       "isrc": "ARF040704995",
-      "uri_deezer": "deezer://track/3412182"
+      "uri_deezer": "deezer://track/3412182",
+      "uri_apple_music": "applemusic://track/724574280"
     },
     {
       "year": 2006,
@@ -316,7 +329,8 @@
       "fun_fact_fr": "Du metal chanté dans la tradition de la payada argentine : le groupe pose la cadence d'un poète gaucho sur des guitares saturées.",
       "fun_fact_nl": "Metal gezongen in de Argentijnse payada-traditie — de band legde de cadans van een gauchodichter over vervormde gitaren.",
       "isrc": "ARF850600142",
-      "uri_deezer": "deezer://track/1490492922"
+      "uri_deezer": "deezer://track/1490492922",
+      "uri_apple_music": "applemusic://track/1585328489"
     },
     {
       "year": 1998,
@@ -335,7 +349,8 @@
       "fun_fact_fr": "Almafuerte a repris le fil d'Hermética, et le titre emploie le vos, le tutoiement argentin qu'aucun cours d'espagnol n'enseigne.",
       "fun_fact_nl": "Almafuerte zette de lijn van Hermética voort, en de titel gebruikt vos — het Argentijnse jij dat geen enkele cursus Spaans leert.",
       "isrc": "ARF099800056",
-      "uri_deezer": "deezer://track/4154478"
+      "uri_deezer": "deezer://track/4154478",
+      "uri_apple_music": "applemusic://track/1443372137"
     },
     {
       "year": 2006,
@@ -354,7 +369,8 @@
       "fun_fact_fr": "Extrait de Ahí Vamos, réalisé quinze ans après Soda Stereo : le son de guitare est volontairement celui qu'il avait abandonné.",
       "fun_fact_nl": "Van Ahí Vamos, vijftien jaar na Soda Stereo gemaakt — de gitaarklank is bewust die welke hij had achtergelaten.",
       "isrc": "ARF030600057",
-      "uri_deezer": "deezer://track/13255149"
+      "uri_deezer": "deezer://track/13255149",
+      "uri_apple_music": "applemusic://track/157364342"
     },
     {
       "year": 2009,
@@ -373,7 +389,8 @@
       "fun_fact_fr": "La chanson-titre de son dernier album : un AVC pendant la tournée qui a suivi l'a plongé dans un coma dont il ne s'est jamais réveillé.",
       "fun_fact_nl": "Het titelnummer van zijn laatste album — een beroerte tijdens de tournee die volgde bracht hem in een coma waaruit hij nooit ontwaakte.",
       "isrc": "ARF100900383",
-      "uri_deezer": "deezer://track/472033662"
+      "uri_deezer": "deezer://track/472033662",
+      "uri_apple_music": "applemusic://track/1358493168"
     },
     {
       "year": 2007,
@@ -392,7 +409,8 @@
       "fun_fact_fr": "Extrait de El Mamut : le groupe a commencé dans les années quatre-vingt en hardcore et arrive ici à quelque chose de proche de la pop.",
       "fun_fact_nl": "Van El Mamut — de band begon in de jaren tachtig als hardcoregroep en kwam hier uit bij iets wat op pop lijkt.",
       "isrc": "ARF470700340",
-      "uri_deezer": "deezer://track/7727689"
+      "uri_deezer": "deezer://track/7727689",
+      "uri_apple_music": "applemusic://track/405156235"
     },
     {
       "year": 2007,
@@ -411,7 +429,8 @@
       "fun_fact_fr": "Également extrait de El Mamut, et la chanson qui a valu au groupe sa première diffusion radio après vingt ans d'existence.",
       "fun_fact_nl": "Ook van El Mamut, en het nummer dat de band na twintig jaar samen zijn eerste radioairplay opleverde.",
       "isrc": "ARF470700345",
-      "uri_deezer": "deezer://track/7727694"
+      "uri_deezer": "deezer://track/7727694",
+      "uri_apple_music": "applemusic://track/405156358"
     },
     {
       "year": 1983,
@@ -449,7 +468,8 @@
       "fun_fact_fr": "Le groupe n'a jamais joué à la télévision ni donné d'interview : d'où l'absence quasi totale d'images pour une chanson si connue.",
       "fun_fact_nl": "De band speelde nooit op televisie en gaf geen interviews — daarom bestaat er van zo'n bekend nummer nauwelijks beeld.",
       "isrc": "AR5CC8800008",
-      "uri_deezer": "deezer://track/2593826682"
+      "uri_deezer": "deezer://track/2593826682",
+      "uri_apple_music": "applemusic://track/1722336139"
     },
     {
       "year": 1991,
@@ -468,7 +488,8 @@
       "fun_fact_fr": "Extrait de La Mosca y la Sopa : le gamin des chantiers navals du titre dépeint les banlieues industrielles d'où venait le groupe.",
       "fun_fact_nl": "Van La Mosca y la Sopa — de werfjongen uit de titel schetst de industriële voorsteden waar de band vandaan kwam.",
       "isrc": "AR5CC9100007",
-      "uri_deezer": "deezer://track/2593932742"
+      "uri_deezer": "deezer://track/2593932742",
+      "uri_apple_music": "applemusic://track/1722348402"
     },
     {
       "year": 1993,
@@ -487,7 +508,8 @@
       "fun_fact_fr": "Extrait de Lobo Suelto, moitié d'un double album sorti le même jour en deux disques distincts.",
       "fun_fact_nl": "Van Lobo Suelto, de ene helft van een dubbelalbum dat op dezelfde dag als twee losse platen verscheen.",
       "isrc": "AR5CC9300011",
-      "uri_deezer": "deezer://track/2594136922"
+      "uri_deezer": "deezer://track/2594136922",
+      "uri_apple_music": "applemusic://track/1722371231"
     },
     {
       "year": 2004,
@@ -506,7 +528,8 @@
       "fun_fact_fr": "L'Indio était le chanteur de Patricio Rey ; ce titre vient de l'album solo réalisé après la séparation définitive du groupe.",
       "fun_fact_nl": "De Indio was de zanger van Patricio Rey; dit komt van het soloalbum dat hij maakte na het definitieve einde van die band.",
       "isrc": "ARG601101170",
-      "uri_deezer": "deezer://track/2593678462"
+      "uri_deezer": "deezer://track/2593678462",
+      "uri_apple_music": "applemusic://track/1722315375"
     },
     {
       "year": 2013,
@@ -525,7 +548,8 @@
       "fun_fact_fr": "À l'époque de ce disque, l'Indio annonçait des concerts pour plus de cent mille personnes dans des villes de province sans stade.",
       "fun_fact_nl": "Ten tijde van deze plaat kondigde de Indio concerten aan voor meer dan honderdduizend mensen in provinciestadjes zonder stadion.",
       "isrc": "ARG601300550",
-      "uri_deezer": "deezer://track/2756585911"
+      "uri_deezer": "deezer://track/2756585911",
+      "uri_apple_music": "applemusic://track/1722315298"
     },
     {
       "year": 2013,
@@ -544,7 +568,8 @@
       "fun_fact_fr": "Le titre est emprunté à une nouvelle de Julio Cortázar, celle qu'Antonioni a portée à l'écran sous le nom de Blow-Up.",
       "fun_fact_nl": "De titel komt uit een kort verhaal van Julio Cortázar, hetzelfde dat Antonioni verfilmde als Blow-Up.",
       "isrc": "ARG601300556",
-      "uri_deezer": "deezer://track/2756585971"
+      "uri_deezer": "deezer://track/2756585971",
+      "uri_apple_music": "applemusic://track/1722315304"
     },
     {
       "year": 2011,
@@ -563,7 +588,8 @@
       "fun_fact_fr": "Extrait de La Luna Hueca : trois décennies plus tard, Skay joue toujours la même Gibson dans le même petit ampli.",
       "fun_fact_nl": "Van La Luna Hueca — drie decennia later speelt Skay nog steeds dezelfde Gibson door dezelfde kleine versterker.",
       "isrc": "ARW251100631",
-      "uri_deezer": "deezer://track/3246179981"
+      "uri_deezer": "deezer://track/3246179981",
+      "uri_apple_music": "applemusic://track/1462846132"
     },
     {
       "year": 2002,
@@ -582,7 +608,8 @@
       "fun_fact_fr": "Skay était le guitariste de Patricio Rey ; ce titre vient de son premier disque solo après la fin de ce groupe.",
       "fun_fact_nl": "Skay was de gitarist van Patricio Rey; dit komt van zijn eerste soloplaat na het einde van die band.",
       "isrc": "QM7281627110",
-      "uri_deezer": "deezer://track/3271796591"
+      "uri_deezer": "deezer://track/3271796591",
+      "uri_apple_music": "applemusic://track/1462847892"
     },
     {
       "year": 2007,
@@ -601,7 +628,8 @@
       "fun_fact_fr": "Extrait de La Marca de Caín : Skay écrit la musique et sa compagne Poli, qui gérait Patricio Rey, dirige toujours l'affaire.",
       "fun_fact_nl": "Van La Marca de Caín — Skay schrijft de muziek en zijn partner Poli, ooit manager van Patricio Rey, runt nog altijd de zaak.",
       "isrc": "ARW251100640",
-      "uri_deezer": "deezer://track/3246179471"
+      "uri_deezer": "deezer://track/3246179471",
+      "uri_apple_music": "applemusic://track/1463034653"
     },
     {
       "year": 1992,
@@ -620,7 +648,8 @@
       "fun_fact_fr": "Extrait de Chac Tu Chac, le premier album : le nom du groupe est de l'argot de Buenos Aires pour les poux, choisi pour ne rien avoir de grandiose.",
       "fun_fact_nl": "Van Chac Tu Chac, het debuut — de bandnaam is Buenos Aires-slang voor luizen, gekozen om vooral niet groots te klinken.",
       "isrc": "ARG601100044",
-      "uri_deezer": "deezer://track/1377576012"
+      "uri_deezer": "deezer://track/1377576012",
+      "uri_apple_music": "applemusic://track/1613774320"
     },
     {
       "year": 2004,
@@ -639,7 +668,8 @@
       "fun_fact_fr": "Nommée d'après le stade de Mexico, extraite de El Cantante, un album fait presque entièrement de chansons des autres.",
       "fun_fact_nl": "Vernoemd naar het stadion in Mexico-Stad, van El Cantante — een album dat bijna volledig uit andermans liedjes bestaat.",
       "isrc": "ES5010400008",
-      "uri_deezer": "deezer://track/3885291"
+      "uri_deezer": "deezer://track/3885291",
+      "uri_apple_music": "applemusic://track/101255701"
     },
     {
       "year": 1999,
@@ -658,7 +688,8 @@
       "fun_fact_fr": "Nommée d'après le personnage des Simpson, prononcé à l'espagnole en Argentine : une blague très locale.",
       "fun_fact_nl": "Vernoemd naar het Simpsons-personage, dat in Argentinië op zijn Spaans wordt uitgesproken — een heel lokale grap.",
       "isrc": "ARF149900164",
-      "uri_deezer": "deezer://track/5498976"
+      "uri_deezer": "deezer://track/5498976",
+      "uri_apple_music": "applemusic://track/1443374248"
     },
     {
       "year": 2013,
@@ -677,7 +708,8 @@
       "fun_fact_fr": "Du rock barrial dans sa forme la plus simple : trois accords, un refrain de stade et un groupe nommé d'après une ligne de bus.",
       "fun_fact_nl": "Rock barrial in zijn eenvoudigste vorm — drie akkoorden, een stadionrefrein en een band vernoemd naar een buslijn.",
       "isrc": "ARJ401300005",
-      "uri_deezer": "deezer://track/72139632"
+      "uri_deezer": "deezer://track/72139632",
+      "uri_apple_music": "applemusic://track/735082554"
     },
     {
       "year": 2001,
@@ -696,7 +728,8 @@
       "fun_fact_fr": "Gieco raconte l'histoire de vrais bandits de la plaine argentine : la chanson tient davantage de la complainte ancienne que du rock.",
       "fun_fact_nl": "Gieco vertelt het verhaal van echte bandieten uit de Argentijnse vlakte — het nummer is eerder een oude ballade dan rock.",
       "isrc": "ARF040100627",
-      "uri_deezer": "deezer://track/3531995"
+      "uri_deezer": "deezer://track/3531995",
+      "uri_apple_music": "applemusic://track/723951558"
     }
   ]
 }

--- a/custom_components/beatify/playlists/community/vallenato-clasico.json
+++ b/custom_components/beatify/playlists/community/vallenato-clasico.json
@@ -1,6 +1,6 @@
 {
   "name": "Vallenato Clásico",
-  "version": "0.1",
+  "version": "0.2",
   "tags": [
     "vallenato",
     "latin",
@@ -31,7 +31,8 @@
       "fun_fact_fr": "On appelait Oñate « el Jilguero de América », le chardonneret, pour une voix restée haute et claire quarante ans.",
       "fun_fact_nl": "Oñate heette 'el Jilguero de América', de putter, vanwege een stem die veertig jaar hoog en helder bleef.",
       "isrc": "COS019800939",
-      "uri_deezer": "deezer://track/1260967672"
+      "uri_deezer": "deezer://track/1260967672",
+      "uri_apple_music": "applemusic://track/309963885"
     },
     {
       "year": 1993,
@@ -69,7 +70,8 @@
       "fun_fact_fr": "Los Diablitos se sont formés à Valledupar et ont passé les années 90 comme le groupe que toute formation de mariage voulait imiter.",
       "fun_fact_nl": "Los Diablitos ontstonden in Valledupar en waren in de jaren negentig de band waar elke bruiloftsband op wilde lijken.",
       "isrc": "COC019321636",
-      "uri_deezer": "deezer://track/11108567"
+      "uri_deezer": "deezer://track/11108567",
+      "uri_apple_music": "applemusic://track/1714010659"
     },
     {
       "year": 1993,
@@ -88,7 +90,8 @@
       "fun_fact_fr": "Omar Geles l'a écrite en voyant sa mère se battre, et elle est devenue la chanson vallenato la plus reprise qui soit.",
       "fun_fact_nl": "Omar Geles schreef het toen hij zijn moeder zag ploeteren, en het werd het meest gecoverde vallenatolied dat er is.",
       "isrc": "COC019321633",
-      "uri_deezer": "deezer://track/1401666"
+      "uri_deezer": "deezer://track/1401666",
+      "uri_apple_music": "applemusic://track/1714010382"
     },
     {
       "year": 1994,
@@ -126,7 +129,8 @@
       "fun_fact_fr": "Un classique des années 90 de la côte du Magdalena, quand un tube voyageait en cassette de bus en bus.",
       "fun_fact_nl": "Een jarennegentigklassieker van de Magdalenakust, toen een hit op cassette van bus naar bus reisde.",
       "isrc": "COF019400762",
-      "uri_deezer": "deezer://track/113292858"
+      "uri_deezer": "deezer://track/113292858",
+      "uri_apple_music": "applemusic://track/14948007"
     },
     {
       "year": 1994,
@@ -145,7 +149,8 @@
       "fun_fact_fr": "Accordéon, tambour caja et guacharaca raclée — trois instruments, patrimoine de l'UNESCO depuis 2015.",
       "fun_fact_nl": "Accordeon, cajatrommel en geschraapte guacharaca — drie instrumenten, sinds 2015 UNESCO-erfgoed.",
       "isrc": "COC019422066",
-      "uri_deezer": "deezer://track/1441559132"
+      "uri_deezer": "deezer://track/1441559132",
+      "uri_apple_music": "applemusic://track/1714007712"
     },
     {
       "year": 1995,
@@ -164,7 +169,8 @@
       "fun_fact_fr": "Morales a l'une des voix les plus aiguës du genre, d'où des chansons qui se placent là où joue l'accordéon.",
       "fun_fact_nl": "Morales heeft een van de hoogste stemmen van het genre, daarom liggen zijn liedjes precies waar het accordeon speelt.",
       "isrc": "COC019522545",
-      "uri_deezer": "deezer://track/1982972"
+      "uri_deezer": "deezer://track/1982972",
+      "uri_apple_music": "applemusic://track/1714260565"
     },
     {
       "year": 1995,
@@ -183,7 +189,8 @@
       "fun_fact_fr": "Patricia Teherán fut l'une des très rares femmes à mener un groupe de vallenato. Elle est morte dans un accident de la route à 26 ans.",
       "fun_fact_nl": "Patricia Teherán was een van de zeer weinige vrouwen die een vallenatogroep leidde. Ze stierf op haar 26e bij een verkeersongeluk.",
       "isrc": "COC019421831",
-      "uri_deezer": "deezer://track/11531391"
+      "uri_deezer": "deezer://track/11531391",
+      "uri_apple_music": "applemusic://track/1713349727"
     },
     {
       "year": 1995,
@@ -202,7 +209,8 @@
       "fun_fact_fr": "Elle venait de Las Musas del Vallenato, groupe entièrement féminin fondé pour prouver que le genre avait de la place.",
       "fun_fact_nl": "Ze kwam uit Las Musas del Vallenato, een vrouwengroep opgericht om te bewijzen dat het genre daar ruimte voor had.",
       "isrc": "COC019120680",
-      "uri_deezer": "deezer://track/11531388"
+      "uri_deezer": "deezer://track/11531388",
+      "uri_apple_music": "applemusic://track/1713349693"
     },
     {
       "year": 1996,
@@ -221,7 +229,8 @@
       "fun_fact_fr": "Les années 90 sont la décennie où les groupes de vallenato ont dépassé les orchestres de salsa sur la côte.",
       "fun_fact_nl": "De jaren negentig waren het decennium waarin vallenatogroepen aan de kust de salsaorkesten voorbijstreefden.",
       "isrc": "COC019622727",
-      "uri_deezer": "deezer://track/489726042"
+      "uri_deezer": "deezer://track/489726042",
+      "uri_apple_music": "applemusic://track/1714001563"
     },
     {
       "year": 1996,
@@ -240,7 +249,8 @@
       "fun_fact_fr": "Los Inquietos ont lancé deux carrières solo d'un coup : Miguel Morales et Nelson Velásquez y ont d'abord chanté.",
       "fun_fact_nl": "Los Inquietos lanceerden twee solocarrières tegelijk: Miguel Morales en Nelson Velásquez zongen hier eerst.",
       "isrc": "COC011308934",
-      "uri_deezer": "deezer://track/104857252"
+      "uri_deezer": "deezer://track/104857252",
+      "uri_apple_music": "applemusic://track/1770649711"
     },
     {
       "year": 1997,
@@ -259,7 +269,8 @@
       "fun_fact_fr": "Le groupe a tant changé de chanteurs que les fans débattent encore de la formation qui compte vraiment.",
       "fun_fact_nl": "De groep wisselde zo vaak van zangers dat fans nog steeds ruziën over welke bezetting de echte is.",
       "isrc": "COC019723063",
-      "uri_deezer": "deezer://track/695600752"
+      "uri_deezer": "deezer://track/695600752",
+      "uri_apple_music": "applemusic://track/1713636579"
     },
     {
       "year": 1997,
@@ -278,7 +289,8 @@
       "fun_fact_fr": "Leur série de la seconde moitié des années 90 est ce que les auditeurs plus âgés appellent « les bonnes années ».",
       "fun_fact_nl": "Hun reeks in de tweede helft van de jaren negentig is wat oudere luisteraars 'de goede jaren' noemen.",
       "isrc": "COC011308948",
-      "uri_deezer": "deezer://track/106211306"
+      "uri_deezer": "deezer://track/106211306",
+      "uri_apple_music": "applemusic://track/1770562567"
     },
     {
       "year": 1997,
@@ -297,7 +309,8 @@
       "fun_fact_fr": "Geles a écrit pour la moitié du genre avant d'enregistrer pour lui ; les tubes des autres ont payé ses disques.",
       "fun_fact_nl": "Geles schreef voor het halve genre voordat hij zelf opnam; andermans hits betaalden zijn eigen platen.",
       "isrc": "COC019723192",
-      "uri_deezer": "deezer://track/1442700"
+      "uri_deezer": "deezer://track/1442700",
+      "uri_apple_music": "applemusic://track/1713462233"
     },
     {
       "year": 1997,
@@ -316,7 +329,8 @@
       "fun_fact_fr": "Il est mort en mai 2024, et les hommages furent surtout d'autres artistes chantant des chansons qu'il leur avait écrites.",
       "fun_fact_nl": "Hij stierf in mei 2024, en de eerbetonen waren vooral andere artiesten die liedjes zongen die hij voor hen had geschreven.",
       "isrc": "COC019723194",
-      "uri_deezer": "deezer://track/1442732"
+      "uri_deezer": "deezer://track/1442732",
+      "uri_apple_music": "applemusic://track/1713462235"
     },
     {
       "year": 1998,
@@ -335,7 +349,8 @@
       "fun_fact_fr": "Binomio de Oro a ajouté « de América » après l'assassinat du chanteur Rafael Orozco en 1992, le groupe ayant continué.",
       "fun_fact_nl": "Binomio de Oro voegde 'de América' toe nadat zanger Rafael Orozco in 1992 werd vermoord en de groep doorging.",
       "isrc": "COC019823620",
-      "uri_deezer": "deezer://track/1963948"
+      "uri_deezer": "deezer://track/1963948",
+      "uri_apple_music": "applemusic://track/1711885415"
     },
     {
       "year": 1998,
@@ -354,7 +369,8 @@
       "fun_fact_fr": "Un vallenato romantique de la fin des années 90, quand les ballades du genre se vendaient mieux que ses morceaux dansants.",
       "fun_fact_nl": "Een romantische vallenato uit de late jaren negentig, toen de ballades van het genre beter verkochten dan de dansnummers.",
       "isrc": "COC019823506",
-      "uri_deezer": "deezer://track/1021507152"
+      "uri_deezer": "deezer://track/1021507152",
+      "uri_apple_music": "applemusic://track/1711687529"
     },
     {
       "year": 1999,
@@ -373,7 +389,8 @@
       "fun_fact_fr": "L'accordéon d'Israel Romero est la constante : il a fondé le groupe en 1976 et ne l'a jamais quitté.",
       "fun_fact_nl": "Het accordeon van Israel Romero is de constante: hij richtte de groep in 1976 op en verliet haar nooit.",
       "isrc": "COC019924109",
-      "uri_deezer": "deezer://track/1913357"
+      "uri_deezer": "deezer://track/1913357",
+      "uri_apple_music": "applemusic://track/1711885417"
     },
     {
       "year": 1999,
@@ -392,7 +409,8 @@
       "fun_fact_fr": "Une chanson d'adieu devenue un incontournable des fêtes où personne ne quitte personne.",
       "fun_fact_nl": "Een afscheidslied dat een vaste waarde werd op feesten waar niemand iemand verlaat.",
       "isrc": "COC019924107",
-      "uri_deezer": "deezer://track/1963988"
+      "uri_deezer": "deezer://track/1963988",
+      "uri_apple_music": "applemusic://track/1711885420"
     },
     {
       "year": 1999,
@@ -430,7 +448,8 @@
       "fun_fact_fr": "Les albums vallenato de cette époque se construisaient pareil : quatre paseos, un merengue, un son et une puya pour finir.",
       "fun_fact_nl": "Vallenato-albums uit die tijd waren identiek opgebouwd: vier paseos, een merengue, een son en een puya als slot.",
       "isrc": "COC019923868",
-      "uri_deezer": "deezer://track/489726432"
+      "uri_deezer": "deezer://track/489726432",
+      "uri_apple_music": "applemusic://track/1714003118"
     },
     {
       "year": 1999,
@@ -449,7 +468,8 @@
       "fun_fact_fr": "À la fin de la décennie, le groupe était assez grand pour que sa séparation fasse les journaux nationaux.",
       "fun_fact_nl": "Aan het eind van het decennium was de groep zo groot dat de breuk het landelijke nieuws haalde.",
       "isrc": "COC011308930",
-      "uri_deezer": "deezer://track/106660326"
+      "uri_deezer": "deezer://track/106660326",
+      "uri_apple_music": "applemusic://track/1770449831"
     },
     {
       "year": 2001,
@@ -468,7 +488,8 @@
       "fun_fact_fr": "Celedón et l'accordéoniste Jimmy Zambrano ont formé un duo fixe pendant des années, ce qui au vallenato est un mariage.",
       "fun_fact_nl": "Celedón en accordeonist Jimmy Zambrano vormden jarenlang een vast duo, wat in de vallenato een huwelijk is.",
       "isrc": "COS010100098",
-      "uri_deezer": "deezer://track/57236501"
+      "uri_deezer": "deezer://track/57236501",
+      "uri_apple_music": "applemusic://track/487291492"
     },
     {
       "year": 2002,
@@ -487,7 +508,8 @@
       "fun_fact_fr": "« Ay hombe » est une exclamation de la côte qui va du ravissement à l'incrédulité ; Celedón en a fait sa signature.",
       "fun_fact_nl": "'Ay hombe' is een kustuitroep voor alles van verrukking tot ongeloof, en Celedón maakte er zijn handelsmerk van.",
       "isrc": "COS010200058",
-      "uri_deezer": "deezer://track/13255682"
+      "uri_deezer": "deezer://track/13255682",
+      "uri_apple_music": "applemusic://track/321735944"
     },
     {
       "year": 2002,
@@ -506,7 +528,8 @@
       "fun_fact_fr": "Les chansons d'amour du vallenato parlent presque toujours d'être quitté, jamais de quitter — celle-ci suit la règle.",
       "fun_fact_nl": "De liefdesliedjes van de vallenato gaan bijna altijd over verlaten worden, nooit over verlaten — deze houdt zich eraan.",
       "isrc": "COC010225263",
-      "uri_deezer": "deezer://track/2512993391"
+      "uri_deezer": "deezer://track/2512993391",
+      "uri_apple_music": "applemusic://track/1713446675"
     },
     {
       "year": 2004,
@@ -525,7 +548,8 @@
       "fun_fact_fr": "Trois ans plus tard, Celedón et Zambrano remportaient un Latin Grammy — l'arrivée du genre à la cérémonie.",
       "fun_fact_nl": "Drie jaar later wonnen Celedón en Zambrano een Latin Grammy — de aankomst van het genre op de ceremonie.",
       "isrc": "COS010400081",
-      "uri_deezer": "deezer://track/57236701"
+      "uri_deezer": "deezer://track/57236701",
+      "uri_apple_music": "applemusic://track/478753993"
     },
     {
       "year": 2005,
@@ -544,7 +568,8 @@
       "fun_fact_fr": "De la Espriella est accordéoniste, et au vallenato l'accordéoniste figure sur la pochette à côté du chanteur.",
       "fun_fact_nl": "De la Espriella is accordeonist, en in de vallenato staat de accordeonist mét de zanger op de hoes.",
       "isrc": "COS010500095",
-      "uri_deezer": "deezer://track/13307180"
+      "uri_deezer": "deezer://track/13307180",
+      "uri_apple_music": "applemusic://track/321603264"
     },
     {
       "year": 2005,
@@ -563,7 +588,8 @@
       "fun_fact_fr": "Son dernier album. Il est mort dans un accident de voiture à 21 ans, quelques semaines après sa sortie ; la nueva ola lui a survécu.",
       "fun_fact_nl": "Zijn laatste album. Hij stierf op zijn 21e bij een auto-ongeluk, weken na het verschijnen; de nueva ola overleefde hem.",
       "isrc": "COS010500007",
-      "uri_deezer": "deezer://track/14927757"
+      "uri_deezer": "deezer://track/14927757",
+      "uri_apple_music": "applemusic://track/337611229"
     },
     {
       "year": 2005,
@@ -582,7 +608,8 @@
       "fun_fact_fr": "Kaleth Morales a inventé la « nueva ola » : du vallenato aux accords pop, destiné à ceux de son âge.",
       "fun_fact_nl": "Kaleth Morales bedacht de 'nueva ola': vallenato met popakkoorden, gericht op leeftijdsgenoten.",
       "isrc": "COSO10500162",
-      "uri_deezer": "deezer://track/13322836"
+      "uri_deezer": "deezer://track/13322836",
+      "uri_apple_music": "applemusic://track/309679406"
     },
     {
       "year": 2008,
@@ -601,7 +628,8 @@
       "fun_fact_fr": "Peláez a fait médecine avant de décider que chanter le vallenato était un meilleur emploi d'une bonne mémoire.",
       "fun_fact_nl": "Peláez studeerde geneeskunde voordat hij besloot dat vallenato zingen een beter gebruik van een goed geheugen was.",
       "isrc": "COSO10801045",
-      "uri_deezer": "deezer://track/71784107"
+      "uri_deezer": "deezer://track/71784107",
+      "uri_apple_music": "applemusic://track/828299686"
     },
     {
       "year": 2009,
@@ -620,7 +648,8 @@
       "fun_fact_fr": "Manjarrés est présenté comme « el Caballero del Vallenato », un titre que la côte décerne avec parcimonie.",
       "fun_fact_nl": "Manjarrés wordt aangekondigd als 'el Caballero del Vallenato', een titel die de kust spaarzaam uitdeelt.",
       "isrc": "COC010927729",
-      "uri_deezer": "deezer://track/4839657"
+      "uri_deezer": "deezer://track/4839657",
+      "uri_apple_music": "applemusic://track/1713205304"
     },
     {
       "year": 2009,
@@ -639,7 +668,8 @@
       "fun_fact_fr": "Ochoa est un accordéoniste qui a accompagné presque toutes les grandes voix des vingt dernières années, celle-ci comprise.",
       "fun_fact_nl": "Ochoa is een accordeonist die bijna elke grote stem van de laatste twintig jaar heeft begeleid, ook deze.",
       "isrc": "FRX202111727",
-      "uri_deezer": "deezer://track/1385283342"
+      "uri_deezer": "deezer://track/1385283342",
+      "uri_apple_music": "applemusic://track/1569624444"
     },
     {
       "year": 2011,
@@ -658,7 +688,8 @@
       "fun_fact_fr": "Martín Elías était le fils de Diomedes Díaz et a porté le nom familial vers un vallenato plus rapide et plus pop.",
       "fun_fact_nl": "Martín Elías was de zoon van Diomedes Díaz en bracht de familienaam naar een sneller, popperiger vallenato.",
       "isrc": "COC011128185",
-      "uri_deezer": "deezer://track/61787325"
+      "uri_deezer": "deezer://track/61787325",
+      "uri_apple_music": "applemusic://track/1712533964"
     },
     {
       "year": 2011,
@@ -677,7 +708,8 @@
       "fun_fact_fr": "Centeno a chanté chez Los Diablitos avant sa carrière solo, d'où ce phrasé si familier.",
       "fun_fact_nl": "Centeno zong bij Los Diablitos voordat hij solo ging, vandaar dat de frasering zo vertrouwd klinkt.",
       "isrc": "COC011128517",
-      "uri_deezer": "deezer://track/24020291"
+      "uri_deezer": "deezer://track/24020291",
+      "uri_apple_music": "applemusic://track/1712801308"
     },
     {
       "year": 2013,
@@ -696,7 +728,8 @@
       "fun_fact_fr": "Dangond est la tête d'affiche des stades du genre, et c'est la chanson qui a transformé ses concerts en chorales.",
       "fun_fact_nl": "Dangond is de stadionact van het genre, en dit is het lied dat zijn concerten in meezingavonden veranderde.",
       "isrc": "COSO11300077",
-      "uri_deezer": "deezer://track/67526510"
+      "uri_deezer": "deezer://track/67526510",
+      "uri_apple_music": "applemusic://track/650738436"
     },
     {
       "year": 2014,
@@ -715,7 +748,8 @@
       "fun_fact_fr": "Le titre emprunte au triple reniement de Pierre, ce qui fait beaucoup de poids pour un disque de danse.",
       "fun_fact_nl": "De titel leent van Petrus die Christus driemaal verloochent, wat veel gewicht is voor een dansplaat.",
       "isrc": "COSO11400454",
-      "uri_deezer": "deezer://track/90697283"
+      "uri_deezer": "deezer://track/90697283",
+      "uri_apple_music": "applemusic://track/935722121"
     },
     {
       "year": 2015,
@@ -734,7 +768,8 @@
       "fun_fact_fr": "Deux ans plus tard, il mourait dans un accident de la route à 26 ans, un âge que ce genre a pleuré trop souvent.",
       "fun_fact_nl": "Twee jaar later kwam hij op zijn 26e om bij een verkeersongeluk, een leeftijd die dit genre te vaak heeft betreurd.",
       "isrc": "COSO11500348",
-      "uri_deezer": "deezer://track/105183412"
+      "uri_deezer": "deezer://track/105183412",
+      "uri_apple_music": "applemusic://track/1027596322"
     },
     {
       "year": 2017,
@@ -753,7 +788,8 @@
       "fun_fact_fr": "Kvrass s'est fait un public sur le circuit des fêtes de la côte plutôt qu'à la radio, un bal en plein air à la fois.",
       "fun_fact_nl": "Kvrass bouwde zijn publiek op via het feestcircuit van de kust in plaats van de radio, één openluchtdansfeest per keer.",
       "isrc": "COC011732269",
-      "uri_deezer": "deezer://track/414935302"
+      "uri_deezer": "deezer://track/414935302",
+      "uri_apple_music": "applemusic://track/1712799908"
     },
     {
       "year": 2019,
@@ -772,7 +808,8 @@
       "fun_fact_fr": "Un autre fils de Diomedes Díaz, et la preuve qu'au vallenato le nom de famille fait la moitié de la carrière.",
       "fun_fact_nl": "Nog een zoon van Diomedes Díaz, en het bewijs dat in de vallenato de achternaam de halve carrière is.",
       "isrc": "COC011933298",
-      "uri_deezer": "deezer://track/712895702"
+      "uri_deezer": "deezer://track/712895702",
+      "uri_apple_music": "applemusic://track/1712550581"
     },
     {
       "year": 2020,
@@ -791,7 +828,8 @@
       "fun_fact_fr": "En 2020, Dangond remplissait des salles hors de Colombie, ce qu'aucun chanteur de vallenato n'avait réussi durablement.",
       "fun_fact_nl": "In 2020 vulde Dangond zalen buiten Colombia, iets wat geen vallenatozanger eerder betrouwbaar lukte.",
       "isrc": "USSD12000513",
-      "uri_deezer": "deezer://track/1111735572"
+      "uri_deezer": "deezer://track/1111735572",
+      "uri_apple_music": "applemusic://track/1540731458"
     }
   ]
 }


### PR DESCRIPTION
The five playlists added in **v4.4.1-rc1** shipped with Spotify (and mostly Deezer) URIs only. On Apple Music they could not be started at all: `create_game` fails the #709 no-playable-songs check, which is what surfaced as a bare 500 in #2530.

This fills 138 of the 159 Apple gaps.

| Playlist | Apple URIs | version |
|---|---|---|
| `vallenato-clasico` | +38 | 0.1 → 0.2 |
| `clasicos-rock-en-espanol` | +33 | 1.0 → 1.1 |
| `rock-rioplatense` | +33 | 1.0 → 1.1 |
| `musica-colombiana-alegre` | +32 | 0.1 → 0.2 |
| `deutschrap-klassiker` | +2 | 1.1 → 1.2 |

## How, and why not the obvious way

Resolved through the **iTunes search path** in `scripts/backfill_apple.py`. The Odesli route in `backfill_tidal.py` was not used because `api.song.link` still answers **401 `PUBLIC_API_ACCESS_DEPRECATED`** — verified again before starting. Running it would have made 159 requests for nothing, which is the "fillable is not the same as reachable" lesson from 2026-08-23.

## What was rejected, and that this is on purpose

- **138 accepted**
- **16 rejected by the match gate** — 7 artist, 5 suffix, 3 title, 1 year. The gate is doing its job: it turned down e.g. Soda Stereo "De Música Ligera - Remasterizado 2007" against an entry whose title was a different song entirely (similarity 0.27), and Ski Aggu "IMMER" against "IMMER (MIT MAKKO)".
- **5 genuine misses** — no Apple entry found.

Both groups are recorded, so the next wave retries them instead of re-querying blindly.

## Versions are bumped — deliberately

`_copy_bundled_playlists` overwrites an installed playlist only when the bundled version is **strictly greater**. A data change without a bump reaches nobody who already has Beatify installed. All five files are bumped here.

(Worth noting separately: #2489 changed 36 playlist files on 2026-09-02 and bumped **none** of them, so those changes are currently unreachable for existing installs. That is its own issue, not fixed here.)

## Tidal is deliberately not in this PR

Two reasons, and the second is the substantive one:

1. `backfill_tidal.py` resolves through the same dead Odesli endpoint.
2. **Tidal does not need the URIs.** It is in `_NAME_FALLBACK_PROVIDERS` (`services/media_player.py`), so a missing URI falls back to a name search and the tracks play. Apple Music is **not** in that set — which is precisely why the Apple gap was the one that blocked playback.

## Checks

- `scripts/validate_playlists.py` — all 66 playlist files valid, schema gate passed
- pytest **2176 passed**, 2 skipped
- Song counts unchanged in all five files (only URI fields and `version` added)
- Spot-checked four of the new Apple IDs against the live iTunes lookup — all four resolve to the right artist and track
