### PR TITLE
fix(media-player): confirm playback by content id, not title alone

### DIFF
--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -238,6 +238,36 @@ def _artist_matches(expected_artist: str, media_artist: str) -> bool:
     return bool(_title_tokens(expected_artist) & _title_tokens(media_artist))
 
 
+def _content_id_advanced(
+    content_id: str, content_id_before: str, match_tokens: list[str]
+) -> bool:
+    """True when media_content_id proves the REQUESTED track is now loaded (#2616).
+
+    `media_title` is not a track identity. Two different songs can share one
+    title — round N plays "Hello" (Adele), round N+1 draws "Hello" (Lionel
+    Richie) — and the title-must-change invariant (#2333/#795) then reads a
+    perfectly successful switch as "the speaker never left the prior track".
+
+    `media_content_id` IS an identity, and `_uri_match_tokens` already knows
+    how to recognise our URI inside it (#1380). Two conditions, both required:
+
+      * the id contains a token of the URI we just asked for — so an unrelated
+        auto-advance of the prior queue cannot qualify, and
+      * the id differs from the one playing before the call — so the #2333
+        failure (MA never switched, prior track keeps running) still cannot
+        qualify, not even when the prior round happened to play this same URI.
+
+    Anything the speaker does not report (`media_content_id` missing on this
+    platform) yields False and leaves the title comparison in sole charge, as
+    before.
+    """
+    if not content_id or not match_tokens:
+        return False
+    if content_id == content_id_before:
+        return False
+    return any(token in content_id for token in match_tokens)
+
+
 # Timeout for waiting for metadata to update after playing (seconds)
 # Wait up to 2s for MA to push fresh metadata (album art, etc.) after a
 # playback transition. Reduced from 5s — that earlier value was the
@@ -1207,9 +1237,18 @@ class MediaPlayerService:
             position_updated_before = state_before.attributes.get(
                 "media_position_updated_at"
             )
+            # #2616: the title alone cannot tell "same song still playing"
+            # apart from "different song, same title". The content id can.
+            content_id_before = state_before.attributes.get("media_content_id") or ""
         else:
             title_before = ""
             position_updated_before = None
+            content_id_before = ""
+
+        # #2616: the substrings that identify THIS uri inside MA's
+        # media_content_id — the same tokens wait_for_metadata_update matches
+        # on (#1380).
+        match_tokens = self._uri_match_tokens(uri)
 
         # #2143: remember the host's own queue BEFORE the replace below wipes
         # it. Idempotent, so this only costs a get_queue call in round one.
@@ -1325,10 +1364,24 @@ class MediaPlayerService:
                 # which is the cold-start case and genuinely a change.
                 title_changed = current_title != title_before
 
+                # #2616: a changed title is sufficient proof of a new track,
+                # but it is not necessary. Two different songs can carry the
+                # same title ("Hello" by Adele, then "Hello" by Lionel
+                # Richie), and #2333's title check then rejects a switch that
+                # actually happened. `media_content_id` settles it: if it now
+                # carries the id of the URI we requested AND differs from what
+                # was loaded before, the speaker demonstrably moved to OUR
+                # track. The #2333 failure stays rejected — there MA never
+                # switched, so the content id never changes either.
+                content_id = state.attributes.get("media_content_id") or ""
+                track_changed = title_changed or _content_id_advanced(
+                    content_id, content_id_before, match_tokens
+                )
+
                 # Path 1: exact-ish title match (substring) — strongest signal,
                 # the only path strong enough to learn a preferred URI field.
                 if (
-                    title_changed
+                    track_changed
                     and expected_lower
                     and expected_lower in current_title.lower()
                 ):
@@ -1344,7 +1397,7 @@ class MediaPlayerService:
                 # title is plausibly our track (shared token / prefix) OR the
                 # artist matches. A bare "any different title" no longer
                 # qualifies — that is the prior-queue auto-advance trap.
-                if current_title and title_changed:
+                if current_title and track_changed:
                     if _titles_plausibly_match(
                         expected_title, current_title
                     ) or _artist_matches(expected_artist, current_artist):
@@ -1458,8 +1511,21 @@ class MediaPlayerService:
             if current_state
             else None
         )
+        content_id_after = (
+            (current_state.attributes.get("media_content_id") or "")
+            if current_state
+            else ""
+        )
         title_advanced = title_after != title_before
-        if not title_advanced:
+        # #2616: same reasoning as in the fast path — an unchanged title is
+        # only evidence of a stuck speaker when the content id has not moved
+        # to the track we asked for. Stopping the speaker here is what made
+        # the collision audible: the room heard the correct song for the full
+        # budget, then silence, then a different song.
+        track_advanced = title_advanced or _content_id_advanced(
+            content_id_after, content_id_before, match_tokens
+        )
+        if not track_advanced:
             position_changed = position_updated_after != position_updated_before
             # #808 follow-up: this is the storefront/region-mismatch
             # signature — MA accepted the URI but couldn't resolve a stream
@@ -1510,6 +1576,16 @@ class MediaPlayerService:
             # subset IS in their catalog.
             self.last_failure_reason = "unavailable"
             return False
+
+        if not title_advanced:
+            _LOGGER.debug(
+                "MA playback: title stayed %r for %s, but media_content_id "
+                "moved to %r — the requested track IS loaded, the two songs "
+                "merely share a title. Not a stale-title failure. (#2616)",
+                title_before,
+                uri,
+                content_id_after,
+            )
 
         # #1863: "still buffering" requires that Music Assistant actually owns
         # this player. An MA-platform entity reports the queue it is playing

--- a/tests/unit/test_ma_same_title_different_track_2616.py
+++ b/tests/unit/test_ma_same_title_different_track_2616.py
@@ -1,0 +1,227 @@
+"""Ein echter Trackwechsel darf nicht am gleichen Titel scheitern (#2616).
+
+Seit #2333 verlangen beide Bestaetigungswege in ``_check_state``, dass sich
+``media_title`` gegenueber dem Stand vor dem ``play_media``-Aufruf geaendert
+hat, und der Zweig nach dem Timeout wertet einen unveraenderten Titel als
+„Lautsprecher haengt auf dem alten Track": er ruft ``media_stop`` und meldet
+``unavailable``.
+
+Der Titel ist aber keine Identitaet. Runde N spielt „Hello" (Adele), Runde N+1
+zieht „Hello" (Lionel Richie). Music Assistant wechselt korrekt, ``media_title``
+bleibt „Hello" — und Beatify stoppt nach der vollen Wartezeit den Lautsprecher,
+markiert den Song als nicht verfuegbar und springt weiter. Im Raum hoert man
+15 Sekunden den richtigen Song, dann Stille, dann einen anderen.
+
+``media_content_id`` ist die Identitaet, und ``_uri_match_tokens`` erkennt
+unsere URI darin bereits (#1380) — ``wait_for_metadata_update`` nutzt genau
+das. ``_check_state`` hat es nie herangezogen.
+
+Die #2333-Invariante bleibt: dort wechselt MA gar nicht, also bewegt sich auch
+die content id nicht. Die Faelle stehen in
+``test_ma_path1_requires_title_change_2333.py`` und muessen gruen bleiben.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.beatify.services.media_player import MediaPlayerService
+from tests.unit.test_media_player import _make_hass, _make_state
+
+ADELE_URI = "spotify:track:1Yc9Q4KJPZa8bxJqQx7WYr"
+RICHIE_URI = "spotify:track:6Y1CnB7ZeF9EAVUCPQpaGF"
+
+
+async def _instant_timeout(awaitable=None, *_a, **_k):
+    """Die Wartezeit sofort ablaufen lassen — der Zweig nach dem Timeout."""
+    if awaitable is not None and asyncio.iscoroutine(awaitable):
+        awaitable.close()
+    raise asyncio.TimeoutError
+
+
+def _state_with_content_id(
+    content_id: str,
+    *,
+    state: str = "playing",
+    media_title: str = "Hello",
+    media_position: float = 5,
+    media_position_updated_at: str = "2020-01-01T00:00:00+00:00",
+) -> MagicMock:
+    """``_make_state`` plus die content id, die der Lautsprecher meldet."""
+    mock = _make_state(
+        state,
+        media_title=media_title,
+        media_position=media_position,
+        media_position_updated_at=media_position_updated_at,
+    )
+    mock.attributes["media_content_id"] = content_id
+    return mock
+
+
+class TestTitleCollisionBetweenRounds:
+    """„Hello" folgt auf „Hello" — zwei verschiedene Songs."""
+
+    @pytest.mark.asyncio
+    async def test_new_track_with_identical_title_confirms(self):
+        """Der Wechsel ist echt: die content id traegt die angeforderte URI."""
+        before = _state_with_content_id(
+            ADELE_URI,
+            media_title="Hello",
+            media_position=120,
+            media_position_updated_at="2020-01-01T00:00:00+00:00",
+        )
+        after = _state_with_content_id(
+            RICHIE_URI,
+            media_title="Hello",
+            media_position=2,
+            media_position_updated_at="2020-01-01T00:00:03+00:00",
+        )
+        hass = _make_hass("playing", media_title="Hello")
+        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        hass.states.get = MagicMock(side_effect=[before, after])
+
+        confirmed = await svc._try_ma_play(RICHIE_URI, "Hello", "Lionel Richie")
+
+        assert confirmed is True, (
+            "Gleicher Titel, andere content id — der Wechsel hat stattgefunden"
+        )
+        assert svc._last_confirm_path == 1
+        assert svc.last_failure_reason is None
+
+    @pytest.mark.asyncio
+    async def test_the_speaker_is_not_stopped_after_the_timeout(self):
+        """Der hoerbare Teil des Fehlers: nach der vollen Wartezeit rief
+        Beatify ``media_stop`` und meldete ``unavailable``. Hier steht die
+        angeforderte URI in der content id — der Lautsprecher spielt richtig
+        und muss weiterspielen."""
+        before = _state_with_content_id(
+            ADELE_URI,
+            media_title="Hello",
+            media_position=120,
+            media_position_updated_at="2020-01-01T00:00:00+00:00",
+        )
+        # Nach dem Timeout: richtiger Track, identischer Titel. Die Position
+        # steht noch, damit der schnelle Weg nicht schon vorher greift.
+        after = _state_with_content_id(
+            RICHIE_URI,
+            media_title="Hello",
+            media_position=120,
+            media_position_updated_at="2020-01-01T00:00:00+00:00",
+        )
+        hass = _make_hass("playing", media_title="Hello")
+        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        hass.states.get = MagicMock(side_effect=[before, after, after])
+
+        with patch(
+            "custom_components.beatify.services.media_player.asyncio.wait_for",
+            new=_instant_timeout,
+        ):
+            confirmed = await svc._try_ma_play(RICHIE_URI, "Hello", "Lionel Richie")
+
+        assert confirmed is True
+        assert svc.last_failure_reason != "unavailable"
+        stop_calls = [
+            call
+            for call in hass.services.async_call.call_args_list
+            if call.args[:2] == ("media_player", "media_stop")
+        ]
+        assert not stop_calls, (
+            "Beatify hat den Lautsprecher gestoppt, obwohl der richtige Song lief"
+        )
+
+
+class TestTheInvariantFrom2333StillHolds:
+    """Die content id darf den Titelvergleich nur ergaenzen, nie ersetzen."""
+
+    @pytest.mark.asyncio
+    async def test_prior_track_still_playing_is_still_rejected(self):
+        """#2333: MA wechselt nicht, der Vorgaenger laeuft weiter. Titel und
+        content id stehen beide — keine Bestaetigung ueber Weg 1."""
+        before = _state_with_content_id(
+            ADELE_URI,
+            media_title="Stay With Me",
+            media_position=120,
+            media_position_updated_at="2020-01-01T00:00:00+00:00",
+        )
+        still_playing = _state_with_content_id(
+            ADELE_URI,
+            media_title="Stay With Me",
+            media_position=126,
+            media_position_updated_at="2020-01-01T00:00:06+00:00",
+        )
+        hass = _make_hass("playing", media_title="Stay With Me")
+        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        hass.states.get = MagicMock(side_effect=[before, still_playing, still_playing])
+
+        with patch(
+            "custom_components.beatify.services.media_player.asyncio.wait_for",
+            new=_instant_timeout,
+        ):
+            confirmed = await svc._try_ma_play(RICHIE_URI, "Stay", "Rihanna")
+
+        assert confirmed is False
+        assert svc._last_confirm_path != 1
+        assert svc.last_failure_reason == "unavailable"
+
+    @pytest.mark.asyncio
+    async def test_a_foreign_content_id_does_not_confirm(self):
+        """Die alte Warteschlange schaltet auf einen fremden Track weiter: die
+        content id bewegt sich, traegt aber nicht unsere URI. Der Titel bleibt
+        gleich (Namensgleichheit auch hier) — das darf nicht reichen."""
+        foreign = "spotify:track:0000000000000000000000"
+        before = _state_with_content_id(
+            ADELE_URI,
+            media_title="Hello",
+            media_position=120,
+            media_position_updated_at="2020-01-01T00:00:00+00:00",
+        )
+        auto_advanced = _state_with_content_id(
+            foreign,
+            media_title="Hello",
+            media_position=3,
+            media_position_updated_at="2020-01-01T00:00:03+00:00",
+        )
+        hass = _make_hass("playing", media_title="Hello")
+        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        hass.states.get = MagicMock(side_effect=[before, auto_advanced, auto_advanced])
+
+        with patch(
+            "custom_components.beatify.services.media_player.asyncio.wait_for",
+            new=_instant_timeout,
+        ):
+            confirmed = await svc._try_ma_play(RICHIE_URI, "Hello", "Lionel Richie")
+
+        assert confirmed is False
+        assert svc._last_confirm_path != 1
+
+    @pytest.mark.asyncio
+    async def test_a_speaker_without_content_id_is_unaffected(self):
+        """Meldet die Plattform keine content id, entscheidet weiterhin allein
+        der Titelvergleich — der Stand von #2333, unveraendert."""
+        before = _make_state(
+            "playing",
+            media_title="Hello",
+            media_position=120,
+            media_position_updated_at="2020-01-01T00:00:00+00:00",
+        )
+        still_playing = _make_state(
+            "playing",
+            media_title="Hello",
+            media_position=126,
+            media_position_updated_at="2020-01-01T00:00:06+00:00",
+        )
+        hass = _make_hass("playing", media_title="Hello")
+        svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+        hass.states.get = MagicMock(side_effect=[before, still_playing, still_playing])
+
+        with patch(
+            "custom_components.beatify.services.media_player.asyncio.wait_for",
+            new=_instant_timeout,
+        ):
+            confirmed = await svc._try_ma_play(RICHIE_URI, "Hello", "Lionel Richie")
+
+        assert confirmed is False
+        assert svc.last_failure_reason == "unavailable"


### PR DESCRIPTION
Blattplan 2026-W38.

## The bug

Round N plays "Hello" (Adele). Round N+1 draws "Hello" (Lionel Richie). Music Assistant switches correctly, but `media_title` stays "Hello" — so Beatify waits out the full 15 second budget, calls `media_stop`, marks the song `unavailable` and moves on. The room hears the right song for 15 seconds, then silence, then a different one.

Two places cause it, both in `_try_ma_play`:

- `_check_state` requires `current_title != title_before` on both acceptance paths (#2333).
- The post-timeout branch treats `title_after == title_before` as "still on the prior track" and stops the speaker (#795/#801).

## Why #2333 stays

The title check was added for a real failure: round N plays "Stay With Me", round N+1 draws "Stay" whose URI is missing from the household's storefront, MA never switches, and `"stay" in "stay with me"` confirms success within a second. Worse, only a path-1 confirmation is strong enough to learn `_ma_preferred_uri_field`, so a false confirmation memorises the field that just played nothing and makes itself more likely for the rest of the session. `position_fresh` is no help — a track that keeps playing keeps advancing its own position.

So this PR does not weaken the title comparison. It adds a second, independent proof of a track change.

`media_content_id` is a track identity where `media_title` is not, and `_uri_match_tokens` already knows how to recognise our URI inside it (#1380) — `wait_for_metadata_update` matches on exactly those tokens. `_check_state` never consulted it.

## The change

A module-level `_content_id_advanced(content_id, content_id_before, match_tokens)` returns True only when **both** hold:

- the content id contains a token of the URI we just requested, so an unrelated auto-advance of the prior queue cannot qualify, and
- the content id differs from the one loaded before the call, so the #2333 case cannot qualify either — a speaker that never switched does not move its content id.

`_try_ma_play` snapshots `media_content_id` alongside `media_title` and builds the match tokens once. `_check_state` uses `track_changed = title_changed or _content_id_advanced(...)` in place of `title_changed`; the post-timeout branch uses the same OR before deciding to stop the speaker. Platforms that report no content id are untouched — the token match yields False and the title comparison stays in sole charge.

## Regression test, counter-checked

`tests/unit/test_ma_same_title_different_track_2616.py`, six cases:

- **the collision, fast path** — same title, content id carries the requested URI → confirms via path 1
- **the collision, post-timeout** — same title, content id carries the requested URI, position frozen → confirms and, the audible part, does **not** call `media_stop`
- **#2333 unchanged** — prior track still playing, title and content id both frozen → still rejected, `unavailable`, no path-1 learning
- **foreign auto-advance** — content id moves but does not carry our URI, title collides → still rejected
- **no content id reported** — behaviour identical to before the change

Counter-check run explicitly. With `custom_components/beatify/services/media_player.py` reverted to `origin/main` and the new test file in place: **2 failed, 7 passed** — the two collision cases fail (`assert False is True`, log line `speaker still on prior track 'Hello' … (#795)`), while all four `test_ma_path1_requires_title_change_2333.py` cases and the three guard cases stay green. With the fix restored: **9 passed**.

## Checks

- `python3 -m ruff format --check .` — 210 files already formatted
- `python3 -m ruff check .` — all checks passed
- `pytest tests/unit tests/integration -q` — 2288 passed, 2 skipped
- `npm test` — 776 passed (80 files)
- `npm run build:check` — all 18 artifacts match source

Closes #2616

🤖 Generated with [Claude Code](https://claude.com/claude-code)
