### PR TITLE
release: v4.4.2-rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [4.4.2-rc3] - 2026-09-05
+
+Der rc2 hat seinen eigenen Live-Test bestanden und dabei einen Fehler gefunden, der erst nach dem
+Abpfiff beginnt. Dieser Kandidat ist rc2 plus dieser eine Fix.
+
+### Fixed
+- **Der Lautsprecher spielte nach dem Spielende weiter (#2605).** Nach `end-game` kam die alte
+  Warteschlange zurueck — und lief. Das Log meldete trotzdem „Queue restored … (paused)", weil die
+  Zeile die Absicht beschrieb und nicht das Ergebnis. Zwei Ursachen: die Pause wurde mit
+  `blocking=False` abgeschickt und nie gegengelesen, und sie stand **vor** `shuffle_set`/`repeat_set`.
+  Jetzt steht sie zuletzt, wird bestaetigt und bei Bedarf einmal wiederholt.
+
 ## [4.4.2-rc2] - 2026-09-05
 
 The week's editorial plan, all fourteen entries. Most of them share a shape: the backend did the

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -20,5 +20,5 @@
     "num2words==0.5.14"
   ],
   "single_config_entry": true,
-  "version": "4.4.2-rc2"
+  "version": "4.4.2-rc3"
 }

--- a/docs/release-notes-v4.4.2-rc3.md
+++ b/docs/release-notes-v4.4.2-rc3.md
@@ -1,0 +1,17 @@
+## 4.4.2-rc3 — Nothing Unsaid
+
+Same as rc2, plus the one thing rc2's own live test found.
+
+### 🔇 The music stops when the game does
+
+When a game ended, your own queue came back — and started playing. Silently on a test rig at volume zero; over the podium at a party. It now comes back paused, the way it was meant to, and the log finally reports what the speaker actually did instead of what it was asked to do.
+
+### 🙏 Thank you
+
+Everything else in this release candidate is unchanged from rc2 — fourteen fixes for small moments that went wrong, or went right without anyone noticing.
+
+---
+
+**66 playlists · 8,403 songs · 5 music platforms · 6 languages**
+
+[Report a Bug](https://github.com/mholzi/beatify/issues) · [Discussions](https://github.com/mholzi/beatify/discussions) · [Full Changelog](https://github.com/mholzi/beatify/blob/main/CHANGELOG.md)


### PR DESCRIPTION
The release candidate that includes what rc2's own live test found.

- manifest `4.4.2-rc2` → `4.4.2-rc3`
- CHANGELOG section for #2605
- `docs/release-notes-v4.4.2-rc3.md`

**Why a third candidate.** #2606 was merged after the rc2 tag, so `main` carried a commit no live test had ever seen. Cutting the stable from there would have shipped it untested — the case gate condition 8 now blocks.

**Playlist version check: nothing to raise.** No playlist file changed between `v4.4.2-rc2` and this cut.