### PR TITLE
site(de): refresh the German page against the current catalogue

### DIFF
--- a/de/index.html
+++ b/de/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Beatify — Das Musikquiz für Home Assistant</title>
-  <meta name="description" content="Musikquiz für die Party, direkt aus Home Assistant. Gäste scannen einen QR-Code, ein Song läuft — ratet das Jahr oder Titel und Interpret. Ohne App, ohne Konto. Mit 1.242 deutschen Titeln von Schlager bis NDW.">
+  <meta name="description" content="Musikquiz für die Party, direkt aus Home Assistant. Gäste scannen einen QR-Code, ein Song läuft — ratet das Jahr oder Titel und Interpret. Ohne App, ohne Konto. Mit 1.189 deutschen Titeln von Schlager bis NDW.">
   <meta name="keywords" content="Musikquiz Home Assistant, Musik Quiz Party, Hitster selber bauen, Schlager Quiz, NDW Quiz, Smart Home Partyspiel, HACS, Sonos, Alexa, Music Assistant">
   <meta name="author" content="Markus Holzhäuser">
 
@@ -19,7 +19,7 @@
   <meta property="og:locale" content="de_DE">
   <meta property="og:locale:alternate" content="en_US">
   <meta property="og:title" content="Beatify — Das Musikquiz für Home Assistant">
-  <meta property="og:description" content="Gäste scannen einen QR-Code, ein Song läuft, alle raten mit. 61 Playlists mit 8.211 Songs, davon 1.242 deutsche Titel. Läuft komplett bei dir zu Hause.">
+  <meta property="og:description" content="Gäste scannen einen QR-Code, ein Song läuft, alle raten mit. 66 Playlists mit 8.403 Songs, davon 1.189 deutsche Titel. Läuft komplett bei dir zu Hause.">
   <meta property="og:url" content="https://mholzi.github.io/beatify/de/">
   <meta property="og:image" content="https://raw.githubusercontent.com/mholzi/beatify/main/images/social-preview.png">
   <meta property="og:image:width" content="1280">
@@ -28,7 +28,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Beatify — Das Musikquiz für Home Assistant">
-  <meta name="twitter:description" content="QR-Code scannen, Song hören, Jahr raten. 1.242 deutsche Titel von Schlager bis NDW. Ohne App, ohne Konto, komplett lokal.">
+  <meta name="twitter:description" content="QR-Code scannen, Song hören, Jahr raten. 1.189 deutsche Titel von Schlager bis NDW. Ohne App, ohne Konto, komplett lokal.">
   <meta name="twitter:image" content="https://raw.githubusercontent.com/mholzi/beatify/main/images/social-preview.png">
 
   <!-- Favicon -->
@@ -100,10 +100,10 @@
           <p class="tagline">QR-Code scannen, Song hören, Jahr raten — oder Titel und Interpret eintippen. Läuft über die Lautsprecher, die ohnehin bei dir stehen.</p>
 
           <div class="hero-stats">
-            <span>488 aktive Installationen</span>
-            <span>61 Playlists</span>
-            <span>8.211 Songs</span>
-            <span>1.242 deutsche Titel</span>
+            <span>498 aktive Installationen</span>
+            <span>66 Playlists</span>
+            <span>8.403 Songs</span>
+            <span>1.189 deutsche Titel</span>
             <span>6 Musikdienste</span>
           </div>
 
@@ -152,7 +152,7 @@
       <!-- ===== DEUTSCHE MUSIK ===== -->
       <section class="features" id="musik">
         <div class="container">
-          <h2 class="section-title">1.242 deutsche Titel, damit alle mitraten können</h2>
+          <h2 class="section-title">1.189 deutsche Titel, damit alle mitraten können</h2>
           <p class="tagline">Bei einem Jahresraten-Spiel steht und fällt der Abend damit, ob die Leute die Songs kennen. Mit einer reinen Billboard-Auswahl raten deutsche Gäste im Nebel. „Skandal im Sperrbezirk" oder „Über den Wolken" erkennt dagegen jeder im Raum sofort — und daraus entsteht das Mitgrölen, das so einen Abend trägt.</p>
           <div class="features-grid">
             <div class="feature">
@@ -178,7 +178,7 @@
             <div class="feature">
               <div class="feature-icon" aria-hidden="true">💃</div>
               <h3>Schlager Klassiker</h3>
-              <p>175 Songs, bei denen die Elterngeneration jedes Mal gewinnt.</p>
+              <p>193 Songs, bei denen die Elterngeneration jedes Mal gewinnt.</p>
             </div>
             <div class="feature">
               <div class="feature-icon" aria-hidden="true">🎹</div>

--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
           <p class="tagline">Beatify is the music party game for the speakers you already own. Guests scan a QR code to join — no app, no accounts — and race to name the release year, or the title and the artist. Beats, laughs, rematches, and one friend who insists it was 1987.</p>
 
           <div class="hero-stats">
-            <span>488 active installs</span>
+            <span>498 active installs</span>
             <span>66 playlists</span>
             <span>8,403 songs</span>
             <span>6 music services</span>


### PR DESCRIPTION
The German landing page had drifted five weeks behind the English one.

| Figure | Was | Now | Source |
|---|---|---|---|
| Playlists | 61 | 66 | playlist files on `main` |
| Songs | 8,211 | 8,403 | playlist files on `main` |
| German titles | 1,242 | **1,189** | playlists tagged German, see below |
| Schlager Klassiker | 175 | 193 | `community/schlager-klassiker.json` |
| Active installs | 488 | 498 | HA analytics, 2026-09-06 |

The install figure was stale on the English page too, so that one line changed there as well. Nothing else on the English page was touched.

### Why the German-titles figure goes down

The definition set on 2026-09-01 is "songs in playlists tagged German". Applied to today's files that gives **1,189 across ten playlists**: ballermann-party-hits, best-of-giraffenaffen, deutschpop-klassiker, deutschrap-klassiker, deutschrock-best-of, disney-hits-deutschland, koelner-karneval, ndw-neue-deutsche-welle, schlager-klassiker, wiesn-party-hits.

1,242 is not reproducible from the current files under that definition. A number that can be derived beats a larger one that cannot.

### One thing worth fixing separately

`sommerklassiker` (60 songs) is German repertoire but carries the tag `international` rather than a German one, so it sits outside the definition and outside the count. That is a tagging gap, not a page problem.

### Language switching

Already in place both ways and unchanged by this PR: the English page links to `de/` in its nav, the German page links back to `../` in its nav and again in the footer, and both carry the `hreflang` alternates plus `x-default`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)