### PR TITLE
fix(playback): hold the pause until the speaker has actually settled

### DIFF
--- a/custom_components/beatify/game/state_reveal_transition.py
+++ b/custom_components/beatify/game/state_reveal_transition.py
@@ -73,6 +73,8 @@ The mixin relies on attributes / methods the host class owns and that live on
 * ``self._lights_set_phase`` / ``self._lights_flash`` / ``self._party_lights`` /
   ``self.disable_party_lights`` — the party-light hooks (live on
   ``MediaControlMixin``).
+* ``self.stop_media`` — the #2605 terminal stop in ``advance_to_end`` (also
+  lives on ``MediaControlMixin``).
 * ``self._cancel_auto_advance`` — the #1012 REVEAL auto-advance cancel hook
   (lives on ``RevealAutoAdvanceMixin``).
 * ``self.end_round`` / ``self.play_deferred_song`` / ``self._on_round_end`` —
@@ -375,6 +377,27 @@ class RevealTransitionMixin:
         self._cancel_auto_advance()  # #1012
         # #1273: transition clears reveal_started_at (#1048) + notifies (#441).
         self._set_phase(GamePhase.END)
+
+        # #2605: stop the round's song here, at the terminal, not only in the
+        # callers that happen to remember.
+        #
+        # `admin_end_game`, `admin_next_round` and the REST `end-game` view all
+        # call `stop_media()` before they get here. The unattended final round
+        # does not: `_reveal_auto_advance` breaks out of its wait loop on
+        # `elapsed >= hard_cap` as well as on `_song_finished()`, and on the
+        # last round that goes straight into the game-end ceremony. With a
+        # REVEAL timer set, the game therefore ended while the round's song was
+        # still playing, and nothing on the way to END asked the speaker to
+        # stop — the podium went up over Beatify's own music.
+        #
+        # Idempotent: `media_stop` on an already-idle speaker is a no-op, so
+        # the callers that stop first lose nothing. It runs BEFORE the podium
+        # TTS below on purpose — announce_winner speaks through this same
+        # speaker, and a stop afterwards would cut it off.
+        try:
+            await self.stop_media()
+        except Exception as err:  # noqa: BLE001 — a stop must never break the podium
+            _LOGGER.warning("advance_to_end: stop playback failed: %s (#2605)", err)
 
         # Issue #331: Celebrate with Party Lights, then stop (#553)
         if self._party_lights:

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -123,11 +123,31 @@ MA_FIRST_PLAY_TIMEOUT_FACTOR = 4 / 3
 # position, not the track — the song comes back either way, just from 0:00.
 MA_QUEUE_RESTORE_WAIT = 5.0
 MA_QUEUE_RESTORE_POLL = 0.25
-# #2605: wie lange auf die Bestaetigung der Pause gewartet wird, je Versuch.
-# Kuerzer als MA_QUEUE_RESTORE_WAIT, weil hier nichts geladen werden muss — der
-# Lautsprecher spielt bereits und soll nur anhalten. Zwei Versuche a 2 s haengen
-# den Abbau um hoechstens vier Sekunden, und das nur im Fehlerfall.
+# #2605: the pause at the end of the queue restore is read back — and the check
+# has to OUTLIVE the device settling rather than fit inside it.
+#
+# The first attempt (#2606) looked once, inside a two-second window, and then
+# stopped looking. On the real installation (Sonos through Music Assistant) the
+# speaker reported `idle` inside exactly that window, the pause counted as
+# confirmed — and from second five onwards it was playing again, for three
+# minutes. The window was the defect, not the state check.
+#
+# So now: confirm, and then KEEP WATCHING. The teardown only counts as done
+# once the speaker has stayed quiet for MA_PAUSE_SETTLE_HOLD seconds in a row;
+# if it starts again before that, it is paused again. MA_PAUSE_GUARD_WINDOW
+# caps the whole thing so `end-game` cannot hang on a speaker something else
+# owns.
 MA_PAUSE_CONFIRM_WAIT = 2.0
+MA_PAUSE_SETTLE_HOLD = 5.0
+MA_PAUSE_GUARD_WINDOW = 12.0
+MA_PAUSE_MAX_ATTEMPTS = 3
+MA_PAUSE_POLL = 0.25
+
+# #2605: "not playing" is too generous. MA reports `buffering` while a track
+# loads, and a reading that lands there looks exactly like a successful pause —
+# the track starts a second later anyway. Both states therefore count as "still
+# going".
+MA_ACTIVE_STATES = frozenset({"playing", "buffering"})
 
 # #1381: Fast-path Path 2 (title-advanced-without-exact-match) must not
 # instant-accept an *arbitrary* title change. If a requested URI fails to
@@ -692,15 +712,19 @@ class MediaPlayerService:
                     {"entity_id": entity_id, "repeat": queue["repeat_mode"]},
                     blocking=False,
                 )
-            # #2605: die Pause steht ZULETZT und wird gegengelesen.
+            # #2605: the pause runs LAST, and it is guarded.
             #
-            # Sie stand vorher vor `shuffle_set`/`repeat_set` und wurde mit
-            # `blocking=False` abgeschickt, ohne dass jemand nachsah. Gemessen am
-            # 05.09.2026: der Lautsprecher stand danach dreimal in Folge auf
-            # `playing` — beim Spielende laeuft also die alte Warteschlange
-            # weiter, ueber das Podium hinweg, in voller Party-Lautstaerke.
-            # Die Log-Zeile unten meldete trotzdem „(paused)", weil sie die
-            # Absicht beschrieb und nicht das Ergebnis.
+            # It originally sat before `shuffle_set`/`repeat_set` and was fired
+            # with `blocking=False` with nobody looking. Measured 2026-09-05:
+            # the speaker read `playing` afterwards three times in a row — the
+            # host's old queue playing on over the podium, at party volume.
+            #
+            # Every call above is deliberately `blocking=False` (MA hangs on
+            # `blocking=True` for `play_media`, see `play_song`). Submission
+            # order is therefore NOT execution order: the `media_seek` can land
+            # after the pause and start Sonos playing again. Rather than guess
+            # which call did it, `_pause_and_confirm` holds the silence instead
+            # of measuring it once.
             paused = await self._pause_and_confirm(entity_id)
         except (HomeAssistantError, ServiceNotFound) as err:
             _LOGGER.warning("Queue restore on %s failed: %s", entity_id, err)
@@ -711,46 +735,128 @@ class MediaPlayerService:
                 entity_id,
                 queue.get("name") or queue["uri"],
                 queue.get("elapsed_time", 0),
-                "paused" if paused else "STILL PLAYING — pause not confirmed",
+                "paused"
+                if paused
+                else "PAUSE NOT CONFIRMED — see the warning above (#2605)",
             )
             return True
 
     async def _pause_and_confirm(self, entity_id: str) -> bool:
-        """Pausieren und gegenlesen, mit genau einem zweiten Versuch (#2605).
+        """Pause, read it back — and then keep looking (#2605).
 
-        Ein `media_pause` mit ``blocking=False`` ist eine Bitte, keine Tatsache.
-        Beim Abbau der Warteschlange kam sie dreimal in Folge nicht an: der
-        Lautsprecher spielte weiter, waehrend das Log „(paused)" meldete.
+        A `media_pause` with ``blocking=False`` is a request, not a fact. That
+        was the finding of #2605, and #2606 answered it by reading the state
+        back. On the real installation that still did not hold: the pause
+        landed, was confirmed, and from second five the speaker was playing
+        again. The check sat in a two-second window; the device takes longer
+        than that to settle.
 
-        Deshalb wird hier gelesen statt geglaubt — und genau einmal wiederholt.
-        Ein zweiter Versuch faengt das Rennen zwischen dem gerade geladenen Track
-        und der Pause ab; ein dritter wuerde nur den Abbau verlaengern, ohne eine
-        neue Ursache abzudecken.
+        So the pause is not merely confirmed here, it is **held**:
+
+        1. pause,
+        2. wait until the speaker no longer reports active playback,
+        3. then watch it for ``MA_PAUSE_SETTLE_HOLD`` seconds in a row.
+
+        If it starts again during step 3 — whether from a ``media_seek`` still
+        in flight, a ``play_media`` that had not finished loading, or Music
+        Assistant resuming its own queue — it is paused again. The guard is
+        deliberately blind to the mechanism; it reacts to what the room does.
+
+        ``MA_PAUSE_GUARD_WINDOW`` caps the whole thing so a speaker something
+        else owns cannot hang the ``end-game`` teardown.
 
         Returns:
-            True, wenn der Lautsprecher danach nicht mehr ``playing`` meldet.
+            True when the speaker actually held the silence (or the entity is
+            gone). False means unconfirmed — the warning in the log says why.
         """
-        for versuch in (1, 2):
+        deadline = asyncio.get_event_loop().time() + MA_PAUSE_GUARD_WINDOW
+        for versuch in range(1, MA_PAUSE_MAX_ATTEMPTS + 1):
             await self._hass.services.async_call(
                 "media_player",
                 "media_pause",
                 {"entity_id": entity_id},
                 blocking=False,
             )
-            deadline = asyncio.get_event_loop().time() + MA_PAUSE_CONFIRM_WAIT
-            while asyncio.get_event_loop().time() < deadline:
-                state = self._hass.states.get(entity_id)
-                # `None` heisst: die Entitaet ist verschwunden. Dann ist nichts
-                # mehr zu pausieren, und ein Warten darauf haelt nur den Abbau auf.
-                if state is None or state.state != "playing":
-                    return True
-                await asyncio.sleep(MA_QUEUE_RESTORE_POLL)
-            _LOGGER.debug(
-                "Queue restore on %s: still playing after pause attempt %d",
-                entity_id,
-                versuch,
-            )
+            if not await self._wait_until_quiet(entity_id, deadline):
+                _LOGGER.debug(
+                    "Queue restore on %s: still playing after pause attempt %d",
+                    entity_id,
+                    versuch,
+                )
+            elif await self._stays_quiet(entity_id, deadline):
+                if versuch > 1:
+                    _LOGGER.info(
+                        "Queue restore on %s: speaker stayed paused after "
+                        "attempt %d (#2605)",
+                        entity_id,
+                        versuch,
+                    )
+                return True
+            else:
+                # This is the observation #2606 could not make: the pause
+                # arrived, and the speaker started itself again afterwards.
+                _LOGGER.info(
+                    "Queue restore on %s: speaker started playing again after "
+                    "pause attempt %d — pausing once more (#2605)",
+                    entity_id,
+                    versuch,
+                )
+            if asyncio.get_event_loop().time() >= deadline:
+                break
+        _LOGGER.warning(
+            "Queue restore on %s: could not get the speaker to stay paused "
+            "within %.0fs — it is still playing the host's queue (#2605)",
+            entity_id,
+            MA_PAUSE_GUARD_WINDOW,
+        )
         return False
+
+    async def _wait_until_quiet(self, entity_id: str, deadline: float) -> bool:
+        """Wait until the speaker stops reporting active playback (#2605).
+
+        ``media_pause`` settles Sonos-through-Music-Assistant to ``idle``, not
+        to ``paused`` — measured 2026-09-05, visible in the service response as
+        playing → idle. So this tests for "not active" rather than for one
+        particular target state.
+
+        ``None`` means the entity is gone. There is nothing left to pause then,
+        and waiting on it would only stall the teardown.
+        """
+        loop = asyncio.get_event_loop()
+        limit = min(loop.time() + MA_PAUSE_CONFIRM_WAIT, deadline)
+        while True:
+            state = self._hass.states.get(entity_id)
+            if state is None or state.state not in MA_ACTIVE_STATES:
+                return True
+            if loop.time() >= limit:
+                return False
+            await asyncio.sleep(MA_PAUSE_POLL)
+
+    async def _stays_quiet(self, entity_id: str, deadline: float) -> bool:
+        """Read the silence back for ``MA_PAUSE_SETTLE_HOLD`` seconds (#2605).
+
+        This is precisely the step #2606 was missing. There the first quiet
+        reading counted as proof — and because it fell inside a two-second
+        window, it was a reading of a speaker that had not finished settling.
+
+        Returns:
+            False as soon as playback is reported again, or when the guard
+            window runs out before the silence has held long enough.
+        """
+        loop = asyncio.get_event_loop()
+        hold_until = loop.time() + MA_PAUSE_SETTLE_HOLD
+        while True:
+            now = loop.time()
+            if now >= hold_until:
+                return True
+            if now >= deadline:
+                return False
+            await asyncio.sleep(MA_PAUSE_POLL)
+            state = self._hass.states.get(entity_id)
+            if state is None:
+                return True
+            if state.state in MA_ACTIVE_STATES:
+                return False
 
     async def _wait_for_playing(self, entity_id: str) -> bool:
         """Poll until the speaker reports playback, at most MA_QUEUE_RESTORE_WAIT."""

--- a/tests/unit/test_game_end_stops_the_speaker_2605.py
+++ b/tests/unit/test_game_end_stops_the_speaker_2605.py
@@ -1,0 +1,101 @@
+"""#2605: every way a game can end has to stop the speaker.
+
+The reopened #2605 was two defects wearing one title. The loud one is in
+``MediaPlayerService._pause_and_confirm`` — see
+``test_queue_restore_stays_paused_2605.py``. The quiet one is here: not every
+route to the podium asked the speaker to stop.
+
+``advance_to_end`` is the documented universal terminal (see the phase-table
+comment in ``game/state.py``), but the stop lived in its *callers*:
+
+* ``admin_end_game`` — host taps End: stops first. ✅
+* ``admin_next_round`` on the last round: stops first. ✅
+* REST ``/beatify/api/end-game``: stops first. ✅
+* the unattended final round — ``_reveal_auto_advance`` — does not. ❌
+
+That last one is the round-exhaustion path, and it is not only reached when the
+song has finished. Its wait loop breaks on ``self._song_finished() or elapsed >=
+hard_cap``, where ``hard_cap`` is the configured REVEAL timer. With a REVEAL
+timer set, the final round therefore ends *while the round's song is still
+playing* and hands straight over to the game-end ceremony — podium on the TV,
+Beatify's own track still on the speaker.
+
+So the stop belongs at the terminal, where every route passes. It is idempotent,
+so the callers that already stop lose nothing.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.beatify.game.state import GamePhase
+from tests.conftest import make_game_state, make_songs
+
+
+def _game_in_reveal():
+    game = make_game_state()
+    game.create_game(
+        playlists=["test.json"],
+        songs=make_songs(2),
+        media_player="media_player.esszimmer",
+        base_url="http://localhost:8123",
+    )
+    game._set_phase(GamePhase.PLAYING)
+    game._set_phase(GamePhase.REVEAL)
+    game._media_player_service = AsyncMock()
+    game._party_lights = None
+    return game
+
+
+class TestAdvanceToEndStopsTheSpeaker:
+    @pytest.mark.asyncio
+    async def test_the_terminal_stops_playback(self):
+        """The unattended final round reaches END through here and nowhere else."""
+        game = _game_in_reveal()
+
+        await game.advance_to_end()
+
+        assert game.phase is GamePhase.END
+        game._media_player_service.stop.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_stop_runs_before_the_podium_announcement(self):
+        """announce_winner speaks through the same speaker.
+
+        Stopping afterwards would cut the podium off mid-sentence, which is
+        why the stop sits directly after the phase flip rather than at the end
+        of the ceremony.
+        """
+        game = _game_in_reveal()
+        order: list[str] = []
+        game._media_player_service.stop = AsyncMock(
+            side_effect=lambda: order.append("stop")
+        )
+        game.announce_winner = AsyncMock(side_effect=lambda: order.append("winner"))
+        game.announce_podium = AsyncMock(side_effect=lambda: order.append("podium"))
+
+        await game.advance_to_end()
+
+        assert order == ["stop", "winner", "podium"]
+
+    @pytest.mark.asyncio
+    async def test_a_failing_stop_does_not_cost_the_podium(self):
+        """A speaker that is gone must not take the end screen down with it."""
+        game = _game_in_reveal()
+        game._media_player_service.stop = AsyncMock(side_effect=RuntimeError("gone"))
+
+        await game.advance_to_end()
+
+        assert game.phase is GamePhase.END
+
+    @pytest.mark.asyncio
+    async def test_no_media_player_is_not_an_error(self):
+        """Games without a speaker (no round ever started) end normally."""
+        game = _game_in_reveal()
+        game._media_player_service = None
+
+        await game.advance_to_end()
+
+        assert game.phase is GamePhase.END

--- a/tests/unit/test_ma_queue_restore_2143.py
+++ b/tests/unit/test_ma_queue_restore_2143.py
@@ -26,8 +26,26 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.beatify.services import media_player as mp
 from custom_components.beatify.services.media_player import MediaPlayerService
 from tests.conftest import make_game_state, make_songs
+
+
+@pytest.fixture(autouse=True)
+def _fast_pause_guard(monkeypatch):
+    """Run the #2605 pause guard on a compressed clock.
+
+    The fixtures here model a speaker that never stops, so the guard spends its
+    full production budget (a 5s hold inside a 12s window) on every restore in
+    this file. Only the durations shrink; the logic is untouched, and the
+    #2605 contract itself is tested in
+    ``test_queue_restore_stays_paused_2605.py``.
+    """
+    monkeypatch.setattr(mp, "MA_PAUSE_CONFIRM_WAIT", 0.05)
+    monkeypatch.setattr(mp, "MA_PAUSE_SETTLE_HOLD", 0.05)
+    monkeypatch.setattr(mp, "MA_PAUSE_GUARD_WINDOW", 0.30)
+    monkeypatch.setattr(mp, "MA_PAUSE_POLL", 0.01)
+
 
 QUEUE_RESPONSE = {
     "media_player.esszimmer": {
@@ -178,9 +196,9 @@ class TestQueueRestore:
         #
         # #2605: this used to assert exactly ONE pause. The fixture's speaker
         # reports `playing` on every read — it never stops — and since #2605 a
-        # pause that does not take is sent a second time. One call was the old
-        # behaviour, not the requirement; what this test is about is that we
-        # pause and never resume.
+        # pause that does not take is sent again until the guard window runs
+        # out. One call was the old behaviour, not the requirement; what this
+        # test is about is that we pause and never resume.
         assert len(_calls_to(hass, "media_player", "media_pause")) >= 1
         assert not _calls_to(hass, "media_player", "media_play")
         assert _calls_to(hass, "media_player", "shuffle_set")[0].args[2]["shuffle"]

--- a/tests/unit/test_queue_restore_stays_paused_2605.py
+++ b/tests/unit/test_queue_restore_stays_paused_2605.py
@@ -5,23 +5,33 @@ handed the host's queue back and logged ``Queue restored on … (paused)``, whil
 `media_player.esszimmer` reported ``playing`` seventy seconds later — three
 times in a row, on two different tracks.
 
-Two causes, both addressed here:
+**This issue was fixed once and came back.** The first attempt (#2606) moved
+the pause behind ``shuffle_set`` / ``repeat_set`` and read the state back
+instead of trusting ``blocking=False``. Measured against v4.4.2-rc3, the build
+that contains it, the pause landed, was confirmed, and the speaker was playing
+again five seconds later — for three minutes.
 
-* the pause was fired with ``blocking=False`` and nobody read the state back,
-* it ran *before* ``shuffle_set`` / ``repeat_set``, so anything those two do to
-  the queue happened after the speaker had been asked to stop.
+What #2606 got wrong was not the state check but its *window*. It looked for at
+most two seconds and then stopped looking, and everything that restarts the
+speaker on this hardware happens after that: a ``media_seek`` that was still in
+flight (every call in the restore is ``blocking=False``, so the order of
+submission is not the order of execution), a ``play_media`` that had not
+finished loading the queue, or Music Assistant resuming its own queue.
 
-The old log line was written unconditionally in the ``else:`` branch — it
-reported the intent, not the outcome, which is why the defect survived every
-previous run of this file.
+So the guard here does not try to name the mechanism. It pauses, waits for the
+speaker to go quiet, and then keeps watching for ``MA_PAUSE_SETTLE_HOLD``
+seconds — pausing again on any relapse. The tests below model the device the
+way the live run behaved: it obeys the pause, and then starts itself again.
 """
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from custom_components.beatify.services import media_player as mp
 from custom_components.beatify.services.media_player import MediaPlayerService
 
 QUEUE = {
@@ -32,20 +42,77 @@ QUEUE = {
     "repeat_mode": "off",
 }
 
+ENTITY = "media_player.esszimmer"
 
-def _hass(states: list[str]) -> MagicMock:
-    """A hass whose speaker walks through ``states`` on successive reads.
 
-    The last entry repeats forever, so a test can model "never stops" with a
-    single element.
+@pytest.fixture(autouse=True)
+def _fast_guard(monkeypatch):
+    """Run the real guard on a compressed clock.
+
+    The production budget is 5s of hold inside a 12s window — correct for a
+    Sonos, unbearable in a unit suite. Only the durations shrink; the logic
+    under test is untouched.
     """
+    monkeypatch.setattr(mp, "MA_PAUSE_CONFIRM_WAIT", 0.20)
+    monkeypatch.setattr(mp, "MA_PAUSE_SETTLE_HOLD", 0.30)
+    monkeypatch.setattr(mp, "MA_PAUSE_GUARD_WINDOW", 2.0)
+    monkeypatch.setattr(mp, "MA_PAUSE_POLL", 0.02)
+    monkeypatch.setattr(mp, "MA_QUEUE_RESTORE_WAIT", 0.20)
+    monkeypatch.setattr(mp, "MA_QUEUE_RESTORE_POLL", 0.02)
+
+
+class Speaker:
+    """A media player that obeys a pause and then starts itself again.
+
+    This is the reopened #2605, reduced to its mechanism: ``media_pause``
+    really does take — the state leaves ``playing`` — and ``resume_after``
+    seconds later the device is playing once more. #2606 stopped looking two
+    seconds after the pause, so from where it stood the teardown had worked.
+
+    Args:
+        resume_after: seconds between an accepted pause and the relapse.
+        obeys_from: the pause command number from which the speaker stays
+            quiet for good. ``None`` means it never settles.
+    """
+
+    def __init__(self, *, resume_after: float, obeys_from: int | None = None) -> None:
+        self.resume_after = resume_after
+        self.obeys_from = obeys_from
+        self.pause_count = 0
+        self.paused_at: float | None = None
+
+    def pause(self) -> None:
+        self.pause_count += 1
+        self.paused_at = asyncio.get_event_loop().time()
+
+    @property
+    def state(self) -> str:
+        if self.paused_at is None:
+            return "playing"
+        if self.obeys_from is not None and self.pause_count >= self.obeys_from:
+            # `idle`, not `paused`: that is what Sonos through Music Assistant
+            # actually settles to — measured 05.09.2026, visible in the service
+            # response as playing → idle.
+            return "idle"
+        if asyncio.get_event_loop().time() - self.paused_at >= self.resume_after:
+            return "playing"
+        return "idle"
+
+
+def _hass_for(speaker: Speaker | None = None, fixed_state: str = "playing"):
+    """A hass whose speaker is either the stateful ``Speaker`` or a fixed state."""
     hass = MagicMock()
-    hass.services.async_call = AsyncMock(return_value=None)
-    seq = list(states)
+
+    async def _call(domain, service, data=None, **kwargs):
+        if (domain, service) == ("media_player", "media_pause") and speaker:
+            speaker.pause()
+        return None
+
+    hass.services.async_call = AsyncMock(side_effect=_call)
 
     def _get(_entity_id):
         st = MagicMock()
-        st.state = seq[0] if len(seq) == 1 else seq.pop(0)
+        st.state = speaker.state if speaker else fixed_state
         st.attributes = {"volume_level": 0.0}
         return st
 
@@ -54,28 +121,146 @@ def _hass(states: list[str]) -> MagicMock:
 
 
 def _service(hass) -> MediaPlayerService:
-    return MediaPlayerService(
-        hass, "media_player.esszimmer", platform="music_assistant"
-    )
+    return MediaPlayerService(hass, ENTITY, platform="music_assistant")
 
 
 def _services_called(hass) -> list[tuple[str, str]]:
     return [c.args[:2] for c in hass.services.async_call.await_args_list]
 
 
-class TestQueueRestoreStaysPaused:
+def _pause_calls(hass) -> int:
+    return sum(
+        1 for c in _services_called(hass) if c == ("media_player", "media_pause")
+    )
+
+
+class TestTheGuardOutlivesTheSettling:
+    """The regression tests for the REOPENED bug.
+
+    Each one passes against a guard that keeps watching and fails against one
+    that confirms the pause once and walks away — which is what #2606 did.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_speaker_that_restarts_itself_is_paused_again(self):
+        """The live symptom, exactly: pause accepted, playback back at +5s.
+
+        #2606 read the state back once, inside two seconds, saw a speaker that
+        had genuinely stopped, and reported success. Everything that restarts
+        this device happens later than that.
+        """
+        speaker = Speaker(resume_after=0.08, obeys_from=2)
+        hass = _hass_for(speaker)
+        svc = _service(hass)
+
+        assert await svc._restore_queue_on(ENTITY, QUEUE) is True
+
+        assert speaker.pause_count >= 2, (
+            "the speaker started playing again after the first pause and the "
+            "guard never noticed — this is #2605 reopened"
+        )
+        assert speaker.state != "playing"
+
+    @pytest.mark.asyncio
+    async def test_the_restore_admits_it_when_the_speaker_will_not_stay_paused(self):
+        """A speaker that keeps restarting must not be reported as paused.
+
+        The log line saying `(paused)` over a playing room is what let this
+        defect survive two live tests.
+        """
+        speaker = Speaker(resume_after=0.08)  # never settles
+        hass = _hass_for(speaker)
+        svc = _service(hass)
+
+        assert await svc._pause_and_confirm(ENTITY) is False
+        assert speaker.pause_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_the_log_line_says_the_speaker_is_still_playing(self, caplog):
+        speaker = Speaker(resume_after=0.08)
+        hass = _hass_for(speaker)
+        svc = _service(hass)
+
+        with caplog.at_level("INFO"):
+            await svc._restore_queue_on(ENTITY, QUEUE)
+
+        restored = [r for r in caplog.records if "Queue restored on" in r.getMessage()]
+        assert restored, "no restore line was logged at all"
+        assert "NOT CONFIRMED" in restored[-1].getMessage(), (
+            "the log claims the speaker is paused while it is still playing"
+        )
+
+    @pytest.mark.asyncio
+    async def test_buffering_is_not_a_paused_speaker(self):
+        """MA reports `buffering` while a track loads.
+
+        A confirmation that lands on it reads like a successful pause and is
+        not one — the track starts a moment later. Treating it as playback is
+        half of why a single reading cannot be trusted.
+        """
+        hass = _hass_for(fixed_state="buffering")
+        svc = _service(hass)
+
+        assert await svc._pause_and_confirm(ENTITY) is False
+        assert _pause_calls(hass) >= 2
+
+
+class TestTheCommonCaseDoesNotPayForIt:
+    @pytest.mark.asyncio
+    async def test_a_speaker_that_stays_paused_is_paused_once(self):
+        speaker = Speaker(resume_after=99.0, obeys_from=1)
+        hass = _hass_for(speaker)
+        svc = _service(hass)
+
+        assert await svc._restore_queue_on(ENTITY, QUEUE) is True
+        assert speaker.pause_count == 1
+
+    @pytest.mark.asyncio
+    async def test_a_vanished_entity_does_not_hold_up_the_teardown(self):
+        """``states.get`` returning None means there is nothing left to pause."""
+        hass = _hass_for()
+        hass.states.get = MagicMock(return_value=None)
+        svc = _service(hass)
+
+        assert await svc._restore_queue_on(ENTITY, QUEUE) is True
+
+    @pytest.mark.asyncio
+    async def test_an_entity_that_vanishes_mid_hold_ends_the_watch(self):
+        """The speaker can be removed while the guard is still watching it."""
+        hass = _hass_for(fixed_state="idle")
+        reads = {"n": 0}
+
+        def _get(_entity_id):
+            reads["n"] += 1
+            if reads["n"] > 2:
+                return None
+            st = MagicMock()
+            st.state = "idle"
+            st.attributes = {}
+            return st
+
+        hass.states.get = MagicMock(side_effect=_get)
+        svc = _service(hass)
+
+        assert await svc._pause_and_confirm(ENTITY) is True
+
+
+class TestOrderingStillHolds:
     @pytest.mark.asyncio
     async def test_pause_is_the_last_thing_that_happens(self):
         """Shuffle and repeat run BEFORE the pause, not after it.
 
-        Ordering is the half of the fix a state check cannot catch: with the
-        pause in the middle, a speaker that resumes on ``repeat_set`` ends up
-        playing while every individual call succeeded.
+        Ordering is the half of #2606 that was right: with the pause in the
+        middle, a speaker that resumes on ``repeat_set`` ends up playing while
+        every individual call succeeded. It is not sufficient — none of these
+        calls block, so submission order is not execution order, which is why
+        the guard above exists as well — but it is still necessary.
         """
-        hass = _hass(["playing", "paused"])
+        speaker = Speaker(resume_after=99.0, obeys_from=1)
+        hass = _hass_for(speaker)
         svc = _service(hass)
 
-        assert await svc._restore_queue_on("media_player.esszimmer", QUEUE) is True
+        assert await svc._restore_queue_on(ENTITY, QUEUE) is True
 
         calls = _services_called(hass)
         pause_at = calls.index(("media_player", "media_pause"))
@@ -87,67 +272,3 @@ class TestQueueRestoreStaysPaused:
             assert calls.index((domain, service)) < pause_at, (
                 f"{service} runs after the pause and can undo it"
             )
-
-    @pytest.mark.asyncio
-    async def test_pause_is_retried_when_the_speaker_keeps_playing(self):
-        """A pause that does not take is sent once more.
-
-        This is the live symptom: the call returns, nothing changes, and the
-        old code moved on regardless.
-        """
-        hass = _hass(["playing"])  # never stops
-        svc = _service(hass)
-
-        await svc._restore_queue_on("media_player.esszimmer", QUEUE)
-
-        pauses = [
-            c for c in _services_called(hass) if c == ("media_player", "media_pause")
-        ]
-        assert len(pauses) == 2, f"expected one retry, got {len(pauses)} pause call(s)"
-
-    @pytest.mark.asyncio
-    async def test_no_retry_when_the_first_pause_lands(self):
-        """The common case must not pay for the fix.
-
-        A retry on every teardown would add seconds to every game end for a
-        fault that is rare.
-        """
-        hass = _hass(["playing", "paused"])
-        svc = _service(hass)
-
-        await svc._restore_queue_on("media_player.esszimmer", QUEUE)
-
-        pauses = [
-            c for c in _services_called(hass) if c == ("media_player", "media_pause")
-        ]
-        assert len(pauses) == 1
-
-    @pytest.mark.asyncio
-    async def test_a_vanished_entity_does_not_hold_up_the_teardown(self):
-        """``states.get`` returning None means there is nothing left to pause."""
-        hass = _hass(["playing", "paused"])
-        hass.states.get = MagicMock(return_value=None)
-        svc = _service(hass)
-
-        # Would hang for two full confirm windows if None were treated as "still playing".
-        assert await svc._restore_queue_on("media_player.esszimmer", QUEUE) is True
-
-    @pytest.mark.asyncio
-    async def test_the_log_reports_the_outcome_not_the_intent(self, caplog):
-        """The line that hid this defect for months.
-
-        It said "(paused)" from inside the ``else:`` branch, so it was true of
-        the attempt and false of the room.
-        """
-        hass = _hass(["playing"])  # never stops
-        svc = _service(hass)
-
-        with caplog.at_level("INFO"):
-            await svc._restore_queue_on("media_player.esszimmer", QUEUE)
-
-        restored = [r for r in caplog.records if "Queue restored on" in r.getMessage()]
-        assert restored, "no restore line was logged at all"
-        assert (
-            "paused" not in restored[-1].getMessage().split("—")[0].lower()
-            or "STILL PLAYING" in restored[-1].getMessage()
-        ), "the log claims the speaker is paused while it is still playing"


### PR DESCRIPTION
Closes #2605

The speaker was still playing the host's queue after `end-game`. This is the **second** attempt — #2606 fixed it once and it came back on real hardware.

## Why #2606 did not hold

#2606 was right that a `blocking=False` `media_pause` is a request, not a fact, and it started reading the state back. What it got wrong was the **window**: `_pause_and_confirm` polled for at most `MA_PAUSE_CONFIRM_WAIT` (2 s) and then stopped looking.

Measured against v4.4.2-rc3 — the build that contains #2606 — the log showed `Queue restored on media_player.esszimmer: … (paused)` with no `still playing after pause attempt` line, so the confirmation returned on its **first** read. And the speaker was `playing` at +5 s, +15 s, +30 s, +45 s, and three minutes later. The pause landed, was verified, and something started playback again after the check had already gone home.

Two things make that easy to happen and impossible to see:

1. **Submission order is not execution order.** Every call in `_restore_queue_on` — `play_media`, `media_seek`, `shuffle_set`, `repeat_set`, `media_pause` — is `blocking=False`, deliberately (`blocking=True` hangs MA on `play_media`; see `play_song`). HA turns each into its own task, so the `media_seek` fired one line earlier can complete *after* the pause, and a seek on Sonos resumes playback. #2606 moved the pause last in the source; it could not move it last in time.
2. **`buffering` reads like a paused speaker.** The old check was `state != "playing"`. MA reports `buffering` while a track loads, and `media_pause` on this player settles to `idle` rather than `paused` — so a reading taken during the restore can look like a successful pause over a device that is about to start.

## What this changes

**The guard now outlives the settling instead of fitting inside it.** `_pause_and_confirm` pauses, waits for playback to stop (`_wait_until_quiet`), and then **keeps watching** for `MA_PAUSE_SETTLE_HOLD = 5 s` (`_stays_quiet`). Any relapse in that window triggers another pause. `MA_PAUSE_GUARD_WINDOW = 12 s` caps the whole thing so a speaker something else owns cannot hang the teardown.

The guard is deliberately **blind to the mechanism**. The issue named two candidates and neither is proven; a late seek, an unfinished `play_media` and MA resuming its own queue are indistinguishable from this side of the boundary, and all three look identical to a watcher that reacts to what the room does.

`buffering` is now treated as active playback (`MA_ACTIVE_STATES`).

**Second hole, same title.** Every way a game can end was walked:

| Exit | Stops the speaker before END? |
|---|---|
| Host taps End (`admin_end_game`) | yes — `stop_media()` first |
| Host taps Next on the last round (`admin_next_round`) | yes |
| REST `POST /beatify/api/end-game` | yes |
| Force reset → `end_game()` | queue restore runs |
| Dismiss / start a new game from END → `end_game()` | queue restore runs |
| **Unattended final round (`_reveal_auto_advance`)** | **no** |

The last one is the round-exhaustion path, and it does not only fire when the song has finished: its wait loop breaks on `self._song_finished() **or** elapsed >= hard_cap`, where `hard_cap` is the configured REVEAL timer. With a REVEAL timer set, the final round therefore ended while the round's song was still playing and went straight into the game-end ceremony — podium on the TV, Beatify's own track on the speaker, and nothing on the way to END asking it to stop.

`advance_to_end` is the documented universal terminal, so the stop now lives there rather than in whichever caller remembers. It is idempotent (`media_stop` on an idle speaker is a no-op) and runs **before** `announce_winner`, which speaks through the same speaker.

The queue restore itself is unchanged in structure: it still only runs from `end_game()`, which every genuine session end reaches.

## Regression tests, verified red first

`tests/unit/test_queue_restore_stays_paused_2605.py` was rewritten around a `Speaker` fake that models the live device: it **obeys** the pause — the state really does leave `playing` — and starts itself again `resume_after` seconds later. That is the shape #2606 could not see.

I verified the tests by breaking the code on purpose: I swapped the #2606 body of `_pause_and_confirm` back in and re-ran the file.

```
4 failed, 4 passed
FAILED …::test_a_speaker_that_restarts_itself_is_paused_again
FAILED …::test_the_restore_admits_it_when_the_speaker_will_not_stay_paused
FAILED …::test_the_log_line_says_the_speaker_is_still_playing
FAILED …::test_buffering_is_not_a_paused_speaker
```

The four that stayed green are the ones #2606 also satisfied (ordering, the single-pause common case, the vanished entity) — they are not the regression, and they should not have moved. With the fix restored: `8 passed`.

Same treatment for the terminal stop. With the `stop_media()` call removed from `advance_to_end`, `tests/unit/test_game_end_stops_the_speaker_2605.py` reports `2 failed, 2 passed`; restored, `4 passed`.

## Cost

The happy path now spends ~5 s holding the silence per restored speaker, so `end-game` teardown gets that much slower — the price of a check that outlives the settling, which is what the issue asked for. Worst case is 12 s, and only when the speaker genuinely keeps restarting; then the log carries a warning and the restore line says `PAUSE NOT CONFIRMED` instead of claiming `(paused)` over a playing room.

The two existing test files that drive this code got an autouse fixture compressing the guard's durations. `test_ma_queue_restore_2143.py` went from 23 s to 0.75 s in the process — its fixture models a speaker that never stops, so it was already paying the old guard's full budget on every restore.

## Checks

- `pytest tests/unit tests/integration -q` → **2346 passed, 2 skipped, 1 failed**
- `npm test` → **800 passed** (83 files)
- `npm run build:check` → **fails**
- `ruff format --check .` → **218 files already formatted**; `ruff check .` → all checks passed

The one pytest failure and the `build:check` failure are the **same thing** and are not from this branch: five `.gz` siblings under `custom_components/beatify/www/` (`i18n/de.json.gz`, `js/dashboard.js.gz`, `js/dashboard.min.js.gz`, `js/player-game.js.gz`, `js/player.bundle.min.js.gz`) do not decompress byte-identically to their sources on my machine. I reproduced both on a clean checkout of `origin/main` with no changes at all, and **CI's own Frontend build check passes on this branch** — so it is a local gzip-toolchain difference, not a stale artifact in the repo. This branch touches no frontend source and regenerates nothing.

## Still unverified until the Thursday live test

Everything here is reasoned from the logs and the HA service semantics; the speaker cannot be reached from CI. The live run has to confirm:

1. **The speaker is actually silent 30 s after `end-game`**, not just at +5 s. That is the measurement that failed twice.
2. **The `(paused)` in the restore log now matches the room.** If the guard gives up, the line reads `PAUSE NOT CONFIRMED` and a warning precedes it — if that appears, something outside HA owns the speaker and the next step is Music Assistant, not this code.
3. **Which mechanism it actually was.** The new INFO line `speaker started playing again after pause attempt N` names the relapse. If it fires on the 107 s restore (which seeks) and not on the 0 s one (which does not), the seek is the culprit and the seek can be made blocking as a follow-up.
4. **Whether 5 s of hold is enough.** If the relapse arrives later than that on this hardware, `MA_PAUSE_SETTLE_HOLD` needs raising — the field data only bounds it at "somewhere under 5 s".
5. **That the added ~5 s teardown is acceptable in the room**, with the podium already on the TV.
6. **The grouped-speaker case** (`media_player.esszimmer` + `media_player.kuche_2`): the guard watches the entity Beatify was given, and a group member resuming independently would not be seen.
7. **The unattended final round with a REVEAL timer set** — play the last round out without touching the host UI and confirm the music stops at the podium rather than under it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKsEKt68KHSqmi617XNCVi
