### PR TITLE
fix(guessing): accept the year range the slider actually offered

### DIFF
--- a/custom_components/beatify/game/serializers.py
+++ b/custom_components/beatify/game/serializers.py
@@ -31,6 +31,33 @@ _LOGGER = logging.getLogger(__name__)
 _SLIDER_DEFAULT_MIN_YEAR = 1950
 
 
+def year_range(gs: GameState) -> dict[str, int]:
+    """Which years a player may offer: a fixed default, widened to cover the
+    playlist (#2337).
+
+    The upper default follows the clock rather than a literal, for the same
+    reason ``_max_year`` does in the playlist schema (#706): a hardcoded year
+    goes stale every January, quietly, and nobody notices until a song from the
+    new year comes up mid-party.
+
+    **This is deliberately module-level and public.** It answers one question —
+    which years are valid in this game — and that question is asked twice: once
+    to draw the slider, once to accept the guess. While the answers lived apart,
+    the slider reached down to the oldest song in the playlist and the handler
+    kept rejecting anything below ``YEAR_MIN``; a player could set the correct
+    year and have the guess thrown away (#2623).
+    """
+    from datetime import datetime, timezone
+
+    low, high = _SLIDER_DEFAULT_MIN_YEAR, datetime.now(timezone.utc).year
+    pm = getattr(gs, "_playlist_manager", None)
+    span = pm.get_year_span() if pm is not None else None
+    if span is not None:
+        low = min(low, span[0])
+        high = max(high, span[1])
+    return {"min": low, "max": high}
+
+
 class GameStateSerializer:
     """Builds broadcast-ready dicts from GameState.
 
@@ -195,22 +222,8 @@ class GameStateSerializer:
 
     @staticmethod
     def _year_range(gs: GameState) -> dict[str, int]:
-        """Slider bounds: a fixed default, widened to cover the playlist (#2337).
-
-        The upper default follows the clock rather than a literal, for the
-        same reason ``_max_year`` does in the playlist schema (#706): a
-        hardcoded year goes stale every January, quietly, and nobody notices
-        until a song from the new year comes up mid-party.
-        """
-        from datetime import datetime, timezone
-
-        low, high = _SLIDER_DEFAULT_MIN_YEAR, datetime.now(timezone.utc).year
-        pm = getattr(gs, "_playlist_manager", None)
-        span = pm.get_year_span() if pm is not None else None
-        if span is not None:
-            low = min(low, span[0])
-            high = max(high, span[1])
-        return {"min": low, "max": high}
+        """Slider bounds for the state payload. See :func:`year_range`."""
+        return year_range(gs)
 
     @staticmethod
     def _add_playing_state(gs: GameState, state: dict[str, Any]) -> None:

--- a/custom_components/beatify/server/ws_handlers/guessing.py
+++ b/custom_components/beatify/server/ws_handlers/guessing.py
@@ -28,9 +28,8 @@ from custom_components.beatify.const import (
     ERR_ROUND_EXPIRED,
     ERR_TARGET_ALREADY_SABOTAGED,
     ERR_TARGET_ALREADY_SUBMITTED,
-    YEAR_MAX,
-    YEAR_MIN,
 )
+from custom_components.beatify.game.serializers import year_range
 from custom_components.beatify.game.state import GamePhase, GameState
 
 if TYPE_CHECKING:
@@ -136,7 +135,13 @@ async def handle_submit(
             return
 
     year = data.get("year")
-    if not isinstance(year, int) or year < YEAR_MIN or year > YEAR_MAX:
+    # #2623: validate against the range the player was actually offered, not
+    # against two constants. The slider widens to cover the playlist, so a
+    # fixed floor of 1950 rejected correct answers for the 27 catalogue songs
+    # dated 1937-1949 — and a fixed ceiling of 2026 would start rejecting the
+    # current year every January.
+    allowed = year_range(game_state)
+    if not isinstance(year, int) or year < allowed["min"] or year > allowed["max"]:
         await ws.send_json(
             {
                 "type": "error",

--- a/tests/unit/test_year_guess_range_2623.py
+++ b/tests/unit/test_year_guess_range_2623.py
@@ -1,0 +1,83 @@
+"""The guess validator must accept the range the slider offered (#2623).
+
+#2337 widened the slider so it always covers the playlist: a song from 1937
+gets a slider that reaches 1937. The validator in ``handle_submit`` was not
+part of that change and kept comparing against ``YEAR_MIN``/``YEAR_MAX``
+(1950/2026). Ten bundled playlists hold **27 songs dated 1937-1949**, so for
+those rounds a player could set the correct year, submit it, and get
+``ERR_INVALID_ACTION "Invalid year"`` back — the guess simply vanished.
+
+The same split bites at the top end on a calendar boundary: the slider maximum
+follows the clock, ``YEAR_MAX`` is a literal, so from January 2027 the current
+year would be offered and rejected.
+
+The fix is not a wider constant. Both sides now ask the same function, so the
+two answers cannot drift apart again — which is the actual defect. A wider
+constant would have fixed today's 27 songs and left the next widening to
+rediscover the bug.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from custom_components.beatify.const import YEAR_MAX, YEAR_MIN
+from custom_components.beatify.game.serializers import (
+    GameStateSerializer,
+    year_range,
+)
+
+
+class _FakeManager:
+    def __init__(self, span):
+        self._span = span
+
+    def get_year_span(self):
+        return self._span
+
+
+class _FakeState:
+    def __init__(self, span=None):
+        self._playlist_manager = _FakeManager(span) if span else None
+
+
+def _this_year() -> int:
+    return datetime.now(timezone.utc).year
+
+
+class TestOneSourceForBothSides:
+    def test_serializer_delegates_to_the_shared_function(self):
+        """The slider bounds and the validator bounds are the same object."""
+        gs = _FakeState((1937, 2001))
+        assert GameStateSerializer._year_range(gs) == year_range(gs)
+
+    def test_a_pre_1950_playlist_widens_the_accepted_range(self):
+        """The 1937-1949 songs are inside the range, not below it."""
+        rng = year_range(_FakeState((1937, 2001)))
+        assert rng["min"] == 1937
+        assert rng["min"] < YEAR_MIN, "otherwise this test proves nothing"
+
+    def test_the_upper_bound_follows_the_clock_not_the_constant(self):
+        """From January 2027 a literal 2026 ceiling would reject the year."""
+        rng = year_range(_FakeState(None))
+        assert rng["max"] == _this_year()
+        assert rng["max"] >= YEAR_MAX
+
+
+class TestValidatorUsesIt:
+    def test_handler_no_longer_reads_the_constants(self):
+        """A source guard: the drift came from two literals, so neither may
+        return to the submit path.
+
+        Asserting on behaviour would need the full websocket handler with a
+        game, a player and a live round; the defect, however, is entirely in
+        *which bounds the check reads*. That is what this pins.
+        """
+        from pathlib import Path
+
+        src = Path(
+            "custom_components/beatify/server/ws_handlers/guessing.py"
+        ).read_text(encoding="utf-8")
+        assert "year_range(game_state)" in src
+        assert "YEAR_MIN" not in src
+        assert "YEAR_MAX" not in src


### PR DESCRIPTION
Blattplan 2026-W38, entry 2 of 32.

## The defect

Two places answer the question "which years are valid in this game", and they had drifted apart.

- `game/serializers.py` widens the slider to cover the playlist, down to 1900 and up to the current year (#2337)
- `server/ws_handlers/guessing.py` compared against `YEAR_MIN` / `YEAR_MAX`, the literals 1950 and 2026

Ten bundled playlists hold **27 songs dated 1937-1949**. For those rounds a player sets the correct year on a slider that reaches it, submits, and gets `ERR_INVALID_ACTION "Invalid year"` back. The guess vanishes with no way to tell why.

The top end fails on a calendar boundary rather than on the catalogue: the slider maximum follows the clock, `YEAR_MAX` does not, so **from January 2027** the current year would be offered and rejected.

## Why not simply widen the constant

That would fix today's 27 songs and leave the next widening to rediscover the bug. The bounds logic moves to a public `year_range()`; the state payload and the submit path both call it, so the two answers cannot drift apart again.

## Side note, not fixed here

`library/version.py` (Crate Digger's changelog, 0.5.7 entry) claims *"YEAR_MIN stays 1900 for server validation"*. `const.py` has never held 1900. That is a stale line in a changelog, and rewriting history there is not this PR's job — flagging it so the next reader does not trust it.

## Checks run locally

- `pytest tests/unit tests/integration` — 2279 passed, 2 skipped
- `npm test` — 773 passed
- `ruff format --check` and `ruff check` — clean

Closes #2623

🤖 Generated with [Claude Code](https://claude.com/claude-code)