### PR TITLE
perf(stats): snapshot the store without deep-copying it on the event loop

### DIFF
--- a/custom_components/beatify/services/stats.py
+++ b/custom_components/beatify/services/stats.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import copy
 import json
 import logging
 import os
@@ -130,6 +129,41 @@ class StatsService:
             self._all_time_avg_cache = None
             await self.save()
 
+    def _snapshot(self) -> dict[str, Any]:
+        """
+        Return a save-stable view of the store, cheaply (#2642).
+
+        This used to be ``copy.deepcopy(self._stats)``. That reconstructs every
+        one of the (uncapped) per-song entries on the event loop thread: at a
+        realistic 8432 songs plus 500 games it costs ~29 ms on an M-series Mac
+        and 5-8x that on a Pi 4, every 30 seconds during a round, with
+        WebSocket broadcasts and round timers stalled for the duration.
+
+        Instead we shallow-copy only the four top-level containers. That is a
+        handful of pointer copies (~0.03 ms at the same size, ~1000x cheaper)
+        and it is enough, because the entries NESTED inside those containers are
+        treated as immutable: instead of editing a song or playlist entry in
+        place, ``record_song_result`` and ``record_game`` build an updated copy
+        and assign it over the old one. A snapshot therefore keeps referencing
+        the old entries, which nobody writes to any more.
+
+        **Contract for anyone touching this class:** the four top-level
+        containers below may be edited freely; anything nested deeper must be
+        replaced, never mutated. Breaking that rule reintroduces #1762 —
+        json.dumps iterating a container that changes under it in the executor —
+        and silently writes a torn state to disk.
+        """
+        stats = self._stats
+        return {
+            **stats,
+            # games entries are written once by record_game and never edited
+            # afterwards, so copying the list itself is sufficient.
+            "games": list(stats.get("games", [])),
+            "playlists": dict(stats.get("playlists", {})),
+            "all_time": dict(stats.get("all_time", {})),
+            "songs": dict(stats.get("songs", {})),
+        }
+
     async def save(self) -> None:
         """
         Persist stats to file with a crash-safe atomic write.
@@ -150,22 +184,19 @@ class StatsService:
                     self._stats_file.parent.mkdir, 0o755, True, True
                 )
 
-                # Take a REAL snapshot on the loop thread before dispatching to
-                # the executor. json.dumps runs in the executor while the loop
-                # keeps mutating self._stats (record_song_result mutates
-                # _stats["songs"] in place, record_game appends/deletes games),
-                # so handing over a live reference would let json.dumps iterate
-                # a dict that changes size — raising RuntimeError mid-serialize
-                # and leaving the batch unwritten (#1762, regression from
-                # #1708's debounce which makes the collision more likely). A
-                # deepcopy is bounded (MAX_DETAILED_GAMES games) and costs a few
-                # ms on the loop thread, cheaply buying the executor a stable,
-                # immutable view. The expensive json.dumps AND the file write
-                # still run together in the executor so neither blocks the loop
-                # (#1402).
+                # Take a snapshot on the loop thread before dispatching to the
+                # executor. json.dumps runs in the executor while the loop keeps
+                # recording rounds and games, so handing over a live reference
+                # would let json.dumps iterate a dict that changes size —
+                # raising RuntimeError mid-serialize and leaving the batch
+                # unwritten (#1762, regression from #1708's debounce which makes
+                # the collision more likely). _snapshot() gives the executor a
+                # stable view without the deepcopy that used to stall the loop
+                # (#2642). The expensive json.dumps AND the file write still run
+                # together in the executor so neither blocks the loop (#1402).
                 stats_path = self._stats_file
                 temp_path = stats_path.with_suffix(".json.tmp")
-                snapshot = copy.deepcopy(self._stats)
+                snapshot = self._snapshot()
 
                 def _serialize_and_write() -> None:
                     content = json.dumps(snapshot, indent=2)
@@ -339,10 +370,15 @@ class StatsService:
         # Add to games list
         self._stats["games"].append(game_entry)
 
-        # Update playlist stats
+        # Update playlist stats. Copy-on-write: work on a fresh dict and assign
+        # it back, so a snapshot handed to an in-flight save keeps seeing the
+        # old entry unchanged (#2642, see _snapshot).
         playlist_key = game_entry["playlist"]
-        if playlist_key not in self._stats["playlists"]:
-            self._stats["playlists"][playlist_key] = {
+        existing_playlist = self._stats["playlists"].get(playlist_key)
+        playlist_stats: dict[str, Any] = (
+            dict(existing_playlist)
+            if existing_playlist
+            else {
                 "times_played": 0,
                 "total_rounds": 0,
                 "avg_score_per_round": 0.0,
@@ -351,8 +387,8 @@ class StatsService:
                 "total_weighted_score": 0.0,
                 "total_weight": 0,
             }
-
-        playlist_stats = self._stats["playlists"][playlist_key]
+        )
+        self._stats["playlists"][playlist_key] = playlist_stats
         playlist_stats["times_played"] += 1
         playlist_stats["total_rounds"] += rounds
         # Maintain avg_score_per_round as a rounds*players-weighted mean,
@@ -369,7 +405,8 @@ class StatsService:
                 2,
             )
 
-        # Update all-time stats
+        # Update all-time stats. This one may be edited in place: all_time is a
+        # top-level container, so _snapshot() already copies it (#2642).
         all_time = self._stats["all_time"]
         all_time["games_played"] += 1
         # Maintain the running weighted score sum that backs all_time_avg, so
@@ -599,9 +636,15 @@ class StatsService:
         if "songs" not in self._stats:
             self._stats["songs"] = {}
 
-        # Initialize song entry if not exists
-        if song_key not in self._stats["songs"]:
-            self._stats["songs"][song_key] = {
+        # Copy-on-write: never edit the entry that is already in the store — an
+        # in-flight save may be serializing it in the executor. Build an updated
+        # copy and assign it over the old one (#2642, see _snapshot). The nested
+        # playlists map gets its own copy for the same reason.
+        existing_song = self._stats["songs"].get(song_key)
+        song: dict[str, Any] = (
+            dict(existing_song)
+            if existing_song
+            else {
                 "times_played": 0,
                 "correct_guesses": 0,
                 "total_guesses": 0,
@@ -615,8 +658,10 @@ class StatsService:
                 "playlists": {},  # playlist_name -> play_count
                 "last_played": 0,
             }
+        )
+        song["playlists"] = dict(song.get("playlists") or {})
+        self._stats["songs"][song_key] = song
 
-        song = self._stats["songs"][song_key]
         song["times_played"] += 1
         song["last_played"] = int(time.time())
 

--- a/tests/unit/test_stats.py
+++ b/tests/unit/test_stats.py
@@ -629,6 +629,19 @@ def _make_real_fs_service(stats_path) -> StatsService:
     return StatsService(mock_hass)
 
 
+def _make_threaded_executor_service(stats_path) -> StatsService:
+    """Like _make_real_fs_service, but executor jobs run on a REAL worker thread
+    so the event loop keeps running while the save serializes (#2642)."""
+    mock_hass = MagicMock()
+    mock_hass.config.path.return_value = str(stats_path)
+
+    async def _run_in_executor(fn, *args):
+        return await asyncio.get_running_loop().run_in_executor(None, fn, *args)
+
+    mock_hass.async_add_executor_job = _run_in_executor
+    return StatsService(mock_hass)
+
+
 class TestAtomicSave:
     """save() must write stats.json atomically (temp file + os.replace)."""
 
@@ -824,9 +837,12 @@ class TestSaveSnapshotIsolation:
         assert service._save_dirty is False
 
     @pytest.mark.asyncio
-    async def test_snapshot_is_deepcopy_not_reference(self, tmp_path):
-        """The object handed to json.dumps must be a distinct deepcopy, so
-        nested containers aren't shared with the live store (#1762)."""
+    async def test_snapshot_containers_are_not_shared_with_live_store(self, tmp_path):
+        """The object handed to json.dumps must not share the containers the
+        recording paths mutate (#1762). Since #2642 the leaf entries ARE shared
+        on purpose — the mutation sites replace them instead of editing them —
+        so what has to hold is that the snapshot's VALUE never changes, which
+        the copy-on-write tests below cover."""
         import json as _json
 
         stats_path = tmp_path / "beatify" / "stats.json"
@@ -848,11 +864,156 @@ class TestSaveSnapshotIsolation:
 
         snap = captured["obj"]
         assert snap is not service._stats
-        assert snap["songs"] is not service._stats["songs"]
-        assert snap["songs"]["s1"] is not service._stats["songs"]["s1"]
-        # Mutating the live store after the snapshot must not touch the copy.
-        service._stats["songs"]["s1"]["times_played"] = 999
+        for key in ("songs", "games", "playlists", "all_time"):
+            assert snap[key] is not service._stats[key]
+        # Adding/removing keys in the live store must not touch the snapshot.
+        service._stats["songs"]["s2"] = {"times_played": 5}
+        del service._stats["songs"]["s1"]
+        assert "s2" not in snap["songs"]
         assert snap["songs"]["s1"]["times_played"] == 1
+
+    @pytest.mark.asyncio
+    async def test_record_song_result_does_not_change_a_taken_snapshot(self, tmp_path):
+        """#2642 copy-on-write contract: recording further rounds for a song
+        that is already in the store must leave an outstanding snapshot — the
+        view an in-flight save is serializing — bit-for-bit unchanged."""
+        import json as _json
+
+        stats_path = tmp_path / "beatify" / "stats.json"
+        service = _make_real_fs_service(stats_path)
+
+        await service.record_song_result(
+            "spotify:track:abc",
+            [{"submitted": True, "years_off": 0}],
+            song_metadata={"title": "Song", "artist": "Artist", "year": 1999},
+            playlist_name="Party",
+        )
+
+        snap = service._snapshot()
+        before = _json.dumps(snap, sort_keys=True)
+
+        # Keep playing: same song (in-place update), same playlist (nested map),
+        # plus a brand-new song.
+        for _ in range(3):
+            await service.record_song_result(
+                "spotify:track:abc",
+                [{"submitted": True, "years_off": 7}],
+                song_metadata={"title": "Song", "artist": "Artist", "year": 1999},
+                playlist_name="Party",
+            )
+        await service.record_song_result(
+            "spotify:track:new",
+            [{"submitted": True, "years_off": 1}],
+            playlist_name="Party",
+        )
+
+        assert _json.dumps(snap, sort_keys=True) == before
+        # ...while the live store really did advance (nothing was lost).
+        live = service._stats["songs"]["spotify_track_abc"]
+        assert live["times_played"] == 4
+        assert live["playlists"]["Party"] == 4
+        assert "spotify_track_new" in service._stats["songs"]
+
+    @pytest.mark.asyncio
+    async def test_record_game_does_not_change_a_taken_snapshot(self, tmp_path):
+        """#2642 copy-on-write contract for the playlist and all_time entries
+        that record_game updates."""
+        import json as _json
+
+        stats_path = tmp_path / "beatify" / "stats.json"
+        service = _make_real_fs_service(stats_path)
+
+        summary = {
+            "playlist": "80s Hits",
+            "rounds": 10,
+            "player_count": 4,
+            "winner": "Ann",
+            "winner_score": 80,
+            "total_points": 200,
+        }
+        await service.record_game(dict(summary))
+
+        snap = service._snapshot()
+        before = _json.dumps(snap, sort_keys=True)
+
+        await service.record_game(dict(summary))
+
+        assert _json.dumps(snap, sort_keys=True) == before
+        assert service._stats["all_time"]["games_played"] == 2
+        assert service._stats["playlists"]["80s Hits"]["times_played"] == 2
+
+    @pytest.mark.asyncio
+    async def test_written_state_is_consistent_while_play_continues(self, tmp_path):
+        """The guarantee the snapshot exists for, exercised with a REAL executor
+        thread (#1762, #2642): while json.dumps runs off-loop, the loop keeps
+        recording rounds. The bytes that reach stats.json must be exactly the
+        store as it stood when the save started — no torn state, no crash."""
+        import json as _json
+        import threading
+
+        stats_path = tmp_path / "beatify" / "stats.json"
+        service = _make_threaded_executor_service(stats_path)
+
+        # Seed the entries the loop will touch mid-save.
+        await service.record_song_result(
+            "spotify:track:abc",
+            [{"submitted": True, "years_off": 0}],
+            song_metadata={"title": "Song", "artist": "Artist", "year": 1999},
+            playlist_name="Party",
+        )
+        service._stats["all_time"]["games_played"] = 3
+        service._stats["games"] = [{"id": f"g{i}"} for i in range(3)]
+
+        real_dumps = _json.dumps
+        expected = _json.loads(real_dumps(service._stats))
+
+        entered = threading.Event()
+        release = threading.Event()
+        captured: dict = {}
+
+        def _slow_dumps(obj, *args, **kwargs):
+            entered.set()
+            release.wait(10)
+            captured["content"] = real_dumps(obj, *args, **kwargs)
+            return captured["content"]
+
+        with patch(
+            "custom_components.beatify.services.stats.json.dumps",
+            side_effect=_slow_dumps,
+        ):
+            save_task = asyncio.create_task(service.save())
+
+            # Wait until the executor thread is parked inside json.dumps.
+            for _ in range(500):
+                if entered.is_set():
+                    break
+                await asyncio.sleep(0.01)
+            assert entered.is_set(), "executor never reached json.dumps"
+
+            # The party goes on while the write is in flight.
+            for _ in range(3):
+                await service.record_song_result(
+                    "spotify:track:abc",
+                    [{"submitted": True, "years_off": 7}],
+                    playlist_name="Party",
+                )
+            await service.record_song_result(
+                "spotify:track:new",
+                [{"submitted": True, "years_off": 2}],
+                playlist_name="Party",
+            )
+
+            release.set()
+            await save_task
+
+        assert save_task.exception() is None
+        # What the executor serialized, and what landed on disk, is the state
+        # from before those rounds — one coherent point in time.
+        assert _json.loads(captured["content"]) == expected
+        assert _json.loads(stats_path.read_text()) == expected
+        # And the rounds recorded mid-save are still in memory for the next save.
+        assert service._stats["songs"]["spotify_track_abc"]["times_played"] == 4
+        assert "spotify_track_new" in service._stats["songs"]
 
     @pytest.mark.asyncio
     async def test_serialize_runtimeerror_sets_dirty_for_retry(self, tmp_path):


### PR DESCRIPTION
Blattplan 2026-W38.

`StatsService.save()` took `copy.deepcopy(self._stats)` on the loop thread so the executor had a stable view to serialize. The comment claimed "a few ms". At a realistic store it is not a few ms, and it runs every 30 seconds during a round plus once at game end — WebSocket broadcasts and round timers are stalled for the whole copy.

## Measured

Same synthetic store as the issue (8432 songs, 500 games, 3.62 MB of JSON), median of 25 runs on an M-series Mac, timing the real `StatsService` code:

| | before (`copy.deepcopy`) | after (`_snapshot`) |
|---|---|---|
| 8432 songs / 500 games | **28.87 ms** | **0.029 ms** |
| 1000 songs / 120 games | **3.47 ms** | **0.0032 ms** |

About 1000x cheaper at both sizes. On a Pi 4, at 5-8x slower, the large case goes from roughly 150-230 ms of loop blocking per save to well under a millisecond.

## How

`_snapshot()` shallow-copies only the four top-level containers (`games`, `playlists`, `all_time`, `songs`) — a few thousand pointer copies instead of rebuilding every song dict.

That is only safe if nothing writes to the entries the snapshot still points at, so the two recording paths became copy-on-write: `record_song_result` and `record_game` now rebuild a song / playlist entry and assign it over the old one instead of editing it in place. `all_time` keeps its in-place update, because `_snapshot()` copies that container itself. The rule is stated in `_snapshot()`'s docstring: top-level containers may be edited freely, anything nested deeper must be replaced.

## Tests

The valuable test here is not "it is faster", it is "the guarantee still holds". `test_written_state_is_consistent_while_play_continues` runs the save with a real executor thread parked inside `json.dumps`, records four more rounds on the loop while it is parked (three updates to a song already in the store, plus a new song), and asserts that the bytes reaching `stats.json` are exactly the store as it stood when the save started — and that the mid-save rounds are still in memory for the next write. Two narrower tests pin the copy-on-write contract for each mutation site; all three fail if either site goes back to editing in place (verified by reverting them).

The old `test_snapshot_is_deepcopy_not_reference` asserted the implementation (every leaf is cloned) rather than the guarantee, so it was rewritten to assert what actually matters — the snapshot's value never changes.

## The unbounded songs map is NOT capped here — on purpose

The issue's second half asks for a cap on `songs`. I did not build one, because it is a product decision and not cleanup:

- Every song entry feeds `get_song_difficulty()` (the star rating players see) and `compute_song_stats()` (most played / hardest / easiest / per-playlist on the analytics dashboard). Evicting an entry silently resets that song's difficulty to "not enough data" and drops it out of the dashboard history. That is visible to the user and irreversible — unlike the games cap, whose contribution is folded into the `all_time` aggregates before the entry is dropped, so nothing is actually lost there. There is no equivalent aggregate for songs.
- The performance argument for a cap is now gone: the save path no longer scales with the number of songs on the loop. What is left is the 3.6 MB rewrite in the executor every 30 seconds, which is SD-card wear on a Pi, not a stall — a real concern, but a different one, and better solved by writing less often or writing only what changed than by deleting history.

If a cap is wanted, my suggestion for a follow-up would be a nameable rule rather than a plain LRU: keep the newest N by `last_played`, but evict only entries below `MIN_PLAYS_FOR_DIFFICULTY` first, so a song that earned a difficulty rating keeps it. At 8432 songs an N of 5000 would drop roughly the oldest 40% of rarely played songs, and those would lose their play history and their star rating for good. Worth a separate issue and an explicit yes.

Closes #2642

🤖 Generated with [Claude Code](https://claude.com/claude-code)
