### PR TITLE
Make the player state payload an allowlist (#2634)

### DIFF
--- a/custom_components/beatify/server/serializers.py
+++ b/custom_components/beatify/server/serializers.py
@@ -7,6 +7,7 @@ need to be made in one place (#352).
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 from custom_components.beatify.const import (
@@ -21,6 +22,8 @@ if TYPE_CHECKING:
 
     from custom_components.beatify.game.service import GameService
     from custom_components.beatify.game.state import GameState
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def get_game_state(hass: HomeAssistant) -> GameState | None:
@@ -55,35 +58,191 @@ def build_state_message(game_state: GameState) -> dict[str, Any] | None:
 REDACTED_PLACEHOLDER = "???"
 
 
+# ---------------------------------------------------------------------------
+# Player-visible state — an allowlist, not a denylist (#2634)
+# ---------------------------------------------------------------------------
+#
+# The ``state`` broadcast carries ~59 top-level keys. Until #2634 the filtering
+# was a denylist of two (``admin_song``, ``song.artist``/``song.title``), so
+# every key added to the serializer reached the player sockets by default. That
+# default produced two leaks — #1366 (``admin_song``) and #2550
+# (``artist_challenge``) — each closed afterwards by widening the denylist.
+#
+# The direction is now reversed: a key reaches a player only if it is listed
+# here, and ``tests/unit/test_player_state_allowlist_2634.py`` fails the build
+# when the serializer grows a key that is in neither set. A new answer field is
+# therefore a red CI run, not a line in someone's network tab.
+#
+# Adding a key here is a deliberate act: ask whether a guest holding the phone
+# may see it *before* they guess.
+
+#: Base keys, present in every phase (``GameStateSerializer.serialize``).
+_PLAYER_VISIBLE_BASE = frozenset(
+    {
+        # ``type`` is the envelope from build_state_message; the HTTP
+        # ``active_game`` payload has no envelope and simply never carries it.
+        "type",
+        "game_id",
+        "phase",
+        "player_count",
+        "players",
+        "language",
+        "difficulty",
+        "round_duration",
+        "intro_mode_enabled",
+        "closest_wins_mode",
+        "rampup_order_enabled",
+        "comeback_token_enabled",
+        "sabotage_enabled",
+        "difficulty_bet_scaling_enabled",
+        "bet_win_multiplier",
+        "sudden_death_mode",
+        "finale_double_enabled",
+        "finale_tiebreaker_enabled",
+        "title_artist_mode",
+        "is_intro_round",
+        "intro_stopped",
+        "intro_splash_pending",
+        "year_range",
+    }
+)
+
+#: LOBBY / PLAYING / REVEAL round context.
+_PLAYER_VISIBLE_ROUND = frozenset(
+    {
+        "join_url",
+        "round",
+        "total_rounds",
+        "last_round",
+        "songs_remaining",
+        "deadline",
+        "server_now_ms",
+        "seconds_remaining",
+        "finale_double_active",
+        "finale_playoff_active",
+        "submitted_count",
+        "all_submitted",
+        # The song card. Its *contents* are filtered separately during PLAYING —
+        # see PLAYING_SONG_PLAYER_KEYS below.
+        "song",
+        "leaderboard",
+        # The three challenge blocks are built with ``include_answer=False``
+        # during PLAYING and ``include_answer=True`` at REVEAL, so the answer
+        # gating lives in the challenge managers, not here.
+        "artist_challenge",
+        "movie_challenge",
+        "title_artist_challenge",
+        # #2557: the host renders the volume, but the frame goes to everyone.
+        "volume_level",
+    }
+)
+
+#: PAUSED-phase recovery banner.
+_PLAYER_VISIBLE_PAUSED = frozenset(
+    {
+        "pause_reason",
+        "last_error_detail",
+        "provider",
+        "media_player",
+    }
+)
+
+#: REVEAL-phase result surface. Everything here is public by the time it is
+#: sent — REVEAL is the moment the answer becomes common knowledge.
+_PLAYER_VISIBLE_REVEAL = frozenset(
+    {
+        "eliminated_this_round",
+        "round_analytics",
+        "game_performance",
+        "song_difficulty",
+        "early_reveal",
+        "idle_halt",
+        "reveal_auto_advance",
+        "reveal_started_at",
+    }
+)
+
+#: END-phase podium.
+_PLAYER_VISIBLE_END = frozenset(
+    {
+        "game_stats",
+        "winner",
+        "superlatives",
+        "highlights",
+        "share_data",
+    }
+)
+
+#: Every top-level key a non-admin socket may receive.
+PLAYER_VISIBLE_KEYS: frozenset[str] = (
+    _PLAYER_VISIBLE_BASE
+    | _PLAYER_VISIBLE_ROUND
+    | _PLAYER_VISIBLE_PAUSED
+    | _PLAYER_VISIBLE_REVEAL
+    | _PLAYER_VISIBLE_END
+)
+
+#: Top-level keys that stay on the spectator-admin socket. Listing a key here
+#: rather than simply leaving it out of the allowlist is what makes the
+#: completeness test meaningful: an unlisted key is an oversight, a listed one
+#: is a decision.
+ADMIN_ONLY_KEYS: frozenset[str] = frozenset(
+    {
+        # #648/#1366: the year answer, the fun facts and the library URI.
+        "admin_song",
+    }
+)
+
+#: Keys of the PLAYING-phase ``song`` sub-dict a player may receive. The song
+#: card is where the answer lives, so it gets the same default-deny treatment
+#: one level down: a ``year`` accidentally added to the PLAYING payload would
+#: otherwise be the answer, printed, before anyone guesses.
+#:
+#: The REVEAL ``song`` is deliberately NOT filtered — by then the year, the fun
+#: facts and the cover hint are the point of the screen.
+PLAYING_SONG_PLAYER_KEYS: frozenset[str] = frozenset(
+    {
+        "artist",
+        "title",
+        "album_art",
+    }
+)
+
+# Keys already reported as unclassified, so the warning below fires once per
+# key per process instead of once per broadcast.
+_UNCLASSIFIED_SEEN: set[str] = set()
+
+
 def redact_state_for_player(message: dict[str, Any]) -> dict[str, Any]:
     """Return a player-safe copy of a ``state`` / ``metadata_update`` message.
 
-    The full broadcast payload built by :func:`build_state_message` (and the
-    ``metadata_update`` payload) carries the round's answers so the spectator
-    admin / TV can display them. Those frames are broadcast identically to
-    every connection, so a player can read the answer straight off the
-    WebSocket before guessing (#1366). This strips the answers for non-admin
-    recipients:
+    The full broadcast payload built by :func:`build_state_message` carries the
+    round's answers so the spectator admin / TV can display them. Those frames
+    are broadcast identically to every connection, so a player could read the
+    answer straight off the WebSocket before guessing (#1366).
 
-    * ``admin_song`` (the year answer + fun facts) is removed entirely — it is
-      never meant for players in any mode.
-    * When ``title_artist_mode`` is active and the game is still ``PLAYING``,
-      ``song.artist`` / ``song.title`` ARE the answers being guessed, so they
-      are replaced with a placeholder. ``album_art`` is left intact (players
-      need it to play along). The REVEAL payload is untouched — by then the
-      answers are public.
-    * When an artist challenge is running in ``PLAYING``, ``song.artist`` alone
-      is the answer and is replaced the same way (#2550). The title is not part
-      of that challenge and stays visible.
+    Three things happen here:
 
-    The input is not mutated; only the keys that need changing are shallow
-    copied.
+    * **Top-level allowlist (#2634).** Only :data:`PLAYER_VISIBLE_KEYS` survive.
+      Anything else is dropped — including, by name, :data:`ADMIN_ONLY_KEYS`
+      (``admin_song``: the year answer, the fun facts, the library URI). A key
+      in neither set is dropped *and* logged, and fails the build in
+      ``tests/unit/test_player_state_allowlist_2634.py``.
+    * **Song allowlist during PLAYING.** The ``song`` card is reduced to
+      :data:`PLAYING_SONG_PLAYER_KEYS`. The REVEAL card is untouched.
+    * **Answer masking.** When ``title_artist_mode`` is active and the game is
+      still ``PLAYING``, ``song.artist`` / ``song.title`` ARE the answers being
+      guessed, so they become :data:`REDACTED_PLACEHOLDER`. ``album_art`` stays
+      — players need it to play along. An artist challenge (#2550) masks
+      ``song.artist`` alone; the title is not part of that challenge.
+
+    The input is never mutated. When nothing needs changing the *same object* is
+    returned, which the broadcast path relies on to serialize a payload once
+    instead of twice (#1711).
     """
     if not isinstance(message, dict):
         return message
 
-    # Nothing to redact if neither answer-bearing key is present.
-    has_admin_song = "admin_song" in message
     playing_with_song = message.get("phase") == "PLAYING" and isinstance(
         message.get("song"), dict
     )
@@ -91,27 +250,52 @@ def redact_state_for_player(message: dict[str, Any]) -> dict[str, Any]:
     # #2550: an artist challenge asks players to name the artist, so during
     # PLAYING `song.artist` is the answer just as much as in title_artist_mode.
     # No client renders it, but the frame is on every player socket and the
-    # network tab is enough to read it — the same leak #1366 closed for
-    # admin_song and title_artist_mode. The title is not part of this challenge
-    # and stays visible.
+    # network tab is enough to read it.
     redact_artist_only = (
         not redact_song
         and playing_with_song
         and isinstance(message.get("artist_challenge"), dict)
     )
-    if not has_admin_song and not redact_song and not redact_artist_only:
+
+    stripped = [key for key in message if key not in PLAYER_VISIBLE_KEYS]
+    song_stripped = (
+        [key for key in message["song"] if key not in PLAYING_SONG_PLAYER_KEYS]
+        if playing_with_song
+        else []
+    )
+    if (
+        not stripped
+        and not song_stripped
+        and not redact_song
+        and not redact_artist_only
+    ):
         return message
 
-    redacted = dict(message)
-    redacted.pop("admin_song", None)
-    if redact_song:
-        song = dict(redacted["song"])
-        song["artist"] = REDACTED_PLACEHOLDER
-        song["title"] = REDACTED_PLACEHOLDER
-        redacted["song"] = song
-    elif redact_artist_only:
-        song = dict(redacted["song"])
-        song["artist"] = REDACTED_PLACEHOLDER
+    for key in stripped:
+        if key in ADMIN_ONLY_KEYS or key in _UNCLASSIFIED_SEEN:
+            continue
+        _UNCLASSIFIED_SEEN.add(key)
+        _LOGGER.warning(
+            "State key %r is in neither PLAYER_VISIBLE_KEYS nor ADMIN_ONLY_KEYS "
+            "(server/serializers.py) — it is being withheld from players. If it "
+            "belongs on a player screen, add it to the allowlist (#2634).",
+            key,
+        )
+
+    redacted = {
+        key: value for key, value in message.items() if key in PLAYER_VISIBLE_KEYS
+    }
+    if playing_with_song:
+        song = {
+            key: value
+            for key, value in message["song"].items()
+            if key in PLAYING_SONG_PLAYER_KEYS
+        }
+        if redact_song:
+            song["artist"] = REDACTED_PLACEHOLDER
+            song["title"] = REDACTED_PLACEHOLDER
+        elif redact_artist_only:
+            song["artist"] = REDACTED_PLACEHOLDER
         redacted["song"] = song
     return redacted
 

--- a/tests/unit/test_player_state_allowlist_2634.py
+++ b/tests/unit/test_player_state_allowlist_2634.py
@@ -1,0 +1,246 @@
+"""The player payload is an allowlist, and the allowlist is complete (#2634).
+
+``redact_state_for_player`` used to be a denylist of two keys over a payload of
+~59. Every key the serializer grew therefore reached the player sockets by
+default, and twice that default was the bug: #1366 (``admin_song``) and #2550
+(``artist_challenge``), each closed afterwards by widening the denylist.
+
+The direction is reversed now. These tests hold the reversal in place:
+
+* :class:`TestAllowlistCompleteness` walks **every** key the serializer can
+  produce and fails when one is in neither ``PLAYER_VISIBLE_KEYS`` nor
+  ``ADMIN_ONLY_KEYS``. A future answer field is a red build here, not a line in
+  a guest's network tab.
+* :class:`TestHistoricLeaks` keeps the two leaks that actually happened closed.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import custom_components.beatify.game.serializers as game_serializers
+from custom_components.beatify.game.state import GamePhase
+from custom_components.beatify.server.serializers import (
+    ADMIN_ONLY_KEYS,
+    PLAYER_VISIBLE_KEYS,
+    PLAYING_SONG_PLAYER_KEYS,
+    REDACTED_PLACEHOLDER,
+    build_state_message,
+    redact_state_for_player,
+)
+from tests.conftest import make_game_state, make_songs
+
+_SERIALIZER_SOURCE = Path(game_serializers.__file__)
+
+# `state["<key>"] = ...` — the form every phase-specific key is written in.
+_ASSIGNED_KEY = re.compile(r'state\[\s*"([A-Za-z_][A-Za-z0-9_]*)"\s*\]\s*=')
+
+# The static scan is the part of this test that sees keys no fixture happens to
+# trigger. If a refactor ever changes how the serializer writes its keys the
+# regex would quietly match nothing and the whole test would pass vacuously, so
+# pin a floor well below today's count (37) and well above zero.
+_MIN_EXPECTED_ASSIGNED_KEYS = 30
+
+
+def _statically_assigned_keys() -> set[str]:
+    """Every ``state["x"] = ...`` key in the serializer, condition or not.
+
+    Read off the source rather than off a fixture on purpose: half the payload
+    is conditional (``early_reveal`` needs an early reveal, ``song_difficulty``
+    needs a wired StatsService, ``eliminated_this_round`` needs Sudden Death),
+    and a test that only sees what it managed to trigger is exactly the gap
+    #2634 is about.
+    """
+    keys = set(_ASSIGNED_KEY.findall(_SERIALIZER_SOURCE.read_text()))
+    assert len(keys) >= _MIN_EXPECTED_ASSIGNED_KEYS, (
+        f"Only {len(keys)} keys matched {_ASSIGNED_KEY.pattern!r} in "
+        f"{_SERIALIZER_SOURCE.name}. The serializer probably changed how it "
+        "writes state keys — update this scan, or the allowlist stops being "
+        "checked at all."
+    )
+    return keys
+
+
+def _make_game(*, title_artist_mode: bool = False):
+    gs = make_game_state()
+    gs.create_game(
+        playlists=["test.json"],
+        songs=make_songs(3),
+        media_player="media_player.test",
+        base_url="http://localhost:8123",
+        title_artist_mode=title_artist_mode,
+    )
+    gs.current_song = {
+        "title": "Hey Jude",
+        "artist": "The Beatles",
+        "year": 1968,
+        "album_art": "/art.png",
+        "fun_fact": "Written for Julian Lennon.",
+    }
+    if title_artist_mode:
+        gs._challenge_manager.init_round(gs.current_song)
+    return gs
+
+
+def _keys_seen_at_runtime() -> set[str]:
+    """Union of the top-level keys an actual broadcast carries, per phase.
+
+    Complements the static scan: it catches the base dict literal in
+    ``GameStateSerializer.serialize`` (which uses no ``state["x"] =`` form) and
+    the ``type`` envelope that ``build_state_message`` adds.
+    """
+    seen: set[str] = set()
+    for phase in (
+        GamePhase.LOBBY,
+        GamePhase.PLAYING,
+        GamePhase.REVEAL,
+        GamePhase.PAUSED,
+        GamePhase.END,
+    ):
+        gs = _make_game()
+        gs.phase = phase
+        message = build_state_message(gs)
+        assert message is not None
+        seen |= set(message)
+    return seen
+
+
+class TestAllowlistCompleteness:
+    """Every key the serializer can emit is classified — or the build fails."""
+
+    def test_every_serializer_key_is_classified(self):
+        produced = _statically_assigned_keys() | _keys_seen_at_runtime()
+        classified = PLAYER_VISIBLE_KEYS | ADMIN_ONLY_KEYS
+
+        unclassified = produced - classified
+
+        assert not unclassified, (
+            "New state key(s) reach the broadcast without a decision: "
+            f"{sorted(unclassified)}.\n"
+            "Ask whether a guest holding their phone may see this BEFORE they "
+            "guess, then add it to PLAYER_VISIBLE_KEYS or to ADMIN_ONLY_KEYS in "
+            "custom_components/beatify/server/serializers.py. Until then it is "
+            "withheld from every player socket, which will look like a missing "
+            "feature rather than a leak (#2634)."
+        )
+
+    def test_no_stale_entries_in_the_lists(self):
+        produced = _statically_assigned_keys() | _keys_seen_at_runtime()
+
+        stale = (PLAYER_VISIBLE_KEYS | ADMIN_ONLY_KEYS) - produced
+
+        assert not stale, (
+            f"Classified key(s) the serializer no longer produces: {sorted(stale)}. "
+            "Drop them, otherwise the lists slowly stop describing the payload."
+        )
+
+    def test_a_key_cannot_be_both_visible_and_admin_only(self):
+        assert PLAYER_VISIBLE_KEYS.isdisjoint(ADMIN_ONLY_KEYS)
+
+    def test_admin_only_keys_are_actually_withheld(self):
+        gs = _make_game()
+        gs.phase = GamePhase.PLAYING
+        message = build_state_message(gs)
+
+        player_view = redact_state_for_player(message)
+
+        for key in ADMIN_ONLY_KEYS:
+            assert key not in player_view, f"{key} is admin-only but reached a player"
+
+    def test_playing_song_card_is_allowlisted_too(self):
+        """The song card is where the answer lives, so it gets the same default.
+
+        A ``year`` added to the PLAYING payload would be the answer, printed,
+        before anyone guessed.
+        """
+        gs = _make_game()
+        gs.phase = GamePhase.PLAYING
+        message = build_state_message(gs)
+        assert set(message["song"]) <= PLAYING_SONG_PLAYER_KEYS, (
+            "The PLAYING song card grew a field. Decide whether players may see "
+            "it and update PLAYING_SONG_PLAYER_KEYS."
+        )
+
+        player_view = redact_state_for_player(message)
+
+        assert set(player_view["song"]) <= PLAYING_SONG_PLAYER_KEYS
+
+    def test_an_unclassified_key_is_dropped_at_runtime(self):
+        """Default-deny: the CI failure above is the loud half, this is the quiet
+        half that holds even when someone ships without running the tests."""
+        message = {
+            "type": "state",
+            "phase": "PLAYING",
+            "song": {"artist": "Queen", "title": "Bohemian Rhapsody"},
+            "tomorrows_answer": 1975,
+        }
+
+        player_view = redact_state_for_player(message)
+
+        assert "tomorrows_answer" not in player_view
+        assert message["tomorrows_answer"] == 1975, "input must not be mutated"
+
+    def test_nothing_to_strip_returns_the_same_object(self):
+        """The broadcast path serializes once when the two variants are identical
+        (#1711) — that shortcut depends on identity, not equality."""
+        gs = _make_game()
+        message = build_state_message(gs)  # LOBBY: no song, no admin_song
+
+        assert redact_state_for_player(message) is message
+
+
+class TestHistoricLeaks:
+    """The two leaks that actually happened stay closed."""
+
+    def test_1366_admin_song_never_reaches_a_player(self):
+        gs = _make_game()
+        gs.phase = GamePhase.PLAYING
+        message = build_state_message(gs)
+        assert message["admin_song"]["year"] == 1968, "the spectator gets the answer"
+
+        player_view = redact_state_for_player(message)
+
+        assert "admin_song" not in player_view
+        assert "admin_song" in message, "input must not be mutated"
+
+    def test_1366_title_artist_mode_masks_both_answers(self):
+        gs = _make_game(title_artist_mode=True)
+        gs.phase = GamePhase.PLAYING
+        message = build_state_message(gs)
+
+        player_view = redact_state_for_player(message)
+
+        assert player_view["song"]["artist"] == REDACTED_PLACEHOLDER
+        assert player_view["song"]["title"] == REDACTED_PLACEHOLDER
+        # Album art must survive — players need it to play along.
+        assert player_view["song"]["album_art"] == "/art.png"
+        assert message["song"]["artist"] == "The Beatles", "input must not be mutated"
+
+    def test_2550_artist_challenge_masks_the_artist_only(self):
+        message = {
+            "type": "state",
+            "phase": "PLAYING",
+            "artist_challenge": {"options": ["Queen", "Abba"]},
+            "song": {"artist": "Queen", "title": "Bohemian Rhapsody", "album_art": "x"},
+        }
+
+        player_view = redact_state_for_player(message)
+
+        assert player_view["song"]["artist"] == REDACTED_PLACEHOLDER
+        # The title is not part of that challenge and stays visible.
+        assert player_view["song"]["title"] == "Bohemian Rhapsody"
+        assert player_view["song"]["album_art"] == "x"
+        assert message["song"]["artist"] == "Queen", "input must not be mutated"
+
+    def test_reveal_is_the_moment_the_answers_go_public(self):
+        gs = _make_game(title_artist_mode=True)
+        gs.phase = GamePhase.REVEAL
+        message = build_state_message(gs)
+
+        player_view = redact_state_for_player(message)
+
+        assert player_view["song"]["artist"] == "The Beatles"
+        assert player_view["song"]["title"] == "Hey Jude"
+        assert player_view["song"]["year"] == 1968
+        assert player_view["song"]["fun_fact"] == "Written for Julian Lennon."


### PR DESCRIPTION
Blattplan 2026-W38.

`redact_state_for_player` knew exactly two keys over a broadcast of 59: `admin_song`, and `song.artist`/`song.title` under two conditions. Everything else the serializer grew went to the player sockets by default — and twice that default *was* the bug. #1366 (`admin_song`) and #2550 (`artist_challenge`) were both closed afterwards, by widening the denylist. A guest with the network tab open could read the answer before guessing.

## What changed

The direction is reversed. `server/serializers.py` now carries:

- **`PLAYER_VISIBLE_KEYS`** — 58 top-level keys a non-admin socket may receive, grouped by phase with a comment per group.
- **`ADMIN_ONLY_KEYS`** — 1 key (`admin_song`: the year answer, the fun facts, the library URI). Naming it here rather than just leaving it out of the allowlist is what makes the completeness test mean something: an unlisted key is an oversight, a listed one is a decision.
- **`PLAYING_SONG_PLAYER_KEYS`** — `{artist, title, album_art}`. The song card is where the answer lives, so it gets the same default-deny one level down: a `year` added to the PLAYING payload cannot become the answer in print. The REVEAL card is deliberately not filtered — by then the year and the fun fact are the point of the screen.

Answer masking is unchanged: `title_artist_mode` masks artist + title during PLAYING, an artist challenge masks the artist alone, `album_art` always survives, REVEAL is untouched. The identity shortcut the broadcast path relies on to serialize once instead of twice (#1711) is preserved — a payload with nothing to strip is returned as the same object.

A key in neither set is dropped **and** logged once per key per process, so the quiet half of default-deny is not actually quiet in production either.

## The completeness argument

`tests/unit/test_player_state_allowlist_2634.py` enumerates the payload two ways and unions them:

1. **Static scan** of `game/serializers.py` for every `state["x"] = …` assignment (37 keys). Half the payload is conditional — `early_reveal` needs an early reveal, `song_difficulty` needs a wired StatsService, `eliminated_this_round` needs Sudden Death — and a test that only sees what it managed to trigger is exactly the gap this issue is about. The scan asserts it found at least 30 keys, so a refactor of the assignment style fails loudly instead of making the test vacuous.
2. **Runtime union** over real LOBBY / PLAYING / REVEAL / PAUSED / END payloads (22 base keys from the dict literal, plus the `type` envelope), which the regex cannot see.

Union = 59. `PLAYER_VISIBLE_KEYS | ADMIN_ONLY_KEYS` = 59. The test fails on any key in neither set, with a message naming the key and pointing at the two lists. A second test fails on stale entries in the other direction, so the lists cannot drift into describing a payload that no longer exists.

## Why the allowlist is wide, and how I know it is safe

58 of 59 keys are player-visible, because what changed is the default, not the payload — this PR deliberately makes no behavioural change beyond `admin_song`, which was already stripped. Narrowing it further is a separate decision (see Findings).

Both consumers of the *redacted* frame were surveyed key by key against the source (never the minified bundles). Only the single socket that sent `admin_connect` (`game_state._admin_ws`) gets the full payload; the TV dashboard and every phone get the redacted copy, so both had to be checked:

**Player bundle — 37 of the 58 keys read.** Examples: `year_range` → `player-game.js:146-158` (year-slider bounds), `bet_win_multiplier` → `player-game.js:505` (bet payout label), `seconds_remaining` → `player-game/timer.js:100-107` (skew-immune countdown), `intro_splash_pending` → `player-core.js:749`, `early_reveal` → `player-core.js:770`, `volume_level` → `player-game.js:2575`, `title_artist_challenge` → `player-reveal.js:1723` (peer-vote panel), `share_data` → `player-end.js:96`.

**TV dashboard — 29 of the 58 keys read.** Examples: `game_id` → `dashboard.js:631`, `eliminated_this_round` → `dashboard.js:1955` (the "OUT" takeover), `game_stats` → `dashboard.js:1735`, `song_difficulty` → `dashboard.js:1272`, `reveal_started_at` → `dashboard.js:1501`.

The union of both is a strict subset of `PLAYER_VISIBLE_KEYS`, so no screen loses a field. I also checked that nothing in the player or dashboard code renders by iterating the whole payload: the only whole-object walks are `player-core.js:646-650` and `dashboard.js:596` / `:626-628` (key-agnostic `Object.assign` copies) and `dashboard.js:113-131` (`_stateRenderKey`, the #1705 repaint fingerprint — key-agnostic, and unaffected because no key that reached the TV before is dropped now).

## Counter-check — both tests were confirmed red against the broken state

| Broken state simulated | Result |
|---|---|
| A new unclassified key added to `_add_playing_state` | `test_every_serializer_key_is_classified` **fails**: `New state key(s) reach the broadcast without a decision: ['tomorrows_answer_field']` |
| Pre-#1366 (`redact_state_for_player` returns the message untouched) | **5 fail**, incl. both `TestHistoricLeaks::test_1366_*` and `test_2550_*` |
| Pre-#2550 (the artist-challenge branch removed) | `test_2550_artist_challenge_masks_the_artist_only` **fails** — and only that one |

Each was reverted and the suite re-run green afterwards.

## Findings — reported, not changed

- **~14 keys reach players today that no player or TV source file reads**: `player_count`, `round_duration`, `songs_remaining`, `submitted_count`, `all_submitted`, `server_now_ms`, `finale_playoff_active`, top-level `winner`, `last_error_detail`, `provider`, `media_player`, and the settings flags `intro_mode_enabled`, `rampup_order_enabled`, `comeback_token_enabled`, `sabotage_enabled`, `difficulty_bet_scaling_enabled`, `finale_double_enabled`, `finale_tiebreaker_enabled` (all read only in `admin.js`). None carries an answer, so none of them is this issue — but `provider` and `media_player` do put the host's music provider and speaker entity id on every guest's phone during a PAUSED round. Worth a follow-up now that moving a key is one line.
- **The TV is not the admin socket.** Only `admin_connect` (sent solely by `www/js/admin/api.js`) receives the full payload; `dashboard.js` connects read-only and is redacted like a phone. Anyone tightening the allowlist further must check the TV, not just the player — that is not obvious from the code.
- **The dashboard test suite would not catch an over-narrow allowlist.** Its fixtures exercise 8 of the 29 keys the TV actually reads. The Python-side completeness test is the guard; there is no JS-side equivalent.
- **`metadata_update` frames bypass the allowlist** — they are handled inline in `websocket.py:_redact_for_player` and carry only `{type, song}` with the song built as exactly `{artist, title, album_art}` (`game/state.py:747`). No leak today, but the two paths are separate lists again, which is the shape of this bug. Out of scope here to keep the diff narrow around #2629.

## Checks

- `python3 -m ruff format --check .` — 210 files already formatted
- `python3 -m ruff check .` — all checks passed
- `pytest tests/unit tests/integration -q` — 2294 passed, 2 skipped (was 2283; +11 new)
- `npm test` — 80 files, 776 passed
- `npm run build:check` — all 18 artifacts match source

Diff is confined to `server/serializers.py` and one new test file. `get_game_service` is untouched, so this does not collide with #2629.

Closes #2634

🤖 Generated with [Claude Code](https://claude.com/claude-code)
