### PR TITLE
chore(lights): remove PartyLightsService.strobe, which no game phase calls

### DIFF
--- a/custom_components/beatify/services/lights.py
+++ b/custom_components/beatify/services/lights.py
@@ -203,9 +203,8 @@ class PartyLightsService:
         """Build the service data (color + intensity-adjusted brightness) for a phase.
 
         Single source of truth for the subtle/intensity brightness logic so that
-        set_phase() and the flash()/strobe() restore paths all agree — in subtle
-        mode they must restore to the gentle pre-game level, not full brightness
-        (#1389).
+        set_phase() and the flash() restore path agree — in subtle mode they
+        must restore to the gentle pre-game level, not full brightness (#1389).
         """
         phase_data = PHASE_COLORS.get(phase_name)
         if not phase_data:
@@ -329,29 +328,6 @@ class PartyLightsService:
                 await asyncio.sleep(interval)
         except asyncio.CancelledError:
             pass
-
-    async def strobe(self, count: int = 5, interval: float = 0.4) -> None:
-        """Rapid on/off strobe for countdown tension (#517)."""
-        for _ in range(count):
-            if not self._active:
-                break
-            await self._apply(
-                self._entity_ids,
-                {"rgb_color": [255, 0, 0], "brightness": 255},
-                transition=0.05,
-            )
-            await asyncio.sleep(interval / 2)
-            await self._apply(
-                self._entity_ids,
-                {"brightness": 10},
-                transition=0.05,
-            )
-            await asyncio.sleep(interval / 2)
-        # Restore phase color at the intensity-adjusted brightness (#1389) — in
-        # subtle mode this restores the gentle pre-game level, not full brightness.
-        restore_data = self._phase_service_data(self._current_phase or "")
-        if restore_data is not None:
-            await self._apply(self._entity_ids, restore_data, transition=0.3)
 
     async def celebrate(self) -> None:
         """Rainbow cycle celebration for ~5 seconds."""

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/markusholzhauser/Development/Beatify/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/markusholzhauser/Development/Beatify/node_modules

--- a/tests/unit/test_lights.py
+++ b/tests/unit/test_lights.py
@@ -650,12 +650,12 @@ class TestFlash:
 
 
 # ---------------------------------------------------------------------------
-# subtle-mode restore (flash / strobe) — #1389
+# subtle-mode restore (flash) — #1389
 # ---------------------------------------------------------------------------
 
 
 class TestSubtleRestore:
-    """flash() and strobe() must restore the subtle (pre-game) brightness, not full."""
+    """flash() must restore the subtle (pre-game) brightness, not full."""
 
     @staticmethod
     def _subtle_hass():
@@ -693,7 +693,8 @@ class TestSubtleRestore:
         assert restore_call[0][2]["rgb_color"] == [0, 100, 255]
 
     @pytest.mark.asyncio
-    async def test_strobe_restores_subtle_brightness_not_full(self):
+    async def test_flash_restores_subtle_brightness_in_reveal_phase(self):
+        """REVEAL has a 0.4 offset and no rgb_color — restore must honour both."""
         hass = self._subtle_hass()
         svc = PartyLightsService(hass)
         await svc.start(["light.living_room"], intensity="subtle")
@@ -701,7 +702,7 @@ class TestSubtleRestore:
         hass.services.async_call.reset_mock()
 
         with patch("asyncio.sleep", new_callable=AsyncMock):
-            await svc.strobe(count=2, interval=0.1)
+            await svc.flash("red")
 
         # REVEAL raw brightness is 204 (full). Subtle restore must be
         # base (100) + 40% of 255 (102) = 202, NOT 204.
@@ -709,37 +710,7 @@ class TestSubtleRestore:
         restore_call = hass.services.async_call.call_args_list[-1]
         assert restore_call[0][2]["brightness"] == expected
         assert restore_call[0][2]["brightness"] != 204
-
-    @pytest.mark.asyncio
-    async def test_strobe_restores_phase_color_in_medium_mode(self):
-        # Regression: non-subtle restore still applies the raw phase color.
-        hass = _make_hass()
-        svc = PartyLightsService(hass)
-        await svc.start(["light.living_room"], intensity="medium")
-        svc._current_phase = "PLAYING"
-        hass.services.async_call.reset_mock()
-
-        with patch("asyncio.sleep", new_callable=AsyncMock):
-            await svc.strobe(count=2, interval=0.1)
-
-        restore_call = hass.services.async_call.call_args_list[-1]
-        assert restore_call[0][2]["rgb_color"] == [0, 100, 255]
-        assert restore_call[0][2]["brightness"] == 153
-
-    @pytest.mark.asyncio
-    async def test_strobe_without_phase_does_not_restore(self):
-        hass = _make_hass()
-        svc = PartyLightsService(hass)
-        await svc.start(["light.living_room"])
-        svc._current_phase = None
-        hass.services.async_call.reset_mock()
-
-        with patch("asyncio.sleep", new_callable=AsyncMock):
-            await svc.strobe(count=1, interval=0.1)
-
-        # Two strobe applies (on + dim), no restore call with rgb_color.
-        for call in hass.services.async_call.call_args_list:
-            assert call[0][2].get("rgb_color") != [0, 100, 255]
+        assert restore_call[0][2]["color_temp_kelvin"] == 3000
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Blattplan 2026-W38.

`services/lights.py` implemented `strobe()` for the countdown effect from #517, but no game phase ever triggered it. Only three restore tests in `tests/unit/test_lights.py` called it, and the restore block at its end was a copy of the end of `flash()` — two code paths for the same #1389 behaviour, one of them alive only for its own tests.

**What changed:** `strobe()` is gone (23 lines), and so are the three tests that only exercised it. Net −61/+8 lines across the two files. The docstring of `_phase_service_data()` no longer names `strobe()` as a caller.

## Verified independently, not taken from the issue

I searched for Python callers, service registrations and plain strings, since a dead method can still be reachable by name:

```
$ grep -rnE "\.(flash|strobe)\(" custom_components --include='*.py'
custom_components/beatify/game/state_media.py:184:  task = asyncio.create_task(self._party_lights.flash(color))
```

`flash()` has exactly one production caller; `strobe()` has none.

```
$ grep -rn "strobe" --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=.venv .
```

Before this change: the definition in `services/lights.py:333`, the `flash()/strobe()` mention in the `_phase_service_data()` docstring, and eight lines in `tests/unit/test_lights.py`. Nothing else.

```
$ grep -rniE "strobe" --include='*.js' --include='*.ts' --include='*.html' \
    --include='*.yaml' --include='*.yml' --include='*.json' --exclude-dir=node_modules .
```

Hits only in `playlists/community/edm-anthems.json` — deadmau5' track "Strobe" and Kaskade's album "Strobelite Seduction". No frontend code, no WebSocket command name, no YAML.

```
$ grep -rn "async_register" custom_components --include='*.py'
```

Only `async_register_static_paths` and `async_register_built_in_panel`. The integration has no `services.yaml` and registers no `hass.services` call at all, so there is no service-layer entry point either.

## The #1389 assurance: one test moved, two deleted as duplicates

This was the part worth checking carefully. The three deleted tests were not equal in value:

- `test_strobe_restores_subtle_brightness_not_full` covered `_current_phase = "REVEAL"` in subtle mode. REVEAL is the only phase with a 0.4 subtle offset **and** `color_temp_kelvin` instead of `rgb_color`, and no `flash()` test covered it — the subtle flash test uses PLAYING (0.2, rgb), the END test uses medium mode. **That assurance moves rather than disappears:** it is now `test_flash_restores_subtle_brightness_in_reveal_phase`, calling `flash("red")`, asserting the same 202-not-204 brightness plus `color_temp_kelvin == 3000`.
- `test_strobe_restores_phase_color_in_medium_mode` asserted PLAYING/medium restore is `rgb_color [0, 100, 255]` at brightness 153 — the identical assertion already stands in `test_flash_gold_sends_color_and_restores`.
- `test_strobe_without_phase_does_not_restore` asserted no restore when `_current_phase is None` — already covered by `test_flash_without_phase_does_not_restore`, which additionally pins the call count at 1.

So #1389 keeps its coverage, and gains a REVEAL case on the path that actually runs in production.

## Deliberately left in place

`server/ws_handlers/admin.py:108-110` registers `set_party_lights`, `toggle_party_lights` and `stop_lights`, which no client currently sends. That is #2649, an open proposal to give the host a light button during the game — **not an oversight in this PR**. Those actions are needed if #2649 is built; `strobe()` would not be, because no button should fire a strobe.

## Checks

- `python3 -m ruff format --check .` — 209 files already formatted
- `python3 -m ruff check .` — all checks passed
- `pytest tests/unit tests/integration -q` — 2281 passed, 2 skipped
- `npm test` — 776 passed in 80 files
- `npm run build:check` — all 18 artifacts match source

Closes #2633

🤖 Generated with [Claude Code](https://claude.com/claude-code)