### PR TITLE
fix(finale): end the last round from REVEAL so the tiebreaker can fire

### DIFF
--- a/custom_components/beatify/game/state_auto_advance.py
+++ b/custom_components/beatify/game/state_auto_advance.py
@@ -197,6 +197,28 @@ class RevealAutoAdvanceMixin:
                 timer_seconds,
                 elapsed,
             )
+            # #2574: on the LAST round, end the game from REVEAL instead of
+            # calling start_round() and letting it fail into END.
+            #
+            # Both paths reached the same ceremony, so this looked like a
+            # detour rather than a bug — but `maybe_start_finale_playoff`
+            # (state.py) only fires while `phase == REVEAL`, deliberately:
+            # a tie is only real once the round that produced it has final
+            # scores. Going through start_round() flips the phase to END
+            # first, so by the time the gate runs, the playoff has already
+            # declined itself. The finale tiebreaker therefore worked when
+            # the host tapped Next and silently did not when the timer fired.
+            #
+            # admin_next_round (ws_handlers/admin.py) has always done it this
+            # way; this is the same branch, not a new mechanism.
+            if self.last_round and self._on_game_end is not None:
+                _LOGGER.info(
+                    "REVEAL auto-advance on the final round — ending from "
+                    "REVEAL so the finale tiebreaker can still fire"
+                )
+                await self._on_game_end()
+                return
+
             # #1697: honors the round-start lock transitively — start_round()
             # acquires _round_start_lock and no-ops (returns True) if a manual
             # admin_next_round already advanced to PLAYING, so this auto-advance

--- a/tests/unit/test_finale_tiebreaker_auto_advance_2574.py
+++ b/tests/unit/test_finale_tiebreaker_auto_advance_2574.py
@@ -1,0 +1,80 @@
+"""#2574: the finale tiebreaker must also fire when the last round ends by timer.
+
+`maybe_start_finale_playoff` only starts a playoff while ``phase == REVEAL`` —
+deliberately, because a tie is only real once the round that produced it has
+final scores. The manual path (``admin_next_round``) checks ``last_round`` and
+calls the game-end gate straight from REVEAL. The auto-advance path called
+``start_round()`` instead, which flips the phase to END on an exhausted
+playlist; by the time the gate ran, the playoff had already declined itself.
+
+Result before the fix: with the tiebreaker enabled and two players tied at the
+top, the game ended in a shared win whenever the host let the reveal timer run
+out instead of tapping Next.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import custom_components.beatify.game.state_auto_advance as auto_advance_mod
+from custom_components.beatify.game.state import GamePhase
+from tests.conftest import make_game_state
+
+
+def _game_in_reveal(monkeypatch, *, last_round: bool):
+    state = make_game_state()
+    monkeypatch.setattr(auto_advance_mod.asyncio, "sleep", AsyncMock())
+    state._song_finished = MagicMock(return_value=True)
+    state._on_round_end = AsyncMock()
+    state.phase = GamePhase.REVEAL
+    state.last_round = last_round
+    return state
+
+
+class TestFinaleTiebreakerOnAutoAdvance:
+    async def test_last_round_ends_from_reveal(self, monkeypatch):
+        """The gate has to run while the phase is still REVEAL."""
+        state = _game_in_reveal(monkeypatch, last_round=True)
+        gesehen: list[GamePhase] = []
+
+        async def _gate() -> None:
+            gesehen.append(state.phase)
+
+        state._on_game_end = AsyncMock(side_effect=_gate)
+        state.start_round = AsyncMock()
+
+        await state._reveal_auto_advance(0)
+
+        state._on_game_end.assert_awaited_once()
+        assert gesehen == [GamePhase.REVEAL]
+        # start_round would have flipped the phase to END before the gate.
+        state.start_round.assert_not_awaited()
+
+    async def test_normal_round_still_starts_the_next_one(self, monkeypatch):
+        """Everything that is not the last round is untouched."""
+        state = _game_in_reveal(monkeypatch, last_round=False)
+        state._on_game_end = AsyncMock()
+        state.start_round = AsyncMock(return_value=True)
+
+        await state._reveal_auto_advance(0)
+
+        state.start_round.assert_awaited_once()
+        state._on_game_end.assert_not_awaited()
+
+    async def test_last_round_without_a_wired_gate_falls_back(self, monkeypatch):
+        """REST/service path and older tests wire no handler — the old route
+        through ``start_round()`` still has to work there."""
+        state = _game_in_reveal(monkeypatch, last_round=True)
+        state._on_game_end = None
+
+        async def _exhausted() -> bool:
+            state.phase = GamePhase.END
+            return False
+
+        state.start_round = AsyncMock(side_effect=_exhausted)
+        state.advance_to_end = AsyncMock()
+
+        await state._reveal_auto_advance(0)
+
+        state.start_round.assert_awaited_once()
+        state.advance_to_end.assert_awaited_once()


### PR DESCRIPTION
Closes #2574

## The scene

The host has the finale tiebreaker enabled. After the last round two players are tied at the top. The host does not tap Next — a reveal timer is configured, or they are pouring a drink. The game ends in a shared win and the playoff never runs.

## Why

`maybe_start_finale_playoff` (`game/state.py`) declines unless `phase == REVEAL`, and that guard is right: a tie is only real once the round that produced it has final scores.

`_reveal_auto_advance` called `start_round()`, which finds no song left and flips the phase to END before returning False. The game-end gate then runs against a phase the playoff refuses.

`admin_next_round` (`server/ws_handlers/admin.py`) has always done it the other way — check `last_round`, call the gate straight from REVEAL. This PR gives the auto path the same branch.

## Tests

`tests/unit/test_finale_tiebreaker_auto_advance_2574.py`, three cases:

- last round → the gate runs and sees `REVEAL`, `start_round` is never called
- any other round → unchanged, `start_round` runs
- last round with no wired handler (REST/service path) → the old route through `start_round()` + `advance_to_end()` still works

Full suite green locally: 2234 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShE8H4kGG5Mz4kXywscPNz