### PR TITLE
perf: copy the bundled playlists in one executor job, not 66

### DIFF
--- a/custom_components/beatify/game/playlist.py
+++ b/custom_components/beatify/game/playlist.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import random
 import re
 from collections.abc import Callable
@@ -577,6 +578,97 @@ def _prune_relocated_playlists(
     return removed
 
 
+def _copy_bundled_playlists_sync(
+    bundled_dir: Path, dest_dir: Path
+) -> tuple[list[tuple[str, str]], list[Path]]:
+    """Copy/refresh every bundled playlist into ``dest_dir``, in ONE executor job.
+
+    #2572: this used to be a loop on the event loop that awaited a separate
+    executor round-trip per playlist, and each round-trip parsed both JSON
+    documents in full just to read the ``version`` field. With 66 bundled
+    playlists at 13.7 MB that is 66 hops and ~110 ms of parsing on every setup,
+    growing with the catalogue. ``_discover_playlists_sync`` further down
+    already had the right shape: one job for the whole walk, plus a stat-based
+    signature that skips the parse when nothing changed. This does the same.
+
+    The stat shortcut is deliberately conservative. A destination counts as
+    current only when it has **exactly** the byte size of the bundled file and
+    was written no earlier than it — which is what :func:`_copy_playlist_file`
+    leaves behind, and what an untouched install looks like at every restart
+    after the first. Anything else (a release that re-installed the bundle, a
+    file the user edited, a truncated copy) fails the check and falls through
+    to the version comparison, so no update can be missed by it.
+
+    Returns ``(log_records, playlist_files)``. Log records are finished
+    ``(level, message)`` pairs the caller emits on the event loop: only the
+    handful of playlists that actually changed produce one, so nothing is
+    formatted for the up-to-date case.
+    """
+    log: list[tuple[str, str]] = []
+    playlist_files = list(bundled_dir.glob("**/*.json"))
+
+    for playlist_file in playlist_files:
+        # Preserve relative path (e.g. community/greatest-metal-songs.json)
+        rel = playlist_file.relative_to(bundled_dir)
+        dest_file = dest_dir / rel
+        try:
+            src_stat = playlist_file.stat()
+            try:
+                dst_stat: os.stat_result | None = dest_file.stat()
+            except FileNotFoundError:
+                dst_stat = None
+
+            if dst_stat is None:
+                # New playlist — copy it. The bundled document is parsed only
+                # here, on the path that writes something anyway.
+                _copy_playlist_file(playlist_file, dest_file)
+                bundled_ver = _get_playlist_version(dest_file)
+                log.append(
+                    (
+                        "info",
+                        f"Copied bundled playlist {playlist_file.name} (v{bundled_ver})",
+                    )
+                )
+                continue
+
+            if (
+                dst_stat.st_size == src_stat.st_size
+                and dst_stat.st_mtime_ns >= src_stat.st_mtime_ns
+            ):
+                # Byte-identical copy written after the bundled file: the common
+                # case at every restart, and it costs two stats instead of two
+                # full JSON parses.
+                continue
+
+            bundled_ver = _get_playlist_version(playlist_file)
+            existing_ver = _get_playlist_version(dest_file)
+            if _compare_versions(bundled_ver, existing_ver) > 0:
+                _copy_playlist_file(playlist_file, dest_file)
+                log.append(
+                    (
+                        "info",
+                        f"Updated playlist {playlist_file.name}: "
+                        f"v{existing_ver} -> v{bundled_ver}",
+                    )
+                )
+        except OSError as err:
+            log.append(
+                ("warning", f"Failed to process playlist {playlist_file.name}: {err}")
+            )
+
+    return log, playlist_files
+
+
+def _copy_playlist_file(src: Path, dst: Path) -> None:
+    """Copy file contents, creating parent dirs (runs in executor).
+
+    #1402 B3: folds the previously-on-event-loop ``mkdir`` in here.
+    """
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    content = src.read_text(encoding="utf-8")
+    dst.write_text(content, encoding="utf-8")
+
+
 async def _copy_bundled_playlists(dest_dir: Path) -> None:
     """Copy bundled playlists to destination, updating if bundled version is newer."""
     # Bundled playlists are in custom_components/beatify/playlists/
@@ -584,68 +676,17 @@ async def _copy_bundled_playlists(dest_dir: Path) -> None:
 
     loop = asyncio.get_running_loop()
 
-    # #1402 B3: `exists()` is a blocking syscall — run it (and the glob) in the
+    # #1402 B3: `exists()` is a blocking syscall — run it (and the walk) in the
     # executor instead of on the event loop.
     if not await loop.run_in_executor(None, bundled_dir.exists):
         return
 
-    def _copy_file(src: Path, dst: Path) -> None:
-        """Copy file contents, creating parent dirs (runs in executor).
-
-        #1402 B3: folds the previously-on-event-loop ``mkdir`` in here.
-        """
-        dst.parent.mkdir(parents=True, exist_ok=True)
-        content = src.read_text(encoding="utf-8")
-        dst.write_text(content, encoding="utf-8")
-
-    def _get_versions(src: Path, dst: Path) -> tuple[str, str, bool]:
-        """Get versions from both files + whether dst exists (runs in executor).
-
-        #1402 B3: returns ``dst_exists`` so the caller reuses this single stat
-        instead of re-running a blocking ``dst.exists()`` on the event loop.
-        """
-        bundled_ver = _get_playlist_version(src)
-        dst_exists = dst.exists()
-        existing_ver = _get_playlist_version(dst) if dst_exists else "0.0"
-        return bundled_ver, existing_ver, dst_exists
-
-    # Offload blocking glob to executor to avoid scandir in event loop (#516)
-    playlist_files = await loop.run_in_executor(
-        None, lambda: list(bundled_dir.glob("**/*.json"))
+    # #2572: walk + stat + copy in a single hop instead of one per playlist.
+    log, playlist_files = await loop.run_in_executor(
+        None, _copy_bundled_playlists_sync, bundled_dir, dest_dir
     )
-    for playlist_file in playlist_files:
-        # Preserve relative path (e.g. community/greatest-metal-songs.json)
-        rel = playlist_file.relative_to(bundled_dir)
-        dest_file = dest_dir / rel
-        try:
-            # Get versions (+ existence, reused below — _copy_file makes the dir)
-            bundled_ver, existing_ver, dest_exists = await loop.run_in_executor(
-                None, _get_versions, playlist_file, dest_file
-            )
-
-            if not dest_exists:
-                # New playlist - copy it
-                await loop.run_in_executor(None, _copy_file, playlist_file, dest_file)
-                _LOGGER.info(
-                    "Copied bundled playlist %s (v%s)", playlist_file.name, bundled_ver
-                )
-            elif _compare_versions(bundled_ver, existing_ver) > 0:
-                # Bundled version is newer - update
-                await loop.run_in_executor(None, _copy_file, playlist_file, dest_file)
-                _LOGGER.info(
-                    "Updated playlist %s: v%s -> v%s",
-                    playlist_file.name,
-                    existing_ver,
-                    bundled_ver,
-                )
-            else:
-                _LOGGER.debug(
-                    "Playlist %s is up to date (v%s)", playlist_file.name, existing_ver
-                )
-        except OSError as err:
-            _LOGGER.warning(
-                "Failed to process playlist %s: %s", playlist_file.name, err
-            )
+    for level, message in log:
+        getattr(_LOGGER, level)(message)
 
     # #1864: every current playlist is on disk now, so anything left at a former
     # path is a stranded duplicate. Runs after the copy loop precisely so the

--- a/tests/unit/test_playlist_copy_stat_shortcut_2572.py
+++ b/tests/unit/test_playlist_copy_stat_shortcut_2572.py
@@ -1,0 +1,171 @@
+"""Tests for the one-hop bundled-playlist copy (#2572).
+
+The copy loop used to await a separate executor round-trip per playlist and
+parse both JSON documents in full just to read ``version``. It now runs as a
+single executor job with a stat-based shortcut. These tests pin the two things
+that shortcut must never get wrong: it has to skip the parse in the common
+case, and it must not swallow a real update.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from custom_components.beatify.game import playlist as playlist_mod
+from custom_components.beatify.game.playlist import (
+    _copy_bundled_playlists,
+    _copy_bundled_playlists_sync,
+)
+
+
+def _write(path: Path, version: str, *, pad: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"version": version, "name": "x", "songs": [], "pad": pad}),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def bundled(tmp_path: Path) -> Path:
+    d = tmp_path / "bundled"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def dest(tmp_path: Path) -> Path:
+    d = tmp_path / "dest"
+    d.mkdir()
+    return d
+
+
+def test_first_run_copies_and_reports(bundled: Path, dest: Path) -> None:
+    _write(bundled / "a.json", "1.0")
+    _write(bundled / "community" / "b.json", "2.0")
+
+    log, files = _copy_bundled_playlists_sync(bundled, dest)
+
+    assert len(files) == 2
+    assert (dest / "a.json").exists()
+    assert (dest / "community" / "b.json").exists()
+    assert sorted(m for _, m in log) == [
+        "Copied bundled playlist a.json (v1.0)",
+        "Copied bundled playlist b.json (v2.0)",
+    ]
+
+
+def test_unchanged_playlist_is_never_parsed(
+    bundled: Path, dest: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The point of the whole change: no JSON parse on a steady-state restart."""
+    _write(bundled / "a.json", "1.0")
+    _copy_bundled_playlists_sync(bundled, dest)
+
+    def _boom(path: Path) -> str:
+        raise AssertionError(f"parsed {path} although nothing changed")
+
+    monkeypatch.setattr(playlist_mod, "_get_playlist_version", _boom)
+    log, _ = _copy_bundled_playlists_sync(bundled, dest)
+
+    assert log == []
+
+
+def test_newer_bundled_version_still_wins(bundled: Path, dest: Path) -> None:
+    """A shipped update changes the size, so the shortcut steps aside."""
+    src = bundled / "a.json"
+    _write(src, "1.0")
+    _copy_bundled_playlists_sync(bundled, dest)
+
+    _write(src, "2.0", pad="grown by a release")
+    log, _ = _copy_bundled_playlists_sync(bundled, dest)
+
+    assert json.loads((dest / "a.json").read_text())["version"] == "2.0"
+    assert log == [("info", "Updated playlist a.json: v1.0 -> v2.0")]
+
+
+def test_same_size_but_older_destination_is_re_examined(
+    bundled: Path, dest: Path
+) -> None:
+    """Equal size alone is not enough — an older copy must be looked at.
+
+    A version bump from 1.0 to 9.0 leaves the byte count untouched. The mtime
+    half of the check is what catches it.
+    """
+    src = bundled / "a.json"
+    _write(src, "1.0")
+    _copy_bundled_playlists_sync(bundled, dest)
+
+    _write(src, "9.0")
+    assert src.stat().st_size == (dest / "a.json").stat().st_size
+    os.utime(dest / "a.json", ns=(0, 0))
+
+    log, _ = _copy_bundled_playlists_sync(bundled, dest)
+
+    assert json.loads((dest / "a.json").read_text())["version"] == "9.0"
+    assert log == [("info", "Updated playlist a.json: v1.0 -> v9.0")]
+
+
+def test_older_bundled_version_does_not_overwrite_a_newer_copy(
+    bundled: Path, dest: Path
+) -> None:
+    src = bundled / "a.json"
+    _write(src, "1.0")
+    _copy_bundled_playlists_sync(bundled, dest)
+    _write(dest / "a.json", "5.0", pad="user is ahead")
+
+    log, _ = _copy_bundled_playlists_sync(bundled, dest)
+
+    assert json.loads((dest / "a.json").read_text())["version"] == "5.0"
+    assert log == []
+
+
+def test_unreadable_playlist_is_reported_not_raised(
+    bundled: Path, dest: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write(bundled / "a.json", "1.0")
+    _write(bundled / "b.json", "1.0")
+
+    real_copy = playlist_mod._copy_playlist_file
+
+    def _fail_on_a(src: Path, dst: Path) -> None:
+        if src.name == "a.json":
+            raise OSError("disk on fire")
+        real_copy(src, dst)
+
+    monkeypatch.setattr(playlist_mod, "_copy_playlist_file", _fail_on_a)
+    log, _ = _copy_bundled_playlists_sync(bundled, dest)
+
+    assert (dest / "b.json").exists()
+    assert not (dest / "a.json").exists()
+    assert ("warning", "Failed to process playlist a.json: disk on fire") in log
+
+
+async def test_async_wrapper_uses_a_single_executor_hop(
+    dest: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """66 playlists used to mean 66+ round-trips. Now it is copy + prune.
+
+    Runs against the real bundled catalogue, so the count is the one an HA
+    setup actually pays.
+    """
+    hops = 0
+    loop = asyncio.get_running_loop()
+    real = loop.run_in_executor
+
+    def _counted(executor, func, *args):  # noqa: ANN001, ANN202
+        nonlocal hops
+        hops += 1
+        return real(executor, func, *args)
+
+    monkeypatch.setattr(loop, "run_in_executor", _counted)
+    await _copy_bundled_playlists(dest)
+
+    assert list(dest.glob("**/*.json")), "expected the real bundle to be copied"
+    # exists() + copy job + prune job — and nothing per playlist.
+    assert hops == 3


### PR DESCRIPTION
Closes #2572

## What it cost

Setup walked the 66 bundled playlists and awaited a **separate executor round-trip for each one**. Every round-trip called `_get_playlist_version` twice — once for the bundled file, once for the copy already on disk — and that function reads and parses the whole document to return a five-character string.

13.7 MB parsed, twice, on every HA restart, plus 66 sequential hops. The largest single file is `community/tomorrowland-top-1000.json` at 964 KB, fully parsed for `"version"`. Nothing blocked the event loop, but the cost grows linearly with a catalogue that has roughly doubled since those lines were written.

## The fix was already in the file

`_discover_playlists_sync`, further down the same module, solves the same shape properly: one executor job for the whole walk, plus a stat signature that skips the parse when nothing changed. `_copy_bundled_playlists_sync` now does both.

**One hop instead of 66+.** The async wrapper is down to three executor calls total — `exists()`, the copy job, the prune job — and a test pins that number against the real bundled catalogue, so it cannot quietly grow back.

**No parse in the steady state.** A destination counts as current when it has exactly the byte size of the bundled file and was written no earlier than it. That is what `_copy_playlist_file` leaves behind, and what an untouched install looks like at every restart after the first.

## Why the shortcut cannot swallow an update

It is deliberately narrow, and the two halves cover each other:

- a release that reinstalls the bundle gives the source a newer mtime → falls through to the version comparison
- a version bump that happens to leave the byte count identical (`1.0` → `9.0`) is caught by the mtime half
- a file the user edited, or a truncated copy, changes the size → falls through

Anything that fails the check is handled exactly as before. Tests cover each of those paths, including the same-size-but-older case.

Logging moved out of the loop: the sync job returns finished `(level, message)` pairs the caller emits, so only playlists that actually changed cost anything to report.

## Tests

`tests/unit/test_playlist_copy_stat_shortcut_2572.py` — 7 tests, including one that fails the run if `_get_playlist_version` is called at all on an unchanged catalogue. The existing #1402 and #1864 suites still pass unchanged.

2258 passed, 2 skipped. mypy and ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShE8H4kGG5Mz4kXywscPNz