### PR TITLE
release: v4.4.2 — Nothing Unsaid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [4.4.2] - 2026-09-05
+
+Die Woche 2026-W37: fuenfzehn Eintraege aus der Redaktionskonferenz, alle gebaut, getestet und
+gemergt. Die Abschnitte der drei Kandidaten stehen unveraendert darunter — sie sind der Inhalt
+dieses Stables.
+
+**Ein Fix aus rc3 ist ausdruecklich NICHT wirksam**: der Lautsprecher spielt nach dem Spielende
+weiter ([#2605](https://github.com/mholzi/beatify/issues/2605)). Der Versuch liegt im Code, der
+Live-Test hat ihn widerlegt, das Issue ist wieder offen und steht auf der Liste fuer die naechste
+Woche. Deshalb nennen die Release Notes ihn nicht.
+
 ## [4.4.2-rc3] - 2026-09-05
 
 Der rc2 hat seinen eigenen Live-Test bestanden und dabei einen Fehler gefunden, der erst nach dem

--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ Playlists are displayed on the main Beatify admin screen:
 
 ### Included Playlists
 
-Beatify comes with 8,330 songs across 64 curated playlists:
+Beatify comes with 8,403 songs across 66 curated playlists:
 
 - 🎸 **100 Greatest Rock Songs** — 122 rock essentials spanning 1964–2026
 - ☀️ **100 Summer Anthems** — 112 feel-good tracks from 1957–2020
@@ -687,7 +687,7 @@ comparison — including where the card game wins.
 
 | | Card-based music party game | Beatify |
 |---|---|---|
-| **What you buy** | A box, and a new box or expansion for more music | Nothing. 55 playlists ship with it, ~6,000 songs |
+| **What you buy** | A box, and a new box or expansion for more music | Nothing. 66 playlists ship with it, 8,403 songs |
 | **Where the music comes from** | A fixed printed deck | Spotify, Apple Music, YouTube Music, Tidal, Deezer, Amazon Music — **or your own Plex / Jellyfin / local library** |
 | **Subscription** | None | None required since v4.3.0 (streaming is one option, your own library is another) |
 | **Playback** | A phone speaker on the table | The Sonos, Alexa or Music Assistant speakers you already own |

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -20,5 +20,5 @@
     "num2words==0.5.14"
   ],
   "single_config_entry": true,
-  "version": "4.4.2-rc3"
+  "version": "4.4.2"
 }

--- a/docs/release-notes-v4.4.2-rc2.md
+++ b/docs/release-notes-v4.4.2-rc2.md
@@ -1,6 +1,6 @@
 ## 4.4.2-rc2 — Nothing Unsaid
 
-Fourteen fixes for moments the game handled correctly and then kept to itself.
+Fourteen fixes for small moments that went wrong — or went right without anyone noticing.
 
 ### 📺 The room can see what happened
 

--- a/docs/release-notes-v4.4.2.md
+++ b/docs/release-notes-v4.4.2.md
@@ -1,4 +1,4 @@
-## 4.4.2-rc3 — Nothing Unsaid
+## 4.4.2 — Nothing Unsaid
 
 Fourteen fixes for small moments that went wrong — or went right without anyone noticing.
 
@@ -23,3 +23,4 @@ Every odd moment somebody bothered to write down.
 **66 playlists · 8,403 songs · 5 music platforms · 6 languages**
 
 [Report a Bug](https://github.com/mholzi/beatify/issues) · [Discussions](https://github.com/mholzi/beatify/discussions) · [Full Changelog](https://github.com/mholzi/beatify/blob/main/CHANGELOG.md)
+


### PR DESCRIPTION
The stable for week 2026-W37. Fifteen entries, all built, tested and merged; the live test ran against `v4.4.2-rc3`.

- manifest `4.4.2-rc3` → `4.4.2`
- CHANGELOG: a stable section above the three candidate sections
- `docs/release-notes-v4.4.2.md` — the rc2 text, which is what actually ships

**README counts recomputed, not remembered.** `8,403 songs across 66 curated playlists`. Both places were stale: the feature line said 8,330 / 64, and the comparison table against Hitster said "55 playlists, ~6,000 songs" — understating the catalogue by a third in the one place where that costs something.

**The two candidate notes files come along.** Their text was corrected on GitHub today; the repository had not caught up.

**#2605 is deliberately not in the release notes.** The fix is in the code, the live test disproved it, and the issue is open again for next week. Notes describe what arrives, not what was merged.