### PR TITLE
fix(pause): re-arm the auto-advance after an elapsed vote window

### DIFF
--- a/custom_components/beatify/game/state_pause.py
+++ b/custom_components/beatify/game/state_pause.py
@@ -334,6 +334,22 @@ class PauseResumeMixin:
                     "Vote window deadline elapsed during pause — finalizing on resume"
                 )
                 await self._finalize_title_artist_window()
+                # #2575: finalizing scores the round but arms nothing. The vote
+                # window had taken over the _auto_advance_task slot, so REVEAL is
+                # left with no song-end advance and no idle-halt — the game holds
+                # until the host taps Next by hand.
+                #
+                # The regular window already re-arms after finalizing
+                # (state_vote_window.py, #1755); the resume path never got the
+                # same follow-up. Same guard as there: only while still in
+                # REVEAL, since finalizing can end the game.
+                from .state import GamePhase  # noqa: PLC0415 — avoid circular import
+
+                if self.phase == GamePhase.REVEAL:
+                    self._schedule_song_end_auto_advance()
+                    _LOGGER.info(
+                        "REVEAL auto-advance re-armed after an elapsed vote window"
+                    )
             return
 
         # No vote window was open — re-arm the song-end auto-advance / idle-halt.

--- a/tests/unit/test_rearm_after_elapsed_vote_window_2575.py
+++ b/tests/unit/test_rearm_after_elapsed_vote_window_2575.py
@@ -1,0 +1,59 @@
+"""#2575: resuming into an elapsed vote window has to re-arm the auto-advance.
+
+Opening a title/artist vote window takes over the ``_auto_advance_task`` slot.
+When the window's deadline passes while the game is paused, ``resume_game``
+finalizes the scoring — and used to stop there. REVEAL was then parked with no
+song-end advance and no idle-halt, so the game held until the host tapped Next.
+
+The regular window path already re-arms after finalizing (#1755,
+``state_vote_window.py``); the resume path never got the same follow-up. The
+existing test for this branch mocks ``_finalize_title_artist_window`` and asserts
+only that it was awaited, so it could not see the missing re-arm.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.beatify.game.state import GamePhase
+from tests.conftest import make_game_state
+
+
+class TestRearmAfterElapsedVoteWindow:
+    @pytest.mark.asyncio
+    async def test_resume_rearms_auto_advance(self):
+        state = make_game_state()
+        state.phase = GamePhase.REVEAL
+        state._title_artist_voting_open = True
+        state._title_artist_vote_deadline = state._now() - 5  # abgelaufen
+        await state.pause_game("admin_disconnected")
+
+        state._finalize_title_artist_window = AsyncMock()
+        state._schedule_song_end_auto_advance = AsyncMock()
+
+        await state.resume_game()
+
+        state._finalize_title_artist_window.assert_awaited_once()
+        state._schedule_song_end_auto_advance.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_rearm_when_finalizing_ended_the_game(self):
+        """Finalizing can end the game — then REVEAL is gone and arming a
+        song-end advance would schedule work for a round that is over."""
+        state = make_game_state()
+        state.phase = GamePhase.REVEAL
+        state._title_artist_voting_open = True
+        state._title_artist_vote_deadline = state._now() - 5
+        await state.pause_game("admin_disconnected")
+
+        async def _ends_the_game() -> None:
+            state.phase = GamePhase.END
+
+        state._finalize_title_artist_window = AsyncMock(side_effect=_ends_the_game)
+        state._schedule_song_end_auto_advance = AsyncMock()
+
+        await state.resume_game()
+
+        state._schedule_song_end_auto_advance.assert_not_called()


### PR DESCRIPTION
Closes #2575

## The scene

Title & Artist mode, a near-miss vote window is open on the TV. The host's phone drops off the wifi and the game pauses after five seconds. The host comes back later than the window had left to run. Scoring is finalized correctly — and then the game sits in REVEAL with nothing armed, until someone taps Next by hand.

## Why

Opening the vote window takes over the `_auto_advance_task` slot. In the "deadline elapsed during the pause" branch, `_rearm_reveal_after_resume` (`game/state_pause.py`) called `_finalize_title_artist_window()` and returned. Neither that branch nor the finalizer schedules a song-end advance, so the slot stayed empty.

`state_vote_window.py` already re-arms after finalizing — that is #1755. The resume path never got the same follow-up.

## Tests

`tests/unit/test_rearm_after_elapsed_vote_window_2575.py`:

- resume into an elapsed window → `_schedule_song_end_auto_advance` is called
- finalizing that ends the game → nothing is armed, because REVEAL is gone

The pre-existing `test_resume_to_reveal_finalizes_elapsed_vote_window` mocks the finalizer and asserts only that it was awaited, which is why it stayed green through the whole defect.

Full suite green locally: 2233 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShE8H4kGG5Mz4kXywscPNz