### PR TITLE
fix(endgame): make the speaker, the join screen and the player payload agree

### DIFF
--- a/custom_components/beatify/game/state_tts.py
+++ b/custom_components/beatify/game/state_tts.py
@@ -341,12 +341,20 @@ class TtsAnnouncerMixin:
         await self._tts_announce(message)
 
     async def announce_winner(self) -> None:
-        """Announce the winner (use case 18)."""
+        """Announce the winner (use case 18).
+
+        #2548: reads ``compute_winners()`` rather than a plain score max. In a
+        Sudden Death game the finish order is survival-first (#827/#1749), so a
+        late-eliminated high scorer is NOT the winner — the END screen and the
+        leaderboard have said so since #1749, while the speaker went on
+        crowning them and contradicted the screen in front of the whole room.
+        """
         if not self._tts_service or not self._tts_announce_winner or not self.players:
             return
         lang = self._lang()
-        top_score = max(p.score for p in self.players.values())
-        winners = [p for p in self.players.values() if p.score == top_score]
+        winners, top_score = self.compute_winners()
+        if not winners:
+            return
         points = tts_phrases.spoken_number(lang, top_score)
         if len(winners) == 1:
             message = tts_phrases.phrase(
@@ -549,14 +557,18 @@ class TtsAnnouncerMixin:
         """
         if not self._tts_service or not self._tts_announce_podium:
             return
-        ranked = sorted(self.players.values(), key=lambda p: p.score, reverse=True)
-        podium = [p for p in ranked if p.score > 0][:3]
+        # #2548: the podium follows get_final_leaderboard's ranking, which is
+        # survival-first once Sudden Death has claimed anyone (#827). Sorting by
+        # score here put eliminated players on a podium the screen ranks below
+        # the cut-line.
+        ranked = self.get_final_leaderboard()
+        podium = [entry for entry in ranked if entry.get("score", 0) > 0][:3]
         if not podium:
             return
         lang = self._lang()
         segments = [
             f"{tts_phrases.place_label(lang, i + 1)}: "
-            f"{podium[i].name}{'!' if i == 0 else '.'}"
+            f"{podium[i]['name']}{'!' if i == 0 else '.'}"
             for i in reversed(range(len(podium)))
         ]
         await self._tts_announce(" ".join(segments))

--- a/custom_components/beatify/server/serializers.py
+++ b/custom_components/beatify/server/serializers.py
@@ -72,6 +72,9 @@ def redact_state_for_player(message: dict[str, Any]) -> dict[str, Any]:
       are replaced with a placeholder. ``album_art`` is left intact (players
       need it to play along). The REVEAL payload is untouched — by then the
       answers are public.
+    * When an artist challenge is running in ``PLAYING``, ``song.artist`` alone
+      is the answer and is replaced the same way (#2550). The title is not part
+      of that challenge and stays visible.
 
     The input is not mutated; only the keys that need changing are shallow
     copied.
@@ -81,12 +84,22 @@ def redact_state_for_player(message: dict[str, Any]) -> dict[str, Any]:
 
     # Nothing to redact if neither answer-bearing key is present.
     has_admin_song = "admin_song" in message
-    redact_song = (
-        message.get("title_artist_mode")
-        and message.get("phase") == "PLAYING"
-        and isinstance(message.get("song"), dict)
+    playing_with_song = message.get("phase") == "PLAYING" and isinstance(
+        message.get("song"), dict
     )
-    if not has_admin_song and not redact_song:
+    redact_song = bool(message.get("title_artist_mode")) and playing_with_song
+    # #2550: an artist challenge asks players to name the artist, so during
+    # PLAYING `song.artist` is the answer just as much as in title_artist_mode.
+    # No client renders it, but the frame is on every player socket and the
+    # network tab is enough to read it — the same leak #1366 closed for
+    # admin_song and title_artist_mode. The title is not part of this challenge
+    # and stays visible.
+    redact_artist_only = (
+        not redact_song
+        and playing_with_song
+        and isinstance(message.get("artist_challenge"), dict)
+    )
+    if not has_admin_song and not redact_song and not redact_artist_only:
         return message
 
     redacted = dict(message)
@@ -95,6 +108,10 @@ def redact_state_for_player(message: dict[str, Any]) -> dict[str, Any]:
         song = dict(redacted["song"])
         song["artist"] = REDACTED_PLACEHOLDER
         song["title"] = REDACTED_PLACEHOLDER
+        redacted["song"] = song
+    elif redact_artist_only:
+        song = dict(redacted["song"])
+        song["artist"] = REDACTED_PLACEHOLDER
         redacted["song"] = song
     return redacted
 
@@ -212,7 +229,13 @@ def build_game_status_response(
         }
 
     phase = game_state.phase.value
-    can_join = phase in ("LOBBY", "PLAYING", "REVEAL")
+    # #2549: PAUSED accepts joins too — add_player only rejects END, and an
+    # admin phone whose screen locked pauses the game after a 5s grace period
+    # (#841), which is a common window for a guest to be scanning the QR code.
+    # Without PAUSED here they were told "game in progress, try again in a
+    # moment" and had to keep retrying by hand against a server that would have
+    # let them straight in.
+    can_join = phase in ("LOBBY", "PLAYING", "REVEAL", "PAUSED")
 
     return {
         "exists": True,

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -438,14 +438,23 @@ class BeatifyWebSocketHandler:
                 GamePhase,
             )
 
-            if (
-                game_state.title_artist_mode
-                and game_state.phase == GamePhase.PLAYING
-                and isinstance(message.get("song"), dict)
-            ):
+            playing_with_song = game_state.phase == GamePhase.PLAYING and isinstance(
+                message.get("song"), dict
+            )
+            if game_state.title_artist_mode and playing_with_song:
                 song = dict(message["song"])
                 song["artist"] = REDACTED_PLACEHOLDER
                 song["title"] = REDACTED_PLACEHOLDER
+                return {**message, "song": song}
+            # #2550: an active artist challenge makes song.artist the answer
+            # here too. The title is not part of that challenge and stays.
+            if (
+                playing_with_song
+                and getattr(game_state, "artist_challenge_enabled", False)
+                and getattr(game_state, "artist_challenge", None) is not None
+            ):
+                song = dict(message["song"])
+                song["artist"] = REDACTED_PLACEHOLDER
                 return {**message, "song": song}
         return message
 

--- a/tests/unit/test_endgame_join_leak_2548_2550.py
+++ b/tests/unit/test_endgame_join_leak_2548_2550.py
@@ -1,0 +1,172 @@
+"""#2548, #2549 and #2550 — three end-of-game / join-time mismatches.
+
+* #2548: the speaker crowned the highest scorer while the screen crowned the
+  sudden-death survivor.
+* #2549: the join screen turned guests away during PAUSED, although
+  ``add_player`` would have accepted them.
+* #2550: an active artist challenge shipped the answer to every player socket.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.beatify.game.state import GamePhase
+from custom_components.beatify.server.serializers import (
+    REDACTED_PLACEHOLDER,
+    build_game_status_response,
+    redact_state_for_player,
+)
+from tests.conftest import make_game_state, make_songs
+
+
+def _make_game(names, *, songs=5, **create_kwargs):
+    gs = make_game_state()
+    gs.create_game(
+        playlists=["t.json"],
+        songs=make_songs(songs),
+        media_player="media_player.x",
+        base_url="http://h",
+        **create_kwargs,
+    )
+    for n in names:
+        ws = MagicMock()
+        ws.closed = False
+        gs.add_player(n, ws)
+        gs.get_player(n).connected = True
+    return gs
+
+
+# ---------------------------------------------------------------------------
+# #2548 — the speaker must agree with the screen
+# ---------------------------------------------------------------------------
+
+
+def _tts_game():
+    gs = _make_game(["Alice", "Bob"])
+    gs._tts_service = "tts.google"
+    gs._tts_announce_winner = True
+    gs._tts_announce_podium = True
+    gs._tts_announce = AsyncMock()
+    return gs
+
+
+class TestSuddenDeathAnnouncements:
+    async def test_winner_is_the_survivor_not_the_high_scorer(self):
+        gs = _tts_game()
+        gs.sudden_death_mode = True
+        alice = gs.get_player("Alice")
+        bob = gs.get_player("Bob")
+        alice.score = 120
+        alice.eliminated = True
+        alice.eliminated_round = 8
+        bob.score = 95
+
+        await gs.announce_winner()
+
+        spoken = gs._tts_announce.await_args.args[0]
+        assert "Bob" in spoken
+        assert "Alice" not in spoken
+
+    async def test_podium_follows_the_leaderboard_order(self):
+        gs = _tts_game()
+        gs.sudden_death_mode = True
+        alice = gs.get_player("Alice")
+        bob = gs.get_player("Bob")
+        alice.score = 120
+        alice.eliminated = True
+        alice.eliminated_round = 8
+        bob.score = 95
+
+        await gs.announce_podium()
+
+        spoken = gs._tts_announce.await_args.args[0]
+        # Bottom-up: 2nd is read first, 1st last.
+        assert spoken.index("Bob") > spoken.index("Alice")
+
+    async def test_normal_game_still_crowns_the_high_scorer(self):
+        gs = _tts_game()
+        gs.get_player("Alice").score = 120
+        gs.get_player("Bob").score = 95
+
+        await gs.announce_winner()
+
+        assert "Alice" in gs._tts_announce.await_args.args[0]
+
+
+# ---------------------------------------------------------------------------
+# #2549 — a paused game still accepts joins
+# ---------------------------------------------------------------------------
+
+
+class TestJoinWhilePaused:
+    def test_paused_can_join(self):
+        gs = _make_game(["Alice"])
+        gs.phase = GamePhase.PAUSED
+
+        payload = build_game_status_response(gs, gs.game_id)
+
+        assert payload["can_join"] is True
+
+    def test_ended_still_cannot_join(self):
+        gs = _make_game(["Alice"])
+        gs.phase = GamePhase.END
+
+        payload = build_game_status_response(gs, gs.game_id)
+
+        assert payload["can_join"] is False
+
+
+# ---------------------------------------------------------------------------
+# #2550 — the artist challenge answer must not reach players
+# ---------------------------------------------------------------------------
+
+
+class TestArtistChallengeRedaction:
+    def test_artist_is_redacted_during_the_challenge(self):
+        message = {
+            "type": "state",
+            "phase": "PLAYING",
+            "artist_challenge": {"options": ["Queen", "Abba"]},
+            "song": {"artist": "Queen", "title": "Bohemian Rhapsody", "album_art": "x"},
+        }
+
+        out = redact_state_for_player(message)
+
+        assert out["song"]["artist"] == REDACTED_PLACEHOLDER
+        assert out["song"]["title"] == "Bohemian Rhapsody"
+        assert out["song"]["album_art"] == "x"
+        assert message["song"]["artist"] == "Queen", "input must not be mutated"
+
+    def test_reveal_is_untouched(self):
+        message = {
+            "type": "state",
+            "phase": "REVEAL",
+            "artist_challenge": {"options": ["Queen"]},
+            "song": {"artist": "Queen", "title": "Bohemian Rhapsody"},
+        }
+
+        assert redact_state_for_player(message)["song"]["artist"] == "Queen"
+
+    def test_no_challenge_leaves_the_artist_alone(self):
+        message = {
+            "type": "state",
+            "phase": "PLAYING",
+            "song": {"artist": "Queen", "title": "Bohemian Rhapsody"},
+        }
+
+        assert redact_state_for_player(message)["song"]["artist"] == "Queen"
+
+    def test_title_artist_mode_still_redacts_both(self):
+        message = {
+            "type": "state",
+            "phase": "PLAYING",
+            "title_artist_mode": True,
+            "artist_challenge": {"options": ["Queen"]},
+            "song": {"artist": "Queen", "title": "Bohemian Rhapsody"},
+        }
+
+        out = redact_state_for_player(message)
+
+        assert out["song"]["artist"] == REDACTED_PLACEHOLDER
+        assert out["song"]["title"] == REDACTED_PLACEHOLDER


### PR DESCRIPTION
## What was wrong

Three places where the server contradicted itself.

**#2548 — the speaker crowned someone the screen had ranked below the cut-line.** `announce_winner` and `announce_podium` both sorted by raw score, while `compute_winners()` and `get_final_leaderboard()` have ranked survivors first since #827/#1749. A player with 120 points eliminated in round 8 loses to a survivor with 95 on screen and wins on the speaker — in front of the whole room.

**#2549 — guests were turned away from a paused game.** `add_player` only rejects END, but `can_join` omitted PAUSED. An admin phone whose screen locks pauses the game after a 5s grace period (#841), which is exactly when a guest is likely to be scanning the QR code. They read "game in progress, try again in a moment" and had to keep retrying by hand against a server that would have let them in.

**#2550 — an active artist challenge shipped its own answer to every player socket.** During PLAYING `song.artist` is the answer being guessed, exactly as in `title_artist_mode`, but redaction only covered the latter. No client renders it, and the network tab is enough to read it — the same leak #1366 closed for `admin_song`.

## What changed

- `announce_winner` reads `compute_winners()`; `announce_podium` follows `get_final_leaderboard()`'s ranking
- `can_join` includes PAUSED, so a late guest lands in the paused view and is in the game when it resumes
- both `redact_state_for_player` and the `metadata_update` variant redact `song.artist` while an artist challenge is running. The title is not part of that challenge and stays visible

## Tests

`tests/unit/test_endgame_join_leak_2548_2550.py`, 9 cases: survivor announced over the high scorer, podium order, normal games unchanged; PAUSED joinable and END still not; artist redacted during the challenge, reveal untouched, no-challenge frames untouched, title-artist mode still redacting both, and the input dict not mutated. Full unit suite green (2189).

Closes #2548
Closes #2549
Closes #2550

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jtjbEFrrGLjjPgb6goziQ