### PR TITLE
fix(multiplayer): leaving on purpose triggers the early reveal too

### DIFF
--- a/custom_components/beatify/server/ws_handlers/lifecycle.py
+++ b/custom_components/beatify/server/ws_handlers/lifecycle.py
@@ -486,5 +486,16 @@ async def handle_leave(
     game_state.remove_player(player_name)
     await ws.send_json({"type": "left"})
     await ws.close()
+
+    # #2577: the deliberate exit has to trigger the same early reveal as a
+    # dropped connection. `_handle_disconnect` runs the #928 check, but it
+    # resolves the player through `get_player_by_ws` — and this handler has
+    # already removed them, so it returns before it gets there. The polite way
+    # out was the one case that left the room waiting on somebody who is gone.
+    try:
+        await game_state.trigger_early_reveal_if_complete()
+    except Exception:  # noqa: BLE001
+        _LOGGER.warning("Early-reveal check after leave failed")
+
     await handler.broadcast_state()
     _LOGGER.info("Player left game intentionally: %s", player_name)

--- a/tests/unit/test_leave_triggers_early_reveal_2577.py
+++ b/tests/unit/test_leave_triggers_early_reveal_2577.py
@@ -1,0 +1,74 @@
+"""#2577: leaving on purpose has to trigger the early reveal too.
+
+Four players, three have submitted. The fourth does not know the song and taps
+"leave game" instead of guessing. Before this fix the other three sat on
+"waiting for the others" until the round timer ran out — even though nobody was
+outstanding any more.
+
+A dropped connection from the same player would have ended the round at once:
+that is #928, checked in `_handle_disconnect`. But that check resolves the
+player through `get_player_by_ws`, and `handle_leave` has already removed them,
+so it returns before reaching it. The deliberate exit was the one case that
+stalled the room.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.beatify.server.ws_handlers.lifecycle import handle_leave
+
+
+def _handler_and_state(*, is_admin: bool = False):
+    spieler = MagicMock()
+    spieler.name = "Ben"
+    spieler.is_admin = is_admin
+
+    state = MagicMock()
+    state.get_player_by_ws = MagicMock(return_value=spieler)
+    state.remove_player = MagicMock()
+    state.trigger_early_reveal_if_complete = AsyncMock()
+
+    handler = MagicMock()
+    handler.broadcast_state = AsyncMock()
+
+    ws = MagicMock()
+    ws.send_json = AsyncMock()
+    ws.close = AsyncMock()
+    return handler, ws, state, spieler
+
+
+class TestLeaveTriggersEarlyReveal:
+    @pytest.mark.asyncio
+    async def test_leave_checks_for_early_reveal(self):
+        handler, ws, state, _ = _handler_and_state()
+
+        await handle_leave(handler, ws, {}, state)
+
+        state.remove_player.assert_called_once_with("Ben")
+        state.trigger_early_reveal_if_complete.assert_awaited_once()
+        handler.broadcast_state.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_failing_check_does_not_break_the_leave(self):
+        """The player is already gone — a check that raises must not swallow
+        the broadcast, or the room never learns they left."""
+        handler, ws, state, _ = _handler_and_state()
+        state.trigger_early_reveal_if_complete = AsyncMock(
+            side_effect=RuntimeError("boom")
+        )
+
+        await handle_leave(handler, ws, {}, state)
+
+        handler.broadcast_state.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_host_cannot_leave_and_nothing_is_checked(self):
+        handler, ws, state, _ = _handler_and_state(is_admin=True)
+
+        await handle_leave(handler, ws, {}, state)
+
+        state.remove_player.assert_not_called()
+        state.trigger_early_reveal_if_complete.assert_not_awaited()


### PR DESCRIPTION
Closes #2577

## The scene

Four players, three have submitted. The fourth does not know the song and taps **leave game** instead of guessing. The other three sit on "waiting for the others" until the round timer expires — even though nobody is outstanding.

Had that same player simply lost their connection, the round would have ended immediately. That is #928.

## Why

`_handle_disconnect` (`server/websocket.py`) runs the early-reveal check, but it resolves the player with `get_player_by_ws` first. `handle_leave` has already called `remove_player`, so the lookup comes back empty and the handler returns before it gets there.

So the one case that did *not* trigger it was the deliberate, polite one.

## The fix

The same call and the same `try/except` the disconnect path uses, placed before the broadcast so the phase change ships with it.

## Tests

`tests/unit/test_leave_triggers_early_reveal_2577.py`:

- leaving → `trigger_early_reveal_if_complete` is awaited, then the broadcast
- a check that raises → the broadcast still happens, so the room learns they left
- host tries to leave → rejected as before, nothing is checked

The existing leave tests in `test_websocket.py` only assert removal and the error message.

Full suite green locally: 2234 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShE8H4kGG5Mz4kXywscPNz