### PR TITLE
fix(game): clear the deferred-deadline flag in RoundManager.reset()

### DIFF
--- a/custom_components/beatify/game/round_manager.py
+++ b/custom_components/beatify/game/round_manager.py
@@ -135,6 +135,15 @@ class RoundManager:
         self.intro_stopped = False
         self._intro_round_start_time = None
         self._intro_splash_pending = False
+        # #2615: the deferral is per-round state like the splash flag above,
+        # so it must not survive into the next game. It is otherwise cleared
+        # only by start_timer_at_playback and confirm_intro_splash, and a game
+        # ended while either was still outstanding (TTS announcements running,
+        # or an unconfirmed intro splash) leaves it True. is_deadline_passed()
+        # then answers False for every round of the next game, which silently
+        # disables force_end_round_if_overdue, the client round watchdogs and
+        # the late-guess guard in handle_submit.
+        self._deadline_deferred = False
         self._intro_splash_shown = False
         self._intro_splash_deferred_song = None
         self._rounds_since_intro = 0

--- a/tests/unit/test_round_timer_deferral_2543.py
+++ b/tests/unit/test_round_timer_deferral_2543.py
@@ -99,3 +99,44 @@ class TestAnnouncementBudgetSurvivesTheRestamp:
         rm.cancel_timer()
 
         assert rm.deadline == int(now * 1000) + 15_000
+
+
+class TestResetClearsTheDeferral:
+    """#2615: a deferral must not leak from one game into the next."""
+
+    def test_reset_clears_a_standing_deferral(self):
+        rm = _make_rm()
+        rm.defer_deadline()
+
+        rm.reset()
+
+        assert rm._deadline_deferred is False
+
+    def test_reset_clears_the_deferral_of_an_unconfirmed_splash(self):
+        rm = _make_rm()
+        rm._intro_splash_pending = True
+        rm.defer_deadline()
+
+        rm.reset()
+
+        assert rm._intro_splash_pending is False
+        assert rm._deadline_deferred is False
+
+    def test_next_game_still_sees_its_own_deadline_pass(self):
+        """The failure the leak causes: game B never reports a passed deadline."""
+        now = 1_000_000.0
+        rm = RoundManager(lambda: now)
+        rm.round_duration = 15
+
+        # Game A: TTS round, announcements still running, host ends the game
+        # while an intro splash is open — neither start_timer_at_playback nor
+        # confirm_intro_splash ever runs, so the deferral is still standing.
+        rm._intro_splash_pending = True
+        rm.defer_deadline()
+        rm.reset()
+
+        # Game B: no TTS, no intro splash. A plain round whose deadline has
+        # long passed must be reported as passed.
+        rm.deadline = int((now - 30) * 1000)
+
+        assert rm.is_deadline_passed() is True


### PR DESCRIPTION
Blattplan 2026-W38.

## The bug

`defer_deadline()` sets `_deadline_deferred` (`game/round_manager.py`), and only two methods ever clear it again: `start_timer_at_playback()` and `confirm_intro_splash()`. `reset()` clears every other piece of per-round state — including the sibling `_intro_splash_pending` — but never touched this one.

So a deferral taken out in one game can outlive it. Game A uses TTS; round 3 is an intro-splash round, the splash is still open, and the host ends the game. Neither clearing path runs, and `reset()` leaves the flag `True`. Game B runs without TTS and without a splash, so nothing ever clears it.

`is_deadline_passed()` short-circuits to `False` while the flag is set. For every round of game B it therefore answers `False`, which silently switches off three safety nets at once:

- `force_end_round_if_overdue` — the server backstop that catches a crashed timer task, so a frozen round stays frozen
- the client-side round watchdogs (`handle_round_timeout` gates on `is_deadline_passed`)
- the late-guess guard in `handle_submit` — guesses are accepted after the deadline

## The fix

Reset `_deadline_deferred` in `reset()`, right next to `_intro_splash_pending`, with a comment explaining why it belongs there.

## Regression test

`tests/unit/test_round_timer_deferral_2543.py` covered the two clearing paths but neither `reset()` nor the transition between two games, so three cases were added in a `TestResetClearsTheDeferral` class: a plain reset, a reset with an unconfirmed splash, and the cross-game transition from the report — game A defers with a splash open, `reset()`, then game B asks about a long-passed deadline.

**Counter-check.** With the one-line fix reverted and the tests kept, all three fail:

```
FAILED ...::TestResetClearsTheDeferral::test_reset_clears_a_standing_deferral
FAILED ...::TestResetClearsTheDeferral::test_reset_clears_the_deferral_of_an_unconfirmed_splash
FAILED ...::TestResetClearsTheDeferral::test_next_game_still_sees_its_own_deadline_pass
3 failed, 6 passed
```

The transition case fails on `assert rm.is_deadline_passed() is True` → `assert False is True`, which is the reported symptom exactly. With the fix restored: `9 passed`.

## Checks

- `python3 -m ruff format --check .` — 209 files already formatted
- `python3 -m ruff check .` — all checks passed
- `pytest tests/unit tests/integration -q` — 2286 passed, 2 skipped
- `npm test` — 776 passed (80 files)
- `npm run build:check` — all 18 artifacts match source

Closes #2615

🤖 Generated with [Claude Code](https://claude.com/claude-code)