### PR TITLE
fix(endgame): stop eliminated players from stalling the round and the finale

### DIFF
--- a/custom_components/beatify/game/playlist.py
+++ b/custom_components/beatify/game/playlist.py
@@ -170,8 +170,18 @@ class PlaylistManager:
         #   a plain ``[:n]`` would serve only the first playlist of a
         #   multi-playlist selection. Sampling keeps the mix.
         self._max_rounds = max(max_rounds, MIN_ROUNDS) if max_rounds else 0
+        # #2547: the songs the cap drops are kept aside rather than discarded.
+        # A capped game ends with get_remaining_count() == 0 by construction, so
+        # the finale tiebreaker (#1725) — which only arms while unplayed songs
+        # remain — could never fire in the actual last round, the one case it
+        # was written for. reserve_songs_for_playoff() hands them back one at a
+        # time, so the cap still governs normal play.
+        self._reserve_songs: list[dict[str, Any]] = []
         if self._max_rounds and len(self._songs) > self._max_rounds:
-            self._songs = random.sample(self._songs, self._max_rounds)
+            sampled = random.sample(self._songs, self._max_rounds)
+            sampled_ids = {id(song) for song in sampled}
+            self._reserve_songs = [s for s in self._songs if id(s) not in sampled_ids]
+            self._songs = sampled
             # #2418: regroup the buckets from the sampled pool. Until this line
             # existed the cap applied to `self._songs` alone, while
             # `self._buckets` — assigned above, before the sample — kept every
@@ -361,6 +371,34 @@ class PlaylistManager:
         # #707: mark_played() accepts any URI (incl. unknown ones), so naive
         # subtraction can go negative. Clamp at 0.
         return max(0, len(self._songs) - len(self._played_uris))
+
+    def reserve_songs_for_playoff(self, count: int = 1) -> int:
+        """Move up to ``count`` capped-out songs back into the playable pool.
+
+        Returns the number of songs actually released (0 when the round cap was
+        never applied, or the reserve is spent).
+
+        The finale tiebreaker (#1725) arms only while unplayed songs remain.
+        With a round cap the pool is sampled down to exactly ``max_rounds``, so
+        after the last round nothing remains and the tiebreaker was unreachable
+        in the situation it exists for — a tie at the end of a normal game
+        (#2547). Rather than lifting the cap and letting normal play run long,
+        the dropped songs stay in reserve and a playoff draws from them.
+        """
+        if count <= 0 or not self._reserve_songs:
+            return 0
+        released = self._reserve_songs[:count]
+        self._reserve_songs = self._reserve_songs[count:]
+        self._songs.extend(released)
+        for song in released:
+            source = song.get("_playlist_source", "__default__")
+            self._buckets.setdefault(source, []).append(song)
+        self._multi_playlist = len(self._buckets) > 1
+        _LOGGER.info(
+            "Finale tiebreaker: released %d reserved song(s) for a playoff round",
+            len(released),
+        )
+        return len(released)
 
     def has_playable_songs(self) -> bool:
         """True if this manager has any songs for its provider (#709)."""

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -1099,6 +1099,24 @@ class GameState(
     # Finale sudden-death tiebreaker (Issue #1725)
     # ------------------------------------------------------------------
 
+    def _release_playoff_song(self) -> bool:
+        """Free one capped-out song so a playoff can be played (#2547).
+
+        With a round cap the playable pool is sampled down to exactly
+        ``max_rounds`` (#1475), so a game that runs to its last round ends with
+        ``songs_remaining == 0`` by construction. The tiebreaker guard below
+        then declined every tie at the end of a normal game — the one situation
+        it was written for. The songs the cap dropped are kept in reserve and
+        released one per playoff round, so the cap still governs normal play.
+
+        Returns ``True`` when a song was released and the playoff may proceed.
+        """
+        manager = getattr(self, "_playlist_manager", None)
+        release = getattr(manager, "reserve_songs_for_playoff", None)
+        if not callable(release):
+            return False
+        return release(1) > 0
+
     async def maybe_start_finale_playoff(self) -> bool:
         """Arm + start a finale tiebreaker playoff round, if one is warranted.
 
@@ -1143,7 +1161,7 @@ class GameState(
                 FINALE_PLAYOFF_MAX_ROUNDS,
             )
             return False
-        if self.songs_remaining < 1:
+        if self.songs_remaining < 1 and not self._release_playoff_song():
             return False
         winners, _top = self.compute_winners()
         if len(winners) <= 1:

--- a/custom_components/beatify/game/state_reveal_transition.py
+++ b/custom_components/beatify/game/state_reveal_transition.py
@@ -123,24 +123,20 @@ class RevealTransitionMixin:
         # or if no one has guessed yet (don't block early reveal for ignored challenges)
         if self.artist_challenge_enabled and self.artist_challenge:
             has_winner = getattr(self.artist_challenge, "winner", None) is not None
-            anyone_guessed = any(
-                p.has_artist_guess for p in self.players.values() if p.is_active
-            )
+            anyone_guessed = any(p.has_artist_guess for p in self._active_guessers())
             if not has_winner and anyone_guessed:
-                for player in self.players.values():
-                    if player.is_active and not player.has_artist_guess:
+                for player in self._active_guessers():
+                    if not player.has_artist_guess:
                         return False
 
         # Issue #28: If movie quiz enabled and active, check movie guesses
         # Skip check if challenge already has correct guesses or no one interacted
         if self.movie_quiz_enabled and self.movie_challenge:
             has_correct = len(self.movie_challenge.correct_guesses) > 0
-            anyone_guessed = any(
-                p.has_movie_guess for p in self.players.values() if p.is_active
-            )
+            anyone_guessed = any(p.has_movie_guess for p in self._active_guessers())
             if not has_correct and anyone_guessed:
-                for player in self.players.values():
-                    if player.is_active and not player.has_movie_guess:
+                for player in self._active_guessers():
+                    if not player.has_movie_guess:
                         return False
 
         # #1180: In Title & Artist mode, wait for every active player to submit
@@ -148,11 +144,24 @@ class RevealTransitionMixin:
         # year guess, so there is no "winner" short-circuit — each player guesses
         # independently and we hold PLAYING until all are in.
         if self.title_artist_mode and self.title_artist_challenge:
-            for player in self.players.values():
-                if player.is_active and not player.has_title_artist_guess:
+            for player in self._active_guessers():
+                if not player.has_title_artist_guess:
                     return False
 
         return True
+
+    def _active_guessers(self) -> list:
+        """Players whose guess the early reveal is allowed to wait for (#2545).
+
+        ``all_submitted()`` has excluded eliminated players since #827, but the
+        follow-up loops below filtered on ``is_active`` alone. An eliminated
+        player is refused by the guess handlers (ERR_ELIMINATED), so they can
+        never satisfy ``has_*_guess`` — from the first sudden-death cut onward
+        every round ran out its full timer with the whole room already done.
+        The same held for the finale playoff round, where #1725 marks every
+        non-leader eliminated.
+        """
+        return [p for p in self.players.values() if p.is_active and not p.eliminated]
 
     async def _trigger_early_reveal(self) -> None:
         """

--- a/tests/unit/test_eliminated_and_finale_2545_2547.py
+++ b/tests/unit/test_eliminated_and_finale_2545_2547.py
@@ -1,0 +1,160 @@
+"""#2545 and #2547 — two ways an eliminated player stalled the endgame.
+
+* #2545: the early-reveal follow-up checks waited for eliminated players, who
+  are refused by the guess handlers and can never satisfy them.
+* #2547: with a round cap the playable pool is sampled down to exactly
+  ``max_rounds``, so the finale tiebreaker's "unplayed songs remain" guard was
+  never true in the actual last round.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.beatify.game.state import GamePhase
+from tests.conftest import make_game_state, make_songs
+
+
+def _stub_media_service() -> MagicMock:
+    svc = MagicMock()
+    svc.is_available.return_value = True
+    svc.play_song = AsyncMock(return_value=True)
+    svc.verify_responsive = AsyncMock(return_value=(True, None))
+    svc.restore_volume = AsyncMock(return_value=True)
+    svc.restore_queue = AsyncMock(return_value=True)
+    svc.stop = AsyncMock(return_value=True)
+    return svc
+
+
+def _make_game(names, *, songs=5, **create_kwargs):
+    gs = make_game_state()
+    gs.create_game(
+        playlists=["t.json"],
+        songs=make_songs(songs),
+        media_player="media_player.x",
+        base_url="http://h",
+        **create_kwargs,
+    )
+    gs._media_player_service = _stub_media_service()
+    gs.platform = "music_assistant"
+    for n in names:
+        ws = MagicMock()
+        ws.closed = False
+        gs.add_player(n, ws)
+        gs.get_player(n).connected = True
+    return gs
+
+
+# ---------------------------------------------------------------------------
+# #2545 — eliminated players must not hold the early reveal open
+# ---------------------------------------------------------------------------
+
+
+class TestEliminatedDoNotBlockEarlyReveal:
+    def test_title_artist_mode_ignores_the_eliminated(self):
+        gs = _make_game(["Alice", "Bob"])
+        gs.title_artist_mode = True
+        gs.title_artist_challenge = MagicMock()
+
+        for p in gs.players.values():
+            p.submitted = True
+        gs.get_player("Alice").has_title_artist_guess = True
+        bob = gs.get_player("Bob")
+        bob.has_title_artist_guess = False
+        bob.eliminated = True
+
+        assert gs.check_all_guesses_complete() is True
+
+    def test_an_active_player_still_holds_it_open(self):
+        gs = _make_game(["Alice", "Bob"])
+        gs.title_artist_mode = True
+        gs.title_artist_challenge = MagicMock()
+
+        for p in gs.players.values():
+            p.submitted = True
+        gs.get_player("Alice").has_title_artist_guess = True
+        gs.get_player("Bob").has_title_artist_guess = False
+
+        assert gs.check_all_guesses_complete() is False
+
+    def test_artist_challenge_ignores_the_eliminated(self):
+        gs = _make_game(["Alice", "Bob"])
+        gs.artist_challenge_enabled = True
+        gs.artist_challenge = MagicMock(winner=None)
+
+        for p in gs.players.values():
+            p.submitted = True
+        gs.get_player("Alice").has_artist_guess = True
+        bob = gs.get_player("Bob")
+        bob.has_artist_guess = False
+        bob.eliminated = True
+
+        assert gs.check_all_guesses_complete() is True
+
+    def test_movie_quiz_ignores_the_eliminated(self):
+        gs = _make_game(["Alice", "Bob"])
+        gs.movie_quiz_enabled = True
+        gs.movie_challenge = MagicMock(correct_guesses=[])
+
+        for p in gs.players.values():
+            p.submitted = True
+        gs.get_player("Alice").has_movie_guess = True
+        bob = gs.get_player("Bob")
+        bob.has_movie_guess = False
+        bob.eliminated = True
+
+        assert gs.check_all_guesses_complete() is True
+
+
+# ---------------------------------------------------------------------------
+# #2547 — the round cap must not lock the finale tiebreaker out
+# ---------------------------------------------------------------------------
+
+
+class TestCappedPoolKeepsAPlayoffReserve:
+    def test_capped_songs_are_held_in_reserve(self):
+        gs = _make_game(["Alice"], songs=50, max_rounds=10)
+        pm = gs._playlist_manager
+        assert pm.get_total_count() == 10
+        assert len(pm._reserve_songs) == 40
+
+    def test_release_puts_one_song_back_into_play(self):
+        gs = _make_game(["Alice"], songs=50, max_rounds=10)
+        pm = gs._playlist_manager
+        before = pm.get_remaining_count()
+
+        assert pm.reserve_songs_for_playoff(1) == 1
+        assert pm.get_remaining_count() == before + 1
+        assert len(pm._reserve_songs) == 39
+
+    def test_release_is_a_noop_without_a_cap(self):
+        gs = _make_game(["Alice"], songs=5)
+        assert gs._playlist_manager.reserve_songs_for_playoff(1) == 0
+
+    async def test_tie_in_the_last_capped_round_starts_a_playoff(self):
+        # A capped game played to its last round: the pool is sampled down to
+        # max_rounds, so every song in it has been played.
+        gs = _make_game(["Alice", "Bob"], songs=50, max_rounds=10)
+        gs.finale_tiebreaker_enabled = True
+        await gs.start_round()
+        pm = gs._playlist_manager
+        for song in list(pm._songs):
+            pm.mark_played(song["_precomputed_uri"])
+        gs.phase = GamePhase.REVEAL
+        gs.get_player("Alice").score = 10
+        gs.get_player("Bob").score = 10
+        assert gs.songs_remaining == 0
+
+        assert await gs.maybe_start_finale_playoff() is True
+
+    async def test_a_genuinely_exhausted_playlist_still_shares_the_win(self):
+        gs = _make_game(["Alice", "Bob"], songs=1)
+        gs.finale_tiebreaker_enabled = True
+        await gs.start_round()
+        gs.phase = GamePhase.REVEAL
+        gs.get_player("Alice").score = 10
+        gs.get_player("Bob").score = 10
+        assert gs.songs_remaining == 0
+
+        assert await gs.maybe_start_finale_playoff() is False
+        assert gs.get_player("Alice").eliminated is False


### PR DESCRIPTION
## What was wrong

Two independent ways an elimination broke the end of a game.

**#2545 — the early reveal waited for players who cannot answer.** `all_submitted()` has excluded eliminated players since #827, but the three follow-up loops in `check_all_guesses_complete` filtered on `is_active` alone. The guess handlers refuse an eliminated player with `ERR_ELIMINATED`, so `has_artist_guess` / `has_movie_guess` / `has_title_artist_guess` can never become true for them. From the first sudden-death cut onward every round ran out its full timer with the whole room already done — the mode's pacing collapses from round 2. The same held for the finale playoff round, where #1725 marks every non-leader eliminated.

**#2547 — the finale tiebreaker could not fire in the last round.** With a round cap the playable pool is sampled down to exactly `max_rounds` (#1475), so a game played to the end has `songs_remaining == 0` by construction. The "unplayed songs remain" guard therefore declined every tie at the end of a normal game — the one situation the feature exists for. The only reachable trigger was pressing "End game" during an *earlier* REVEAL, where the end button then surprises the host by starting a new round.

## What changed

- the three loops share an `_active_guessers()` helper that filters eliminated players, matching `all_submitted()`
- `PlaylistManager` keeps the songs the cap drops in `_reserve_songs` instead of discarding them, and `reserve_songs_for_playoff()` releases them one at a time
- `maybe_start_finale_playoff` releases one reserved song when the pool is empty

Normal play is unaffected: the cap still governs the pool one song at a time, and a genuinely exhausted playlist still ends in a shared winner — `test_no_trigger_when_no_songs_remain` in `test_finale_1725.py` passes unchanged.

## Tests

`tests/unit/test_eliminated_and_finale_2545_2547.py`, 9 cases: all three challenge types ignoring the eliminated while an active player still holds the reveal open; the reserve being kept, released, and a no-op without a cap; a tie in the last capped round starting a playoff; an exhausted playlist still sharing the win. Full unit suite green (2189).

Closes #2545
Closes #2547

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jtjbEFrrGLjjPgb6goziQ