### PR TITLE
fix(game): reset the consecutive playback-failure budget between games

### DIFF
--- a/custom_components/beatify/game/state_setup.py
+++ b/custom_components/beatify/game/state_setup.py
@@ -273,6 +273,13 @@ class GameSetupMixin:
 
         # Reset error detail
         self.last_error_detail = ""
+        # #2614: the #1936 consecutive-timeout budget belongs to ONE game.
+        # It is not config-managed, so nothing above clears it — and
+        # create_game does not route through _reset_game_internals. Without
+        # this line a game that ended two timeouts deep hands the next game a
+        # budget of one: a single slow start in round 1 pauses it with the
+        # re-authenticate banner instead of skipping the song.
+        self._consecutive_playback_failures = 0
 
         self._playlist_manager = playlist_manager
 
@@ -405,6 +412,13 @@ class GameSetupMixin:
         # auto-advance and double-scoring the round on host-advance.
         self._title_artist_voting_open = False
         self._title_artist_vote_deadline = None
+
+        # #2614: same story for the #1936 consecutive-playback-failure streak.
+        # It is round-start retry state, not a config field, so _apply_config
+        # leaves it alone. Clearing it here covers both teardown paths at once
+        # — end_game and rematch_game — which is exactly what this shared
+        # reset exists for.
+        self._consecutive_playback_failures = 0
 
         # Issue #351: Reset power-up state
         self._powerup_manager.reset()

--- a/tests/unit/test_failure_counter_reset_2614.py
+++ b/tests/unit/test_failure_counter_reset_2614.py
@@ -1,0 +1,127 @@
+"""The consecutive playback-failure budget must not leak across games (#2614).
+
+``_consecutive_playback_failures`` is the #1936 budget: the first timeouts in a
+row skip the song silently, and only ``MAX_CONSECUTIVE_PLAYBACK_FAILURES`` of
+them in a row mean "systemic" and pause the game with the re-authenticate
+banner. The counter was cleared on a confirmed start and when the budget was
+spent, but by no lifecycle boundary — so a game that ended two timeouts deep
+handed the next game a budget of one, and a single slow start in its round 1
+ended the evening for a provider that was working.
+
+These tests pin the reset at all three boundaries that mint a new game
+identity (``create_game`` / ``end_game`` / ``rematch_game``), plus the
+behavior the host actually notices.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.beatify.const import MAX_CONSECUTIVE_PLAYBACK_FAILURES
+from tests.conftest import make_game_state, make_songs
+
+
+def _stub_media_service() -> MagicMock:
+    svc = MagicMock()
+    svc.is_available.return_value = True
+    svc.last_failure_reason = "error"
+    svc.last_attempted_uri = "apple_music://track/1122776156"
+    svc.play_song = AsyncMock(return_value=True)
+    svc.stop = AsyncMock(return_value=True)
+    svc.restore_volume = AsyncMock(return_value=True)
+    svc.restore_queue = AsyncMock(return_value=True)
+    return svc
+
+
+def _make_game():
+    """A created game wired to a stub speaker, ready for start_round()."""
+    gs = make_game_state()
+    gs.create_game(
+        playlists=["test.json"],
+        songs=make_songs(30),
+        media_player="media_player.esszimmer",
+        base_url="http://localhost:8123",
+    )
+    gs._media_player_service = _stub_media_service()
+    gs.media_player = "media_player.esszimmer"
+    gs.platform = "music_assistant"
+    return gs
+
+
+# --------------------------------------------------------- the three boundaries
+
+
+def test_create_game_clears_the_streak() -> None:
+    gs = _make_game()
+    gs._consecutive_playback_failures = MAX_CONSECUTIVE_PLAYBACK_FAILURES - 1
+
+    gs.create_game(
+        playlists=["test.json"],
+        songs=make_songs(30),
+        media_player="media_player.esszimmer",
+        base_url="http://localhost:8123",
+    )
+
+    assert gs._consecutive_playback_failures == 0
+
+
+@pytest.mark.asyncio
+async def test_end_game_clears_the_streak() -> None:
+    gs = _make_game()
+    gs._consecutive_playback_failures = MAX_CONSECUTIVE_PLAYBACK_FAILURES - 1
+
+    await gs.end_game()
+
+    assert gs._consecutive_playback_failures == 0
+
+
+def test_rematch_game_clears_the_streak() -> None:
+    gs = _make_game()
+    gs._consecutive_playback_failures = MAX_CONSECUTIVE_PLAYBACK_FAILURES - 1
+
+    gs.rematch_game()
+
+    assert gs._consecutive_playback_failures == 0
+
+
+# ------------------------------------------------------------ what the host sees
+
+
+@pytest.mark.asyncio
+async def test_a_finished_game_does_not_shorten_the_next_games_budget() -> None:
+    """Game A ended two timeouts deep; one timeout in game B must still skip.
+
+    This is the report in #2614: the host ends a game whose last two songs
+    timed out, starts a fresh one, and round 1 pauses on the re-authenticate
+    banner after a single slow start instead of moving to the next song.
+    """
+    gs = _make_game()
+    # Game A limps to its end one timeout short of the budget.
+    gs._consecutive_playback_failures = MAX_CONSECUTIVE_PLAYBACK_FAILURES - 1
+    await gs.end_game()
+
+    # Game B — a fresh session on the same GameState.
+    gs.create_game(
+        playlists=["test.json"],
+        songs=make_songs(30),
+        media_player="media_player.esszimmer",
+        base_url="http://localhost:8123",
+    )
+    svc = _stub_media_service()
+    # Round 1 times out once, the next song plays.
+    svc.play_song = AsyncMock(side_effect=[False, True])
+    gs._media_player_service = svc
+    gs.media_player = "media_player.esszimmer"
+    gs.platform = "music_assistant"
+    gs.pause_game = AsyncMock()
+
+    with patch(
+        "custom_components.beatify.game.state.asyncio.sleep",
+        new_callable=AsyncMock,
+    ):
+        await gs.start_round()
+
+    gs.pause_game.assert_not_awaited()
+    assert svc.play_song.await_count == 2


### PR DESCRIPTION
Blattplan 2026-W38.

## The bug

`_consecutive_playback_failures` is the #1936 budget: the first playback timeouts in a row skip the song silently, and only `MAX_CONSECUTIVE_PLAYBACK_FAILURES` (3) of them in a row count as systemic and pause the game with the re-authenticate banner.

The counter was cleared in exactly two places, both inside `_start_round_locked` — on a confirmed start, and once the budget was spent. No lifecycle boundary touched it. So a game that ended two timeouts deep handed the next game a budget of one: a single slow start in round 1 of game B reached 3, and the host got the re-authenticate banner for a provider that was working, instead of the silent skip #1936 was written for.

## Where the reset belongs, and why there

The counter now goes back to zero at the three boundaries that mint a new game identity — the same three places that already bump `_game_epoch`:

- **`_reset_game_internals`** — the shared field reset that `end_game` and `rematch_game` both route through. Its whole purpose (per its #108/#464 docstring) is that the two teardown paths can never drift, so one line there covers both and covers any third teardown path added later.
- **`create_game`** — which deliberately does *not* route through `_reset_game_internals`; it builds a session from scratch and clears its non-config runtime fields inline. The precedent is right above it: the #1359 title/artist vote-window flags are reset in both places for exactly this reason. Without the `create_game` line, any path that stands a game up without an intervening `end_game` (crash recovery, a force-reset that leaves `GameState` alive) still inherits the streak.

Two places it deliberately does **not** go:

- **`GameStateConfig` / `_apply_config`** — that dataclass is the admin-facing config surface. This is transient round-start retry state, not a setting; putting it there would widen the config contract and drag it into serialization for no gain.
- **`start_game`** — it would catch most cases, but it leaves a stale value sitting on the object through the whole LOBBY, and it is the wrong concept: the budget belongs to the game session, not to the moment the host presses Start.

`game/state_lifecycle.py` is untouched — the increment and the two existing resets there are correct as they stand.

## Regression test — red/green counter-check

New file `tests/unit/test_failure_counter_reset_2614.py`: one test per boundary plus one behavioral test that replays the report (game A ends at 2, game B round 1 times out once → must skip, not pause).

Verified in both directions, as required:

- **Fix reverted** (`git stash` on `state_setup.py`): `4 failed`. The behavioral test fails with `Expected mock to not have been awaited. Awaited 1 times.` and the log line `Playback failed … pausing game` — i.e. it reproduces the exact user-visible symptom, not just the counter value.
- **Fix restored**: `4 passed`.

## Checks

| Check | Result |
|---|---|
| `python3 -m ruff format --check .` | 210 files already formatted |
| `python3 -m ruff check .` | All checks passed |
| `pytest tests/unit tests/integration -q` | 2287 passed, 2 skipped |
| `npm test` | 80 files, 776 tests passed |
| `npm run build:check` | all 18 artifacts match source |

Closes #2614

🤖 Generated with [Claude Code](https://claude.com/claude-code)
