### PR TITLE
fix(playback): the resume watchdog no longer undoes a deliberate stop

### DIFF
--- a/custom_components/beatify/game/state_lifecycle.py
+++ b/custom_components/beatify/game/state_lifecycle.py
@@ -685,6 +685,30 @@ class RoundLifecycleMixin:
                         pass
                 for tick in range(20):
                     await _asyncio.sleep(1.0)
+                    # #2576: der Wachhund darf nur wiederbeleben, was von allein
+                    # stehengeblieben ist — nie etwas, das jemand absichtlich
+                    # angehalten hat.
+                    #
+                    # Ohne diese Pruefung liest er zwei gewollte Zustaende als
+                    # Haenger: der Host tippt „Song stoppen" (media_stop laesst
+                    # einen MA-Player als `idle` MIT Titel zurueck — genau die
+                    # Signatur, die weiter unten als steckengeblieben gilt), und
+                    # das Spiel pausiert (pause_game stoppt den Lautsprecher).
+                    # In beiden Faellen startete er die Musik wieder: einmal
+                    # gegen den ausdruecklichen Wunsch des Gastgebers, einmal
+                    # unter dem Pause-Banner.
+                    from .state import GamePhase  # noqa: PLC0415 — Zirkelbezug
+
+                    if self.phase != GamePhase.PLAYING or getattr(
+                        self, "song_stopped", False
+                    ):
+                        _LOGGER.info(
+                            "Resume watchdog: phase=%s song_stopped=%s — exit "
+                            "(playback stopped on purpose)",
+                            self.phase,
+                            getattr(self, "song_stopped", None),
+                        )
+                        return
                     st = self._hass.states.get(self.media_player)
                     if st is None:
                         _LOGGER.info("Resume watchdog: entity vanished — exit")

--- a/tests/unit/test_watchdog_respects_deliberate_stop_2576.py
+++ b/tests/unit/test_watchdog_respects_deliberate_stop_2576.py
@@ -1,0 +1,68 @@
+"""#2576: the TTS resume watchdog must not undo a deliberate stop.
+
+After every round start a watchdog runs for ~20 seconds and pushes `media_play`
+as soon as the player reports `paused`, or reports `idle` with a title twice in
+a row. It checked neither the game phase nor `song_stopped`, so it read two
+*wanted* states as a hang:
+
+* the host taps "stop song" — `media_stop` leaves a Music Assistant player as
+  `idle` WITH a title, which is exactly the stuck signature; the watchdog
+  restarted the song the host had just stopped.
+* the game pauses (host phone drops off the wifi) — `pause_game` stops the
+  speaker, and the watchdog pushed play, so the music kept going under the
+  PAUSED banner.
+
+The watchdog itself is a closure inside `_start_round_locked` and cannot be
+called directly, so this pins the guard in the source *and* the two inputs it
+relies on: that stopping sets `song_stopped`, and that pausing leaves PLAYING.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from custom_components.beatify.game.state import GamePhase
+from tests.conftest import make_game_state
+
+SRC = (
+    Path(__file__).parents[2]
+    / "custom_components"
+    / "beatify"
+    / "game"
+    / "state_lifecycle.py"
+).read_text(encoding="utf-8")
+
+
+class TestWatchdogGuard:
+    def test_the_guard_exists(self):
+        assert "song_stopped" in SRC, "watchdog does not consult song_stopped"
+        assert "self.phase != GamePhase.PLAYING" in SRC
+
+    def test_the_guard_runs_before_the_state_is_read(self):
+        """Order is the whole point: reading the player first and deciding
+        afterwards would still fire one kick on the tick where the host
+        stopped the song."""
+        guard = SRC.index("playback stopped on purpose")
+        # the first `states.get` inside the polling loop
+        loop = SRC.index("for tick in range(20):")
+        lookup = SRC.index("st = self._hass.states.get(self.media_player)", loop)
+        assert loop < guard < lookup
+
+
+class TestTheInputsTheGuardRelieson:
+    @pytest.mark.asyncio
+    async def test_pausing_leaves_the_playing_phase(self):
+        state = make_game_state()
+        state.phase = GamePhase.PLAYING
+        await state.pause_game("admin_disconnected")
+        assert state.phase is GamePhase.PAUSED
+
+    def test_song_stopped_is_a_per_round_flag(self):
+        """`song_stopped` belongs to the round — a stop in round 3 must not
+        keep the watchdog disarmed in round 4."""
+        state = make_game_state()
+        state.song_stopped = True
+        state._round_manager.reset()
+        assert state.song_stopped is False


### PR DESCRIPTION
Closes #2576

## Two scenes, both in the first ~20 seconds of a round and both only with TTS on

**The host taps "stop song".** `admin_stop_song` sends `media_stop`, and a Music Assistant player then reports `idle` with a title still loaded — exactly the signature the watchdog reads as "stuck" (its own comment says so). It restarted the song the host had just stopped.

**The host's phone drops off the wifi.** After five seconds `pause_game` stops the speaker. The watchdog pushed `media_play` and the music kept going under the PAUSED banner.

## The fix

A guard at the top of the polling loop: leave immediately unless the phase is PLAYING and `song_stopped` is false.

**Placement matters.** Reading the player state first and deciding afterwards would still fire one kick on the tick where the host stopped the song — so the guard runs before `states.get`, and a test pins that order.

**Why a guard and not cancellation.** Cancelling `_tts_resume_task` in `pause_game` and `admin_stop_song` was the alternative. The guard covers both cases — and any future one — from a single place, touches one file instead of three, and costs at most one second before the watchdog notices.

## Tests

`tests/unit/test_watchdog_respects_deliberate_stop_2576.py`. The watchdog is a closure inside `_start_round_locked` and cannot be called directly, so the tests pin the guard and its ordering in the source, plus the two inputs it relies on: pausing leaves PLAYING, and `song_stopped` resets per round.

2243 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShE8H4kGG5Mz4kXywscPNz