### PR TITLE
fix(playback): the speaker stays paused after the game ends

### DIFF
--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -123,6 +123,11 @@ MA_FIRST_PLAY_TIMEOUT_FACTOR = 4 / 3
 # position, not the track — the song comes back either way, just from 0:00.
 MA_QUEUE_RESTORE_WAIT = 5.0
 MA_QUEUE_RESTORE_POLL = 0.25
+# #2605: wie lange auf die Bestaetigung der Pause gewartet wird, je Versuch.
+# Kuerzer als MA_QUEUE_RESTORE_WAIT, weil hier nichts geladen werden muss — der
+# Lautsprecher spielt bereits und soll nur anhalten. Zwei Versuche a 2 s haengen
+# den Abbau um hoechstens vier Sekunden, und das nur im Fehlerfall.
+MA_PAUSE_CONFIRM_WAIT = 2.0
 
 # #1381: Fast-path Path 2 (title-advanced-without-exact-match) must not
 # instant-accept an *arbitrary* title change. If a requested URI fails to
@@ -643,12 +648,6 @@ class MediaPlayerService:
                     },
                     blocking=False,
                 )
-            await self._hass.services.async_call(
-                "media_player",
-                "media_pause",
-                {"entity_id": entity_id},
-                blocking=False,
-            )
             if queue.get("shuffle") is not None:
                 await self._hass.services.async_call(
                     "media_player",
@@ -663,17 +662,65 @@ class MediaPlayerService:
                     {"entity_id": entity_id, "repeat": queue["repeat_mode"]},
                     blocking=False,
                 )
+            # #2605: die Pause steht ZULETZT und wird gegengelesen.
+            #
+            # Sie stand vorher vor `shuffle_set`/`repeat_set` und wurde mit
+            # `blocking=False` abgeschickt, ohne dass jemand nachsah. Gemessen am
+            # 05.09.2026: der Lautsprecher stand danach dreimal in Folge auf
+            # `playing` — beim Spielende laeuft also die alte Warteschlange
+            # weiter, ueber das Podium hinweg, in voller Party-Lautstaerke.
+            # Die Log-Zeile unten meldete trotzdem „(paused)", weil sie die
+            # Absicht beschrieb und nicht das Ergebnis.
+            paused = await self._pause_and_confirm(entity_id)
         except (HomeAssistantError, ServiceNotFound) as err:
             _LOGGER.warning("Queue restore on %s failed: %s", entity_id, err)
             return False
         else:
             _LOGGER.info(
-                "Queue restored on %s: %s at %.0fs (paused)",
+                "Queue restored on %s: %s at %.0fs (%s)",
                 entity_id,
                 queue.get("name") or queue["uri"],
                 queue.get("elapsed_time", 0),
+                "paused" if paused else "STILL PLAYING — pause not confirmed",
             )
             return True
+
+    async def _pause_and_confirm(self, entity_id: str) -> bool:
+        """Pausieren und gegenlesen, mit genau einem zweiten Versuch (#2605).
+
+        Ein `media_pause` mit ``blocking=False`` ist eine Bitte, keine Tatsache.
+        Beim Abbau der Warteschlange kam sie dreimal in Folge nicht an: der
+        Lautsprecher spielte weiter, waehrend das Log „(paused)" meldete.
+
+        Deshalb wird hier gelesen statt geglaubt — und genau einmal wiederholt.
+        Ein zweiter Versuch faengt das Rennen zwischen dem gerade geladenen Track
+        und der Pause ab; ein dritter wuerde nur den Abbau verlaengern, ohne eine
+        neue Ursache abzudecken.
+
+        Returns:
+            True, wenn der Lautsprecher danach nicht mehr ``playing`` meldet.
+        """
+        for versuch in (1, 2):
+            await self._hass.services.async_call(
+                "media_player",
+                "media_pause",
+                {"entity_id": entity_id},
+                blocking=False,
+            )
+            deadline = asyncio.get_event_loop().time() + MA_PAUSE_CONFIRM_WAIT
+            while asyncio.get_event_loop().time() < deadline:
+                state = self._hass.states.get(entity_id)
+                # `None` heisst: die Entitaet ist verschwunden. Dann ist nichts
+                # mehr zu pausieren, und ein Warten darauf haelt nur den Abbau auf.
+                if state is None or state.state != "playing":
+                    return True
+                await asyncio.sleep(MA_QUEUE_RESTORE_POLL)
+            _LOGGER.debug(
+                "Queue restore on %s: still playing after pause attempt %d",
+                entity_id,
+                versuch,
+            )
+        return False
 
     async def _wait_for_playing(self, entity_id: str) -> bool:
         """Poll until the speaker reports playback, at most MA_QUEUE_RESTORE_WAIT."""

--- a/tests/unit/test_ma_queue_restore_2143.py
+++ b/tests/unit/test_ma_queue_restore_2143.py
@@ -175,7 +175,14 @@ class TestQueueRestore:
 
         # Paused, not playing: the host just ended the game. Starting their
         # music unasked would be its own surprise.
-        assert len(_calls_to(hass, "media_player", "media_pause")) == 1
+        #
+        # #2605: this used to assert exactly ONE pause. The fixture's speaker
+        # reports `playing` on every read — it never stops — and since #2605 a
+        # pause that does not take is sent a second time. One call was the old
+        # behaviour, not the requirement; what this test is about is that we
+        # pause and never resume.
+        assert len(_calls_to(hass, "media_player", "media_pause")) >= 1
+        assert not _calls_to(hass, "media_player", "media_play")
         assert _calls_to(hass, "media_player", "shuffle_set")[0].args[2]["shuffle"]
         assert _calls_to(hass, "media_player", "repeat_set")[0].args[2]["repeat"] == (
             "all"

--- a/tests/unit/test_queue_restore_stays_paused_2605.py
+++ b/tests/unit/test_queue_restore_stays_paused_2605.py
@@ -1,0 +1,153 @@
+"""#2605: the speaker must not keep playing after the game ends.
+
+Found by the live test on v4.4.2-rc2 (2026-09-05). After `end-game` the restore
+handed the host's queue back and logged ``Queue restored on … (paused)``, while
+`media_player.esszimmer` reported ``playing`` seventy seconds later — three
+times in a row, on two different tracks.
+
+Two causes, both addressed here:
+
+* the pause was fired with ``blocking=False`` and nobody read the state back,
+* it ran *before* ``shuffle_set`` / ``repeat_set``, so anything those two do to
+  the queue happened after the speaker had been asked to stop.
+
+The old log line was written unconditionally in the ``else:`` branch — it
+reported the intent, not the outcome, which is why the defect survived every
+previous run of this file.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.beatify.services.media_player import MediaPlayerService
+
+QUEUE = {
+    "uri": "apple_music://track/1705321808",
+    "name": "(I'll Never Be) María Magdalena",
+    "elapsed_time": 0,
+    "shuffle": False,
+    "repeat_mode": "off",
+}
+
+
+def _hass(states: list[str]) -> MagicMock:
+    """A hass whose speaker walks through ``states`` on successive reads.
+
+    The last entry repeats forever, so a test can model "never stops" with a
+    single element.
+    """
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock(return_value=None)
+    seq = list(states)
+
+    def _get(_entity_id):
+        st = MagicMock()
+        st.state = seq[0] if len(seq) == 1 else seq.pop(0)
+        st.attributes = {"volume_level": 0.0}
+        return st
+
+    hass.states.get = MagicMock(side_effect=_get)
+    return hass
+
+
+def _service(hass) -> MediaPlayerService:
+    return MediaPlayerService(
+        hass, "media_player.esszimmer", platform="music_assistant"
+    )
+
+
+def _services_called(hass) -> list[tuple[str, str]]:
+    return [c.args[:2] for c in hass.services.async_call.await_args_list]
+
+
+class TestQueueRestoreStaysPaused:
+    @pytest.mark.asyncio
+    async def test_pause_is_the_last_thing_that_happens(self):
+        """Shuffle and repeat run BEFORE the pause, not after it.
+
+        Ordering is the half of the fix a state check cannot catch: with the
+        pause in the middle, a speaker that resumes on ``repeat_set`` ends up
+        playing while every individual call succeeded.
+        """
+        hass = _hass(["playing", "paused"])
+        svc = _service(hass)
+
+        assert await svc._restore_queue_on("media_player.esszimmer", QUEUE) is True
+
+        calls = _services_called(hass)
+        pause_at = calls.index(("media_player", "media_pause"))
+        for domain, service in (
+            ("media_player", "shuffle_set"),
+            ("media_player", "repeat_set"),
+        ):
+            assert (domain, service) in calls, f"{service} was not called at all"
+            assert calls.index((domain, service)) < pause_at, (
+                f"{service} runs after the pause and can undo it"
+            )
+
+    @pytest.mark.asyncio
+    async def test_pause_is_retried_when_the_speaker_keeps_playing(self):
+        """A pause that does not take is sent once more.
+
+        This is the live symptom: the call returns, nothing changes, and the
+        old code moved on regardless.
+        """
+        hass = _hass(["playing"])  # never stops
+        svc = _service(hass)
+
+        await svc._restore_queue_on("media_player.esszimmer", QUEUE)
+
+        pauses = [
+            c for c in _services_called(hass) if c == ("media_player", "media_pause")
+        ]
+        assert len(pauses) == 2, f"expected one retry, got {len(pauses)} pause call(s)"
+
+    @pytest.mark.asyncio
+    async def test_no_retry_when_the_first_pause_lands(self):
+        """The common case must not pay for the fix.
+
+        A retry on every teardown would add seconds to every game end for a
+        fault that is rare.
+        """
+        hass = _hass(["playing", "paused"])
+        svc = _service(hass)
+
+        await svc._restore_queue_on("media_player.esszimmer", QUEUE)
+
+        pauses = [
+            c for c in _services_called(hass) if c == ("media_player", "media_pause")
+        ]
+        assert len(pauses) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_vanished_entity_does_not_hold_up_the_teardown(self):
+        """``states.get`` returning None means there is nothing left to pause."""
+        hass = _hass(["playing", "paused"])
+        hass.states.get = MagicMock(return_value=None)
+        svc = _service(hass)
+
+        # Would hang for two full confirm windows if None were treated as "still playing".
+        assert await svc._restore_queue_on("media_player.esszimmer", QUEUE) is True
+
+    @pytest.mark.asyncio
+    async def test_the_log_reports_the_outcome_not_the_intent(self, caplog):
+        """The line that hid this defect for months.
+
+        It said "(paused)" from inside the ``else:`` branch, so it was true of
+        the attempt and false of the room.
+        """
+        hass = _hass(["playing"])  # never stops
+        svc = _service(hass)
+
+        with caplog.at_level("INFO"):
+            await svc._restore_queue_on("media_player.esszimmer", QUEUE)
+
+        restored = [r for r in caplog.records if "Queue restored on" in r.getMessage()]
+        assert restored, "no restore line was logged at all"
+        assert (
+            "paused" not in restored[-1].getMessage().split("—")[0].lower()
+            or "STILL PLAYING" in restored[-1].getMessage()
+        ), "the log claims the speaker is paused while it is still playing"


### PR DESCRIPTION
Closes #2605

After `end-game` the queue restore handed the host's music back and logged `Queue restored on … (paused)`, while the speaker reported `playing` seventy seconds later. Measured three times in a row during the v4.4.2-rc2 live test, on two different tracks. At a party that is the old playlist starting over the podium, at party volume rather than the test's zero.

**Two things were wrong, and only together do they explain it.** The pause was fired with `blocking=False` and nobody read the state back — a request treated as a fact. And it ran *before* `shuffle_set` and `repeat_set`, so the last thing to touch the queue was not the pause. Every individual call succeeded; the room disagreed.

**The fix.** The pause now runs last and is confirmed. `_pause_and_confirm` reads the state back and sends one more pause if the speaker is still playing — one retry, not a loop: a second attempt covers the race with the just-loaded track, a third would only lengthen every teardown without covering a new cause. A vanished entity counts as paused rather than holding the teardown for two windows. Worst case the game end takes four seconds longer, and only when something is actually wrong.

**The log line reports the outcome instead of the intent.** It sat in the `else:` branch and said `(paused)` unconditionally — which is precisely why this survived: anyone reading the log saw a successful teardown.

**One existing test changed.** #2143's `test_plays_the_saved_track_seeks_to_position_and_pauses` asserted exactly one pause call; its fixture's speaker never stops, so a retry is correct there now. It asserts what it was about: we pause, and we never resume.

Verified: 2275 Python tests, ruff clean on 205 files.