### PR TITLE
chore(playlists): youtube backfill — +49 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/community/schlager-klassiker.json
+++ b/custom_components/beatify/playlists/community/schlager-klassiker.json
@@ -1,6 +1,6 @@
 {
   "name": "Schlager Classics 🇩🇪",
-  "version": "1.26",
+  "version": "1.27",
   "tags": [
     "german",
     "schlager",
@@ -3621,7 +3621,8 @@
       "fun_fact_de": "Aloha Heja He ist Achim Reichels bekanntestes Lied und eröffnete 1991 sein Album Melancholie und Sturmflut. Der Shanty-Refrain machte es noch lange nach der Veröffentlichung zum festen Bestandteil deutscher Feste und Stadionchöre.",
       "fun_fact_es": "Aloha Heja He es la canción más conocida de Achim Reichel y abrió su álbum de 1991 Melancholie und Sturmflut. Su estribillo de canción marinera la convirtió en un clásico de las fiestas alemanas mucho después de su lanzamiento.",
       "fun_fact_fr": "Aloha Heja He est la chanson la plus connue d'Achim Reichel et ouvrait son album Melancholie und Sturmflut en 1991. Son refrain de chant de marins en a fait un incontournable des fêtes allemandes bien après sa sortie.",
-      "fun_fact_nl": "Aloha Heja He is het bekendste nummer van Achim Reichel en opende in 1991 zijn album Melancholie und Sturmflut. Het shantyrefrein maakte het nog jarenlang tot een vaste waarde op Duitse feesten."
+      "fun_fact_nl": "Aloha Heja He is het bekendste nummer van Achim Reichel en opende in 1991 zijn album Melancholie und Sturmflut. Het shantyrefrein maakte het nog jarenlang tot een vaste waarde op Duitse feesten.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=2Z6xtLcyNm0"
     },
     {
       "artist": "G.G. Anderson",
@@ -3677,7 +3678,8 @@
       "fun_fact_de": "Das Lied der Schlümpfe ist die deutsche Fassung des niederländischen Hits, den der Sänger Pierre Kartner als Vader Abraham aufnahm. Das Schlumpflied verkaufte sich europaweit millionenfach und zog eine ganze Reihe von Nachfolgern nach sich.",
       "fun_fact_es": "Das Lied der Schlümpfe es la versión alemana del éxito neerlandés que el cantante Pierre Kartner grabó como Vader Abraham. La canción de los Pitufos vendió millones en toda Europa y dio pie a toda una serie de continuaciones.",
       "fun_fact_fr": "Das Lied der Schlümpfe est la version allemande du tube néerlandais enregistré par le chanteur Pierre Kartner sous le nom de Vader Abraham. La chanson des Schtroumpfs s'est vendue à des millions d'exemplaires en Europe et a donné lieu à toute une série de suites.",
-      "fun_fact_nl": "Das Lied der Schlümpfe is de Duitse versie van de Nederlandse hit die zanger Pierre Kartner als Vader Abraham opnam. Het Smurfenlied ging in heel Europa miljoenen keren over de toonbank en kreeg een hele reeks opvolgers."
+      "fun_fact_nl": "Das Lied der Schlümpfe is de Duitse versie van de Nederlandse hit die zanger Pierre Kartner als Vader Abraham opnam. Het Smurfenlied ging in heel Europa miljoenen keren over de toonbank en kreeg een hele reeks opvolgers.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=L14dxvSyCrk"
     },
     {
       "artist": "Maite Kelly",
@@ -3771,7 +3773,8 @@
       "fun_fact_de": "Die deutsche Fassung eines niederländischen Liedes von Pierre Kartner — demselben Autor, der als Vader Abraham das Schlumpflied aufnahm. Peter Alexander machte aus dem Hafencafé des Originals die Eckkneipe einer ganzen Generation.",
       "fun_fact_es": "La versión alemana de una canción neerlandesa de Pierre Kartner, el mismo autor que grabó la canción de los Pitufos como Vader Abraham. Peter Alexander convirtió el café portuario del original en la taberna de toda una generación.",
       "fun_fact_fr": "La version allemande d'une chanson néerlandaise de Pierre Kartner, l'auteur même qui a enregistré la chanson des Schtroumpfs sous le nom de Vader Abraham. Peter Alexander a transformé le café du port en bistrot de toute une génération.",
-      "fun_fact_nl": "De Duitse versie van een Nederlands lied van Pierre Kartner — dezelfde schrijver die als Vader Abraham het Smurfenlied opnam. Peter Alexander maakte van het havencafé uit het origineel de stamkroeg van een hele generatie."
+      "fun_fact_nl": "De Duitse versie van een Nederlands lied van Pierre Kartner — dezelfde schrijver die als Vader Abraham het Smurfenlied opnam. Peter Alexander maakte van het havencafé uit het origineel de stamkroeg van een hele generatie.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=G59dTZGh1xI"
     },
     {
       "artist": "Peter Maffay",
@@ -4036,7 +4039,8 @@
       "fun_fact_de": "Der Wiener Sänger hatte 1982 mit Adios Amor seinen Durchbruch und moderierte später jahrelang den Musikantenstadl, eine der meistgesehenen Schlagersendungen im deutschsprachigen Raum.",
       "fun_fact_es": "El cantante vienés triunfó en 1982 con Adios Amor y más tarde presentó durante años el Musikantenstadl, uno de los programas de Schlager más vistos del ámbito germanohablante.",
       "fun_fact_fr": "Le chanteur viennois a percé en 1982 avec Adios Amor et a ensuite animé pendant des années le Musikantenstadl, l'une des émissions de Schlager les plus regardées de l'espace germanophone.",
-      "fun_fact_nl": "De Weense zanger brak in 1982 door met Adios Amor en presenteerde later jarenlang de Musikantenstadl, een van de best bekeken Schlagerprogramma's in het Duitse taalgebied."
+      "fun_fact_nl": "De Weense zanger brak in 1982 door met Adios Amor en presenteerde later jarenlang de Musikantenstadl, een van de best bekeken Schlagerprogramma's in het Duitse taalgebied.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Fz6FMB5KXNQ"
     },
     {
       "artist": "Klostertaler",
@@ -4054,7 +4058,8 @@
       "fun_fact_de": "Die Klostertaler sind nach dem Vorarlberger Tal benannt, aus dem sie kommen. Sie gehören zum volkstümlichen Flügel des Schlagers, in dem die Ziehharmonika keine Verzierung ist, sondern das Leitinstrument.",
       "fun_fact_es": "Los Klostertaler llevan el nombre del valle de Vorarlberg del que proceden. Pertenecen al ala folclórica del Schlager, donde el acordeón no es un adorno sino el instrumento principal.",
       "fun_fact_fr": "Les Klostertaler portent le nom de la vallée du Vorarlberg d'où ils viennent. Ils appartiennent à l'aile folklorique du Schlager, où l'accordéon n'est pas un ornement mais l'instrument principal.",
-      "fun_fact_nl": "De Klostertaler zijn vernoemd naar het dal in Vorarlberg waar ze vandaan komen. Ze horen bij de volkse tak van de Schlager, waar de accordeon geen versiering is maar het hoofdinstrument."
+      "fun_fact_nl": "De Klostertaler zijn vernoemd naar het dal in Vorarlberg waar ze vandaan komen. Ze horen bij de volkse tak van de Schlager, waar de accordeon geen versiering is maar het hoofdinstrument.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=4Zk45BP5qDI"
     },
     {
       "artist": "Olaf Henning",
@@ -4262,7 +4267,8 @@
       "fun_fact_de": "Von der Lippe ist Komiker und Fernsehmoderator, der immer wieder in die Charts geriet. Zwei Jahre vor diesem Lied stand er mit Guten Morgen, liebe Sorgen auf Platz eins.",
       "fun_fact_es": "Von der Lippe es humorista y presentador de televisión que una y otra vez acababa en las listas. Dos años antes de esta canción llegó al número uno con Guten Morgen, liebe Sorgen.",
       "fun_fact_fr": "Von der Lippe est humoriste et animateur de télévision, et il s'égarait régulièrement dans les classements. Deux ans avant cette chanson, il était numéro un avec Guten Morgen, liebe Sorgen.",
-      "fun_fact_nl": "Von der Lippe is komiek en televisiepresentator die telkens weer in de hitlijsten belandde. Twee jaar voor dit nummer stond hij met Guten Morgen, liebe Sorgen op één."
+      "fun_fact_nl": "Von der Lippe is komiek en televisiepresentator die telkens weer in de hitlijsten belandde. Twee jaar voor dit nummer stond hij met Guten Morgen, liebe Sorgen op één.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vu04bh9O5Gc"
     },
     {
       "artist": "Das Stoakogler Trio",
@@ -4546,7 +4552,8 @@
       "fun_fact_de": "Haller schrieb und produzierte ihre Platten selbst, zu einer Zeit, in der der deutsche Schlager Frauen selten ans Mischpult ließ. Sie schrieb auch für andere Sängerinnen, oft ohne ihren Namen auf dem Cover.",
       "fun_fact_es": "Haller escribía y producía sus propios discos en una época en que el Schlager alemán rara vez dejaba a una mujer acercarse a la mesa de mezclas. También escribía para otras cantantes, a menudo sin su nombre en la portada.",
       "fun_fact_fr": "Haller écrivait et produisait ses propres disques à une époque où le Schlager allemand laissait rarement une femme approcher la console. Elle écrivait aussi pour d'autres chanteuses, souvent sans son nom sur la pochette.",
-      "fun_fact_nl": "Haller schreef en produceerde haar eigen platen in een tijd waarin de Duitse Schlager vrouwen zelden bij de mengtafel liet. Ze schreef ook voor andere zangeressen, vaak zonder haar naam op de hoes."
+      "fun_fact_nl": "Haller schreef en produceerde haar eigen platen in een tijd waarin de Duitse Schlager vrouwen zelden bij de mengtafel liet. Ze schreef ook voor andere zangeressen, vaak zonder haar naam op de hoes.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=G03w_38B5vs"
     },
     {
       "artist": "Ibo",
@@ -4659,7 +4666,8 @@
       "fun_fact_de": "Jordi gewann 1998 den Grand Prix der Volksmusik und vertrat die Schweiz 2002 beim Eurovision Song Contest. Zwischen beidem wechselte sie von der Volksmusik in den breiten Schlager.",
       "fun_fact_es": "Jordi ganó el Grand Prix der Volksmusik en 1998 y representó a Suiza en Eurovisión en 2002. Entre ambos hitos pasó de la música folclórica al Schlager mayoritario.",
       "fun_fact_fr": "Jordi a remporté le Grand Prix der Volksmusik en 1998 et a représenté la Suisse à l'Eurovision en 2002. Entre les deux, elle est passée de la musique folklorique au Schlager grand public.",
-      "fun_fact_nl": "Jordi won in 1998 de Grand Prix der Volksmusik en vertegenwoordigde Zwitserland in 2002 op het Eurovisiesongfestival. Daartussen stapte ze van volksmuziek over naar de brede Schlager."
+      "fun_fact_nl": "Jordi won in 1998 de Grand Prix der Volksmusik en vertegenwoordigde Zwitserland in 2002 op het Eurovisiesongfestival. Daartussen stapte ze van volksmuziek over naar de brede Schlager.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=GRyJxbe6SgE"
     },
     {
       "year": 1983,
@@ -4679,7 +4687,8 @@
       "fun_fact_es": "El disco existe en dos versiones, una cantada desde el punto de vista del hombre y otra desde el de la mujer; esta es la original femenina de 1983.",
       "fun_fact_fr": "Le disque existe en deux versions, l'une chantée du point de vue de l'homme, l'autre de celui de la femme ; voici l'original féminin de 1983.",
       "fun_fact_nl": "De plaat bestaat in twee versies, één vanuit de man en één vanuit de vrouw gezongen; dit is het vrouwelijke origineel uit 1983.",
-      "fun_fact_it": "Il disco esiste in due versioni, una cantata dal punto di vista dell'uomo e una da quello della donna; questa è l'originale femminile del 1983."
+      "fun_fact_it": "Il disco esiste in due versioni, una cantata dal punto di vista dell'uomo e una da quello della donna; questa è l'originale femminile del 1983.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=F7LcMD9ZhXw"
     },
     {
       "year": 2015,
@@ -4699,7 +4708,8 @@
       "fun_fact_es": "Los dos austriacos la subieron a internet como broma, y en semanas llevaba meses en el número uno y había desatado una fiebre por el pop en dialecto vienés.",
       "fun_fact_fr": "Les deux Autrichiens l'ont mise sur internet pour plaisanter, et en quelques semaines elle occupait la première place depuis des mois et lançait une vague de pop en dialecte viennois.",
       "fun_fact_nl": "De twee Oostenrijkers zetten het als grap op internet, en binnen weken stond het maandenlang op nummer één en begon een golf van Weense dialectpop.",
-      "fun_fact_it": "I due austriaci la misero in rete per scherzo, e in poche settimane era da mesi al primo posto e aveva avviato una corsa al pop in dialetto viennese."
+      "fun_fact_it": "I due austriaci la misero in rete per scherzo, e in poche settimane era da mesi al primo posto e aveva avviato una corsa al pop in dialetto viennese.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=GWgisTPKCdk"
     },
     {
       "year": 1962,
@@ -4719,7 +4729,8 @@
       "fun_fact_es": "Froboess tenía doce años cuando la cantó, y la oficina de turismo italiana protestó por el verso sobre mezclar vino con gaseosa.",
       "fun_fact_fr": "Froboess avait douze ans quand elle l'a chantée, et l'office du tourisme italien s'est plaint du vers sur le vin mêlé de limonade.",
       "fun_fact_nl": "Froboess was twaalf toen ze het zong, en het Italiaanse toeristenbureau klaagde over de regel over wijn met limonade.",
-      "fun_fact_it": "Froboess aveva dodici anni quando la cantò, e l'ente del turismo italiano protestò per il verso sul vino mescolato alla gazzosa."
+      "fun_fact_it": "Froboess aveva dodici anni quando la cantò, e l'ente del turismo italiano protestò per il verso sul vino mescolato alla gazzosa.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=J3QziNCnZ1E"
     },
     {
       "year": 1963,
@@ -4739,7 +4750,8 @@
       "fun_fact_es": "La cantante danesa quedó segunda con ella en la preselección alemana para Eurovisión; del ganador ya no se acuerda nadie.",
       "fun_fact_fr": "La chanteuse danoise a terminé deuxième avec elle à la présélection allemande de l'Eurovision ; plus personne ne se souvient du vainqueur.",
       "fun_fact_nl": "De Deense zangeres werd er tweede mee bij de Duitse voorronde voor Eurovisie; aan de winnaar herinnert niemand zich nog.",
-      "fun_fact_it": "La cantante danese arrivò seconda con questa alla preselezione tedesca per l'Eurovision; del vincitore non si ricorda più nessuno."
+      "fun_fact_it": "La cantante danese arrivò seconda con questa alla preselezione tedesca per l'Eurovision; del vincitore non si ricorda più nessuno.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=O30iggYXKZU"
     },
     {
       "year": 1965,
@@ -4759,7 +4771,8 @@
       "fun_fact_es": "March era estadounidense, tuvo un número uno en su país a los quince, se mudó a Alemania y cantó el resto de su carrera en un idioma que tuvo que aprender.",
       "fun_fact_fr": "March était américaine, a eu un numéro un aux États-Unis à quinze ans, s'est installée en Allemagne et a chanté le reste de sa carrière dans une langue qu'elle a dû apprendre.",
       "fun_fact_nl": "March was Amerikaanse, had op haar vijftiende een Amerikaanse nummer één, verhuisde naar Duitsland en zong de rest van haar loopbaan in een taal die ze moest leren.",
-      "fun_fact_it": "March era americana, a quindici anni ebbe un numero uno negli Stati Uniti, si trasferì in Germania e cantò il resto della carriera in una lingua che dovette imparare."
+      "fun_fact_it": "March era americana, a quindici anni ebbe un numero uno negli Stati Uniti, si trasferì in Germania e cantò il resto della carriera in una lingua che dovette imparare.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=yYsOucFRrDI"
     },
     {
       "year": 1968,
@@ -4779,7 +4792,8 @@
       "fun_fact_es": "La cantante noruega vendió más discos en Alemania que en su país, y esta canción la convirtió durante dos décadas en fija de la televisión de los sábados.",
       "fun_fact_fr": "La chanteuse norvégienne a vendu plus de disques en Allemagne que chez elle, et ce titre en a fait pendant vingt ans une habituée des samedis soir à la télévision.",
       "fun_fact_nl": "De Noorse zangeres verkocht in Duitsland meer platen dan thuis, en dit nummer maakte haar twee decennia lang een vaste waarde op zaterdagavond.",
-      "fun_fact_it": "La cantante norvegese vendette in Germania più dischi che in patria, e questo brano la rese per vent'anni una presenza fissa del sabato sera televisivo."
+      "fun_fact_it": "La cantante norvegese vendette in Germania più dischi che in patria, e questo brano la rese per vent'anni una presenza fissa del sabato sera televisivo.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=sk_PAhfe0EY"
     },
     {
       "year": 1970,
@@ -4799,7 +4813,8 @@
       "fun_fact_es": "Silvester cantó la versión alemana de un original neerlandés, que era entonces la vía habitual para colar un éxito en alemán en las listas.",
       "fun_fact_fr": "Silvester a chanté la version allemande d'un original néerlandais, la voie habituelle à l'époque pour un tube en allemand.",
       "fun_fact_nl": "Silvester zong de Duitse versie van een Nederlands origineel, destijds de gebruikelijke weg voor een Duitstalige hit naar de lijsten.",
-      "fun_fact_it": "Silvester cantò la versione tedesca di un originale olandese, all'epoca la via consueta perché un successo in tedesco entrasse in classifica."
+      "fun_fact_it": "Silvester cantò la versione tedesca di un originale olandese, all'epoca la via consueta perché un successo in tedesco entrasse in classifica.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=WU8Tt__LRnY"
     },
     {
       "year": 1971,
@@ -4819,7 +4834,8 @@
       "fun_fact_es": "Marshall se formó como cantante de ópera y se pasó al schlager por dinero; después le preguntaron por esa decisión durante cuarenta años.",
       "fun_fact_fr": "Marshall avait une formation de chanteur d'opéra et est passé au schlager pour l'argent ; on lui a ensuite posé la question pendant quarante ans.",
       "fun_fact_nl": "Marshall was opgeleid als operazanger en stapte voor het geld over op schlager; daarna werd hem er veertig jaar naar gevraagd.",
-      "fun_fact_it": "Marshall era un cantante lirico di formazione e passò allo schlager per soldi; poi gli fu chiesto conto di quella scelta per quarant'anni."
+      "fun_fact_it": "Marshall era un cantante lirico di formazione e passò allo schlager per soldi; poi gli fu chiesto conto di quella scelta per quarant'anni.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Sc0_8Pu6mlc"
     },
     {
       "year": 1971,
@@ -4839,7 +4855,8 @@
       "fun_fact_es": "Roberts era el ídolo adolescente de la televisión alemana a comienzos de los setenta, y sus discos vendían más en Alemania que donde su nombre se pronunciaba bien.",
       "fun_fact_fr": "Roberts était l'idole des adolescents à la télévision allemande au tournant des années soixante-dix, et ses disques se vendaient mieux en Allemagne que là où l'on prononçait son nom correctement.",
       "fun_fact_nl": "Roberts was rond 1970 het tieneridool van de Duitse televisie, en zijn platen verkochten in Duitsland beter dan waar zijn naam correct werd uitgesproken.",
-      "fun_fact_it": "Roberts era l'idolo dei teenager della televisione tedesca all'inizio degli anni settanta, e i suoi dischi vendevano in Germania più che dove il suo nome si pronunciava bene."
+      "fun_fact_it": "Roberts era l'idolo dei teenager della televisione tedesca all'inizio degli anni settanta, e i suoi dischi vendevano in Germania più che dove il suo nome si pronunciava bene.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=npJLz0RBUzg"
     },
     {
       "year": 1972,
@@ -4859,7 +4876,8 @@
       "fun_fact_es": "Gildo cantó durante veinticinco años sobre un último baile sin poder decir nunca en público con quién bailaba.",
       "fun_fact_fr": "Gildo a chanté pendant vingt-cinq ans une dernière danse sans jamais pouvoir dire publiquement avec qui il dansait.",
       "fun_fact_nl": "Gildo zong vijfentwintig jaar over een laatste dans zonder ooit publiekelijk te mogen zeggen met wie hij danste.",
-      "fun_fact_it": "Gildo cantò per venticinque anni di un ultimo ballo senza poter mai dire in pubblico con chi ballava."
+      "fun_fact_it": "Gildo cantò per venticinque anni di un ultimo ballo senza poter mai dire in pubblico con chi ballava.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ZXusT8nKcw8"
     },
     {
       "year": 1972,
@@ -4879,7 +4897,8 @@
       "fun_fact_es": "Anders escribía su propio material, algo poco común en un género donde al cantante se le entregaba la canción terminada.",
       "fun_fact_fr": "Anders écrivait ses propres chansons, ce qui était rare dans un genre où l'on remettait au chanteur un titre déjà terminé.",
       "fun_fact_nl": "Anders schreef zijn eigen materiaal, ongebruikelijk in een genre waarin de zanger normaal een kant-en-klaar lied kreeg.",
-      "fun_fact_it": "Anders scriveva i propri pezzi, cosa insolita in un genere dove al cantante si consegnava una canzone già pronta."
+      "fun_fact_it": "Anders scriveva i propri pezzi, cosa insolita in un genere dove al cantante si consegnava una canzone già pronta.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=RKn0hiT9tyc"
     },
     {
       "year": 1973,
@@ -4899,7 +4918,8 @@
       "fun_fact_es": "Marcus se llamaba en realidad Jürgen Beumer y adoptó el nombre artístico porque una discográfica juzgó que el verdadero no cabía en un cartel.",
       "fun_fact_fr": "Marcus s'appelait en réalité Jürgen Beumer et a pris ce nom de scène parce qu'une maison de disques trouvait le vrai trop encombrant pour une affiche.",
       "fun_fact_nl": "Marcus heette eigenlijk Jürgen Beumer en nam de artiestennaam aan omdat een platenmaatschappij de echte te log vond voor een poster.",
-      "fun_fact_it": "Marcus si chiamava in realtà Jürgen Beumer e prese il nome d'arte perché una casa discografica trovava quello vero troppo ingombrante per un manifesto."
+      "fun_fact_it": "Marcus si chiamava in realtà Jürgen Beumer e prese il nome d'arte perché una casa discografica trovava quello vero troppo ingombrante per un manifesto.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=C4yP2iL-BxY"
     },
     {
       "year": 1976,
@@ -4919,7 +4939,8 @@
       "fun_fact_es": "Rosenberg tenía diecisiete años cuando empezó y décadas después se volvió una fija de los clubes gays alemanes, un público con el que la industria del schlager no contaba.",
       "fun_fact_fr": "Rosenberg avait dix-sept ans à ses débuts et est devenue, des décennies plus tard, une habituée des clubs gays allemands — un public que l'industrie du schlager n'avait pas prévu.",
       "fun_fact_nl": "Rosenberg was zeventien toen haar loopbaan begon en werd decennia later een vaste waarde in Duitse homoclubs, een publiek waar de schlagerindustrie niet op had gerekend.",
-      "fun_fact_it": "Rosenberg aveva diciassette anni all'esordio e divenne, decenni dopo, una presenza fissa nei locali gay tedeschi: un pubblico che l'industria dello schlager non aveva previsto."
+      "fun_fact_it": "Rosenberg aveva diciassette anni all'esordio e divenne, decenni dopo, una presenza fissa nei locali gay tedeschi: un pubblico che l'industria dello schlager non aveva previsto.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=x41IzYLmFLE"
     },
     {
       "year": 1976,
@@ -4939,7 +4960,8 @@
       "fun_fact_es": "La melodía es una polca checa de 1927 que desde entonces es un clásico de las carpas cerveceras en tres idiomas.",
       "fun_fact_fr": "La mélodie est une polka tchèque de 1927, devenue depuis un standard des tentes à bière en trois langues.",
       "fun_fact_nl": "De melodie is een Tsjechische polka uit 1927 die sindsdien in drie talen een biertentklassieker is.",
-      "fun_fact_it": "La melodia è una polka ceca del 1927, da allora uno standard dei tendoni della birra in tre lingue."
+      "fun_fact_it": "La melodia è una polka ceca del 1927, da allora uno standard dei tendoni della birra in tre lingue.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7FBmyFyYNws"
     },
     {
       "year": 1979,
@@ -4959,7 +4981,8 @@
       "fun_fact_es": "Carpendale es sudafricano y aprendió alemán de adulto; de ahí el acento de sus primeros discos, que al público alemán acabó gustándole.",
       "fun_fact_fr": "Carpendale est sud-africain et a appris l'allemand adulte, d'où l'accent de ses premiers disques, que le public allemand a fini par apprécier.",
       "fun_fact_nl": "Carpendale is Zuid-Afrikaan en leerde pas als volwassene Duits; vandaar het accent op zijn vroege platen, dat het Duitse publiek ging waarderen.",
-      "fun_fact_it": "Carpendale è sudafricano e imparò il tedesco da adulto: da qui l'accento dei suoi primi dischi, che al pubblico tedesco finì per piacere."
+      "fun_fact_it": "Carpendale è sudafricano e imparò il tedesco da adulto: da qui l'accento dei suoi primi dischi, che al pubblico tedesco finì per piacere.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rcXDO4_SZjA"
     },
     {
       "year": 1979,
@@ -4979,7 +5002,8 @@
       "fun_fact_es": "El grupo se formó para una única candidatura a Eurovisión y nunca se disolvió del todo: cuarenta años de gira con formaciones cambiantes.",
       "fun_fact_fr": "Le groupe a été monté pour une seule participation à l'Eurovision et ne s'est jamais vraiment séparé : quarante ans de tournée avec des formations changeantes.",
       "fun_fact_nl": "De groep werd voor één Eurovisie-inzending samengesteld en viel nooit echt uit elkaar: veertig jaar toeren met wisselende bezettingen.",
-      "fun_fact_it": "Il gruppo fu messo insieme per una sola partecipazione all'Eurovision e non si sciolse mai davvero: quarant'anni di tournée con formazioni diverse."
+      "fun_fact_it": "Il gruppo fu messo insieme per una sola partecipazione all'Eurovision e non si sciolse mai davvero: quarant'anni di tournée con formazioni diverse.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vl5LOT_0Qto"
     },
     {
       "year": 1981,
@@ -4999,7 +5023,8 @@
       "fun_fact_es": "Kaiser creció en un hogar infantil de Berlín y trabajó de vendedor de coches hasta los veintiocho; la carrera musical vino después.",
       "fun_fact_fr": "Kaiser a grandi dans un foyer pour enfants à Berlin et a été vendeur de voitures jusqu'à vingt-huit ans ; la carrière de chanteur est venue après.",
       "fun_fact_nl": "Kaiser groeide op in een Berlijns kindertehuis en werkte tot zijn achtentwintigste als autoverkoper; de zangcarrière kwam daarna.",
-      "fun_fact_it": "Kaiser crebbe in un istituto per minori a Berlino e fece il venditore di auto fino a ventotto anni; la carriera da cantante venne dopo."
+      "fun_fact_it": "Kaiser crebbe in un istituto per minori a Berlino e fece il venditore di auto fino a ventotto anni; la carriera da cantante venne dopo.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6ga2uOXdvDI"
     },
     {
       "year": 1985,
@@ -5019,7 +5044,8 @@
       "fun_fact_es": "G.G. Anderson es Gerd Grabowski, de Baviera; el nombre artístico de sonido inglés se eligió precisamente porque no sonaba a schlager.",
       "fun_fact_fr": "G.G. Anderson est Gerd Grabowski, de Bavière ; le nom de scène à consonance anglaise a été choisi précisément parce qu'il ne sonnait pas schlager.",
       "fun_fact_nl": "G.G. Anderson is Gerd Grabowski uit Beieren; de Engels klinkende artiestennaam werd juist gekozen omdat hij naar alles klonk behalve schlager.",
-      "fun_fact_it": "G.G. Anderson è Gerd Grabowski, bavarese; il nome d'arte dal suono inglese fu scelto proprio perché non sapeva di schlager."
+      "fun_fact_it": "G.G. Anderson è Gerd Grabowski, bavarese; il nome d'arte dal suono inglese fu scelto proprio perché non sapeva di schlager.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=x6axbvm5meA"
     },
     {
       "year": 1997,
@@ -5039,7 +5065,8 @@
       "fun_fact_es": "Petry dejó los escenarios en 2006 en la cima del éxito y pasó una década rechazando toda oferta de regreso.",
       "fun_fact_fr": "Petry a arrêté la scène en 2006 au sommet de son succès et a refusé pendant dix ans toute offre de retour.",
       "fun_fact_nl": "Petry stopte in 2006 op het hoogtepunt van zijn succes en wees tien jaar lang elk comeback-aanbod af.",
-      "fun_fact_it": "Petry lasciò le scene nel 2006 all'apice del successo e per un decennio rifiutò ogni offerta di ritorno."
+      "fun_fact_it": "Petry lasciò le scene nel 2006 all'apice del successo e per un decennio rifiutò ogni offerta di ritorno.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=iO7P18zxp6M"
     },
     {
       "year": 2001,
@@ -5059,7 +5086,8 @@
       "fun_fact_es": "Michelle había representado a Alemania en Eurovisión y quedó octava; la carrera en el schlager que siguió duró más que la de todos los que la superaron.",
       "fun_fact_fr": "Michelle avait représenté l'Allemagne à l'Eurovision et terminé huitième ; la carrière schlager qui a suivi a duré plus longtemps que celle de tous ceux qui l'avaient devancée.",
       "fun_fact_nl": "Michelle had Duitsland vertegenwoordigd op Eurovisie en werd achtste; de schlagercarrière daarna hield langer stand dan die van iedereen die boven haar eindigde.",
-      "fun_fact_it": "Michelle aveva rappresentato la Germania all'Eurovision arrivando ottava; la carriera nello schlager che seguì durò più di quella di tutti quelli che l'avevano battuta."
+      "fun_fact_it": "Michelle aveva rappresentato la Germania all'Eurovision arrivando ottava; la carriera nello schlager che seguì durò più di quella di tutti quelli che l'avevano battuta.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HF_nIjQOIaU"
     },
     {
       "year": 2004,
@@ -5079,7 +5107,8 @@
       "fun_fact_es": "El disco se hizo para el circuito de fiestas de Mallorca, no para la radio, y aun así entró en las listas alemanas.",
       "fun_fact_fr": "Le disque a été fait pour les fêtes de Majorque et non pour la radio, et il est quand même entré dans les classements allemands.",
       "fun_fact_nl": "De plaat werd gemaakt voor het Mallorca-feestcircuit en niet voor de radio, en haalde toch de Duitse lijsten.",
-      "fun_fact_it": "Il disco fu fatto per il giro delle feste di Maiorca e non per la radio, ed entrò comunque nelle classifiche tedesche."
+      "fun_fact_it": "Il disco fu fatto per il giro delle feste di Maiorca e non per la radio, ed entrò comunque nelle classifiche tedesche.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=S1uwdhHSi8A"
     },
     {
       "year": 2007,
@@ -5099,7 +5128,8 @@
       "fun_fact_es": "Nik P. había publicado la canción solo en 1998 sin efecto alguno; la versión con DJ Ötzi nueve años después se mantuvo más de un año en las listas alemanas.",
       "fun_fact_fr": "Nik P. avait sorti la chanson seul en 1998 sans effet ; la version avec DJ Ötzi neuf ans plus tard est restée plus d'un an dans les classements allemands.",
       "fun_fact_nl": "Nik P. had het nummer in 1998 alleen uitgebracht zonder effect; de versie met DJ Ötzi negen jaar later stond ruim een jaar in de Duitse lijsten.",
-      "fun_fact_it": "Nik P. aveva pubblicato la canzone da solo nel 1998 senza effetto; la versione con DJ Ötzi nove anni dopo restò oltre un anno nelle classifiche tedesche."
+      "fun_fact_it": "Nik P. aveva pubblicato la canzone da solo nel 1998 senza effetto; la versione con DJ Ötzi nove anni dopo restò oltre un anno nelle classifiche tedesche.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=2Ua9af7xC9c"
     },
     {
       "year": 2011,
@@ -5119,7 +5149,8 @@
       "fun_fact_es": "Gabalier la escribió después de que su padre y su hermana se quitaran la vida, y la canta en dialecto estirio ante estadios llenos.",
       "fun_fact_fr": "Gabalier l'a écrite après les suicides de son père et de sa sœur, et la chante en dialecte styrien devant des stades.",
       "fun_fact_nl": "Gabalier schreef het nadat zijn vader en zijn zus zich van het leven hadden beroofd, en zingt het in Stiers dialect voor stadions.",
-      "fun_fact_it": "Gabalier la scrisse dopo che il padre e la sorella si erano tolti la vita, e la canta in dialetto stiriano davanti agli stadi."
+      "fun_fact_it": "Gabalier la scrisse dopo che il padre e la sorella si erano tolti la vita, e la canta in dialetto stiriano davanti agli stadi.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vyQf9nB4eYk"
     },
     {
       "year": 1992,
@@ -5138,7 +5169,8 @@
       "fun_fact_fr": "Mario Jordan est un nom de scène : le chanteur s'appelle Mario Lehner, et le texte est signé Michael Kunze, qui a aussi écrit pour Udo Jürgens.",
       "fun_fact_nl": "Mario Jordan is een artiestennaam — de zanger heet Mario Lehner, en de tekst komt van Michael Kunze, die ook voor Udo Jürgens schreef.",
       "uri_apple_music": "applemusic://track/313132976",
-      "uri_deezer": "deezer://track/3801813892"
+      "uri_deezer": "deezer://track/3801813892",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=w-nAB_eI4Rw"
     },
     {
       "year": 1994,
@@ -5156,7 +5188,8 @@
       "fun_fact_es": "La banda austriaca tuvo que cambiar su nombre a Caraboo por motivos legales, así que el mismo grupo aparece con dos nombres.",
       "fun_fact_fr": "Le groupe autrichien a dû se rebaptiser Caraboo pour des raisons juridiques : la même formation existe donc sous deux noms.",
       "fun_fact_nl": "De Oostenrijkse band moest zich om juridische redenen Caraboo gaan noemen, dus dezelfde groep staat onder twee namen in de rekken.",
-      "uri_deezer": "deezer://track/2267596"
+      "uri_deezer": "deezer://track/2267596",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=l833niS_w0o"
     },
     {
       "year": 1996,
@@ -5175,7 +5208,8 @@
       "fun_fact_fr": "Le premier single de la chanteuse autrichienne, peintre de formation avant d'enregistrer quoi que ce soit.",
       "fun_fact_nl": "De debuutsingle van de Oostenrijkse zangeres, die schilderes was voordat ze ook maar iets opnam.",
       "uri_apple_music": "applemusic://track/1822469931",
-      "uri_deezer": "deezer://track/10495720"
+      "uri_deezer": "deezer://track/10495720",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vIjFGV-mIuM"
     },
     {
       "year": 2000,
@@ -5194,7 +5228,8 @@
       "fun_fact_fr": "Le titre vient du dernier album d'Ibo : le chanteur de discofox est mort la même année à 44 ans, et la chanson lui a survécu comme classique de fête.",
       "fun_fact_nl": "Het nummer komt van Ibo's laatste album — de discofoxzanger stierf datzelfde jaar op zijn 44e, en het lied overleefde hem als partyklassieker.",
       "uri_apple_music": "applemusic://track/311136341",
-      "uri_deezer": "deezer://track/2759281"
+      "uri_deezer": "deezer://track/2759281",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=WepjcMRfdIQ"
     },
     {
       "year": 2001,
@@ -5212,7 +5247,8 @@
       "fun_fact_es": "Simone es la austriaca Simone Stelzer, y esta es la canción que da título al álbum que lleva solo su nombre de pila en la portada.",
       "fun_fact_fr": "Simone, c'est l'Autrichienne Simone Stelzer, et voici la chanson-titre de l'album qui ne porte que son prénom en couverture.",
       "fun_fact_nl": "Simone is de Oostenrijkse Simone Stelzer, en dit is het titelnummer van het album dat alleen haar voornaam op de hoes draagt.",
-      "uri_deezer": "deezer://track/2488095"
+      "uri_deezer": "deezer://track/2488095",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jyNdEEk-sgs"
     },
     {
       "year": 2002,
@@ -5231,7 +5267,8 @@
       "fun_fact_fr": "Sandy Wagner est un homme : Stefan Dietmar Wagner, animateur de télévision, qui a écrit, chanté et produit lui-même ce titre.",
       "fun_fact_nl": "Sandy Wagner is een man — Stefan Dietmar Wagner, tv-presentator, die dit nummer zelf schreef, zong en produceerde.",
       "uri_apple_music": "applemusic://track/311150929",
-      "uri_deezer": "deezer://track/2195346"
+      "uri_deezer": "deezer://track/2195346",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=j77vDCNOvZI"
     },
     {
       "year": 2004,
@@ -5249,7 +5286,8 @@
       "fun_fact_es": "Hilbert escribió varios sencillos alemanes de top ten para otros artistas y fue jurado en Popstars: se le conocía más como autor que como cantante.",
       "fun_fact_fr": "Hilbert a écrit plusieurs singles allemands du top dix pour d'autres et a siégé au jury de Popstars : il était plus connu comme auteur que comme chanteur.",
       "fun_fact_nl": "Hilbert schreef een reeks Duitse toptienhits voor anderen en zat in de jury van Popstars — als auteur was hij bekender dan als zanger.",
-      "uri_deezer": "deezer://track/776910"
+      "uri_deezer": "deezer://track/776910",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YVRfqE2iV8s"
     },
     {
       "year": 2006,
@@ -5268,7 +5306,8 @@
       "fun_fact_fr": "Du discofox à 132 battements par minute : assez rapide pour que ce soit la piste qui donne le tempo, pas la chanson.",
       "fun_fact_nl": "Discofox op 132 slagen per minuut — snel genoeg dat de dansvloer het tempo bepaalt en niet het nummer.",
       "uri_apple_music": "applemusic://track/375149661",
-      "uri_deezer": "deezer://track/40137411"
+      "uri_deezer": "deezer://track/40137411",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=sprL6v0OFsM"
     },
     {
       "year": 2007,
@@ -5286,7 +5325,8 @@
       "fun_fact_es": "El sencillo salió con un mix Stadl, uno de rock y uno de DJ: una canción en tres versiones para tres salas distintas.",
       "fun_fact_fr": "Le single est sorti avec un mix Stadl, un mix rock et un mix DJ : une chanson en trois versions pour trois salles différentes.",
       "fun_fact_nl": "De single verscheen met een Stadl-mix, een rockmix en een dj-mix — één lied in drie versies voor drie verschillende zalen.",
-      "uri_deezer": "deezer://track/3303554"
+      "uri_deezer": "deezer://track/3303554",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=eLaWqsqUrb8"
     },
     {
       "year": 2014,
@@ -5304,7 +5344,8 @@
       "fun_fact_es": "Cinco semanas seguidas en el número uno de las listas de radiodifusión alemanas, la canción más pinchada en la radio schlager de ese año.",
       "fun_fact_fr": "Cinq semaines d'affilée en tête des classements radio allemands : le titre le plus diffusé de l'année sur les radios schlager.",
       "fun_fact_nl": "Vijf weken op rij op nummer één in de Duitse airplaylijsten — daarmee het meest gedraaide nummer op schlagerradio dat jaar.",
-      "uri_deezer": "deezer://track/2044258827"
+      "uri_deezer": "deezer://track/2044258827",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ME_5F7H7EOA"
     },
     {
       "year": 2018,
@@ -5323,7 +5364,8 @@
       "fun_fact_fr": "Jordi a gagné le Grand Prix der Volksmusik en 1998 et a chanté pour la Suisse à l'Eurovision en 2002 — en français, pas en allemand.",
       "fun_fact_nl": "Jordi won in 1998 de Grand Prix der Volksmusik en zong in 2002 voor Zwitserland op het Eurovisiesongfestival — in het Frans, niet in het Duits.",
       "uri_apple_music": "applemusic://track/1436587677",
-      "uri_deezer": "deezer://track/546259292"
+      "uri_deezer": "deezer://track/546259292",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xGl5ZaYP2s8"
     },
     {
       "year": 2019,
@@ -5341,7 +5383,8 @@
       "fun_fact_es": "La compañera de dueto es la cantante austriaca Allessa, y el tema sigue a Der Einzige, que grabaron juntos antes.",
       "fun_fact_fr": "La partenaire de duo est la chanteuse autrichienne Allessa, et le titre fait suite à leur précédent, Der Einzige.",
       "fun_fact_nl": "De duetpartner is de Oostenrijkse zangeres Allessa, en het nummer volgt op hun eerdere Der Einzige.",
-      "uri_apple_music": "applemusic://track/1822532767"
+      "uri_apple_music": "applemusic://track/1822532767",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Op61Eg83abw"
     },
     {
       "year": 2020,
@@ -5360,7 +5403,8 @@
       "fun_fact_fr": "La chanson-titre de son premier album et seulement son deuxième single — son cœur penche vers le country et le rock, d'où les guitares.",
       "fun_fact_nl": "Het titelnummer van haar debuutalbum en pas haar tweede single — haar hart ligt bij country en rock, vandaar de gitaren.",
       "uri_apple_music": "applemusic://track/1512422192",
-      "uri_deezer": "deezer://track/1015644662"
+      "uri_deezer": "deezer://track/1015644662",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=bgEEOI2kP2c"
     },
     {
       "year": 2020,
@@ -5379,7 +5423,8 @@
       "fun_fact_fr": "Grosch a atteint la finale de la troisième saison de Deutschland sucht den Superstar et a perdu face à Tobias Regner ; ce titre marque son retour, quatorze ans plus tard.",
       "fun_fact_nl": "Grosch haalde de finale van het derde seizoen van Deutschland sucht den Superstar en verloor van Tobias Regner; dit nummer was veertien jaar later zijn comeback.",
       "uri_apple_music": "applemusic://track/1530420079",
-      "uri_deezer": "deezer://track/1294955122"
+      "uri_deezer": "deezer://track/1294955122",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=pk0edki-syI"
     },
     {
       "year": 2021,
@@ -5397,7 +5442,8 @@
       "fun_fact_es": "Una nueva grabación del éxito de Roger Whittaker de 1982, con el propio Whittaker cantándolo de nuevo casi cuarenta años después.",
       "fun_fact_fr": "Un nouvel enregistrement du tube de Roger Whittaker de 1982 — avec Whittaker lui-même qui le rechante près de quarante ans plus tard.",
       "fun_fact_nl": "Een nieuwe opname van Roger Whittakers hit uit 1982 — met Whittaker die hem bijna veertig jaar later zelf opnieuw zingt.",
-      "uri_apple_music": "applemusic://track/1562335293"
+      "uri_apple_music": "applemusic://track/1562335293",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=EEWlxdTw1WA"
     },
     {
       "year": 2022,
@@ -5416,7 +5462,8 @@
       "fun_fact_fr": "Le groupe joue Andrea Berg et Udo Jürgens à la contrebasse et à la guitare électrique, et appelle ça du Schlagerbilly.",
       "fun_fact_nl": "De band speelt Andrea Berg en Udo Jürgens op contrabas en elektrische gitaar en noemt het resultaat Schlagerbilly.",
       "uri_apple_music": "applemusic://track/1822479497",
-      "uri_deezer": "deezer://track/3783462492"
+      "uri_deezer": "deezer://track/3783462492",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=4_pJ7VePgXk"
     },
     {
       "year": 2026,
@@ -5434,7 +5481,8 @@
       "fun_fact_es": "Publicada en carnaval y llevada directamente al verano mallorquín: uno de los dos temas de Julian Sommer sobre los que se construyó la apertura de 2026.",
       "fun_fact_fr": "Sorti pendant le carnaval et porté directement dans l'été majorquin — l'un des deux titres de Julian Sommer sur lesquels reposait l'ouverture 2026.",
       "fun_fact_nl": "Uitgebracht in het carnavalsseizoen en meteen doorgedragen naar de Mallorca-zomer — een van de twee Julian Sommer-nummers waarop de opening van 2026 leunde.",
-      "uri_apple_music": "applemusic://track/6805916976"
+      "uri_apple_music": "applemusic://track/6805916976",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6Es_OiNVx3k"
     },
     {
       "year": 2026,
@@ -5453,7 +5501,8 @@
       "fun_fact_fr": "Le texte est de Tobias Reitz, qui écrit aussi pour Helene Fischer et Vanessa Mai — un auteur qu'on entend bien plus souvent qu'on ne le nomme.",
       "fun_fact_nl": "De tekst is van Tobias Reitz, die ook voor Helene Fischer en Vanessa Mai schrijft — een auteur die je veel vaker hoort dan noemt.",
       "uri_apple_music": "applemusic://track/1891981430",
-      "uri_deezer": "deezer://track/3952473041"
+      "uri_deezer": "deezer://track/3952473041",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wP6bV5BtRU4"
     }
   ]
 }


### PR DESCRIPTION
A `provider-uri-backfill` run, driven automatically by `com.beatify.youtube-backfill`.

- `schlager-klassiker` YouTube 144 -> **193**/193

**Draft on purpose** — merged only once the maintainer approves.