### PR TITLE
perf(playlists): keep transient mixes out of the discovery walk

### DIFF
--- a/custom_components/beatify/game/playlist.py
+++ b/custom_components/beatify/game/playlist.py
@@ -1030,6 +1030,46 @@ def filter_songs_for_provider(
 # hass.data[DOMAIN] key holding the memoised discovery result (#1704).
 _DISCOVERY_CACHE_KEY = "_playlist_discovery_cache"
 
+# --- Transient smart-mix files (#1538 / #1547, excluded here since #2639) ----
+# The Smart Playlist Mixer writes one throwaway document per game start to
+# ``<playlist dir>/mix/__mix__-<uuid>.json`` and unlinks stale ones an hour
+# later. It is an implementation detail of a single start-game call, never
+# catalogue content — which is why the mixer itself already refuses to re-mix
+# one.
+#
+# #2639: it must therefore stay out of discovery altogether. Fingerprinting it
+# meant every mix write AND every cleanup unlink changed the signature, so the
+# start-game call that follows milliseconds later — the one that exists to reuse
+# the cached parse (#1766) — plus the 3 s lobby poll re-read, re-parsed and
+# re-validated the entire catalogue (66 files / 13 MB / 8.4k songs) while the
+# host was already looking at a spinner. Skipping these files keeps the
+# signature made of catalogue content only: a real add / edit / delete still
+# changes it and still invalidates, a mix no longer does. Skipping them from the
+# walk (rather than from the fingerprint alone) also keeps the transient
+# document out of the hub playlist list, where it used to appear as a
+# ``source: "bundled"`` playlist until cleanup.
+#
+# These constants live here, not in ``server/mix_views.py``, because that module
+# imports from this one — the reverse direction would be an import cycle.
+TRANSIENT_MIX_PREFIX = "__mix__"
+TRANSIENT_MIX_SUBDIR = "mix"
+
+
+def is_transient_mix(path: str | Path) -> bool:
+    """True if ``path`` points at a transient smart-mix file.
+
+    Matches on the ``mix/`` parent dir OR a ``__mix__``-prefixed filename so
+    EVERY uniquely-named transient mix (``__mix__-<uuid>.json``) is recognised,
+    not just the legacy fixed ``__mix__.json`` (#1547).
+    """
+    if not path:
+        return False
+    p = Path(path)
+    return p.parent.name == TRANSIENT_MIX_SUBDIR or p.name.startswith(
+        TRANSIENT_MIX_PREFIX
+    )
+
+
 # Signature entry per playlist file: (absolute path, mtime_ns, size). The whole
 # tuple of these — sorted, over every *.json under the playlist dir — is the
 # cache key. It changes on add / delete (path set changes) AND on in-place edit
@@ -1062,7 +1102,11 @@ def _discover_playlists_sync(
         return [], {}, empty_sig
 
     # Offload blocking glob to executor to avoid scandir in event loop (#516).
-    json_files = sorted(playlist_dir.glob("**/*.json"))
+    # Transient smart-mix files are skipped here so neither the signature nor
+    # the parsed result ever sees them (#2639, see ``is_transient_mix``).
+    json_files = sorted(
+        f for f in playlist_dir.glob("**/*.json") if not is_transient_mix(f)
+    )
 
     sig_parts: list[tuple[str, int, int]] = []
     for f in json_files:

--- a/custom_components/beatify/server/mix_views.py
+++ b/custom_components/beatify/server/mix_views.py
@@ -15,9 +15,10 @@ Design goals (kept deliberately minimal-invasive):
 * Transient mixes land in ``<config>/beatify/playlists/mix/__mix__-<uuid>.json``
   with a UNIQUE stem per run (so two parallel games never clobber each other —
   #1547) — they are an implementation detail, not a saved artefact. Stale
-  transient files are best-effort cleaned up on each write. The ``mix/`` folder
-  is treated as ``bundled`` by discovery (only ``community``/``user`` count as
-  community), so a transient mix never pollutes the Community tab.
+  transient files are best-effort cleaned up on each write. Discovery skips the
+  ``mix/`` folder entirely (#2639), so a transient mix neither shows up in the
+  playlist list nor churns the discovery cache; start-game reads the returned
+  path directly through its own cache-miss fallback.
 * When the host ticks "save as community playlist" the assembled set is instead
   persisted into ``user/<slug>.json`` (the same place ``SavePlaylistView`` uses)
   so ``async_discover_playlists`` surfaces it in the Community tab on refresh.
@@ -40,10 +41,13 @@ from homeassistant.components.http import HomeAssistantView
 from custom_components.beatify.const import PROVIDER_DEFAULT
 from custom_components.beatify.game.playlist import (
     MIN_YEAR,
+    TRANSIENT_MIX_PREFIX,
+    TRANSIENT_MIX_SUBDIR,
     _max_year,
     async_discover_playlists_detailed,
     get_playlist_directory,
     get_song_uri,
+    is_transient_mix,
     validate_playlist,
 )
 from custom_components.beatify.server.base import (
@@ -68,35 +72,14 @@ DEFAULT_TARGET_COUNT = 50
 # is far smaller).
 MAX_TAGS = 40
 
-# Filename-stem prefix for transient (non-saved) mixes. Each mix run gets a
-# UNIQUE stem (``__mix__-<short-uuid>.json``) so two games started in parallel
-# never clobber each other's transient file (#1547 — was a fixed
-# ``__mix__.json`` with last-writer-wins). Anything whose name starts with this
-# prefix — OR lives in the ``mix/`` subdir — is treated as a transient mix and
-# excluded from re-mixing / the Community tab.
-TRANSIENT_MIX_PREFIX = "__mix__"
-# Subdirectory (under the playlist dir) that holds transient mixes.
-TRANSIENT_MIX_SUBDIR = "mix"
+# Naming of transient mixes (``mix/__mix__-<uuid>.json``) lives in
+# ``game/playlist.py`` next to the discovery walk that has to skip it (#2639) —
+# this module imports it above and re-exports it for existing importers.
+#
 # Transient mixes older than this are removed on the next write. Must comfortably
 # exceed the POST /mix → start-game gap so a concurrent run's fresh file is never
 # cleaned out from under it (#1657).
 TRANSIENT_MIX_MAX_AGE_S = 3600
-
-
-def _is_transient_mix(path: str) -> bool:
-    """True if ``path`` points at a transient mix file.
-
-    Matches on the ``mix/`` parent dir OR a ``__mix__``-prefixed filename so
-    EVERY uniquely-named transient mix (``__mix__-<uuid>.json``) is recognised,
-    not just the legacy fixed ``__mix__.json``. Used to keep transient mixes out
-    of the re-mix source set (and, defensively, out of any name-based filter).
-    """
-    if not path:
-        return False
-    p = Path(path)
-    return p.parent.name == TRANSIENT_MIX_SUBDIR or p.name.startswith(
-        TRANSIENT_MIX_PREFIX
-    )
 
 
 def _assemble_mix_songs(
@@ -132,8 +115,10 @@ def _assemble_mix_songs(
         # Never re-mix a previous transient mix into a new one. Match on the
         # mix/ dir or the __mix__ prefix so EVERY uniquely-named transient file
         # is excluded, not just the legacy fixed __mix__.json (#1547).
+        # Defensive only since #2639 — discovery no longer returns transient
+        # mixes at all, so this can normally never match.
         path = meta.get("path") or ""
-        if _is_transient_mix(path):
+        if is_transient_mix(path):
             continue
 
         songs = songs_by_path.get(path)

--- a/tests/unit/test_mix_file_cache_2639.py
+++ b/tests/unit/test_mix_file_cache_2639.py
@@ -1,0 +1,227 @@
+"""A transient mix file must not invalidate the discovery cache (#2639).
+
+The Smart Playlist Mixer writes ``playlists/mix/__mix__-<uuid>.json`` right
+before start-game, and unlinks stale ones an hour later. Both events used to
+change the discovery signature, so the start-game call that follows — the one
+that exists to reuse the cached parse (#1766) — and the 3 s lobby poll re-read,
+re-parsed and re-validated the whole catalogue while the host waited on the
+Start tap.
+
+Discovery now skips transient mixes entirely. The second class of test here is
+the more important one: the fix must not be allowed to grow into "the signature
+ignores changes", so a real add, a real in-place edit and a real delete must all
+still invalidate.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest import mock
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.beatify.game import playlist as pl
+from custom_components.beatify.server.mix_views import (
+    TRANSIENT_MIX_PREFIX,
+    TRANSIENT_MIX_SUBDIR,
+)
+
+
+def _song(tag: str, year: int = 1985) -> dict:
+    return {
+        "artist": "Artist " + tag,
+        "title": "Song " + tag,
+        "year": year,
+        "uri": "spotify:track:" + tag.rjust(22, "0"),
+    }
+
+
+def _write(pdir: Path, filename: str, name: str, tags: list[str], songs) -> Path:
+    target = pdir / filename
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(
+            {
+                "name": name,
+                "version": "1.0",
+                "tags": tags,
+                "language": "en",
+                "author": "Tester",
+                "added_date": "2026-09-06",
+                "songs": songs,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return target
+
+
+def _fake_hass(pdir: Path):
+    """Minimal hass double with a REAL ``data`` dict so the cache survives."""
+    hass = MagicMock()
+    hass.config.path = MagicMock(return_value=str(pdir))
+    hass.data = {}
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *a: fn(*a))
+    return hass
+
+
+def _catalogue(tmp_path: Path) -> Path:
+    pdir = tmp_path / "beatify" / "playlists"
+    pdir.mkdir(parents=True)
+    _write(pdir, "80s.json", "80s", ["1980s", "pop"], [_song("0001"), _song("0002")])
+    _write(pdir, "90s.json", "90s", ["1990s", "pop"], [_song("0003", 1995)])
+    return pdir
+
+
+def _write_transient_mix(pdir: Path, stem: str = "a1b2c3d4") -> Path:
+    """Write a file exactly where MixPlaylistView writes its transient doc."""
+    return _write(
+        pdir,
+        f"{TRANSIENT_MIX_SUBDIR}/{TRANSIENT_MIX_PREFIX}-{stem}.json",
+        "Smart Mix · Pop",
+        ["pop"],
+        [_song("0001"), _song("0003", 1995)],
+    )
+
+
+class TestMixDoesNotInvalidate:
+    """The point of the fix: a mix write/delete leaves the cache intact."""
+
+    async def test_mix_write_and_cleanup_keep_the_cache_hot(self, tmp_path):
+        pdir = _catalogue(tmp_path)
+        hass = _fake_hass(pdir)
+
+        metas1, songs1 = await pl.async_discover_playlists_detailed(hass)
+
+        with mock.patch.object(
+            pl, "validate_playlist", wraps=pl.validate_playlist
+        ) as spy:
+            # 1. The mixer writes its transient document…
+            mix_file = _write_transient_mix(pdir)
+            metas2, songs2 = await pl.async_discover_playlists_detailed(hass)
+            assert spy.call_count == 0, "mix write forced a catalogue re-parse"
+            assert metas2 is metas1
+            assert songs2 is songs1
+
+            # 2. …and the hourly cleanup removes it again.
+            mix_file.unlink()
+            metas3, _ = await pl.async_discover_playlists_detailed(hass)
+            assert spy.call_count == 0, "mix cleanup forced a catalogue re-parse"
+            assert metas3 is metas1
+
+    async def test_transient_mix_is_not_listed_as_a_playlist(self, tmp_path):
+        """Side effect of the same bug: the mix showed up in the hub list as a
+        ``source: "bundled"`` playlist until cleanup an hour later."""
+        pdir = _catalogue(tmp_path)
+        hass = _fake_hass(pdir)
+        mix_file = _write_transient_mix(pdir)
+
+        metas, songs_by_path = await pl.async_discover_playlists_detailed(hass)
+
+        assert {m["filename"] for m in metas} == {"80s.json", "90s.json"}
+        assert str(mix_file) not in songs_by_path
+
+    async def test_end_to_end_mix_post_leaves_cache_intact(self, tmp_path):
+        """Same claim, but driving the real ``MixPlaylistView.post``."""
+        import asyncio
+
+        from aiohttp import StreamReader
+        from aiohttp.test_utils import make_mocked_request
+
+        from custom_components.beatify.server.mix_views import MixPlaylistView
+
+        pdir = _catalogue(tmp_path)
+        hass = _fake_hass(pdir)
+        view = MixPlaylistView(hass)
+
+        # Warm the cache the way the lobby poll does.
+        metas1, _ = await pl.async_discover_playlists_detailed(hass)
+
+        body = json.dumps(
+            {"tags": ["pop"], "target_count": 50, "provider": "spotify"}
+        ).encode()
+        reader = StreamReader(
+            mock.Mock(_reading_paused=False), 2**16, loop=asyncio.get_event_loop()
+        )
+        reader.feed_data(body)
+        reader.feed_eof()
+        request = make_mocked_request(
+            "POST",
+            "/beatify/api/playlists/mix",
+            headers={"Content-Type": "application/json"},
+            payload=reader,
+        )
+        with mock.patch(
+            "custom_components.beatify.server.mix_views.is_authorized_http",
+            new=MagicMock(return_value=True),
+        ):
+            resp = await view.post(request)
+        assert resp.status == 200
+        mix_path = Path(json.loads(resp.body)["path"])
+        assert mix_path.exists()
+
+        # The start-game discovery right after the mix must be a cache hit.
+        with mock.patch.object(
+            pl, "validate_playlist", wraps=pl.validate_playlist
+        ) as spy:
+            metas2, _ = await pl.async_discover_playlists_detailed(hass)
+        assert spy.call_count == 0
+        assert metas2 is metas1
+
+
+class TestRealChangesStillInvalidate:
+    """The guard: the fix must not blunt the signature for real content."""
+
+    async def test_new_playlist_still_invalidates(self, tmp_path):
+        pdir = _catalogue(tmp_path)
+        hass = _fake_hass(pdir)
+        await pl.async_discover_playlists_detailed(hass)
+
+        _write(pdir, "user/fresh.json", "Fresh", ["pop"], [_song("0009", 2001)])
+
+        metas = await pl.async_discover_playlists(hass)
+        assert "Fresh" in {m["name"] for m in metas}
+
+    async def test_new_playlist_next_to_a_mix_still_invalidates(self, tmp_path):
+        """The interesting ordering: a transient mix already sits in the dir
+        when the real playlist lands. Skipping the mix must not skip the walk."""
+        pdir = _catalogue(tmp_path)
+        hass = _fake_hass(pdir)
+        _write_transient_mix(pdir)
+        await pl.async_discover_playlists_detailed(hass)
+
+        _write(pdir, "user/fresh.json", "Fresh", ["pop"], [_song("0009", 2001)])
+
+        metas = await pl.async_discover_playlists(hass)
+        assert "Fresh" in {m["name"] for m in metas}
+
+    async def test_inplace_edit_still_invalidates(self, tmp_path):
+        pdir = _catalogue(tmp_path)
+        hass = _fake_hass(pdir)
+        _write_transient_mix(pdir)
+        await pl.async_discover_playlists_detailed(hass)
+
+        _write(
+            pdir,
+            "80s.json",
+            "80s",
+            ["1980s", "pop"],
+            [_song("0001"), _song("0002"), _song("0005")],
+        )
+
+        metas = await pl.async_discover_playlists(hass)
+        edited = next(m for m in metas if m["filename"] == "80s.json")
+        assert edited["song_count"] == 3
+
+    async def test_delete_still_invalidates(self, tmp_path):
+        pdir = _catalogue(tmp_path)
+        hass = _fake_hass(pdir)
+        _write_transient_mix(pdir)
+        await pl.async_discover_playlists_detailed(hass)
+
+        (pdir / "90s.json").unlink()
+
+        metas = await pl.async_discover_playlists(hass)
+        names = {m["filename"] for m in metas}
+        assert "90s.json" not in names, "delete did not invalidate the cache"
+        assert "80s.json" in names


### PR DESCRIPTION
Blattplan 2026-W38.

## The problem

The Smart Playlist Mixer writes one throwaway document per game start to `playlists/mix/__mix__-<uuid>.json` and unlinks stale ones an hour later (`server/mix_views.py`). Discovery fingerprints that same directory recursively via `playlist_dir.glob("**/*.json")`, taking each file's path, mtime and size (`game/playlist.py`).

So every mix write — and every cleanup unlink — changed the signature. The `start-game` call that follows milliseconds later, the one that exists precisely to reuse the cached parse (#1766), and the 3-second lobby poll then re-read, re-parsed and re-validated the whole catalogue. That happens while the host has already tapped Start and is watching a spinner.

## The fix, and the two options I did not take

**Chosen: skip transient mixes in the discovery walk.** One predicate on the glob result, so these files are neither fingerprinted, nor parsed, nor listed.

*Rejected: move the transient file out of the playlist directory* (e.g. into a scratch dir). This is the cleanest in principle — a non-catalogue file has no business in the catalogue directory — but the path the mixer returns is fed straight into `start-game`, which resolves it against the playlist dir and rejects anything outside it as path traversal (`server/game_views.py`). Taking the file out means relaxing that guard, which is a security-relevant change for a latency fix. Not worth it.

*Rejected: exclude the mix from the fingerprint only, keep parsing it.* Half a fix. The transient file would still be listed as a playlist, and worse: a file that is parsed but not fingerprinted is a staleness bug waiting to happen — a mix written after a cached parse would never appear in the parsed result, so the two halves of the cache entry would describe different sets of files.

**The fingerprint keeps doing its job.** It is still built from path + mtime_ns + size of every catalogue file, so a new playlist, an in-place edit and a delete all still change it and still invalidate. Only files that are, by construction, not catalogue content are left out.

The constants and `is_transient_mix` move from `server/mix_views.py` to `game/playlist.py`, because mix_views already imports from playlist — the reverse direction would be an import cycle. mix_views re-exports them, and keeps its own defensive `is_transient_mix` filter in `_assemble_mix_songs` even though discovery can no longer hand it one.

## Side effect: yes, fixed

The issue notes the mix file also showed up in the hub playlist list as a `source: "bundled"` playlist until cleanup an hour later. Because the file is skipped from the walk rather than just from the fingerprint, that is gone too — covered by `test_transient_mix_is_not_listed_as_a_playlist`.

## Consequence worth naming

`songs_by_path` no longer carries the mix, so `start-game` takes its existing cache-miss fallback for that one path: a single executor read plus parse of a document capped at 100 songs. That replaces a full re-parse of the catalogue, so it is the trade this PR is making on purpose.

## Measured

Shipped catalogue, 66 files / 13.7 MB / 8432 songs. Timing the discovery call that follows a mix write, median of 7 runs on an M-series Mac:

- **before: 63 ms** (a full re-read, re-parse, re-validate — identical to a cold parse, measured at 65 ms)
- **after: 0.5 ms** (stat-only walk, cache hit)

That is the cost the host pays at the Start tap. The issue puts a Pi 4 at roughly 1–1.5 s for the same full parse.

## Tests, and the counter-proofs

`tests/unit/test_mix_file_cache_2639.py`, 7 tests in two classes. Both classes were run against a deliberately wrong implementation to check they actually bite:

**Against the pre-fix code** (mix files back in the glob): `TestMixDoesNotInvalidate` fails 3/3 — the mix write forces a re-parse, the mix appears in the list, and the end-to-end `MixPlaylistView.post` leaves the cache cold. `TestRealChangesStillInvalidate` stays green, as it should.

**Against an over-reaching fix** (signature reduced to the path set, dropping mtime_ns/size — the tempting shortcut that also makes mix churn harmless): `test_inplace_edit_still_invalidates` fails. That is the test that matters: it stops the fix from turning a slow lobby into a playlist that never refreshes after an edit.

The guard class covers a new playlist, a new playlist added while a mix already sits in the directory, an in-place edit, and a delete.

## Checks

- `python3 -m ruff format --check .` — 210 files already formatted
- `python3 -m ruff check .` — All checks passed
- `pytest tests/unit tests/integration -q` — 2290 passed, 2 skipped
- `npm test` — 776 passed (80 files); `npm run build:check` — all 18 artifacts match source

Closes #2639

🤖 Generated with [Claude Code](https://claude.com/claude-code)
