### PR TITLE
ci: run the test matrix against Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Home Assistant verlangt seit 2026.3 `requires-python >= 3.14.2` (2026.1 noch
+# 3.13.2). Wer die Integration heute betreibt, faehrt sie also auf 3.14 —
+# vorher lief hier kein einziger Test dagegen (#2581).
+#
+# 3.12 bleibt, weil `hacs.json` als Minimum noch HA 2025.1.0 nennt und erst
+# 2025.2.0 Python 3.13 verlangt. Faellt dieses Minimum, kann 3.12 mit weg.
 env:
-  PYTHON_VERSION: "3.13"
+  PYTHON_VERSION: "3.14"
 
 jobs:
   # ==========================================================================
@@ -39,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -71,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -129,7 +135,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/tests/unit/test_ci_python_matrix_2581.py
+++ b/tests/unit/test_ci_python_matrix_2581.py
@@ -1,0 +1,56 @@
+"""#2581: the CI has to run against the Python version Home Assistant requires.
+
+Home Assistant's own `pyproject.toml` moved to `requires-python >= 3.14.2` with
+2026.3 (2026.1 was still 3.13.2). Every user on a current Home Assistant runs
+this integration on Python 3.14 — and before this change the CI matrix stopped
+at 3.13, so not one test had ever executed there.
+
+The lower bound stays at 3.12 as long as `hacs.json` names HA 2025.1.0 as the
+minimum: HA 2025.2.0 is the first release to require 3.13.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "test.yml"
+HACS = ROOT / "hacs.json"
+
+_MATRIX = re.compile(r"python-version:\s*\[([^\]]+)\]")
+
+
+def _matrices() -> list[list[str]]:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    return [
+        [v.strip().strip('"').strip("'") for v in m.split(",")]
+        for m in _MATRIX.findall(text)
+    ]
+
+
+class TestCiPythonMatrix:
+    def test_every_matrix_covers_314(self):
+        matrices = _matrices()
+        assert matrices, "no python-version matrix found in test.yml"
+        for versions in matrices:
+            assert "3.14" in versions, f"matrix {versions} does not test 3.14"
+
+    def test_burn_in_runs_on_314(self):
+        text = WORKFLOW.read_text(encoding="utf-8")
+        assert 'PYTHON_VERSION: "3.14"' in text
+
+    def test_lower_bound_matches_the_declared_hacs_minimum(self):
+        """3.12 may only be dropped once hacs.json stops claiming HA 2025.1.0."""
+        minimum = json.loads(HACS.read_text(encoding="utf-8")).get("homeassistant")
+        versions = _matrices()[0]
+        if minimum == "2025.1.0":
+            assert "3.12" in versions, (
+                "hacs.json still claims HA 2025.1.0, which runs on Python 3.12 — "
+                "keep it in the matrix or raise the declared minimum first"
+            )
+        else:  # pragma: no cover - guard for a future bump
+            pytest.skip(f"hacs.json minimum moved to {minimum}; revisit the floor")


### PR DESCRIPTION
Closes #2581

## The gap

| HA version | requires-python |
|---|---|
| 2026.1.0 | `>=3.13.2` |
| 2026.3.0 | `>=3.14.2` |
| 2026.9.0 (current) | `>=3.14.2` |

Lint, typecheck and test ran on `["3.12", "3.13"]`, burn-in on 3.13. So every user on a current Home Assistant has been running this integration on a Python version the CI never touched.

## What changed

`"3.14"` added to all three matrices, `PYTHON_VERSION` moved to 3.14 for the burn-in job.

**3.12 stays.** `hacs.json` still declares HA 2025.1.0 as the minimum and 2025.2.0 is the first release to need 3.13 — dropping the floor means raising that declaration first, which is its own decision.

`[tool.mypy] python_version` stays at 3.13, the lowest version the scoped module set is checked against.

## Test

`tests/unit/test_ci_python_matrix_2581.py` asserts every matrix covers 3.14 and that the burn-in job does too — so the next matrix edit cannot silently drop it again. The third case ties the 3.12 floor to `hacs.json`: if the declared minimum ever moves, the test says so instead of leaving a stale version behind.

If the new job surfaces deprecation warnings, that is not a complication — that is the finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShE8H4kGG5Mz4kXywscPNz