### PR TITLE
chore(release): v4.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [4.4.1] - 2026-09-03
+
+Everything from the `v4.4.1-rc1` candidate, plus three defects found by testing the candidate
+against a live install and one that an external report surfaced.
+
+### Fixed
+- **A playlist with nothing playable said "Server got itself in trouble" (#2530).**
+  `StartGameView.post` called `create_game` without a `try`/`except`, so the #709 fail-fast
+  `ValueError` escaped into aiohttp and became a bare 500 — a response with no `code` at all,
+  which defeated #2294 for that path and left the `errors.<CODE>` lookup with nothing to resolve.
+  The no-playable-songs case now raises `NoPlayableSongsError`, a `ValueError` subclass, so the
+  view can map it to `NO_PLAYABLE_SONGS` without mislabelling the round-duration rejection.
+- **The host's game-over podium showed stands nobody was on (#2534).** `player-end.js` and
+  `dashboard.js` have hidden empty stands since #2130; `showAdminEndView` was the one view the fix
+  never reached. It uses `hidden` rather than dashboard's `podium-place--empty`, whose only rule
+  lives in `dashboard.css` — a sheet `admin.html` does not load. Ranks skip on a tie, so a full
+  room with two players sharing first place showed two empty plinths.
+- **A refused join answered in English on a translated screen (#2532).** #2511 passed the
+  server's `message` straight through. All four codes in `JOIN_REJECTED_CODES` have an
+  `errors.<CODE>` entry in every locale; the lookup simply never happened. It now uses `t`'s
+  two-argument form — `t(key) || message` can never reach its right-hand side, because `t`
+  returns the key on a miss.
+- **Auto-generated issue titles arrived as Latin-1 mojibake (#2526).** The Cloudflare Worker is
+  deployed by hand, and that copy once passed through a terminal buffer. The source is now pure
+  ASCII with `\u` escapes, which survives the same route; a guard test fails on the next raw
+  character.
+
+### Changed
+- **The five playlists new in 4.4.1-rc1 play on Apple Music (#2540).** They shipped with Spotify
+  and Deezer URIs only, so `create_game` refused to start them on Apple. 138 of 159 gaps were
+  filled through the iTunes search path — Odesli still answers 401. Tidal is untouched on purpose:
+  it is in `_NAME_FALLBACK_PROVIDERS` and already plays these tracks by name search.
+- **Thirty-four playlists carry a raised `version` again.** #2489 rewrote them without bumping,
+  and `_copy_bundled_playlists` only overwrites an installed playlist when the bundled version is
+  strictly greater — the chart badges it added would never have reached an existing install.
+
+
 ## [4.4.1-rc1] - 2026-09-02
 
 A patch number, and it holds: no new mechanic, no new provider. Six defects from a full review of

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -20,5 +20,5 @@
     "num2words==0.5.14"
   ],
   "single_config_entry": true,
-  "version": "4.4.1-rc1"
+  "version": "4.4.1"
 }

--- a/custom_components/beatify/playlists/2000s-pop-anthems.json
+++ b/custom_components/beatify/playlists/2000s-pop-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "2000s Pop Anthems",
-  "version": "1.27",
+  "version": "1.28",
   "tags": [
     "2000s",
     "pop",

--- a/custom_components/beatify/playlists/70s-hits.json
+++ b/custom_components/beatify/playlists/70s-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "70s Hits",
-  "version": "1.22",
+  "version": "1.23",
   "tags": [
     "1970s",
     "classic-rock",

--- a/custom_components/beatify/playlists/80er-hits.json
+++ b/custom_components/beatify/playlists/80er-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "80s Hits",
-  "version": "2.27",
+  "version": "2.28",
   "tags": [
     "1980s",
     "pop",

--- a/custom_components/beatify/playlists/90er-hits.json
+++ b/custom_components/beatify/playlists/90er-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "90s Hits",
-  "version": "1.31",
+  "version": "1.32",
   "tags": [
     "1990s",
     "pop",

--- a/custom_components/beatify/playlists/community/100-greatest-rock-songs.json
+++ b/custom_components/beatify/playlists/community/100-greatest-rock-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "100 Greatest Rock Songs",
-  "version": "0.14",
+  "version": "0.15",
   "tags": [
     "rock",
     "classic-rock",

--- a/custom_components/beatify/playlists/community/best-canadian-hits.json
+++ b/custom_components/beatify/playlists/community/best-canadian-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Best Canadian Hits: Top 100 🇨🇦",
-  "version": "0.18",
+  "version": "0.19",
   "tags": [
     "canadian",
     "canada",

--- a/custom_components/beatify/playlists/community/british-invasion-britpop.json
+++ b/custom_components/beatify/playlists/community/british-invasion-britpop.json
@@ -1,6 +1,6 @@
 {
   "name": "British Invasion & Britpop 🇬🇧",
-  "version": "1.13",
+  "version": "1.14",
   "tags": [
     "1960s",
     "1990s",

--- a/custom_components/beatify/playlists/community/deutschpop-klassiker.json
+++ b/custom_components/beatify/playlists/community/deutschpop-klassiker.json
@@ -1,6 +1,6 @@
 {
   "name": "Deutschpop Klassiker 🇩🇪",
-  "version": "0.17",
+  "version": "0.18",
   "tags": [
     "german",
     "pop",

--- a/custom_components/beatify/playlists/community/essential-alternative.json
+++ b/custom_components/beatify/playlists/community/essential-alternative.json
@@ -1,6 +1,6 @@
 {
   "name": "Essential Alternative 🎸",
-  "version": "0.13",
+  "version": "0.14",
   "tags": [
     "alternative",
     "rock",

--- a/custom_components/beatify/playlists/community/eurodance-90s.json
+++ b/custom_components/beatify/playlists/community/eurodance-90s.json
@@ -1,6 +1,6 @@
 {
   "name": "Eurodance 90s 💥",
-  "version": "1.19",
+  "version": "1.20",
   "tags": [
     "1990s",
     "eurodance",

--- a/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
+++ b/custom_components/beatify/playlists/community/finnish-iskelma-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Finnish Schlager Classics 🇫🇮",
-  "version": "1.42",
+  "version": "1.43",
   "tags": [
     "finnish",
     "iskelma",

--- a/custom_components/beatify/playlists/community/funk-carioca.json
+++ b/custom_components/beatify/playlists/community/funk-carioca.json
@@ -1,6 +1,6 @@
 {
   "name": "🌪️ Funk Carioca",
-  "version": "0.9",
+  "version": "0.10",
   "tags": [
     "2000s",
     "funk",

--- a/custom_components/beatify/playlists/community/greatest-metal-songs.json
+++ b/custom_components/beatify/playlists/community/greatest-metal-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "Greatest Metal Songs of All Time 🤘",
-  "version": "1.19",
+  "version": "1.20",
   "tags": [
     "metal",
     "rock",

--- a/custom_components/beatify/playlists/community/hitster-100-en-espanol.json
+++ b/custom_components/beatify/playlists/community/hitster-100-en-espanol.json
@@ -1,6 +1,6 @@
 {
   "name": "100% en Español 🇪🇸",
-  "version": "1.14",
+  "version": "1.15",
   "tags": [
     "spanish",
     "spain",

--- a/custom_components/beatify/playlists/community/hitster-brasil.json
+++ b/custom_components/beatify/playlists/community/hitster-brasil.json
@@ -1,6 +1,6 @@
 {
   "name": "100% Brasil 🇧🇷",
-  "version": "0.5",
+  "version": "0.6",
   "tags": [
     "brazil",
     "brasil",

--- a/custom_components/beatify/playlists/community/iconic-movie-songs.json
+++ b/custom_components/beatify/playlists/community/iconic-movie-songs.json
@@ -1,6 +1,6 @@
 {
   "name": "ICONIC movie songs 🎬",
-  "version": "0.14",
+  "version": "0.15",
   "tags": [
     "movies",
     "soundtracks",

--- a/custom_components/beatify/playlists/community/koelner-karneval.json
+++ b/custom_components/beatify/playlists/community/koelner-karneval.json
@@ -1,6 +1,6 @@
 {
   "name": "Cologne Carnival 🎭",
-  "version": "1.14",
+  "version": "1.15",
   "tags": [
     "german",
     "carnival",

--- a/custom_components/beatify/playlists/community/musica-italiana.json
+++ b/custom_components/beatify/playlists/community/musica-italiana.json
@@ -1,7 +1,7 @@
 {
   "name": "Musica Italiana 🇮🇹",
   "description": "Italian classics from the 1960s to the 2000s — cantautori, Sanremo winners and the songs every Italian party sings along to. Merged from playlist requests #2228 and #2229.",
-  "version": "0.14",
+  "version": "0.15",
   "songs": [
     {
       "year": 1962,

--- a/custom_components/beatify/playlists/community/ndw-neue-deutsche-welle.json
+++ b/custom_components/beatify/playlists/community/ndw-neue-deutsche-welle.json
@@ -1,6 +1,6 @@
 {
   "name": "NDW – Neue Deutsche Welle",
-  "version": "0.14",
+  "version": "0.15",
   "tags": [
     "ndw",
     "neue deutsche welle",

--- a/custom_components/beatify/playlists/community/pure-pop-punk.json
+++ b/custom_components/beatify/playlists/community/pure-pop-punk.json
@@ -1,6 +1,6 @@
 {
   "name": "Pure Pop Punk 🎸",
-  "version": "1.13",
+  "version": "1.14",
   "tags": [
     "2000s",
     "pop-punk",

--- a/custom_components/beatify/playlists/community/sanremo-vincitori.json
+++ b/custom_components/beatify/playlists/community/sanremo-vincitori.json
@@ -1,7 +1,7 @@
 {
   "name": "Sanremo: I Vincitori 🇮🇹",
   "description": "Every winning song of the Sanremo Music Festival, from Nilla Pizzi in 1951 to Sal Da Vinci in 2026. Years verified against the official Albo d'oro. Requested in #2230.",
-  "version": "0.9",
+  "version": "0.10",
   "tags": [
     "italian",
     "sanremo",

--- a/custom_components/beatify/playlists/community/schweizer-hits.json
+++ b/custom_components/beatify/playlists/community/schweizer-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Schweizer Hits 🇨🇭",
-  "version": "0.15",
+  "version": "0.16",
   "tags": [
     "swiss",
     "mundart",

--- a/custom_components/beatify/playlists/community/sommerklassiker.json
+++ b/custom_components/beatify/playlists/community/sommerklassiker.json
@@ -1,6 +1,6 @@
 {
   "name": "Sommerklassiker ☀️",
-  "version": "0.15",
+  "version": "0.16",
   "tags": [
     "summer",
     "pop",

--- a/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
+++ b/custom_components/beatify/playlists/community/top100-allertijden-nederlandstalig.json
@@ -1,6 +1,6 @@
 {
   "name": "Top 100 Dutch Classics 🇳🇱",
-  "version": "1.21",
+  "version": "1.22",
   "tags": [
     "nederlandstalig",
     "dutch",

--- a/custom_components/beatify/playlists/community/wiesn-party-hits.json
+++ b/custom_components/beatify/playlists/community/wiesn-party-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "Wiesn Party Hits 🍻",
-  "version": "0.22",
+  "version": "0.23",
   "tags": [
     "party",
     "schlager",

--- a/custom_components/beatify/playlists/community/yacht-rock.json
+++ b/custom_components/beatify/playlists/community/yacht-rock.json
@@ -1,6 +1,6 @@
 {
   "name": "Yacht Rock ⛵",
-  "version": "1.11",
+  "version": "1.12",
   "tags": [
     "1970s",
     "1980s",

--- a/custom_components/beatify/playlists/disco-funk-classics.json
+++ b/custom_components/beatify/playlists/disco-funk-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Disco & Funk Classics",
-  "version": "1.22",
+  "version": "1.23",
   "tags": [
     "1970s",
     "1980s",

--- a/custom_components/beatify/playlists/disney-classics.json
+++ b/custom_components/beatify/playlists/disney-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Disney Classics",
-  "version": "1.10",
+  "version": "1.11",
   "tags": [
     "disney",
     "movies",

--- a/custom_components/beatify/playlists/greatest-hits-of-all-time.json
+++ b/custom_components/beatify/playlists/greatest-hits-of-all-time.json
@@ -1,6 +1,6 @@
 {
   "name": "Greatest Hits of All Time",
-  "version": "2.23",
+  "version": "2.24",
   "tags": [
     "classics",
     "top-hits",

--- a/custom_components/beatify/playlists/motown-soul-classics.json
+++ b/custom_components/beatify/playlists/motown-soul-classics.json
@@ -1,6 +1,6 @@
 {
   "name": "Motown & Soul Classics",
-  "version": "1.18",
+  "version": "1.19",
   "tags": [
     "1960s",
     "1970s",

--- a/custom_components/beatify/playlists/one-hit-wonders.json
+++ b/custom_components/beatify/playlists/one-hit-wonders.json
@@ -1,6 +1,6 @@
 {
   "name": "One-Hit Wonders",
-  "version": "1.16",
+  "version": "1.17",
   "tags": [
     "one-hit",
     "classics",

--- a/custom_components/beatify/playlists/summer-party-anthems.json
+++ b/custom_components/beatify/playlists/summer-party-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "100 Summer Anthems ☀️",
-  "version": "1.16",
+  "version": "1.17",
   "tags": [
     "party",
     "classics",

--- a/custom_components/beatify/playlists/top-songs-der-60er.json
+++ b/custom_components/beatify/playlists/top-songs-der-60er.json
@@ -1,6 +1,6 @@
 {
   "name": "60s Classics 🎸",
-  "version": "1.18",
+  "version": "1.19",
   "source": "https://open.spotify.com/playlist/6rtsNFUv2UK3j78PRVMpSd",
   "tags": [
     "1960s",

--- a/custom_components/beatify/playlists/world-cup-anthems.json
+++ b/custom_components/beatify/playlists/world-cup-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "World Cup Anthems",
-  "version": "1.14",
+  "version": "1.15",
   "tags": [
     "world-cup",
     "fifa",

--- a/docs/release-notes-v4.4.1.md
+++ b/docs/release-notes-v4.4.1.md
@@ -1,0 +1,23 @@
+## Beatify v4.4.1 — "Nothing Lost"
+
+### 🎭 The sabotage token actually arrives
+
+Turn sabotage on and every player gets their one token at the start. Until now the setting was there, the button was there, and the token never reached anybody.
+
+### 🔄 A reload no longer costs you your score
+
+If your phone reloaded mid-game you could come back as a brand-new player on the room average, points gone, while the room watched your name drop to the bottom. Your seat is held, and you come back as yourself.
+
+### 🔧 Also fixed
+
+The Join button no longer sticks on "Joining…" after you leave a game, and a refused join now says why — name taken, room full — on the join screen and in your language, instead of leaving you on a spinner. Title & Artist takes one guess per player per round, a game needs two players before it starts, and only the host can take the host role back. The onboarding tour no longer counts "Step 5 of 4"; a German or Spanish party stops finding English labels on the TV; Spanish has its accents back in a hundred places, including the word for *year*, which appears after every round. The host's end screen drops the empty podium stands in a two-player game, every page shows the same icon in the browser tab thanks to **@slmingol**, and picking a playlist your music service has nothing for now gives you a sentence rather than a server error page.
+
+### 🎉 Five new playlists
+
+**Deutschrap Klassiker** · **Clásicos del Rock en Español** · **Rock Rioplatense** · **Vallenato Clásico** · **Música Colombiana Alegre** — German rap from 1995 on, and four lists that take the catalogue across Spain, Argentina, Uruguay and the Colombian coast. All five now play on Apple Music too.
+
+---
+
+**66 playlists · 8,403 songs · 5 music platforms · 5 languages**
+
+[Report a Bug](https://github.com/mholzi/beatify/issues) · [Discussions](https://github.com/mholzi/beatify/discussions) · [Full Changelog](https://github.com/mholzi/beatify/blob/main/CHANGELOG.md)


### PR DESCRIPTION
Prepares the **v4.4.1** stable release.

## The playlist bumps are the substantive part

#2489 rewrote **36 playlist files** on 2026-09-02 — renaming drifted chart fields so the reveal screen would finally render badges it had researched but never shown — and bumped **none** of their versions.

`_copy_bundled_playlists` overwrites an installed playlist only when the bundled version is **strictly greater**. Without a bump, that work ships in the release and still reaches nobody who already has Beatify installed. Cutting the tag without this would have made that part of the release a no-op for all ~498 existing installs.

34 files needed it (two of the 36 were bumped by later commits). Each gets its least significant version component raised by one — `1.27 → 1.28`, `0.14 → 0.15`, `2.27 → 2.28`. `_compare_versions` parses each dot-part as an integer, so the ordering holds.

**The diff is 34 lines across those files, one per file, and touches nothing else.** Verified with `git diff --numstat`.

## The rest is the usual release commit

- `manifest.json` `4.4.1-rc1 → 4.4.1`
- `CHANGELOG.md` gains a `[4.4.1]` section
- `docs/release-notes-v4.4.1.md`

## How the files were identified

For each of the 66 playlists, the most recent commit that changed its `version` field was located, then the number of commits touching the file *after* that point was counted. Anything greater than zero is a file whose content moved without its version. That found exactly 34, all of them one commit past their last bump, all of them #2489.

## Checks

- pytest **2176 passed**, 2 skipped
- `scripts/validate_playlists.py` — all 66 playlist files valid, schema gate passed
- `npm run build:check` — 18/18 artifacts match source
- ruff check clean
