### PR TITLE
fix(rounds): broadcast when auto-advance pauses the game

### DIFF
--- a/custom_components/beatify/game/state_auto_advance.py
+++ b/custom_components/beatify/game/state_auto_advance.py
@@ -232,6 +232,21 @@ class RevealAutoAdvanceMixin:
                 else:
                     await self.advance_to_end()
                 success = True
+            # #2544: start_round() can also fail by PAUSING — three playback
+            # timeouts or a rate limit end in pause_game("media_player_error").
+            # pause_game only notifies the HA sensors, so without a broadcast
+            # here the backend sits in PAUSED while every client still shows
+            # REVEAL with a Next button that answers ERR_INVALID_ACTION, and the
+            # recovery banner carrying Resume never renders — only a reload gets
+            # the host out. admin_next_round already broadcasts on this branch;
+            # since #1012 made song-end auto-advance the default way into a
+            # round, this path needs it more than the manual one does.
+            if not success and self.phase == GamePhase.PAUSED:
+                _LOGGER.warning(
+                    "REVEAL auto-advance could not start the next round — game "
+                    "paused, broadcasting so clients can offer recovery"
+                )
+
             # start_round() only fires sync state-callbacks via
             # _notify_state_callbacks; the async WebSocket broadcast
             # (`_on_round_end` = ws_handler.broadcast_state) is what actually
@@ -240,7 +255,7 @@ class RevealAutoAdvanceMixin:
             # after start_round / advance_to_end — mirror that here, otherwise
             # music starts (or the game ends) but the admin + player UIs stay
             # frozen on REVEAL.
-            if success and self._on_round_end:
+            if (success or self.phase == GamePhase.PAUSED) and self._on_round_end:
                 try:
                     await self._on_round_end()
                 except (ConnectionError, OSError, TypeError) as err:

--- a/tests/unit/test_auto_advance_pause_broadcast_2544.py
+++ b/tests/unit/test_auto_advance_pause_broadcast_2544.py
@@ -1,0 +1,69 @@
+"""#2544: a failed auto-advance that pauses the game must still broadcast.
+
+`pause_game` only notifies the HA sensors, so when `start_round()` fails by
+pausing (three playback timeouts, a rate limit) the backend sits in PAUSED
+while every client still renders REVEAL with a Next button that answers
+ERR_INVALID_ACTION. The recovery banner carrying Resume never appears and only
+a page reload gets the host out. `admin_next_round` already broadcasts on this
+branch; the auto path did not.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+
+import custom_components.beatify.game.state_auto_advance as auto_advance_mod
+from custom_components.beatify.game.state import GamePhase
+from tests.conftest import make_game_state
+
+
+def _game_in_reveal(monkeypatch):
+    state = make_game_state()
+    monkeypatch.setattr(auto_advance_mod.asyncio, "sleep", AsyncMock())
+    state._song_finished = MagicMock(return_value=True)
+    state._on_round_end = AsyncMock()
+    state.phase = GamePhase.REVEAL
+    return state
+
+
+class TestAutoAdvancePauseBroadcast:
+    async def test_pause_during_auto_advance_is_broadcast(self, monkeypatch):
+        state = _game_in_reveal(monkeypatch)
+
+        async def _pause() -> bool:
+            state.phase = GamePhase.PAUSED
+            return False
+
+        state.start_round = AsyncMock(side_effect=_pause)
+
+        await state._reveal_auto_advance(0)
+
+        state._on_round_end.assert_awaited_once()
+
+    async def test_failure_without_pause_still_stays_quiet(self, monkeypatch):
+        """A failed start that leaves the phase on REVEAL is the pre-existing
+        retry case and must not gain a spurious broadcast."""
+        state = _game_in_reveal(monkeypatch)
+
+        async def _fail() -> bool:
+            return False
+
+        state.start_round = AsyncMock(side_effect=_fail)
+
+        await state._reveal_auto_advance(0)
+
+        state._on_round_end.assert_not_awaited()
+
+    async def test_successful_advance_still_broadcasts(self, monkeypatch):
+        state = _game_in_reveal(monkeypatch)
+
+        async def _ok() -> bool:
+            state.phase = GamePhase.PLAYING
+            return True
+
+        state.start_round = AsyncMock(side_effect=_ok)
+
+        await state._reveal_auto_advance(0)
+
+        state._on_round_end.assert_awaited_once()


### PR DESCRIPTION
## What was wrong

`start_round()` has three outcomes, and the auto-advance path only handled two of them.

It can succeed. It can flip the phase to END on an exhausted playlist — handled since #1360/#1753. Or it can **pause**: three playback timeouts or a rate limit end in `pause_game("media_player_error")`, and the playlist can come back `no_songs_available`. `pause_game` only notifies the HA sensors (`register_state_callback` is used solely by `sensor.py` and `binary_sensor.py`), so nothing reached the clients.

The result: the backend sits in PAUSED while the admin UI, every phone and the TV still render REVEAL with a Next button. Tapping it returns `ERR_INVALID_ACTION "Cannot advance round in current phase"`, and the recovery banner carrying Resume never renders. Only a page reload gets the host out.

`admin_next_round` already broadcasts on this branch. Since #1012 made song-end auto-advance the default way into every round, the automatic path needs it more than the manual one does.

## What changed

The broadcast condition becomes `success or phase == PAUSED`, plus a warning log so the pause is visible in the HA log rather than only inferable from a stuck UI. A failed start that leaves the phase on REVEAL is the pre-existing retry case and deliberately stays quiet.

## Tests

`tests/unit/test_auto_advance_pause_broadcast_2544.py`, 3 cases: pause broadcasts, plain failure stays quiet, success still broadcasts. Full unit suite green (2183).

Closes #2544

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jtjbEFrrGLjjPgb6goziQ