### PR TITLE
fix(security): one data-quality report per player and round

### DIFF
--- a/custom_components/beatify/game/player.py
+++ b/custom_components/beatify/game/player.py
@@ -88,6 +88,11 @@ class PlayerSession:
     # sieht der Fernseher dann sechs Totenkoepfe, obwohl niemand rausgeflogen
     # ist. Ein eigenes Feld trennt „zaehlt diese Runde nicht" von „ist raus".
     playoff_spectator: bool = False
+    # #2579: die Runde, in der dieser Spieler zuletzt einen Datenfehler gemeldet
+    # hat. Ein Report je Spieler und Runde reicht — der Knopf sitzt neben der
+    # Aufloesung, und ohne Riegel oeffnet jeder weitere Tipp ein weiteres
+    # oeffentliches Issue.
+    reported_round: int | None = None
 
     @property
     def out_of_play(self) -> bool:
@@ -318,6 +323,7 @@ class PlayerSession:
         self.eliminated = False
         self.eliminated_round = None
         self.playoff_spectator = False
+        self.reported_round = None
         # #1752: clear late-join grace tracking so a rematch/new game never
         # grants a carried-over player Sudden Death grace on a stale round number.
         self.joined_round = None

--- a/custom_components/beatify/server/ws_handlers/__init__.py
+++ b/custom_components/beatify/server/ws_handlers/__init__.py
@@ -100,6 +100,11 @@ _LOGGER = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
+# #2579: wie viele Meldungen die Datei haelt. Sie ist eine Arbeitsliste fuer den
+# music-data-check-Job, kein Archiv — die dauerhafte Spur ist das GitHub-Issue.
+MAX_DATA_QUALITY_REPORTS = 500
+
+
 def _write_report(reports_path: Path, report: dict) -> None:
     """Append a data quality report to the JSON file (blocking I/O).
 
@@ -111,6 +116,12 @@ def _write_report(reports_path: Path, report: dict) -> None:
     if reports_path.exists():
         existing = json.loads(reports_path.read_text(encoding="utf-8"))
     existing.append(report)
+    # #2579: Deckel. Die Datei wird bei jedem Report komplett gelesen und neu
+    # geschrieben — ohne Grenze wird jeder weitere Eintrag teurer als der
+    # vorige. Aeltere fallen hinten weg; wer sie braucht, findet sie als
+    # GitHub-Issue, das ist der eigentliche Ausgang dieser Meldungen.
+    if len(existing) > MAX_DATA_QUALITY_REPORTS:
+        existing = existing[-MAX_DATA_QUALITY_REPORTS:]
     reports_path.write_text(
         json.dumps(existing, indent=2, ensure_ascii=False), encoding="utf-8"
     )
@@ -166,6 +177,29 @@ async def handle_report_data(
 
     if game_state.phase != GamePhase.REVEAL:
         return
+
+    # #2579: ein Report je Spieler und Runde.
+    #
+    # Der Knopf sitzt neben der Aufloesung, und Spieler sind bewusst nicht
+    # angemeldet — das ist der Punkt eines Partyspiels, bei dem Gaeste einen
+    # QR-Code scannen. Ohne Riegel konnte ein Gast mit einem Skript in einer
+    # einzigen Reveal-Phase beliebig viele **oeffentliche GitHub-Issues**
+    # ausloesen und die Report-Datei aufblaehen, bis jeder weitere Schreibvorgang
+    # teurer wird. Das `disabled` am Knopf steht nur im Frontend und ist
+    # umgehbar.
+    #
+    # Das Gegenstueck fuer Crate Digger (`_flag_library_song`, gleich unten)
+    # kappt sich seit jeher ausdruecklich — „must never be able to grow
+    # unboundedly from repeated taps". Dieser Pfad zieht damit nach.
+    if player.reported_round == game_state.round:
+        _LOGGER.debug(
+            "Ignoring repeat data report from %s in round %s",
+            player.name,
+            game_state.round,
+        )
+        await ws.send_json({"type": "report_data_ack", "duplicate": True})
+        return
+    player.reported_round = game_state.round
 
     song = game_state.current_song or {}
     artist = song.get("artist", "Unknown")

--- a/tests/unit/test_report_data_guard_2579.py
+++ b/tests/unit/test_report_data_guard_2579.py
@@ -1,0 +1,116 @@
+"""#2579: one data-quality report per player and round.
+
+The report button sits next to the reveal, and players are deliberately not
+authenticated — that is the point of a party game where guests scan a QR code.
+Without a guard, one guest with a script could raise arbitrarily many
+**public GitHub issues** from a single reveal phase and inflate
+`data_quality_reports.json` until every further write got more expensive
+(the file is fully read and rewritten each time).
+
+The `disabled` attribute on the button lives in the frontend and is bypassable.
+
+The Crate Digger counterpart in the same module has always capped itself —
+"must never be able to grow unboundedly from repeated taps". This path now
+does the same.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.beatify.game.state import GamePhase
+from custom_components.beatify.server.ws_handlers import (
+    MAX_DATA_QUALITY_REPORTS,
+    _write_report,
+    handle_report_data,
+)
+
+
+def _aufbau(runde: int = 7):
+    spieler = MagicMock()
+    spieler.name = "Ben"
+    spieler.reported_round = None
+
+    gs = MagicMock()
+    gs.phase = GamePhase.REVEAL
+    gs.round = runde
+    gs.game_id = "g1"
+    gs.get_player_by_ws = MagicMock(return_value=spieler)
+    gs.current_song = {
+        "artist": "Joe Cocker",
+        "title": "You Can Leave Your Hat On",
+        "year": 1986,
+        "_playlist_source": "80er-hits.json",
+    }
+
+    handler = MagicMock()
+    handler.hass = MagicMock()
+    handler.hass.async_add_executor_job = AsyncMock()
+
+    # Die Coroutine `_create_gh_issue` wird gebaut, aber nie erwartet — HA
+    # nimmt sie sonst in seine Task-Registry. Hier schliessen wir sie, damit
+    # pytest keine „never awaited"-Warnung wirft und die Absicht sichtbar ist.
+    def _schluck(coro, name=None):
+        coro.close()
+
+    handler.hass.async_create_background_task = MagicMock(side_effect=_schluck)
+
+    ws = MagicMock()
+    ws.send_json = AsyncMock()
+    return handler, ws, gs, spieler
+
+
+class TestOneReportPerRound:
+    @pytest.mark.asyncio
+    async def test_the_first_report_goes_through(self):
+        handler, ws, gs, spieler = _aufbau()
+
+        await handle_report_data(handler, ws, {}, gs)
+
+        handler.hass.async_add_executor_job.assert_awaited_once()
+        handler.hass.async_create_background_task.assert_called_once()
+        assert spieler.reported_round == 7
+
+    @pytest.mark.asyncio
+    async def test_the_second_one_in_the_same_round_does_not(self):
+        handler, ws, gs, spieler = _aufbau()
+
+        await handle_report_data(handler, ws, {}, gs)
+        handler.hass.async_add_executor_job.reset_mock()
+        handler.hass.async_create_background_task.reset_mock()
+
+        await handle_report_data(handler, ws, {}, gs)
+
+        handler.hass.async_add_executor_job.assert_not_awaited()
+        handler.hass.async_create_background_task.assert_not_called()
+        # The player still gets an answer — silence would read as a broken button.
+        letzte = ws.send_json.await_args_list[-1].args[0]
+        assert letzte["type"] == "report_data_ack"
+        assert letzte["duplicate"] is True
+
+    @pytest.mark.asyncio
+    async def test_the_next_round_may_report_again(self):
+        handler, ws, gs, spieler = _aufbau()
+        await handle_report_data(handler, ws, {}, gs)
+        handler.hass.async_add_executor_job.reset_mock()
+
+        gs.round = 8
+        await handle_report_data(handler, ws, {}, gs)
+
+        handler.hass.async_add_executor_job.assert_awaited_once()
+        assert spieler.reported_round == 8
+
+
+class TestFileCap:
+    def test_the_file_stops_growing(self, tmp_path):
+        pfad = tmp_path / "beatify" / "data_quality_reports.json"
+        for i in range(MAX_DATA_QUALITY_REPORTS + 25):
+            _write_report(pfad, {"n": i})
+
+        inhalt = json.loads(pfad.read_text(encoding="utf-8"))
+        assert len(inhalt) == MAX_DATA_QUALITY_REPORTS
+        # The newest survive — the oldest are already GitHub issues.
+        assert inhalt[-1]["n"] == MAX_DATA_QUALITY_REPORTS + 24


### PR DESCRIPTION
Closes #2579

## What was possible

`handle_report_data` accepted any number of `report_data` messages from any connected player socket while the phase was REVEAL. Each one appended to `<config>/beatify/data_quality_reports.json` — a full read-modify-write with no cap — **and** opened a public GitHub issue through the Cloudflare worker.

There was no per-player or per-round guard, and the rate limit in `server/websocket.py` limits **connections**, not messages. The only thing in the way was the `disabled` attribute on the button, which is client-side.

Players are unauthenticated by design. So one guest with a script could open hundreds of issues on the public repository during a single reveal.

## The fix was already written, twenty lines up

`_flag_library_song`, the Crate Digger path added later, bounds itself and says why:

> "a flag is a hint for this session's host, not a durable record, and it **must never be able to grow unboundedly from repeated taps**"

It caps the map at 200 and the reporter list at 10. The Crate Digger path was guarded; the public one was not.

## Three limits

- **one report per (player, round)** — `player.reported_round`. A repeat is dropped but still answered with `{"duplicate": true}`, because silence reads as a broken button.
- **the file is capped at 500 entries**, oldest first out. It is a worklist for the 20:00 `music-data-check` job, not an archive — the durable trace is the GitHub issue.
- **the worker call rides on the same guard**, so it fires once per player per round instead of once per tap.

## Tests

`tests/unit/test_report_data_guard_2579.py` — the first report goes through, the second in the same round does not (and still gets an ack), the next round may report again, and the file stops growing while keeping the newest entries.

2250 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShE8H4kGG5Mz4kXywscPNz