### PR TITLE
chore: untrack the node_modules symlink that reached main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,13 @@ coverage/
 .nox/
 
 # ---- Node ----
+# Both spellings on purpose: the trailing slash matches the directory, the
+# bare name also matches a SYMLINK called node_modules. Agents building in
+# throwaway worktrees link the real tree in rather than reinstalling, and on
+# 2026-09-06 one such link was committed to main by a `git add -A` — a dead
+# absolute path into someone's home directory, for everyone who clones.
 node_modules/
+node_modules
 
 # ---- Python artifacts ----
 __pycache__/

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/markusholzhauser/Development/Beatify/node_modules


### PR DESCRIPTION
Not a Blattplan entry — repository hygiene, found while building one.

## What is on main

`origin/main` tracks a symlink:

```
120000 blob 147ddc64	node_modules  ->  /Users/markusholzhauser/Development/Beatify/node_modules
```

An absolute path into one machine's home directory, and a dead link for anyone else who clones.

## Where it came from

The build workflow, not the change it rode in on. Throwaway worktrees link the real dependency tree in rather than running `npm install` again, and a `git add -A` swept the link up with the diff in #2655.

HACS ships only `custom_components/beatify/`, so **nothing reached an installation**. This is hygiene, not a user-facing defect.

## Why .gitignore did not catch it

The entry read `node_modules/`. The trailing slash matches a **directory** and not a **symlink** of the same name — which is exactly the case here. Both spellings are now listed, with the reason in a comment so the apparently duplicate line does not get tidied away later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)