### PR TITLE
refactor(game): one list for game options instead of four

### DIFF
--- a/custom_components/beatify/game/config.py
+++ b/custom_components/beatify/game/config.py
@@ -1,4 +1,4 @@
-"""Game state configuration for Beatify (Issue #464).
+"""Game state configuration for Beatify (Issue #464, #2635).
 
 ``GameStateConfig`` is a dataclass whose fields define every resettable
 attribute on ``GameState`` that is **not** delegated to a subsystem manager
@@ -7,6 +7,11 @@ attribute on ``GameState`` that is **not** delegated to a subsystem manager
 ``GameState.__init__`` and ``_reset_game_internals`` call
 ``_apply_config(self._default_config)`` to (re-)set these attributes
 to their default values.
+
+``GameOptions`` (#2635) answers the other half of the question: what the admin
+*configured* this game with.  It is the single list that ``create_game``,
+``rematch_game`` and the HTTP create-game view all read, so a new game option
+is one field here instead of four parallel edits.
 """
 
 from __future__ import annotations
@@ -15,6 +20,7 @@ from dataclasses import dataclass, field, fields
 from typing import Any
 
 from custom_components.beatify.const import (
+    DEFAULT_ROUND_DURATION,
     DIFFICULTY_DEFAULT,
     PROVIDER_DEFAULT,
 )
@@ -98,3 +104,109 @@ class GameStateConfig:
         """
         delegated = {"title_artist_mode"}
         return [f.name for f in fields(cls) if f.name not in delegated]
+
+
+#: Session attributes a rematch carries over that are **not** game options
+#: (#2635): the session's content, the derived join URL, and the language,
+#: which the HTTP layer sets *after* ``create_game`` returns.  They are all
+#: ``GameStateConfig`` fields, so ``_reset_game_internals`` clears them and the
+#: rematch has to put them back.  Unlike the options below, this tuple does not
+#: grow when a new game option is added.
+REMATCH_CARRYOVER_ATTRS: tuple[str, ...] = (
+    "playlists",
+    "songs",
+    "media_player",
+    "join_url",
+    "language",
+)
+
+
+@dataclass
+class GameOptions:
+    """The admin-configured options of one game session (Issue #2635).
+
+    **One list.**  Before this dataclass the same option was written out four
+    times — as a parameter of ``create_game``, as a field of
+    ``GameStateConfig``, as an entry in the hand-written ``preserved`` dict of
+    ``rematch_game`` and as a key of ``create_kwargs`` in ``game_views``.
+    Forgetting one of them broke the rematch *silently*: the option fell back
+    to its default with no error anywhere.
+
+    Now ``create_game`` takes this object, ``rematch_game`` captures and
+    re-applies it, and the HTTP layer builds it from the request body.  Adding
+    a game option means adding a field here.
+
+    Every field name is also an attribute (or a manager-delegating property) of
+    ``GameState``, which is what makes :meth:`capture` and :meth:`apply_to`
+    work by name.
+
+    Note the overlap with :class:`GameStateConfig`, which is a *different*
+    question: ``GameStateConfig`` says what ``_reset_game_internals`` resets,
+    this says what a game is configured with.  The state-owned flags appear in
+    both; ``tests/unit/test_game_options_2635.py`` asserts their defaults stay
+    in step.
+    """
+
+    # --- Playback / scoring basics -------------------------------------
+    round_duration: int = DEFAULT_ROUND_DURATION
+    difficulty: str = DIFFICULTY_DEFAULT
+    provider: str = PROVIDER_DEFAULT
+    #: Platform identifier for playback routing (music_assistant, sonos, ...).
+    platform: str = "unknown"
+    #: #1475: 0 = play every playable song (the historic behaviour).
+    max_rounds: int = 0
+    #: #1012: seconds to dwell in REVEAL before advancing (0 = manual only).
+    reveal_auto_advance: int = 0
+
+    # --- Challenges (owned by ChallengeManager) ------------------------
+    artist_challenge_enabled: bool = True
+    movie_quiz_enabled: bool = True
+    #: Issue #1180: Title & Artist guessing replaces the year guess.
+    title_artist_mode: bool = False
+
+    # --- Round flow (owned by RoundManager) ----------------------------
+    #: Issue #23: intro mode (~20% random rounds).
+    intro_mode_enabled: bool = False
+
+    # --- Mode flags (owned by GameState) -------------------------------
+    #: Issue #442: only the closest guess(es) earn points.
+    closest_wins_mode: bool = False
+    #: Issue #1726: songs arranged into a difficulty arc instead of random.
+    rampup_order_enabled: bool = False
+    #: Issue #827: last-place player eliminated each round.
+    sudden_death_mode: bool = False
+    #: Issue #1725: the last round's score is doubled.
+    finale_double_enabled: bool = False
+    #: Issue #1725: a tie for first with songs left triggers a playoff.
+    finale_tiebreaker_enabled: bool = False
+    #: Issue #1724: bottom-third players get a one-time catch-up steal.
+    comeback_token_enabled: bool = False
+    #: Issue #1727: the won-bet payout scales with difficulty (2x/3x/5x).
+    difficulty_bet_scaling_enabled: bool = False
+    #: Issue #1665: one sabotage token per player per game.
+    sabotage_enabled: bool = False
+
+    @classmethod
+    def field_names(cls) -> list[str]:
+        """Return the option names, in declaration order."""
+        return [f.name for f in fields(cls)]
+
+    @classmethod
+    def capture(cls, state: Any) -> GameOptions:
+        """Read the current options off a ``GameState``.
+
+        Used by ``rematch_game`` in place of the hand-written ``preserved``
+        dict: whatever the admin configured is read back by field name, so a
+        newly added field is carried over without touching the rematch.
+        """
+        return cls(**{name: getattr(state, name) for name in cls.field_names()})
+
+    def apply_to(self, state: Any) -> None:
+        """Write every option onto a ``GameState``.
+
+        Plain ``setattr`` throughout — the manager-owned names (challenges,
+        round flow) go through ``GameState``'s delegation properties, exactly
+        as the old ``preserved``-restore loop did.
+        """
+        for name in self.field_names():
+            setattr(state, name, getattr(self, name))

--- a/custom_components/beatify/game/state_setup.py
+++ b/custom_components/beatify/game/state_setup.py
@@ -17,8 +17,10 @@ the two builders attach to their PlaylistManager. It is **behavior-preserving**:
 it carries the exact same methods that previously lived on ``GameState``, so its
 public API and every caller / test are unchanged.
 
-* ``create_game`` — the new-session builder. Validates the round duration,
-  clears any leftover sessions, mints a fresh ``game_id`` / ``admin_token``,
+* ``create_game`` — the new-session builder, taking its options as a single
+  :class:`~custom_components.beatify.game.config.GameOptions` (#2635) rather
+  than 18 parameters. Validates the round duration, clears any leftover
+  sessions, mints a fresh ``game_id`` / ``admin_token``,
   builds the join URL, constructs the :class:`PlaylistManager` (failing fast on
   a provider with zero playable songs, #709), resets round tracking + the
   config-managed fields, and configures the challenge / power-up / intro / mode
@@ -37,6 +39,10 @@ public API and every caller / test are unchanged.
   settings, runs ``_reset_game_internals``, restores the snapshot, re-detects the
   storefront + re-creates the PlaylistManager, resets each player's per-game
   stats, mints a new ``game_id`` / ``admin_token`` and regenerates the join URL.
+  The snapshot is a :class:`~custom_components.beatify.game.config.GameOptions`
+  read back by field name (#2635), not a hand-written dict — the dict was a
+  transcript of ``create_game``'s parameter list, and an option missing from it
+  silently fell back to its default on the rematch.
 * ``_detect_storefront`` — resolves the Apple-Music storefront (#808 follow-up)
   from ``hass.config.country`` (lower-cased) or ``None``; used only by the two
   builders above.
@@ -78,16 +84,15 @@ from __future__ import annotations
 
 import logging
 import secrets
+from dataclasses import replace
 from typing import Any
 
 from custom_components.beatify.const import (
-    DEFAULT_ROUND_DURATION,
-    DIFFICULTY_DEFAULT,
-    PROVIDER_DEFAULT,
     ROUND_DURATION_MAX,
     ROUND_DURATION_MIN,
 )
 
+from .config import REMATCH_CARRYOVER_ATTRS, GameOptions
 from .playlist import PlaylistManager
 
 _LOGGER = logging.getLogger(__name__)
@@ -117,30 +122,14 @@ class GameSetupMixin:
     expects on ``self`` at runtime.
     """
 
-    def create_game(  # noqa: PLR0913
+    def create_game(
         self,
         playlists: list[str],
         songs: list[dict[str, Any]],
         media_player: str,
         base_url: str,
-        round_duration: int = DEFAULT_ROUND_DURATION,
-        difficulty: str = DIFFICULTY_DEFAULT,
-        provider: str = PROVIDER_DEFAULT,
-        platform: str = "unknown",
-        artist_challenge_enabled: bool = True,
-        movie_quiz_enabled: bool = True,
-        intro_mode_enabled: bool = False,
-        closest_wins_mode: bool = False,
-        sudden_death_mode: bool = False,
-        title_artist_mode: bool = False,
-        reveal_auto_advance: int = 0,
-        rampup_order_enabled: bool = False,
-        finale_double_enabled: bool = False,
-        finale_tiebreaker_enabled: bool = False,
-        comeback_token_enabled: bool = False,
-        difficulty_bet_scaling_enabled: bool = False,
-        sabotage_enabled: bool = False,
-        max_rounds: int = 0,
+        options: GameOptions | None = None,
+        **option_overrides: Any,
     ) -> dict[str, Any]:
         """
         Create a new game session.
@@ -150,40 +139,36 @@ class GameSetupMixin:
             songs: List of song dicts loaded from playlists
             media_player: Entity ID of media player
             base_url: HA base URL for join URL construction
-            round_duration: Round timer duration in seconds (10-60, default 30)
-            difficulty: Difficulty level (easy/normal/hard, default normal)
-            provider: Music provider (spotify/apple_music, default spotify)
-            platform: Platform identifier for playback routing (music_assistant, sonos, alexa_media)
-            artist_challenge_enabled: Whether to enable artist guessing (default True)
-            movie_quiz_enabled: Whether to enable movie quiz bonus (default True)
-            intro_mode_enabled: Whether to enable intro mode (~20% random rounds)
-            closest_wins_mode: Whether only the closest guess(es) earn points
-            title_artist_mode: Whether title/artist guessing replaces the year guess
-            rampup_order_enabled: Whether to order songs into a difficulty arc
-                instead of uniform random (#1726). Opt-in; default False.
-            finale_double_enabled: Whether the last round's score is doubled
-                (#1725). Opt-in; default False.
-            finale_tiebreaker_enabled: Whether an end-game tie for first with
-                songs remaining triggers a sudden-death playoff (#1725). Opt-in;
-                default False.
-            comeback_token_enabled: Whether bottom-third players are handed a
-                one-time catch-up steal after the halfway round (#1724). Opt-in;
-                default False.
-            difficulty_bet_scaling_enabled: Whether the won-bet payout scales
-                with difficulty (easy 2x / normal 3x / hard 5x) instead of a flat
-                3x (#1727). Opt-in; default False = flat 3x, unchanged.
+            options: The admin-configured game options (:class:`GameOptions`).
+                Defaults to every option at its default value.
+            **option_overrides: Individual :class:`GameOptions` fields, applied
+                on top of ``options``. This is what keeps the long-standing
+                ``create_game(..., sudden_death_mode=True)`` call style working
+                — including from ``GameService.create_game(**kwargs)`` — now
+                that the option list lives in the dataclass (#2635). An unknown
+                name raises ``TypeError``, exactly as a stray keyword argument
+                did when every option was spelled out in this signature.
 
         Returns:
             dict with game_id, join_url, song_count, phase
 
         Raises:
+            TypeError: If an unknown option name is passed
             ValueError: If round_duration is outside valid range (10-60)
 
         """
         from .state import GamePhase
 
+        # #2635: one list. The options arrive as a dataclass instead of 18
+        # parameters that had to be repeated in the rematch's `preserved` dict
+        # and in game_views' `create_kwargs` — miss one there and the option
+        # silently fell back to its default on the rematch.
+        opts = options if options is not None else GameOptions()
+        if option_overrides:
+            opts = replace(opts, **option_overrides)
+
         # Validate round duration (Story 13.1)
-        if not (ROUND_DURATION_MIN <= round_duration <= ROUND_DURATION_MAX):
+        if not (ROUND_DURATION_MIN <= opts.round_duration <= ROUND_DURATION_MAX):
             raise ValueError(
                 f"Round duration must be between {ROUND_DURATION_MIN} "
                 f"and {ROUND_DURATION_MAX} seconds"
@@ -211,14 +196,18 @@ class GameSetupMixin:
         # provider). #1726: when ramp-up ordering is opted in, the manager also
         # gets a difficulty-lookup so it can arrange the songs into an arc.
         playlist_manager = self._build_playlist_manager(
-            songs, provider, storefront, rampup_order_enabled, max_rounds
+            songs,
+            opts.provider,
+            storefront,
+            opts.rampup_order_enabled,
+            opts.max_rounds,
         )
 
         # #709: if the chosen provider has zero playable songs, fail fast with
         # a clear error rather than silently starting a game that will stall.
         if not playlist_manager.has_playable_songs():
             raise NoPlayableSongsError(
-                f"No playable songs for provider '{provider}' in the selected "
+                f"No playable songs for provider '{opts.provider}' in the selected "
                 f"playlist(s). Pick a different playlist or provider."
             )
 
@@ -259,15 +248,14 @@ class GameSetupMixin:
         self.join_url = f"{base_url}/beatify/play?game={self.game_id}"
         self.players = {}
 
-        # #1475: gewaehlte Rundenzahl merken (0 = alle). Der Rematch liest sie
-        # aus `preserved` zurueck, damit die Revanche gleich lang ist.
-        self.max_rounds = max_rounds
-
-        # Store provider setting (Story 17.2)
-        self.provider = provider
-
-        # Store platform for playback routing
-        self.platform = platform
+        # #2635: every admin-configured option in one go — round_duration,
+        # difficulty, provider, platform, max_rounds (#1475), the REVEAL dwell
+        # (#1012) and all the mode flags. The rematch re-applies the very same
+        # object, so an option can no longer be forgotten on the way back.
+        # The challenge configure() below still runs afterwards: it is what
+        # nulls the per-round challenge objects and enforces the
+        # artist-challenge / Title & Artist exclusion.
+        opts.apply_to(self)
 
         self.storefront = storefront
 
@@ -292,22 +280,20 @@ class GameSetupMixin:
         self.pause_reason = None
         self._previous_phase = None
 
-        # Reset timing for speed bonus (Story 5.1) and configurable duration (Story 13.1)
+        # Reset timing for speed bonus (Story 5.1). The configurable duration
+        # (Story 13.1) came from opts.apply_to above.
         self.round_start_time = None
-        self.round_duration = round_duration
 
-        # Set difficulty (Story 14.1). Explicit annotation so mypy has a
-        # declared type at the assignment point — without it the gated
+        # Set difficulty (Story 14.1) — already written by opts.apply_to; this
+        # repeats it purely for the explicit annotation, which mypy needs as a
+        # declared type at an assignment point. Without it the gated
         # game/service.py read (self._game_state.difficulty) hit a mypy
         # has-type deferral once GameState grew to 9 mixins (#1271).
-        self.difficulty: str = difficulty
+        self.difficulty: str = opts.difficulty
 
         # Reset song stopped flag (Story 6.2)
         self.song_stopped = False
 
-        # #1012: REVEAL auto-advance — seconds to wait in REVEAL before
-        # starting the next round automatically (0 = off / manual only).
-        self.reveal_auto_advance = reveal_auto_advance
         # #1359: cancel any leftover auto-advance / vote-window task from a
         # prior game instead of just dropping the handle — a bare
         # ``self._auto_advance_task = None`` would orphan a still-running
@@ -332,33 +318,19 @@ class GameSetupMixin:
         # Issue #351: Reset power-up state for new game
         self._powerup_manager.reset()
 
-        # Story 20.1 / Issue #28 / Issue #1180: Set challenge configuration
+        # Story 20.1 / Issue #28 / Issue #1180: Set challenge configuration.
+        # Runs after opts.apply_to so the Title & Artist exclusion wins and the
+        # per-round challenge objects are nulled for the new game.
         self._challenge_manager.configure(
-            artist_challenge_enabled=artist_challenge_enabled,
-            movie_quiz_enabled=movie_quiz_enabled,
-            title_artist_mode=title_artist_mode,
+            artist_challenge_enabled=opts.artist_challenge_enabled,
+            movie_quiz_enabled=opts.movie_quiz_enabled,
+            title_artist_mode=opts.title_artist_mode,
         )
 
-        # Issue #23: Set intro mode configuration
-        self.intro_mode_enabled = intro_mode_enabled
-
-        # Issue #442: Set closest wins mode
-        self.closest_wins_mode = closest_wins_mode
-        # Issue #1726: Set ramp-up (difficulty-arc) ordering mode
-        self.rampup_order_enabled = rampup_order_enabled
-        # Issue #827: Set sudden death mode
-        self.sudden_death_mode = sudden_death_mode
-        # Issue #1725: Finale ×2 + finale sudden-death tiebreaker (opt-in)
-        self.finale_double_enabled = finale_double_enabled
-        self.finale_tiebreaker_enabled = finale_tiebreaker_enabled
+        # #1725: runtime bookkeeping for the tiebreaker playoff — not an
+        # option, so opts.apply_to does not cover it.
         self._finale_playoff_rounds = 0
         self._finale_playoff_active = False
-        # Issue #1724: Comeback Token — opt-in catch-up steal for trailing players
-        self.comeback_token_enabled = comeback_token_enabled
-        # Issue #1727: Difficulty-aware bet scaling (opt-in; default flat 3x)
-        self.difficulty_bet_scaling_enabled = difficulty_bet_scaling_enabled
-        # Issue #1665: Sabotage powerup (opt-in; default off = no tokens)
-        self.sabotage_enabled = sabotage_enabled
         self.is_intro_round = False
         self.intro_stopped = False
         self._round_manager._intro_round_start_time = None
@@ -496,31 +468,18 @@ class GameSetupMixin:
         _LOGGER.info("Rematch initiated from game: %s", self.game_id)
         self.cancel_timer()
 
-        # Preserve game settings that the admin configured (Issue #591)
-        preserved = {
-            "playlists": self.playlists,
-            "songs": list(self.songs),
-            "media_player": self.media_player,
-            "join_url": self.join_url,
-            "provider": self.provider,
-            "platform": self.platform,
-            "difficulty": self.difficulty,
-            "language": self.language,
-            "round_duration": self.round_duration,
-            "artist_challenge_enabled": self.artist_challenge_enabled,
-            "movie_quiz_enabled": self.movie_quiz_enabled,
-            "intro_mode_enabled": self.intro_mode_enabled,
-            "closest_wins_mode": self.closest_wins_mode,
-            "sudden_death_mode": self.sudden_death_mode,
-            "title_artist_mode": self.title_artist_mode,
-            "rampup_order_enabled": self.rampup_order_enabled,  # #1726
-            "finale_double_enabled": self.finale_double_enabled,  # #1725
-            "finale_tiebreaker_enabled": self.finale_tiebreaker_enabled,  # #1725
-            "comeback_token_enabled": self.comeback_token_enabled,  # #1724
-            "difficulty_bet_scaling_enabled": self.difficulty_bet_scaling_enabled,  # #1727
-            "sabotage_enabled": self.sabotage_enabled,  # #1665
-            "max_rounds": self.max_rounds,  # #1475
-        }
+        # Preserve game settings that the admin configured (Issue #591).
+        # #2635: read back by field name from GameOptions instead of a
+        # hand-written dict. That dict was a transcript of create_game's
+        # parameter list, and a new option that missed it fell back to its
+        # default on the rematch with no error anywhere.
+        preserved = GameOptions.capture(self)
+        # The rest of the session the rematch keeps: content, the derived join
+        # URL, and the language the HTTP layer sets after create_game. All of
+        # them are GameStateConfig fields, so the reset below clears them.
+        carryover = {name: getattr(self, name) for name in REMATCH_CARRYOVER_ATTRS}
+        # The rematch works on its own copy of the song list.
+        carryover["songs"] = list(carryover["songs"])
 
         self._reset_game_internals()
         # #1725: the playoff counters are runtime state, not config fields, so
@@ -529,8 +488,9 @@ class GameSetupMixin:
         self._finale_playoff_active = False
 
         # Restore preserved settings for seamless rematch
-        for attr, value in preserved.items():
+        for attr, value in carryover.items():
             setattr(self, attr, value)
+        preserved.apply_to(self)
 
         # Re-create PlaylistManager with fresh song list
         # #808 follow-up: re-detect storefront for the rematch (in case
@@ -541,11 +501,11 @@ class GameSetupMixin:
         # einzelnen Partie. Ohne diese Zeile waere die Revanche wieder ueber
         # die volle Playlist gelaufen, obwohl der Gastgeber 20 eingestellt hat.
         self._playlist_manager = self._build_playlist_manager(
-            preserved["songs"],
-            preserved["provider"],
+            carryover["songs"],
+            preserved.provider,
             self.storefront,
-            preserved["rampup_order_enabled"],
-            preserved["max_rounds"],
+            preserved.rampup_order_enabled,
+            preserved.max_rounds,
         )
         # #1377: derive total_rounds from the filtered/deduped playable pool
         # (exactly like create_game, state_setup.py), not the raw song list.
@@ -567,8 +527,8 @@ class GameSetupMixin:
         self.admin_token = secrets.token_urlsafe(16)  # Issue #386
 
         # Regenerate join_url with new game_id
-        if preserved["join_url"]:
-            base_url = preserved["join_url"].split("/beatify/play")[0]
+        if carryover["join_url"]:
+            base_url = carryover["join_url"].split("/beatify/play")[0]
             self.join_url = f"{base_url}/beatify/play?game={self.game_id}"
 
         _LOGGER.info(

--- a/custom_components/beatify/server/game_views.py
+++ b/custom_components/beatify/server/game_views.py
@@ -6,6 +6,7 @@ import contextlib
 import functools
 import json
 import logging
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -14,7 +15,6 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.helpers import entity_registry as er
 
 from custom_components.beatify.const import (
-    DEFAULT_ROUND_DURATION,
     DIFFICULTY_DEFAULT,
     DIFFICULTY_EASY,
     DIFFICULTY_HARD,
@@ -36,6 +36,7 @@ from custom_components.beatify.const import (
     ROUND_DURATION_MAX,
     ROUND_DURATION_MIN,
 )
+from custom_components.beatify.game.config import GameOptions
 from custom_components.beatify.game.playlist import (
     async_discover_playlists_detailed,
 )
@@ -443,34 +444,33 @@ class StartGameView(RateLimitMixin, HomeAssistantView):
                 details={"speaker": speaker_name, "provider": "Amazon Music"},
             )
 
-        # Build create_game kwargs with optional round_duration (Story 13.1),
-        # difficulty (Story 14.1), provider (Story 17.2), platform,
-        # and artist_challenge_enabled (Story 20.7)
-        create_kwargs: dict[str, Any] = {
-            "playlists": playlist_paths,
-            "songs": songs,
-            "media_player": media_player,
-            "base_url": base_url,
-            "difficulty": difficulty,
-            "provider": provider,
-            "platform": platform,
-            "artist_challenge_enabled": artist_challenge_enabled,  # Story 20.7
-            "movie_quiz_enabled": movie_quiz_enabled,  # Issue #28
-            "intro_mode_enabled": intro_mode_enabled,  # Issue #23
-            "closest_wins_mode": closest_wins_mode,  # Issue #442
-            "sudden_death_mode": sudden_death_mode,  # Issue #827
-            "title_artist_mode": title_artist_mode,  # #1180
-            "rampup_order_enabled": rampup_order_enabled,  # Issue #1726
-            "finale_double_enabled": finale_double_enabled,  # Issue #1725
-            "finale_tiebreaker_enabled": finale_tiebreaker_enabled,  # Issue #1725
-            "comeback_token_enabled": comeback_token_enabled,  # Issue #1724
-            "difficulty_bet_scaling_enabled": difficulty_bet_scaling_enabled,  # Issue #1727
-            "sabotage_enabled": sabotage_enabled,  # Issue #1665
-            "reveal_auto_advance": reveal_auto_advance,  # #1012
-            "max_rounds": max_rounds,  # #1475
-        }
+        # #2635: the admin's options as ONE object, not a kwargs dict that had
+        # to be kept in step with create_game's parameter list by hand. An
+        # option missing here used to reach create_game as its default with no
+        # error; a wrong name is now a TypeError at construction.
+        # Story 13.1 (round_duration), Story 14.1 (difficulty),
+        # Story 17.2 (provider), Story 20.7 (artist_challenge_enabled).
+        create_options = GameOptions(
+            difficulty=difficulty,
+            provider=provider,
+            platform=platform,
+            artist_challenge_enabled=artist_challenge_enabled,  # Story 20.7
+            movie_quiz_enabled=movie_quiz_enabled,  # Issue #28
+            intro_mode_enabled=intro_mode_enabled,  # Issue #23
+            closest_wins_mode=closest_wins_mode,  # Issue #442
+            sudden_death_mode=sudden_death_mode,  # Issue #827
+            title_artist_mode=title_artist_mode,  # #1180
+            rampup_order_enabled=rampup_order_enabled,  # Issue #1726
+            finale_double_enabled=finale_double_enabled,  # Issue #1725
+            finale_tiebreaker_enabled=finale_tiebreaker_enabled,  # Issue #1725
+            comeback_token_enabled=comeback_token_enabled,  # Issue #1724
+            difficulty_bet_scaling_enabled=difficulty_bet_scaling_enabled,  # Issue #1727
+            sabotage_enabled=sabotage_enabled,  # Issue #1665
+            reveal_auto_advance=reveal_auto_advance,  # #1012
+            max_rounds=max_rounds,  # #1475
+        )
         if round_duration is not None:
-            create_kwargs["round_duration"] = round_duration
+            create_options = replace(create_options, round_duration=round_duration)
 
         # #1867: state the round timer's provenance at the one moment it is
         # decided. The only prior trace was "Round N started (%.1fs timer)",
@@ -480,7 +480,7 @@ class StartGameView(RateLimitMixin, HomeAssistantView):
         # which no log had; one line here makes the next report a lookup.
         _LOGGER.info(
             "Game created with round_duration=%ss (client sent %r)",
-            create_kwargs.get("round_duration", DEFAULT_ROUND_DURATION),
+            create_options.round_duration,
             body.get("round_duration"),
         )
 
@@ -491,7 +491,13 @@ class StartGameView(RateLimitMixin, HomeAssistantView):
         # rejection gets its own code so the client can say WHICH one fired) and
         # sends the i18n lookup in errors.<CODE> looking for nothing.
         try:
-            result = game_state.create_game(**create_kwargs)
+            result = game_state.create_game(
+                playlists=playlist_paths,
+                songs=songs,
+                media_player=media_player,
+                base_url=base_url,
+                options=create_options,
+            )
         except NoPlayableSongsError as err:
             return _json_error(str(err), 400, code=ERR_NO_PLAYABLE_SONGS)
         except ValueError as err:

--- a/tests/unit/test_game_options_2635.py
+++ b/tests/unit/test_game_options_2635.py
@@ -1,0 +1,354 @@
+"""GameOptions completeness tests (Issue #2635).
+
+The bug this file exists to prevent: the same game option used to be written
+out four times — as a parameter of ``create_game``, as a field of
+``GameStateConfig``, as an entry in the hand-written ``preserved`` dict of
+``rematch_game``, and as a key of ``create_kwargs`` in ``server/game_views.py``.
+Miss one of them and the rematch broke *silently*: the option fell back to its
+default with no error, no log line and no failing test.
+
+``GameOptions`` collapses that to one list. The tests below are what keeps it
+one list:
+
+* ``test_every_option_survives_the_rematch`` sets EVERY option to a non-default
+  value, creates a game, runs a rematch, and asserts every option is still
+  there. It is driven by ``fields(GameOptions)``, so a newly added option is
+  covered the moment it is declared — no test edit needed.
+* ``test_completeness_test_fails_when_an_option_is_dropped`` is the counter-
+  proof: it re-runs that same check against a deliberately broken
+  ``GameOptions`` (one field omitted from the capture/apply loop, exactly the
+  historic failure mode) and asserts it goes red.
+* ``test_sentinel_covers_every_option`` fails loudly when someone adds a
+  non-bool option without telling this file what a non-default value looks
+  like — better a red test than a silently uncovered field.
+* ``test_state_owned_options_are_config_managed`` keeps ``GameStateConfig`` in
+  step, so ``end_game`` still resets what it used to reset.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields, replace
+from typing import Any
+
+import pytest
+
+from custom_components.beatify.const import (
+    DIFFICULTY_HARD,
+    PROVIDER_APPLE_MUSIC,
+)
+from custom_components.beatify.game.config import (
+    REMATCH_CARRYOVER_ATTRS,
+    GameOptions,
+    GameStateConfig,
+)
+from custom_components.beatify.game.state import GamePhase, GameState
+
+from tests.conftest import make_game_state
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+#: Non-default values for the options whose type does not tell us one. Bools
+#: are flipped automatically; everything else has to be listed here, and
+#: ``test_sentinel_covers_every_option`` fails if a new option is neither.
+_NON_BOOL_SENTINELS: dict[str, Any] = {
+    "round_duration": 30,  # != DEFAULT_ROUND_DURATION, inside 15..60
+    "difficulty": DIFFICULTY_HARD,
+    "provider": PROVIDER_APPLE_MUSIC,
+    "platform": "music_assistant",
+    "max_rounds": 12,
+    "reveal_auto_advance": 60,
+}
+
+
+def _songs(n: int = 20) -> list[dict[str, Any]]:
+    """Songs playable on both the default and the sentinel provider."""
+    return [
+        {
+            "year": 1980 + i,
+            "title": f"Song {i}",
+            "artist": f"Artist {i}",
+            "uri": f"spotify:track:test{i:022d}",
+            "uri_spotify": f"spotify:track:test{i:022d}",
+            "uri_apple_music": f"applemusic://track/{100 + i}",
+        }
+        for i in range(n)
+    ]
+
+
+def _sentinel_options() -> tuple[GameOptions, list[str]]:
+    """Build a GameOptions in which every field differs from its default.
+
+    Returns the options plus the list of option names with no sentinel rule, so
+    the caller can turn that into a readable failure.
+    """
+    defaults = GameOptions()
+    values: dict[str, Any] = {}
+    uncovered: list[str] = []
+    for f in fields(GameOptions):
+        current = getattr(defaults, f.name)
+        if isinstance(current, bool):
+            values[f.name] = not current
+        elif f.name in _NON_BOOL_SENTINELS:
+            values[f.name] = _NON_BOOL_SENTINELS[f.name]
+        else:
+            uncovered.append(f.name)
+    return replace(defaults, **values), uncovered
+
+
+def _create(state: GameState, options: GameOptions) -> None:
+    state.create_game(
+        playlists=["test.json"],
+        songs=_songs(),
+        media_player="media_player.party",
+        base_url="http://localhost:8123",
+        options=options,
+    )
+
+
+def _assert_options_on_state(state: GameState, expected: GameOptions) -> None:
+    """Assert every GameOptions field reads back off the state."""
+    mismatches = {
+        f.name: (getattr(expected, f.name), getattr(state, f.name))
+        for f in fields(GameOptions)
+        if getattr(state, f.name) != getattr(expected, f.name)
+    }
+    assert not mismatches, (
+        "Game option(s) did not survive: "
+        + ", ".join(
+            f"{name} expected {want!r}, got {got!r}"
+            for name, (want, got) in sorted(mismatches.items())
+        )
+        + ". A new option has to be a GameOptions field — nothing else."
+    )
+
+
+# ---------------------------------------------------------------------------
+# The completeness test
+# ---------------------------------------------------------------------------
+
+
+class TestRematchCompleteness:
+    """Every configured option must survive the rematch (#2635)."""
+
+    def test_sentinel_covers_every_option(self):
+        """A new non-bool option must get a sentinel here, or this fails."""
+        options, uncovered = _sentinel_options()
+        assert not uncovered, (
+            "New GameOptions field(s) with no test sentinel: "
+            f"{', '.join(uncovered)}. Add a non-default value to "
+            "_NON_BOOL_SENTINELS in this file so the rematch completeness "
+            "test actually covers them."
+        )
+        # And every sentinel really is non-default — otherwise the round-trip
+        # below would pass on an option that was silently reset.
+        defaults = GameOptions()
+        same = [
+            f.name
+            for f in fields(GameOptions)
+            if getattr(options, f.name) == getattr(defaults, f.name)
+        ]
+        assert not same, f"Sentinel equals the default for: {', '.join(same)}"
+
+    def test_every_option_survives_the_rematch(self):
+        """Set every option, rematch, and find all of them still set."""
+        options, _ = _sentinel_options()
+        state = make_game_state()
+
+        _create(state, options)
+        # Sanity: create_game itself applied them.
+        _assert_options_on_state(state, options)
+
+        state.rematch_game()
+
+        assert state.phase == GamePhase.LOBBY
+        _assert_options_on_state(state, options)
+
+    def test_completeness_test_fails_when_an_option_is_dropped(self, monkeypatch):
+        """The counter-proof: the check above goes red on the historic bug.
+
+        ``sabotage_enabled`` (#1665) is dropped from the capture/apply loop —
+        precisely what happened when an option was added to ``create_game`` but
+        forgotten in the ``preserved`` dict. The option then falls back to its
+        default on the rematch, and the assertion must catch it.
+        """
+        dropped = "sabotage_enabled"
+        full = GameOptions.field_names()
+        assert dropped in full
+
+        monkeypatch.setattr(
+            GameOptions,
+            "field_names",
+            classmethod(lambda cls: [n for n in full if n != dropped]),
+        )
+
+        options, _ = _sentinel_options()
+        state = make_game_state()
+        _create(state, options)
+        state.rematch_game()
+
+        # The option is a GameStateConfig field, so _reset_game_internals put it
+        # back to its default and nothing carried it over again.
+        assert getattr(state, dropped) is not getattr(options, dropped)
+        with pytest.raises(AssertionError, match=dropped):
+            _assert_options_on_state(state, options)
+
+    def test_carryover_attrs_survive_the_rematch(self):
+        """Content / join URL / language are kept too (#591)."""
+        state = make_game_state()
+        songs = _songs()
+        state.create_game(
+            playlists=["party.json"],
+            songs=songs,
+            media_player="media_player.party",
+            base_url="http://ha.local:8123",
+        )
+        state.language = "de"
+        before = {name: getattr(state, name) for name in REMATCH_CARRYOVER_ATTRS}
+        game_id_before = state.game_id
+
+        state.rematch_game()
+
+        assert state.playlists == before["playlists"]
+        assert state.songs == before["songs"]
+        assert state.media_player == before["media_player"]
+        assert state.language == "de"
+        # join_url keeps its base but carries the NEW game id.
+        assert state.game_id != game_id_before
+        assert (
+            state.join_url == f"http://ha.local:8123/beatify/play?game={state.game_id}"
+        )
+
+    def test_rematch_works_on_its_own_song_copy(self):
+        """The rematch must not hand back the caller's list object."""
+        state = make_game_state()
+        songs = _songs()
+        state.create_game(
+            playlists=["test.json"],
+            songs=songs,
+            media_player="media_player.party",
+            base_url="http://localhost:8123",
+        )
+        state.rematch_game()
+        assert state.songs == songs
+        assert state.songs is not songs
+
+
+# ---------------------------------------------------------------------------
+# The two dataclasses must not drift apart
+# ---------------------------------------------------------------------------
+
+
+class TestConfigAgreement:
+    """GameOptions and GameStateConfig overlap — keep the overlap honest."""
+
+    #: Options that are NOT reset by ``_reset_game_internals`` today and are
+    #: not manager-owned either. Documented, not fixed: adding them to
+    #: ``GameStateConfig`` would make ``end_game`` clear them, which is a
+    #: behaviour change and belongs in its own change (#2635 follow-up).
+    NOT_RESET_TODAY = frozenset({"platform", "reveal_auto_advance", "max_rounds"})
+
+    def test_state_owned_options_are_config_managed(self):
+        """Options GameState owns itself must be in GameStateConfig.
+
+        Options owned by a manager (ChallengeManager / RoundManager) reach
+        GameState through a delegation property and are reset by that manager's
+        own ``reset()``; they are detected here by being a ``property`` on the
+        class rather than a plain instance attribute.
+        """
+        config_fields = set(GameStateConfig.field_names())
+        missing = []
+        for name in GameOptions.field_names():
+            if isinstance(getattr(GameState, name, None), property):
+                continue  # manager-owned, reset by that manager
+            if name in self.NOT_RESET_TODAY:
+                continue
+            if name not in config_fields:
+                missing.append(name)
+        assert not missing, (
+            "Option(s) that GameState owns but GameStateConfig does not reset: "
+            f"{', '.join(missing)}. Add the field to GameStateConfig too, or "
+            "list it in NOT_RESET_TODAY with a reason."
+        )
+
+    def test_shared_defaults_agree(self):
+        """A field in both dataclasses must default to the same value."""
+        options = GameOptions()
+        config = GameStateConfig()
+        shared = set(GameOptions.field_names()) & {
+            f.name for f in fields(GameStateConfig)
+        }
+        assert shared, "expected some overlap between the two dataclasses"
+        drift = {
+            name: (getattr(options, name), getattr(config, name))
+            for name in shared
+            if getattr(options, name) != getattr(config, name)
+        }
+        assert not drift, f"default drift between GameOptions/GameStateConfig: {drift}"
+
+
+# ---------------------------------------------------------------------------
+# create_game's new signature
+# ---------------------------------------------------------------------------
+
+
+class TestCreateGameSignature:
+    """The dataclass replaced 18 parameters — the call styles still work."""
+
+    def test_keyword_overrides_still_work(self):
+        """The historic create_game(..., sabotage_enabled=True) call style."""
+        state = make_game_state()
+        state.create_game(
+            playlists=["test.json"],
+            songs=_songs(),
+            media_player="media_player.party",
+            base_url="http://localhost:8123",
+            sabotage_enabled=True,
+            sudden_death_mode=True,
+        )
+        assert state.sabotage_enabled is True
+        assert state.sudden_death_mode is True
+        assert state.closest_wins_mode is False
+
+    def test_overrides_win_over_the_options_object(self):
+        state = make_game_state()
+        state.create_game(
+            playlists=["test.json"],
+            songs=_songs(),
+            media_player="media_player.party",
+            base_url="http://localhost:8123",
+            options=GameOptions(sabotage_enabled=True, closest_wins_mode=True),
+            sabotage_enabled=False,
+        )
+        assert state.sabotage_enabled is False
+        assert state.closest_wins_mode is True
+
+    def test_unknown_option_is_a_type_error(self):
+        """A typo must still be loud, as it was with an explicit signature."""
+        state = make_game_state()
+        with pytest.raises(TypeError):
+            state.create_game(
+                playlists=["test.json"],
+                songs=_songs(),
+                media_player="media_player.party",
+                base_url="http://localhost:8123",
+                sabotage_enable=True,  # typo
+            )
+
+    def test_title_artist_mode_still_disables_the_artist_challenge(self):
+        """#1180's exclusion is applied by configure(), not by apply_to."""
+        state = make_game_state()
+        state.create_game(
+            playlists=["test.json"],
+            songs=_songs(),
+            media_player="media_player.party",
+            base_url="http://localhost:8123",
+            artist_challenge_enabled=True,
+            title_artist_mode=True,
+        )
+        assert state.title_artist_mode is True
+        assert state.artist_challenge_enabled is False
+        # ...and the rematch keeps the resolved value, not the requested one.
+        state.rematch_game()
+        assert state.artist_challenge_enabled is False


### PR DESCRIPTION
Blattplan 2026-W38.

The same game option was written out four times: as a parameter of `create_game` (22 of them, carrying `noqa: PLR0913`), as a field of `GameStateConfig`, as an entry in the hand-written `preserved` dict of `rematch_game`, and as a key of `create_kwargs` in `server/game_views.py`. Miss one and the rematch broke **silently** — the option fell back to its default with no error, no log line and no failing test.

## What changed

`GameOptions` in `game/config.py` is now that one list — 18 fields, each with its default and the issue it came from.

- **`create_game(playlists, songs, media_player, base_url, options=None, **option_overrides)`** — the 18-parameter signature and its `noqa: PLR0913` are gone. A single `opts.apply_to(self)` replaces the assignments that were scattered over ~90 lines.
- **`rematch_game`** — `GameOptions.capture(self)` instead of the hand-written `preserved` dict. The dict was a transcript of `create_game`'s parameter list; the capture reads by field name, so a newly declared option is carried over without touching the rematch.
- **`server/game_views.py`** — one `GameOptions(...)` instead of the 21-key `create_kwargs` dict. A wrong name there is now a `TypeError` at construction instead of an option silently arriving as its default.

## The completeness test

`tests/unit/test_game_options_2635.py` is the actual deliverable. `test_every_option_survives_the_rematch` sets **every** option to a non-default value, creates a game, runs a rematch, and asserts every option is still there. It iterates `fields(GameOptions)`, so a new option is covered the moment it is declared — no test edit needed. Non-bool options need a sentinel value; `test_sentinel_covers_every_option` fails loudly if a new one has none, rather than skipping it quietly.

**Counter-proof, run for real, not just asserted.** I put the pre-#2635 world back: `rematch_game` restoring from a hand-written list that forgot `sabotage_enabled`. The test goes red with the message it was written to give:

```
AssertionError: Game option(s) did not survive: sabotage_enabled expected True,
got False. A new option has to be a GameOptions field — nothing else.
```

`test_completeness_test_fails_when_an_option_is_dropped` keeps that proof in the suite: it drops one field from the capture loop and asserts the check fails.

## Behaviour

**No existing test was changed.** 2312 unit + integration tests pass on the code as it stood — that is the strongest evidence I have that nothing moved, and it is why I did not touch a single one.

Three places where behaviour could plausibly have shifted, and did not:

- **Call style.** `create_game(..., sabotage_enabled=True)` still works, via `**option_overrides`. All 65 existing call sites and `GameService.create_game(**kwargs)` are untouched. An unknown name is still a `TypeError`.
- **The Title & Artist exclusion (#1180).** `ChallengeManager.configure` still runs after `apply_to`, so `artist_challenge_enabled` is still forced off in TA mode, and the rematch still preserves the *resolved* value, not the requested one. Covered by a test.
- **The song list copy.** The rematch still works on its own copy of `songs` (`list(...)`), not the caller's object. Covered by a test.

`round_duration` validation, the `#1378` validate-before-mutate ordering, the `#709` no-playable-songs fast fail and the `#1867` round-duration log line all read from the options object and are otherwise unchanged.

## The 39 attributes `_reset_game_internals` does not touch

The issue counts 39 attributes that `create_game` sets and the shared reset never clears. **This PR does not change that number, deliberately.** `create_game` sets the same attributes as before; the reset does the same thing as before. Where the two lists meet, the change is only in how the values get there.

What the PR does add is a name for the gap and a test that watches it. `test_state_owned_options_are_config_managed` asserts that every option `GameState` owns directly is a `GameStateConfig` field — so `end_game` still resets it — while options owned by a manager (detected as a `property` on the class) are skipped, because `ChallengeManager.reset()` / `RoundManager.reset()` handle them. Three options are neither, and the test names them in `NOT_RESET_TODAY`:

- `platform`, `max_rounds` and `reveal_auto_advance` are set at create and never reset. They survive a rematch by accident today — nothing clears them, so nothing needed to restore them. The rematch now restores them explicitly, which is a no-op, and they stay out of `GameStateConfig`.

Adding them to `GameStateConfig` would make `end_game` clear them. That is very likely the right end state, but it is a behaviour change on the game's most sensitive path, so it is not in this PR. The test now makes it a documented exception rather than an invisible one: a fourth such option cannot be added without either fixing it or writing down why.

**Still open beyond that:** `GameStateConfig` remains a second place to touch when adding a state-owned flag. `test_shared_defaults_agree` catches the defaults drifting apart and `test_state_owned_options_are_config_managed` catches the field going missing entirely — loud instead of silent — but the two dataclasses answer different questions (*what gets reset* vs *what the game is configured with*) and folding them into one is its own change.

## Checks

- `ruff format --check .` / `ruff check .` — clean
- `pytest tests/unit tests/integration` — 2312 passed, 2 skipped
- `npm test` — 785 passed
- `npm run build:check` — 18/18 artifacts match
- `mypy` — no issues (`game/config.py` is inside the gate)

Closes #2635

🤖 Generated with [Claude Code](https://claude.com/claude-code)
