### PR TITLE
fix(rounds): keep the round clock off an unconfirmed intro splash

### DIFF
--- a/custom_components/beatify/game/round_manager.py
+++ b/custom_components/beatify/game/round_manager.py
@@ -174,7 +174,9 @@ class RoundManager:
         """Mark the stamped deadline as not-yet-started (announcements)."""
         self._deadline_deferred = True
 
-    def start_timer_at_playback(self, timer_countdown: Any = None) -> None:
+    def start_timer_at_playback(
+        self, timer_countdown: Any = None, extra_seconds: float = 0.0
+    ) -> None:
         """Re-stamp the deadline from NOW, because the song is now audible.
 
         Round-start announcements run between ``initialize_round`` and the
@@ -187,15 +189,35 @@ class RoundManager:
         and re-arm the countdown. Idempotent — calling it without a deferral
         pending does nothing, so a provider that never announces is
         unaffected.
+
+        #2543: an intro-splash round must NOT be started here. With intro mode
+        and TTS both on, ``_start_round_locked`` defers the deadline for the
+        announcements while ``_prepare_intro_round`` also holds playback back
+        for the splash. Re-stamping here would arm a real countdown on a round
+        whose song has not played yet — a host who takes longer than
+        ``round_duration`` to confirm would see the round end in silence, every
+        player scored as "missed". The deferral is left standing for
+        ``confirm_intro_splash``, which owns the clock for that round.
+
+        ``extra_seconds`` (#2546) keeps the announcement budget the caller
+        already computed: the announce_* helpers queue their phrases rather
+        than blocking until the speaker is done, so at this point the room may
+        still be listening to the round number and the countdown. Without it
+        the re-stamp silently discards both the measured announcement cost and
+        the user's #1211 "Timer delay" — the very setting that exists to keep
+        that time out of the round.
         """
+        if self._intro_splash_pending:
+            return
         if not self._deadline_deferred:
             return
         self._deadline_deferred = False
         self.cancel_timer()
         now = self._now()
         self.round_start_time = now
-        self.deadline = int(now * 1000) + int(self.round_duration * 1000)
-        delay = self.round_duration
+        extra_ms = max(0, int(float(extra_seconds) * 1000))
+        self.deadline = int(now * 1000) + int(self.round_duration * 1000) + extra_ms
+        delay = self.round_duration + (extra_ms / 1000.0)
         countdown = timer_countdown or self._timer_countdown
         self._timer_task = asyncio.create_task(countdown(delay))
         self._timer_task.add_done_callback(_log_timer_task_failure)
@@ -439,6 +461,11 @@ class RoundManager:
 
         self._intro_splash_pending = False
         self._intro_splash_shown = True
+        # #2543: this method stamps its own deadline below, so any deferral
+        # taken out for the round-start announcements is consumed here. Left
+        # standing it would make is_deadline_passed() report False for the rest
+        # of the round, disabling the client-side round watchdog.
+        self._deadline_deferred = False
 
         song = self._intro_splash_deferred_song
         if song:

--- a/custom_components/beatify/game/state_lifecycle.py
+++ b/custom_components/beatify/game/state_lifecycle.py
@@ -601,10 +601,26 @@ class RoundLifecycleMixin:
             # The song is (or is about to be) audible: start the round clock
             # from here rather than from initialize_round, so players get the
             # full round duration of MUSIC.
+            # #2543: on an intro-splash round the clock belongs to
+            # confirm_intro_splash — the song has not played yet, so there is
+            # nothing to start here and the "clock started" log would lie.
             start_now = getattr(self._round_manager, "start_timer_at_playback", None)
-            if callable(start_now):
+            if callable(start_now) and not will_defer_for_splash:
                 with contextlib.suppress(Exception):
-                    start_now(self._timer_countdown)
+                    # #2546: hand the remaining announcement budget along. The
+                    # announce_* calls above queue their phrases (see
+                    # _tts_announce) instead of blocking until the speaker is
+                    # free, so "the song is audible" is not yet true when we get
+                    # here. announcement_busy_seconds() is what the queue itself
+                    # believes is left, and _tts_pre_round_delay is the user's
+                    # manual #1211 allowance for device overhead we cannot see.
+                    _extra = 0.0
+                    with contextlib.suppress(Exception):
+                        busy = getattr(self, "announcement_busy_seconds", None)
+                        if callable(busy):
+                            _extra += max(0.0, float(busy()))
+                    _extra += max(0.0, float(self._tts_pre_round_delay or 0.0))
+                    start_now(self._timer_countdown, _extra)
                     _LOGGER.info(
                         "Round %s: clock started at playback (%.0fs of music)",
                         getattr(self, "round", "?"),

--- a/tests/unit/test_round_timer_deferral_2543.py
+++ b/tests/unit/test_round_timer_deferral_2543.py
@@ -1,0 +1,101 @@
+"""Regression tests for #2543 and #2546 (round clock vs. announcements/splash)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from custom_components.beatify.game.round_manager import RoundManager
+
+
+def _make_rm(now: float = 1_000_000.0) -> RoundManager:
+    rm = RoundManager(lambda: now)
+    rm.round_duration = 15
+    return rm
+
+
+class TestIntroSplashKeepsTheClock:
+    """#2543: an unconfirmed intro splash must not get a running timer."""
+
+    @pytest.mark.asyncio
+    async def test_start_timer_at_playback_is_a_noop_while_splash_pending(self):
+        now = 1_000_000.0
+        rm = _make_rm(now)
+        rm._intro_splash_pending = True
+        rm.defer_deadline()
+        placeholder = int(now * 1000)
+        rm.deadline = placeholder
+
+        rm.start_timer_at_playback(lambda _d: asyncio.sleep(0))
+
+        assert rm.deadline == placeholder, "deadline was re-stamped during the splash"
+        assert rm._timer_task is None, "a countdown was armed for an unplayed song"
+        assert rm._deadline_deferred is True, "the deferral must survive for confirm"
+
+    @pytest.mark.asyncio
+    async def test_pending_splash_never_reports_the_deadline_as_passed(self):
+        now = 1_000_000.0
+        rm = _make_rm(now)
+        rm._intro_splash_pending = True
+        rm.defer_deadline()
+        rm.deadline = int((now - 999) * 1000)
+
+        rm.start_timer_at_playback(lambda _d: asyncio.sleep(0))
+
+        assert rm.is_deadline_passed() is False
+
+    @pytest.mark.asyncio
+    async def test_confirm_consumes_the_deferral(self):
+        now = 1_000_000.0
+        rm = _make_rm(now)
+        rm._intro_splash_pending = True
+        rm._intro_splash_deferred_song = None
+        rm.defer_deadline()
+
+        async def _played(_song):
+            return True
+
+        await rm.confirm_intro_splash(_played, None, lambda _d: asyncio.sleep(0))
+        rm.cancel_timer()
+
+        assert rm._deadline_deferred is False
+        assert rm.is_deadline_passed() is False
+        assert rm.deadline == int(now * 1000) + rm.round_duration * 1000
+
+
+class TestAnnouncementBudgetSurvivesTheRestamp:
+    """#2546: the announcement budget must not be dropped by the re-stamp."""
+
+    @pytest.mark.asyncio
+    async def test_extra_seconds_extend_the_deadline(self):
+        now = 1_000_000.0
+        rm = _make_rm(now)
+        rm.defer_deadline()
+
+        rm.start_timer_at_playback(lambda _d: asyncio.sleep(0), 6.0)
+        rm.cancel_timer()
+
+        assert rm.deadline == int(now * 1000) + 15_000 + 6_000
+
+    @pytest.mark.asyncio
+    async def test_no_extra_keeps_the_plain_round_duration(self):
+        now = 1_000_000.0
+        rm = _make_rm(now)
+        rm.defer_deadline()
+
+        rm.start_timer_at_playback(lambda _d: asyncio.sleep(0))
+        rm.cancel_timer()
+
+        assert rm.deadline == int(now * 1000) + 15_000
+
+    @pytest.mark.asyncio
+    async def test_negative_extra_is_ignored(self):
+        now = 1_000_000.0
+        rm = _make_rm(now)
+        rm.defer_deadline()
+
+        rm.start_timer_at_playback(lambda _d: asyncio.sleep(0), -5.0)
+        rm.cancel_timer()
+
+        assert rm.deadline == int(now * 1000) + 15_000


### PR DESCRIPTION
## What was wrong

Two ways the round clock and the announcements disagreed, both in the same re-stamp.

**#2543 — the timer ran on a round whose song had not played.** With intro mode and TTS both on, `_start_round_locked` defers the deadline for the announcements while `_prepare_intro_round` holds playback back for the splash. `start_timer_at_playback` re-stamped the deadline and armed a countdown anyway, because it only checked `_deadline_deferred`. A host who took longer than `round_duration` to confirm saw the round end in silence with every player scored as "missed" — streaks broken, and in sudden death somebody eliminated for a round they never heard. Confirming afterwards started the song in the middle of REVEAL.

**#2546 — the announcement budget was discarded.** The `announce_*` helpers queue their phrases rather than blocking until the speaker is free, so "the song is audible" is not yet true when the re-stamp happens. `deadline = now + round_duration` therefore threw away both the measured announcement cost and the user's #1211 "Timer delay" — the setting exists for exactly this and had no effect in the only case it applies to.

## What changed

- `start_timer_at_playback` returns early while `_intro_splash_pending`, leaving the deferral standing for `confirm_intro_splash`, which owns the clock for that round
- `confirm_intro_splash` now consumes the deferral. Left standing it would have made `is_deadline_passed` report `False` for the rest of the round, disabling the client-side round watchdog
- `start_timer_at_playback` takes `extra_seconds`; the caller passes `announcement_busy_seconds()` plus `_tts_pre_round_delay`
- the caller skips the whole block on a splash round, so the "clock started at playback" log no longer lies

## Tests

`tests/unit/test_round_timer_deferral_2543.py`, 6 cases: the splash no-op, the deadline never reporting as passed while pending, confirm consuming the deferral, and the extra-seconds budget (present, absent, negative). Full unit suite green (2186).

Closes #2543
Closes #2546

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jtjbEFrrGLjjPgb6goziQ