### PR TITLE
refactor(game): inject Home Assistant services into GameState, move the admin socket to the server

### DIFF
--- a/custom_components/beatify/__init__.py
+++ b/custom_components/beatify/__init__.py
@@ -88,6 +88,7 @@ from .server.library_views import (
 from .server.setup_state import clear_setup
 from .server.websocket import BeatifyWebSocketHandler
 from .server.ws_handlers._helpers import finalize_and_end
+from .services.factories import ha_service_factories
 from .services.media_player import async_get_media_players
 from .services.stats import StatsService
 
@@ -153,8 +154,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         len(playlists),
     )
 
-    # Initialize game state
-    game_state = GameState()
+    # Initialize game state. #2638: this is the composition root — the only
+    # place that decides the game's outputs are Home-Assistant-backed. The
+    # domain package itself never names a concrete service class, which is what
+    # makes GameState constructible (and testable) without hass.
+    game_state = GameState(service_factories=ha_service_factories(hass))
     game_state.set_hass(hass)
 
     # Initialize stats service (Story 14.4)
@@ -193,6 +197,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Connect analytics to websocket handler for error recording (Story 19.1)
     ws_handler.set_analytics(analytics)
+
+    # #2638: the admin spectator socket belongs to the WebSocket handler now.
+    # A game teardown/rebuild used to null it inside _reset_game_internals; the
+    # reset callback fires at that same point so the timing is unchanged.
+    game_state.register_reset_callback(ws_handler.clear_admin_socket)
 
     # #1357: Companion auth-bypass opt-in. Read once at setup; the auth helper
     # in server/companion_auth.py reads this live from hass.data per request,

--- a/custom_components/beatify/game/protocols.py
+++ b/custom_components/beatify/game/protocols.py
@@ -1,7 +1,23 @@
-"""Protocols for game service dependencies — avoids circular imports (#465)."""
+"""Protocols for game service dependencies — avoids circular imports (#465).
+
+#2638: the domain package no longer builds its own Home Assistant services.
+``GameState`` receives a :class:`GameOutputFactories` bundle at construction
+time; the composition root (``custom_components/beatify/__init__.py``, and the
+defensive fallback in ``server/game_views.py``) fills it via
+``services.factories.ha_service_factories``, which is the only place that knows
+the concrete ``services.*`` classes exist.
+
+A caller that passes no bundle — every game-logic unit test — gets a
+``GameState`` with no output backends at all: the media player, party lights and
+TTS announcements are simply absent, which is exactly what those code paths
+already guard for (``if self._media_player_service``, ``if self._party_lights``,
+``if not self._tts_service``). Tests that DO want an output pass a fake factory
+instead of mocking Home Assistant.
+"""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Protocol, runtime_checkable
 
 
@@ -41,3 +57,73 @@ class PartyLightsProtocol(Protocol):
     async def celebrate(self) -> None: ...
     async def stop(self) -> None: ...
     def snapshot_saved_states(self) -> dict[str, dict[str, Any]]: ...
+
+
+@runtime_checkable
+class TtsProtocol(Protocol):
+    """Interface that GameState expects from a TTS announcement service (#2638).
+
+    ``TtsAnnouncerMixin`` only ever calls ``speak``; everything else about an
+    announcement (phrasing, language, staleness, the busy-window reservation)
+    is game logic and stays in the domain package.
+    """
+
+    async def speak(self, message: str, language: str | None = None) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# Factory ports (#2638)
+# ---------------------------------------------------------------------------
+#
+# The domain never names a concrete service class. It asks for one through
+# these call signatures, which carry only game-level values (an entity id, the
+# platform, the provider). Whatever a factory needs from Home Assistant it
+# closes over at the composition root.
+
+
+class MediaPlayerFactory(Protocol):
+    """Builds the media-player service for one speaker."""
+
+    def __call__(
+        self,
+        entity_id: str,
+        *,
+        platform: str = "unknown",
+        provider: str = "spotify",
+        inherited_states: dict[str, dict[str, Any]] | None = None,
+    ) -> MediaPlayerProtocol: ...
+
+
+class PartyLightsFactory(Protocol):
+    """Builds a fresh party-lights service (one per ``configure_party_lights``)."""
+
+    def __call__(self) -> PartyLightsProtocol: ...
+
+
+class TtsFactory(Protocol):
+    """Builds the TTS announcement service for a (provider, speaker) pair."""
+
+    def __call__(
+        self,
+        *,
+        tts_entity_id: str,
+        media_player_entity_id: str,
+    ) -> TtsProtocol: ...
+
+
+@dataclass(frozen=True)
+class GameOutputFactories:
+    """Where ``GameState`` gets its output services from (#2638).
+
+    "Outputs" = the three things the game does to the room it is played in:
+    play music, drive the lights, speak. Nothing to do with the retired
+    ``GameService`` transport facade removed in #2670.
+
+    Every field defaults to ``None`` = "this output is not wired". That is the
+    default a bare ``GameState()`` gets, which is what makes the game logic
+    constructible — and testable — without Home Assistant.
+    """
+
+    media_player: MediaPlayerFactory | None = None
+    party_lights: PartyLightsFactory | None = None
+    tts: TtsFactory | None = None

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -11,11 +11,20 @@ a reference to) the following subsystems:
 * ``RoundManager`` — round number, timer/deadline, intro mode, metadata
 * ``HighlightsTracker`` — game highlights reel (exact matches, streaks, …)
 
-It **references** (does not own, receives via setter):
+It **references** (does not own, receives from outside):
 
 * ``StatsService`` — historical game statistics and song difficulty
-* ``MediaPlayerService`` — lazy-created on first round via Home Assistant
-* ``PartyLightsService`` — optional party-lights integration
+* media player — built on first round from the injected factory (#2638)
+* party lights — optional, built from the injected factory (#2638)
+* TTS announcer — optional, built from the injected factory (#2638)
+
+#2638: GameState does not import ``services.*`` and does not know Home
+Assistant exists when it builds these. It is handed a
+``GameOutputFactories`` bundle (game/protocols.py) at construction; the
+composition root fills it with HA-backed factories, a test fills it with fakes
+or leaves it empty. The admin spectator WebSocket used to live here too — it is
+an aiohttp socket the server opens and closes, so it now lives on
+``BeatifyWebSocketHandler``.
 
 Serialization is handled by ``GameStateSerializer`` (game/serializers.py)
 which builds broadcast-ready dicts from GameState without GameState
@@ -50,7 +59,11 @@ from .round_manager import RoundManager
 from .scoring import (
     ScoringService,
 )
-from .protocols import MediaPlayerProtocol, PartyLightsProtocol
+from .protocols import (
+    GameOutputFactories,
+    MediaPlayerProtocol,
+    PartyLightsProtocol,
+)
 from .state_auto_advance import RevealAutoAdvanceMixin
 from .state_challenge import ChallengeMixin
 from .state_leaderboard import LeaderboardMixin
@@ -71,7 +84,6 @@ from .types import RoundAnalytics, _get_decade_label
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
-    from aiohttp import web
     from homeassistant.core import HomeAssistant
 
     from custom_components.beatify.services.stats import StatsService
@@ -268,15 +280,25 @@ class GameState(
     :class:`~custom_components.beatify.game.state_round_delegation.RoundManagerDelegationMixin`.
     """
 
-    def __init__(self, time_fn: Callable[[], float] | None = None) -> None:
+    def __init__(
+        self,
+        time_fn: Callable[[], float] | None = None,
+        *,
+        service_factories: GameOutputFactories | None = None,
+    ) -> None:
         """
         Initialize game state.
 
         Args:
             time_fn: Optional time function for testing. Defaults to time.time.
+            service_factories: How to build the media player / party lights /
+                TTS services (#2638). Omitted = none of them are wired, which is
+                how the game logic is constructed without Home Assistant.
 
         """
         self._now = time_fn or time.time
+        # #2638: the only route from the domain to a concrete output service.
+        self._service_factories = service_factories or GameOutputFactories()
         self._hass: HomeAssistant | None = None
         self.game_id: str | None = None
         self.admin_token: str | None = None  # Issue #386: REST admin auth
@@ -400,9 +422,6 @@ class GameState(
         # an opponent who is still guessing. Opt-in; default off = no tokens.
         self.sabotage_enabled: bool = False
 
-        # Issue #477: Admin spectator WebSocket (host without being a player)
-        self._admin_ws: web.WebSocketResponse | None = None
-
         # Issue #42: Metadata update callback
         self._on_metadata_update: Callable[[dict[str, Any]], Awaitable[None]] | None = (
             None
@@ -416,6 +435,11 @@ class GameState(
 
         # Issue #441: Observer callbacks for HA entity updates
         self._state_callbacks: list[Callable[[], None]] = []
+
+        # #2638: observers notified when a game is torn down or rebuilt
+        # (``_reset_game_internals``). The server uses this to drop its admin
+        # spectator socket at exactly the moment GameState used to null it.
+        self._reset_callbacks: list[Callable[[], None]] = []
 
     def _apply_config(self, config: GameStateConfig) -> None:
         """Apply a GameStateConfig to self, setting all config-managed fields."""
@@ -440,6 +464,19 @@ class GameState(
     def _notify_state_callbacks(self) -> None:
         """Notify all registered state observers (Issue #441)."""
         for cb in self._state_callbacks:
+            cb()
+
+    def register_reset_callback(self, cb: Callable[[], None]) -> None:
+        """Register a callback invoked on every game teardown/rebuild (#2638).
+
+        Fired from ``_reset_game_internals`` — i.e. by ``end_game()`` and
+        ``rematch_game()``, at the one point both share.
+        """
+        self._reset_callbacks.append(cb)
+
+    def _notify_reset_callbacks(self) -> None:
+        """Notify all registered reset observers (#2638)."""
+        for cb in self._reset_callbacks:
             cb()
 
     def async_shutdown(self) -> None:

--- a/custom_components/beatify/game/state_lifecycle.py
+++ b/custom_components/beatify/game/state_lifecycle.py
@@ -24,9 +24,9 @@ unchanged.
   round-start TTS announcements (#471 / #841 / #842). The single entry point
   every "advance to the next round" caller (``ws_handlers``, ``game_views``)
   hits.
-* ``_ensure_media_player_service`` — lazily constructs the
-  :class:`MediaPlayerService` on the first round (and wires analytics for
-  error recording, Story 19.1) so the service is only created once a media
+* ``_ensure_media_player_service`` — lazily builds the media-player service on
+  the first round via the injected factory (#2638) and wires analytics for
+  error recording (Story 19.1), so the service is only created once a media
   player is configured.
 * ``_prepare_intro_round`` — thin pass-through to
   ``RoundManager.prepare_intro_round`` (intro-splash deferral decision).
@@ -62,6 +62,8 @@ The mixin relies on attributes / methods the host class owns and that live on
   ``self.media_player`` — URI resolution and media-player dispatch context.
 * ``self._media_player_service`` / ``self._stats_service`` — lazily-built
   playback service + the analytics sink wired into it.
+* ``self._service_factories`` — the #2638 injection bundle; supplies the
+  media-player factory ``_ensure_media_player_service`` calls.
 * ``self._round_manager`` — the :class:`RoundManager` the intro/metadata/commit
   helpers delegate to; also supplies ``_timer_countdown`` / ``_on_round_end``
   callbacks.
@@ -85,8 +87,9 @@ The mixin relies on attributes / methods the host class owns and that live on
 
 It carries no state of its own. ``GamePhase`` is imported lazily inside the
 methods that need it (``# noqa: PLC0415``) to avoid a top-level circular import
-back into ``state.py``; ``MediaPlayerService`` is likewise imported lazily
-inside ``_ensure_media_player_service`` (matching the original).
+back into ``state.py``. The concrete ``MediaPlayerService`` is no longer
+imported here at all (#2638) — ``_ensure_media_player_service`` calls the
+injected factory, so the import graph stays acyclic without a lazy import.
 """
 
 from __future__ import annotations
@@ -855,22 +858,25 @@ class RoundLifecycleMixin:
         return True
 
     def _ensure_media_player_service(self) -> None:
-        """Create MediaPlayerService lazily on first round.
+        """Create the media-player service lazily on first round.
 
         Idempotent: if the service was already built (e.g. by the #1540 LOBBY
         pre-warm — see :meth:`prewarm_media_player_service`), the
         ``not self._media_player_service`` guard makes this a no-op, so the
         round path keeps working unchanged whether or not the pre-warm ran.
+
+        #2638: the concrete class is no longer named here. The injected
+        ``media_player`` factory builds it; with no factory wired (a game-logic
+        unit test) the game simply has no speaker, which every caller of
+        ``self._media_player_service`` already guards for.
         """
-        # Lazy import: only the concrete class for instantiation; type hints
-        # use MediaPlayerProtocol (module-level) to keep the import graph acyclic.
-        from custom_components.beatify.services.media_player import (
-            MediaPlayerService,
-        )
+        factory = self._service_factories.media_player
+        if factory is None:
+            _LOGGER.debug("No media-player factory wired — playback unavailable")
+            return
 
         if self.media_player and not self._media_player_service:
-            self._media_player_service = MediaPlayerService(
-                self._hass,
+            self._media_player_service = factory(
                 self.media_player,
                 platform=self.platform,
                 provider=self.provider,

--- a/custom_components/beatify/game/state_media.py
+++ b/custom_components/beatify/game/state_media.py
@@ -18,7 +18,9 @@ at runtime:
 * ``self._media_player_service`` — :class:`MediaPlayerProtocol` instance (or
   ``None`` before the first round), the transport all playback flows through.
 * ``self._party_lights`` — :class:`PartyLightsProtocol` instance (or ``None``).
-* ``self._hass`` — Home Assistant instance (to construct the lights service).
+* ``self._service_factories`` — the #2638 injection bundle; its ``party_lights``
+  factory builds the service ``configure_party_lights`` installs. The mixin no
+  longer touches ``self._hass`` at all.
 * ``self._bg_tasks`` — set of fire-and-forget background tasks.
 * ``self.volume_level`` — current game volume, clamped 0.0–1.0.
 
@@ -136,10 +138,16 @@ class MediaControlMixin:
         light_mode: str = "dynamic",
         wled_presets: dict[str, int] | None = None,
     ) -> None:
-        """Configure and start Party Lights for the game."""
-        # Lazy import: only the concrete class for instantiation; type hints
-        # use PartyLightsProtocol (module-level) to keep the import graph acyclic.
-        from custom_components.beatify.services.lights import PartyLightsService  # noqa: PLC0415
+        """Configure and start Party Lights for the game.
+
+        #2638: the concrete service is built by the injected ``party_lights``
+        factory. With no factory wired (a game-logic unit test) this is a
+        silent no-op and the game runs without lights.
+        """
+        factory = self._service_factories.party_lights
+        if factory is None:
+            _LOGGER.debug("No party-lights factory wired — party lights unavailable")
+            return
 
         # #1402 B2: a reconfigure (admin changes intensity / mode / entities
         # mid-game via admin_set_party_lights) previously replaced the active
@@ -154,7 +162,7 @@ class MediaControlMixin:
             self._party_lights.snapshot_saved_states() if self._party_lights else None
         )
 
-        self._party_lights = PartyLightsService(self._hass)
+        self._party_lights = factory()
         await self._party_lights.start(
             entity_ids,
             intensity,

--- a/custom_components/beatify/game/state_setup.py
+++ b/custom_components/beatify/game/state_setup.py
@@ -367,8 +367,12 @@ class GameSetupMixin:
         service refs (_stats_service, _on_round_end, _on_metadata_update),
         or volume_level (caller's responsibility).
         """
-        # Issue #477: Clear admin spectator WS (connection stays open, just de-ref)
-        self._admin_ws = None
+        # #2638: the admin spectator WebSocket is an aiohttp socket the server
+        # opens; it used to be de-referenced here. GameState no longer holds
+        # it, so instead we tell whoever registered — in production
+        # ``BeatifyWebSocketHandler.clear_admin_socket`` — at the exact same
+        # point in the teardown (Issue #477 behaviour, unchanged).
+        self._notify_reset_callbacks()
 
         # Issue #464: Reset round lifecycle (timers, metadata, intro state)
         self._round_manager.reset()

--- a/custom_components/beatify/game/state_tts.py
+++ b/custom_components/beatify/game/state_tts.py
@@ -14,7 +14,9 @@ and every caller / test are unchanged.
 The mixin relies on attributes that the host class owns and that live on
 ``self`` at runtime:
 
-* ``self._hass`` — Home Assistant instance (for the TTS provider).
+* ``self._service_factories`` — the #2638 injection bundle; its ``tts`` factory
+  builds the announcement service ``configure_tts`` installs.
+  The mixin no longer touches ``self._hass`` at all.
 * ``self._bg_tasks`` — set of fire-and-forget background tasks.
 * ``self.media_player`` — speaker entity the audio is routed through.
 * ``self.language`` — game language (resolved defensively via ``_lang``).
@@ -32,9 +34,12 @@ import asyncio
 import contextlib
 import logging
 import time
-from typing import Any
+from typing import TYPE_CHECKING
 
 from . import tts_phrases
+
+if TYPE_CHECKING:
+    from .protocols import TtsProtocol
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,7 +58,8 @@ class TtsAnnouncerMixin:
         bloating ``GameState.__init__``.
         """
         # Issue #447: TTS announcement service
-        self._tts_service: Any = None  # TTSService (lazy import)
+        # #2638: built by the injected TTS factory (see game/protocols.py).
+        self._tts_service: TtsProtocol | None = None
         self._tts_announce_game_start: bool = True
         self._tts_announce_winner: bool = True
         # Issue #471 Phase 1: Game Flow announcements
@@ -137,13 +143,19 @@ class TtsAnnouncerMixin:
         the most common host expectation (round start + time's up + correct
         answer announced; per-round 3-2-1 countdown opt-in only).
         """
-        from custom_components.beatify.services.tts import TTSService
-
-        self._tts_service = TTSService(
-            self._hass,
-            tts_entity_id=entity_id,
-            media_player_entity_id=self.media_player,
-        )
+        # #2638: the concrete TTSService is built by the injected ``tts``
+        # factory. With no factory wired (a game-logic unit test) the flags
+        # below are still applied but no announcement is ever spoken — every
+        # announce_* method already guards on ``self._tts_service``.
+        factory = self._service_factories.tts
+        if factory is None:
+            _LOGGER.debug("No TTS factory wired — announcements unavailable")
+            self._tts_service = None
+        else:
+            self._tts_service = factory(
+                tts_entity_id=entity_id,
+                media_player_entity_id=self.media_player,
+            )
         self._tts_announce_game_start = announce_game_start
         self._tts_announce_winner = announce_winner
         self._tts_announce_round_start = announce_round_start

--- a/custom_components/beatify/server/game_views.py
+++ b/custom_components/beatify/server/game_views.py
@@ -54,6 +54,7 @@ from custom_components.beatify.server.serializers import (
     build_state_message,
 )
 from custom_components.beatify.server.setup_state import clear_setup
+from custom_components.beatify.services.factories import ha_service_factories
 from custom_components.beatify.services.media_player import (
     async_get_native_twin_remap,
     get_platform_capabilities,
@@ -373,7 +374,10 @@ class StartGameView(RateLimitMixin, HomeAssistantView):
 
         # Initialize game state if needed
         if not game_state:
-            game_state = GameState()
+            # #2638: a composition point, so it wires the HA-backed service
+            # factories just like async_setup_entry does. (Defensive branch:
+            # async_setup_entry always seeds hass.data[DOMAIN]["game"].)
+            game_state = GameState(service_factories=ha_service_factories(self.hass))
             self.hass.data[DOMAIN]["game"] = game_state
             # Connect stats service if available (Story 14.4)
             stats_service = self.hass.data.get(DOMAIN, {}).get("stats")

--- a/custom_components/beatify/server/websocket.py
+++ b/custom_components/beatify/server/websocket.py
@@ -85,11 +85,17 @@ class BeatifyWebSocketHandler:
         """
         self.hass = hass
         self.connections: set[web.WebSocketResponse] = set()
+        # Issue #477 / #2638: the admin spectator socket (a host watching
+        # without being a player). This handler opens it, redacts for it and
+        # drops it on disconnect, so it lives here rather than on GameState —
+        # an aiohttp socket is not game logic. GameState calls back into
+        # clear_admin_socket on teardown (see register_reset_callback).
+        self.admin_ws: web.WebSocketResponse | None = None
         self._admin_disconnect_task: asyncio.Task | None = None
         self._analytics: AnalyticsStorage | None = None
         # #1702: game_ids whose terminal end sequence (finalize_game +
         # record_game + advance_to_end) has already been claimed. An admin has
-        # two admin-capable sockets (participant WS + spectator _admin_ws); on
+        # two admin-capable sockets (participant WS + spectator admin_ws); on
         # the final round both can pass the REVEAL/last_round checks. The claim
         # (see _claim_game_end) makes the end run exactly once per game.
         self._recorded_game_ids: set[str] = set()
@@ -120,6 +126,17 @@ class BeatifyWebSocketHandler:
             "report_data": handle_report_data,
             "round_timeout": handle_round_timeout,
         }
+
+    def clear_admin_socket(self) -> None:
+        """Forget the admin spectator socket (#477 / #2638).
+
+        Wired into ``GameState.register_reset_callback`` at the composition
+        root, so a game teardown (``end_game``) or rebuild (``rematch_game``)
+        drops the reference exactly where ``_reset_game_internals`` used to
+        null ``GameState._admin_ws``. The connection itself stays open — this
+        is a de-reference, not a close.
+        """
+        self.admin_ws = None
 
     def set_analytics(self, analytics: AnalyticsStorage) -> None:
         """
@@ -386,8 +403,9 @@ class BeatifyWebSocketHandler:
 
         # Issue #550: Ensure admin spectator WS is included
         game_state = get_game_state(self.hass)
-        if game_state and game_state._admin_ws is not None:
-            targets.add(game_state._admin_ws)
+        admin_ws = self.admin_ws if game_state else None
+        if admin_ws is not None:
+            targets.add(admin_ws)
 
         if not targets:
             return
@@ -398,8 +416,6 @@ class BeatifyWebSocketHandler:
         # before guessing. Redact per-recipient: only the spectator admin WS
         # gets the answers; every player connection gets a redacted copy.
         player_message = self._redact_for_player(message, game_state)
-
-        admin_ws = game_state._admin_ws if game_state else None
 
         # #1711: there are at most two payload variants per broadcast (the
         # admin/spectator copy and the redacted player copy). Serialize each to a
@@ -565,8 +581,8 @@ class BeatifyWebSocketHandler:
             player.connected = False
 
         # Issue #477: Clear admin spectator WS if it disconnected
-        if game_state._admin_ws is ws:
-            game_state._admin_ws = None
+        if self.admin_ws is ws:
+            self.admin_ws = None
             _LOGGER.info("Admin spectator WebSocket disconnected")
 
         if not player_name or not player:
@@ -681,5 +697,9 @@ class BeatifyWebSocketHandler:
                         "Error closing WebSocket during unload", exc_info=True
                     )
         self.connections.clear()
+        # #2638: the admin spectator socket is one of the connections just
+        # closed above, so drop the handler's own reference too — the owner
+        # closes it AND forgets it.
+        self.admin_ws = None
 
         _LOGGER.debug("Closed all WebSocket connections on unload")

--- a/custom_components/beatify/server/ws_handlers/_helpers.py
+++ b/custom_components/beatify/server/ws_handlers/_helpers.py
@@ -26,19 +26,22 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def _send_state_to(
-    ws: web.WebSocketResponse, state_msg: dict, game_state: GameState
+    handler: BeatifyWebSocketHandler, ws: web.WebSocketResponse, state_msg: dict
 ) -> None:
     """Send a ``state`` message to a single recipient, redacted for players.
 
     #1366: ``state`` frames carry the round's answers (admin_song year;
     song.artist/title in title_artist_mode). Only the spectator admin WS
-    (``game_state._admin_ws``) may receive them unfiltered; every other
-    connection — including an admin who joined as a *participant* — gets a
-    redacted copy, matching the per-recipient filtering in
+    (``handler.admin_ws``) may receive them unfiltered; every other connection —
+    including an admin who joined as a *participant* — gets a redacted copy,
+    matching the per-recipient filtering in
     ``BeatifyWebSocketHandler.broadcast``.
+
+    #2638: the recipient check reads the socket off the handler, which owns it,
+    instead of off ``GameState``.
     """
     payload = state_msg
-    if ws is not game_state._admin_ws:
+    if ws is not handler.admin_ws:
         payload = redact_state_for_player(state_msg)
     await ws.send_json(payload)
 
@@ -144,7 +147,7 @@ async def finalize_and_end(
 
     The final-round terminal path is reachable from THREE places at the same
     time: the two admin-capable sockets (participant WS + spectator
-    ``_admin_ws``) driving ``next_round``/``end_game``, and the unattended
+    ``handler.admin_ws``) driving ``next_round``/``end_game``, and the unattended
     REVEAL auto-advance carrying the final round (#1753, wired via
     ``GameState.set_game_end_callback``). Gating on the handler's one-shot claim
     keyed by ``game_id`` makes ``finalize_game`` / ``record_game`` (double

--- a/custom_components/beatify/server/ws_handlers/admin.py
+++ b/custom_components/beatify/server/ws_handlers/admin.py
@@ -57,7 +57,7 @@ async def handle_admin_connect(
         )
         return
 
-    game_state._admin_ws = ws
+    handler.admin_ws = ws
     _LOGGER.info("Admin spectator connected via WebSocket")
 
     await ws.send_json({"type": "admin_connect_ack", "game_id": game_state.game_id})
@@ -75,7 +75,7 @@ async def handle_admin(
     """Handle admin action messages — dispatches to admin sub-handlers."""
     action = data.get("action")
 
-    is_admin_ws = game_state._admin_ws is not None and game_state._admin_ws is ws
+    is_admin_ws = handler.admin_ws is not None and handler.admin_ws is ws
 
     sender = None
     for player in list(game_state.players.values()):
@@ -212,7 +212,7 @@ async def admin_next_round(
         # ends, so accepted near-misses count toward the leaderboard.
         await game_state.resolve_title_artist_if_pending()
         # #1702: a second admin-capable socket (participant WS + spectator
-        # _admin_ws) may have advanced/ended the game while we awaited above.
+        # handler.admin_ws) may have advanced/ended the game while we awaited above.
         # Re-check before driving the round forward; if it already left REVEAL,
         # just re-broadcast the current state.
         if game_state.phase != GamePhase.REVEAL:
@@ -456,7 +456,7 @@ async def admin_rematch_game(
     await game_state.announce_rematch()
     _LOGGER.info("Rematch started with %d players", player_count)
 
-    game_state._admin_ws = ws
+    handler.admin_ws = ws
     await ws.send_json(
         {
             "type": "admin_token_update",

--- a/custom_components/beatify/server/ws_handlers/guessing.py
+++ b/custom_components/beatify/server/ws_handlers/guessing.py
@@ -929,7 +929,7 @@ async def handle_title_artist_override(
         )
         return
 
-    is_admin_ws = game_state._admin_ws is not None and game_state._admin_ws is ws
+    is_admin_ws = handler.admin_ws is not None and handler.admin_ws is ws
     sender = game_state.get_player_by_ws(ws)
     if not (is_admin_ws or (sender and sender.is_admin)):
         await ws.send_json(

--- a/custom_components/beatify/server/ws_handlers/lifecycle.py
+++ b/custom_components/beatify/server/ws_handlers/lifecycle.py
@@ -245,7 +245,7 @@ async def handle_join(
         if not state_msg:
             return
         try:
-            await _send_state_to(ws, state_msg, game_state)
+            await _send_state_to(handler, ws, state_msg)
         except (ConnectionError, RuntimeError) as err:
             _LOGGER.warning("Failed to send state to new player: %s", err)
             return
@@ -276,7 +276,7 @@ async def handle_get_state(
     """Handle dashboard/observer state request (Story 10.4)."""
     state_msg = build_state_message(game_state)
     if state_msg:
-        await _send_state_to(ws, state_msg, game_state)
+        await _send_state_to(handler, ws, state_msg)
 
 
 async def handle_round_timeout(
@@ -451,7 +451,7 @@ async def handle_reconnect(
 
     state_msg = build_state_message(game_state)
     if state_msg:
-        await _send_state_to(ws, state_msg, game_state)
+        await _send_state_to(handler, ws, state_msg)
 
     await handler.broadcast_state()
 

--- a/custom_components/beatify/services/factories.py
+++ b/custom_components/beatify/services/factories.py
@@ -1,0 +1,67 @@
+"""Binds the game's output ports to the concrete Home Assistant services (#2638).
+
+This module is the seam. ``game/`` declares what it needs
+(``game/protocols.py``); ``services/`` knows how to build it against a live
+``hass``; and this file is the single place where the two meet. It is imported
+only from composition points (``custom_components/beatify/__init__.py`` and the
+defensive fallback in ``server/game_views.py``), never from ``game/`` — which is
+why the domain package no longer carries lazy ``services.`` imports to break an
+import cycle.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from custom_components.beatify.game.protocols import (
+    GameOutputFactories,
+    MediaPlayerProtocol,
+    PartyLightsProtocol,
+    TtsProtocol,
+)
+
+from .lights import PartyLightsService
+from .media_player import MediaPlayerService
+from .tts import TTSService
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+def ha_service_factories(hass: HomeAssistant) -> GameOutputFactories:
+    """Return factories that build the real HA-backed services for ``hass``."""
+
+    def _media_player(
+        entity_id: str,
+        *,
+        platform: str = "unknown",
+        provider: str = "spotify",
+        inherited_states: dict[str, dict[str, Any]] | None = None,
+    ) -> MediaPlayerProtocol:
+        return MediaPlayerService(
+            hass,
+            entity_id,
+            platform=platform,
+            provider=provider,
+            inherited_states=inherited_states,
+        )
+
+    def _party_lights() -> PartyLightsProtocol:
+        return PartyLightsService(hass)
+
+    def _tts(
+        *,
+        tts_entity_id: str,
+        media_player_entity_id: str,
+    ) -> TtsProtocol:
+        return TTSService(
+            hass,
+            tts_entity_id=tts_entity_id,
+            media_player_entity_id=media_player_entity_id,
+        )
+
+    return GameOutputFactories(
+        media_player=_media_player,
+        party_lights=_party_lights,
+        tts=_tts,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ _er_stub.async_get = MagicMock()  # type: ignore[attr-defined]
 sys.modules.setdefault("homeassistant.helpers.entity_registry", _er_stub)
 
 from custom_components.beatify.game.player import PlayerSession  # noqa: E402
+from custom_components.beatify.game.protocols import GameOutputFactories  # noqa: E402
 from custom_components.beatify.game.state import GameState  # noqa: E402
 
 
@@ -21,9 +22,29 @@ def make_player(name: str = "Alice", score: int = 0, **kwargs) -> PlayerSession:
     return PlayerSession(name=name, ws=MagicMock(), score=score, **kwargs)
 
 
-def make_game_state(time_fn=None) -> GameState:
-    """Create a fresh GameState (optionally with injected time function)."""
-    return GameState(time_fn=time_fn)
+def make_game_state(
+    time_fn=None,
+    *,
+    media_player=None,
+    party_lights=None,
+    tts=None,
+) -> GameState:
+    """Create a fresh GameState with no Home Assistant behind it (#2638).
+
+    The game logic needs none: with no factories the media player, party
+    lights and TTS announcer are simply absent, which every caller of them
+    already guards for. A test that exercises one of those outputs passes a
+    fake factory for that one output — a callable returning a stub — instead
+    of mocking ``hass`` and patching the concrete service class.
+    """
+    return GameState(
+        time_fn=time_fn,
+        service_factories=GameOutputFactories(
+            media_player=media_player,
+            party_lights=party_lights,
+            tts=tts,
+        ),
+    )
 
 
 def make_songs(n: int = 5) -> list[dict]:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -10,6 +10,7 @@ import pytest
 
 from custom_components.beatify.const import DOMAIN
 from custom_components.beatify.game.player import PlayerSession
+from custom_components.beatify.game.protocols import GameOutputFactories
 from custom_components.beatify.game.state import GameState
 from custom_components.beatify.server.views import StartGameView
 
@@ -19,9 +20,29 @@ def make_player(name: str = "Alice", score: int = 0, **kwargs) -> PlayerSession:
     return PlayerSession(name=name, ws=MagicMock(), score=score, **kwargs)
 
 
-def make_game_state(time_fn=None) -> GameState:
-    """Create a fresh GameState (optionally with injected time function)."""
-    return GameState(time_fn=time_fn)
+def make_game_state(
+    time_fn=None,
+    *,
+    media_player=None,
+    party_lights=None,
+    tts=None,
+) -> GameState:
+    """Create a fresh GameState with no Home Assistant behind it (#2638).
+
+    The game logic needs none: with no factories the media player, party
+    lights and TTS announcer are simply absent, which every caller of them
+    already guards for. A test that exercises one of those outputs passes a
+    fake factory for that one output — a callable returning a stub — instead
+    of mocking ``hass`` and patching the concrete service class.
+    """
+    return GameState(
+        time_fn=time_fn,
+        service_factories=GameOutputFactories(
+            media_player=media_player,
+            party_lights=party_lights,
+            tts=tts,
+        ),
+    )
 
 
 def make_songs(n: int = 5) -> list[dict]:

--- a/tests/unit/test_ma_queue_restore_2143.py
+++ b/tests/unit/test_ma_queue_restore_2143.py
@@ -340,16 +340,25 @@ class TestGameStateKeepsThePromiseAcrossTheSwitch:
         assert gs._pending_speaker_states == {"media_player.esszimmer": {"volume": 0.2}}
 
     def test_the_new_service_inherits_what_the_old_one_owed(self):
-        gs = make_game_state()
+        # #2638: the game asks its injected factory for a speaker service; the
+        # fake records what it was handed, so no hass is needed to see the
+        # promise travel.
+        built = {}
+
+        def _factory(entity_id, **kwargs):
+            built["entity_id"] = entity_id
+            built.update(kwargs)
+            return MagicMock()
+
+        gs = make_game_state(media_player=_factory)
         gs.media_player = "media_player.kueche"
         gs.platform = "music_assistant"
         gs._pending_speaker_states = {"media_player.esszimmer": {"volume": 0.2}}
 
         gs._ensure_media_player_service()
 
-        assert gs._media_player_service._inherited_states == {
-            "media_player.esszimmer": {"volume": 0.2}
-        }
+        assert built["entity_id"] == "media_player.kueche"
+        assert built["inherited_states"] == {"media_player.esszimmer": {"volume": 0.2}}
         # Handed over, not shared — a later release/build cycle must not
         # restore the same speaker twice.
         assert gs._pending_speaker_states == {}

--- a/tests/unit/test_media_player_prewarm.py
+++ b/tests/unit/test_media_player_prewarm.py
@@ -86,10 +86,22 @@ async def test_prewarm_constructs_service_and_probes() -> None:
 
 @pytest.mark.asyncio
 async def test_prewarm_is_idempotent_with_ensure() -> None:
-    """A real round-path _ensure_media_player_service reuses the pre-warmed service."""
-    state = make_game_state()
+    """A real round-path _ensure_media_player_service reuses the pre-warmed service.
+
+    #2638: the speaker service comes from the injected factory, so the "was it
+    built twice?" question is answered by counting factory calls instead of by
+    standing up a mock Home Assistant.
+    """
+    builds = []
+
+    def _factory(entity_id, **kwargs):
+        svc = MagicMock()
+        svc.verify_responsive = AsyncMock(return_value=(True, ""))
+        builds.append(svc)
+        return svc
+
+    state = make_game_state(media_player=_factory)
     hass = MagicMock()
-    hass.states.get.return_value = None  # verify_responsive bails gracefully
     hass.async_create_background_task = MagicMock(side_effect=_closing_background_task)
     state.set_hass(hass)
     _create_game(state)
@@ -97,10 +109,23 @@ async def test_prewarm_is_idempotent_with_ensure() -> None:
     await state.prewarm_media_player_service()
     warmed = state._media_player_service
     assert warmed is not None
+    assert len(builds) == 1
 
     # The round path's lazy fallback must NOT rebuild — same instance is kept.
     state._ensure_media_player_service()
     assert state._media_player_service is warmed
+    assert len(builds) == 1
+
+
+@pytest.mark.asyncio
+async def test_no_factory_means_no_speaker_service() -> None:
+    """#2638: without a media-player factory the game simply has no speaker."""
+    state = make_game_state()
+    _create_game(state)
+
+    state._ensure_media_player_service()
+
+    assert state._media_player_service is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_redact_answers_1366.py
+++ b/tests/unit/test_redact_answers_1366.py
@@ -135,7 +135,7 @@ class TestBroadcastRedaction:
 
         admin_ws = _make_ws()
         player_ws = _make_ws()
-        gs._admin_ws = admin_ws
+        handler.admin_ws = admin_ws
         handler.connections = {admin_ws, player_ws}
 
         msg = build_state_message(gs)
@@ -160,7 +160,7 @@ class TestBroadcastRedaction:
 
         admin_ws = _make_ws()
         player_ws = _make_ws()
-        gs._admin_ws = admin_ws
+        handler.admin_ws = admin_ws
         handler.connections = {admin_ws, player_ws}
 
         await handler.broadcast_metadata_update(

--- a/tests/unit/test_service_injection_2638.py
+++ b/tests/unit/test_service_injection_2638.py
@@ -1,0 +1,190 @@
+"""#2638: the game logic is constructible without Home Assistant.
+
+``GameState`` used to import ``services.media_player`` / ``services.lights`` /
+``services.tts`` lazily and build them itself out of ``self._hass``, and it held
+``_admin_ws`` — an ``aiohttp`` socket only the server ever touched. Both are
+gone: the services arrive as factories (``game/protocols.py``), and the socket
+lives on ``BeatifyWebSocketHandler``.
+
+These tests pin that contract. Every one of them builds real game logic with no
+``hass`` anywhere in sight — which is the whole point.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.beatify.const import DOMAIN
+from custom_components.beatify.game.protocols import GameOutputFactories
+from custom_components.beatify.game.state import GameState
+from custom_components.beatify.server.websocket import BeatifyWebSocketHandler
+from tests.conftest import make_game_state, make_songs
+
+
+def _create_game(state: GameState, **kwargs) -> dict:
+    return state.create_game(
+        playlists=["test.json"],
+        songs=make_songs(3),
+        media_player="media_player.test",
+        base_url="http://localhost:8123",
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# No factories = no outputs, and nothing blows up
+# ---------------------------------------------------------------------------
+
+
+class TestBareGameStateHasNoOutputs:
+    def test_constructs_without_hass(self):
+        state = GameState()
+        assert state._hass is None
+        assert state._service_factories == GameOutputFactories()
+
+    def test_ensure_media_player_service_is_a_no_op(self):
+        state = make_game_state()
+        _create_game(state)
+        state._ensure_media_player_service()
+        assert state._media_player_service is None
+
+    @pytest.mark.asyncio
+    async def test_configure_party_lights_is_a_no_op(self):
+        state = make_game_state()
+        await state.configure_party_lights(["light.a"], "medium")
+        assert state._party_lights is None
+
+    @pytest.mark.asyncio
+    async def test_configure_tts_still_applies_its_flags(self):
+        """No factory means no voice, but the per-event toggles still land.
+
+        The announce_* methods all guard on ``self._tts_service``, so a game
+        with no TTS backend is simply silent.
+        """
+        state = make_game_state()
+        await state.configure_tts("tts.google", announce_winner=False)
+        assert state._tts_service is None
+        assert state._tts_announce_winner is False
+
+
+# ---------------------------------------------------------------------------
+# What the factories are handed
+# ---------------------------------------------------------------------------
+
+
+class TestFactoriesReceiveTheGameContext:
+    def test_media_player_factory_gets_entity_platform_provider(self):
+        seen = {}
+
+        def _factory(entity_id, **kwargs):
+            seen["entity_id"] = entity_id
+            seen.update(kwargs)
+            return MagicMock()
+
+        state = make_game_state(media_player=_factory)
+        _create_game(state)
+        state.platform = "music_assistant"
+
+        state._ensure_media_player_service()
+
+        assert seen["entity_id"] == "media_player.test"
+        assert seen["platform"] == "music_assistant"
+        assert seen["provider"] == "spotify"
+        assert seen["inherited_states"] is None
+
+    def test_media_player_service_is_built_once_per_game(self):
+        builds = []
+        state = make_game_state(
+            media_player=lambda *_a, **_kw: builds.append(1) or MagicMock()
+        )
+        _create_game(state)
+
+        state._ensure_media_player_service()
+        state._ensure_media_player_service()
+
+        assert len(builds) == 1
+
+    @pytest.mark.asyncio
+    async def test_tts_factory_gets_both_entity_ids(self):
+        seen = {}
+
+        def _factory(**kwargs):
+            seen.update(kwargs)
+            return MagicMock(speak=AsyncMock())
+
+        state = make_game_state(tts=_factory)
+        _create_game(state)
+
+        await state.configure_tts("tts.google_gemini_tts")
+
+        assert seen == {
+            "tts_entity_id": "tts.google_gemini_tts",
+            "media_player_entity_id": "media_player.test",
+        }
+        assert state._tts_service is not None
+
+
+# ---------------------------------------------------------------------------
+# The admin spectator socket belongs to the server (#477 / #2638)
+# ---------------------------------------------------------------------------
+
+
+class TestAdminSocketOwnership:
+    def test_game_state_no_longer_holds_the_socket(self):
+        assert not hasattr(make_game_state(), "_admin_ws")
+
+    def test_handler_owns_it_and_can_drop_it(self):
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"game": make_game_state()}}
+        handler = BeatifyWebSocketHandler(hass)
+        assert handler.admin_ws is None
+
+        handler.admin_ws = MagicMock()
+        handler.clear_admin_socket()
+
+        assert handler.admin_ws is None
+
+    def test_teardown_notifies_the_registered_owner(self):
+        """``_reset_game_internals`` fires where it used to null ``_admin_ws``."""
+        state = make_game_state()
+        calls = []
+        state.register_reset_callback(lambda: calls.append("reset"))
+
+        state._reset_game_internals()
+
+        assert calls == ["reset"]
+
+    @pytest.mark.asyncio
+    async def test_end_game_and_rematch_both_notify(self):
+        state = make_game_state()
+        _create_game(state)
+        calls = []
+        state.register_reset_callback(lambda: calls.append("reset"))
+
+        await state.end_game()
+        assert calls == ["reset"]
+
+        _create_game(state)
+        state.rematch_game()
+        assert calls == ["reset", "reset"]
+
+    @pytest.mark.asyncio
+    async def test_unload_closes_and_forgets_the_socket(self):
+        """The owner closes the socket it opened, then drops the reference."""
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"game": make_game_state()}}
+        handler = BeatifyWebSocketHandler(hass)
+
+        ws = AsyncMock()
+        ws.closed = False
+        ws.close = AsyncMock()
+        handler.connections.add(ws)
+        handler.admin_ws = ws
+
+        await handler.async_close_all()
+
+        ws.close.assert_awaited_once()
+        assert handler.connections == set()
+        assert handler.admin_ws is None

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -1930,6 +1930,9 @@ class TestStartRoundGhostRoundGuard:
     """
 
     def _setup(self) -> GameState:
+        # #2638: the speaker comes from the injected factory, so the round path
+        # picks up the mock on its own — no monkey-patching of
+        # _ensure_media_player_service to "keep our mock service".
         state = make_game_state()
         _create_fresh_game(state)
         state.add_player("Admin", MagicMock())
@@ -1943,7 +1946,6 @@ class TestStartRoundGhostRoundGuard:
         media = AsyncMock()
         media.is_available = MagicMock(return_value=True)
         state._media_player_service = media
-        state._ensure_media_player_service = MagicMock()  # keep our mock service
         return state
 
     @pytest.mark.asyncio
@@ -2308,14 +2310,28 @@ class TestPauseSnapshotRace:
         assert state._previous_phase == GamePhase.PLAYING
 
 
+class _RecordingLights:
+    """A party-lights stub that records what ``start`` was handed."""
+
+    def __init__(self) -> None:
+        self.inherited = None
+
+    async def start(self, *args, **kwargs):
+        self.inherited = kwargs.get("inherited_states")
+
+
 class TestConfigurePartyLightsPreservesStates:
     """#1402 B2 finding 5: a reconfigure must carry the genuine pre-party light
-    states forward, not lose them by replacing the service outright."""
+    states forward, not lose them by replacing the service outright.
+
+    #2638: no ``hass`` and no patching of the concrete service — the game is
+    handed a party-lights factory and the test reads what it built.
+    """
 
     @pytest.mark.asyncio
     async def test_reconfigure_inherits_prior_saved_states(self):
-        state = make_game_state()
-        state._hass = MagicMock()
+        lights = _RecordingLights()
+        state = make_game_state(party_lights=lambda: lights)
 
         snap_calls = {"n": 0}
 
@@ -2326,46 +2342,29 @@ class TestConfigurePartyLightsPreservesStates:
 
         state._party_lights = PriorService()
 
-        captured = {}
-
-        class FakeService:
-            def __init__(self, hass):
-                self.hass = hass
-
-            async def start(self, *args, **kwargs):
-                captured["inherited"] = kwargs.get("inherited_states")
-
-        with patch(
-            "custom_components.beatify.services.lights.PartyLightsService",
-            FakeService,
-        ):
-            await state.configure_party_lights(["light.a"], "medium")
+        await state.configure_party_lights(["light.a"], "medium")
 
         assert snap_calls["n"] == 1
-        assert captured["inherited"] == {"light.a": {"state": "on", "brightness": 42}}
+        assert lights.inherited == {"light.a": {"state": "on", "brightness": 42}}
 
     @pytest.mark.asyncio
     async def test_first_configure_passes_no_inherited_states(self):
-        state = make_game_state()
-        state._hass = MagicMock()
+        lights = _RecordingLights()
+        state = make_game_state(party_lights=lambda: lights)
         state._party_lights = None
 
-        captured = {}
+        await state.configure_party_lights(["light.a"], "medium")
 
-        class FakeService:
-            def __init__(self, hass):
-                pass
+        assert lights.inherited is None
 
-            async def start(self, *args, **kwargs):
-                captured["inherited"] = kwargs.get("inherited_states")
+    @pytest.mark.asyncio
+    async def test_no_factory_means_no_party_lights(self):
+        """#2638: a game with no lights factory runs without lights."""
+        state = make_game_state()
 
-        with patch(
-            "custom_components.beatify.services.lights.PartyLightsService",
-            FakeService,
-        ):
-            await state.configure_party_lights(["light.a"], "medium")
+        await state.configure_party_lights(["light.a"], "medium")
 
-        assert captured["inherited"] is None
+        assert state._party_lights is None
 
 
 # ---------------------------------------------------------------------------
@@ -2549,10 +2548,10 @@ class TestSuddenDeathAutoEnd:
         state.get_player("Carol").eliminated = True
         state.round = 3
         state.phase = GamePhase.PLAYING
-        # Stub playback so start_round can proceed past the guard without media.
-        with patch.object(state, "_ensure_media_player_service"):
-            state._media_player_service = None
-            await state.start_round()
+        # #2638: no media-player factory is wired, so start_round proceeds past
+        # the guard with no speaker at all — nothing to stub.
+        assert state._media_player_service is None
+        await state.start_round()
         # The auto-end guard did not fire (phase is not END from the guard).
         assert state.phase != GamePhase.END
 

--- a/tests/unit/test_state_title_artist_window.py
+++ b/tests/unit/test_state_title_artist_window.py
@@ -18,11 +18,11 @@ def _ta_songs(n: int = 3) -> list[dict]:
 
 
 def _stub_media_service() -> MagicMock:
-    """A fake MediaPlayerService that reports a healthy, playing speaker.
+    """A fake media-player service that reports a healthy, playing speaker.
 
-    Injected so _ensure_media_player_service skips constructing a real
-    (hass-less) service — tests stub the dependency instead of branching
-    production code on a None hass.
+    #2638: handed to ``make_game_state(media_player=...)`` as the game's
+    speaker factory, so the game builds it the same way production builds the
+    real one — no hass, and no ordering trap around ``create_game``.
     """
     svc = MagicMock()
     svc.is_available.return_value = True
@@ -35,6 +35,11 @@ def _stub_media_service() -> MagicMock:
     return svc
 
 
+def _make_gs():
+    """A GameState whose speaker factory hands out the stub above (#2638)."""
+    return make_game_state(media_player=lambda *_a, **_kw: _stub_media_service())
+
+
 async def _start_round(gs):
     gs.create_game(
         playlists=["t.json"],
@@ -43,11 +48,6 @@ async def _start_round(gs):
         base_url="http://h",
         title_artist_mode=True,
     )
-    # Inject a stub service (truthy) so the lazy _ensure_media_player_service
-    # is a no-op and real playback never runs. Must come *after* create_game,
-    # which now nulls _media_player_service so a fresh game rebuilds it with the
-    # new selection (#1526) — injecting before would be wiped out by that reset.
-    gs._media_player_service = _stub_media_service()
     gs.platform = "music_assistant"  # skip the verify_responsive branch
     gs.add_player("Alice", MagicMock())
     gs.add_player("Bob", MagicMock())
@@ -57,14 +57,14 @@ async def _start_round(gs):
 
 class TestDelegation:
     def test_delegation_methods_present(self):
-        gs = make_game_state()
+        gs = _make_gs()
         assert hasattr(gs, "register_title_artist_vote")
         assert hasattr(gs, "set_title_artist_override")
         assert hasattr(gs, "get_near_misses")
         assert hasattr(gs, "has_near_misses")
 
     def test_register_vote_delegates(self):
-        gs = make_game_state()
+        gs = _make_gs()
         gs._challenge_manager.configure(
             artist_challenge_enabled=False,
             movie_quiz_enabled=False,
@@ -81,7 +81,7 @@ class TestDelegation:
 
 class TestConditionalWindow:
     async def test_no_near_miss_resolves_immediately(self):
-        gs = make_game_state()
+        gs = _make_gs()
         await _start_round(gs)
         await gs.start_round()
         # Both guess exactly -> no near-misses.
@@ -100,7 +100,7 @@ class TestConditionalWindow:
         assert gs.is_title_artist_voting_open() is False
 
     async def test_near_miss_opens_window(self):
-        gs = make_game_state()
+        gs = _make_gs()
         await _start_round(gs)
         await gs.start_round()
         gs._challenge_manager.submit_title_artist_guess(
@@ -119,7 +119,7 @@ class TestConditionalWindow:
         gs._cancel_auto_advance()
 
     async def test_host_advance_resolves_first(self):
-        gs = make_game_state()
+        gs = _make_gs()
         await _start_round(gs)
         await gs.start_round()
         gs._challenge_manager.submit_title_artist_guess(
@@ -144,7 +144,7 @@ class TestConditionalWindow:
         assert gs.is_title_artist_voting_open() is False
 
     async def test_window_resolves_after_timeout(self):
-        gs = make_game_state()
+        gs = _make_gs()
         await _start_round(gs)
         await gs.start_round()
         gs._challenge_manager.submit_title_artist_guess(
@@ -194,7 +194,7 @@ class TestVoteWindowScoring:
 
     async def test_scoring_deferred_while_window_open(self):
         """With a near-miss pending, scoring is held until the window closes."""
-        gs = make_game_state()
+        gs = _make_gs()
         await self._setup_near_miss(gs)
         await gs.end_round()
         assert gs.is_title_artist_voting_open() is True
@@ -206,7 +206,7 @@ class TestVoteWindowScoring:
         gs._cancel_auto_advance()
 
     async def test_override_accept_increases_leaderboard(self):
-        gs = make_game_state()
+        gs = _make_gs()
         await self._setup_near_miss(gs)
         await gs.end_round()
         gs.set_title_artist_override("Alice:title", True)
@@ -225,7 +225,7 @@ class TestVoteWindowScoring:
         assert bob.rounds_played == 1
 
     async def test_rejected_near_miss_scores_without_partial(self):
-        gs = make_game_state()
+        gs = _make_gs()
         await self._setup_near_miss(gs)
         await gs.end_round()
         # No vote and no override -> default reject on resolve.
@@ -238,7 +238,7 @@ class TestVoteWindowScoring:
         assert alice.rounds_played == 1
 
     async def test_vote_accept_increases_leaderboard(self):
-        gs = make_game_state()
+        gs = _make_gs()
         await self._setup_near_miss(gs)
         await gs.end_round()
         # Bob votes 👍 on Alice's title near-miss (majority of one).
@@ -251,7 +251,7 @@ class TestVoteWindowScoring:
         assert alice.rounds_played == 1
 
     async def test_timeout_applies_accepted_points(self):
-        gs = make_game_state()
+        gs = _make_gs()
         await self._setup_near_miss(gs)
         gs.set_title_artist_override("Alice:title", True)
         import custom_components.beatify.game.state_vote_window as state_mod
@@ -271,7 +271,7 @@ class TestVoteWindowScoring:
 
     async def test_no_near_miss_scores_in_main_loop(self):
         """Immediate-resolve path scores during end_round (no window)."""
-        gs = make_game_state()
+        gs = _make_gs()
         await _start_round(gs)
         await gs.start_round()
         gs._challenge_manager.submit_title_artist_guess(
@@ -293,7 +293,7 @@ class TestVoteWindowScoring:
 
     async def test_resolve_is_idempotent(self):
         """A double finalize (host-advance + late timer) must not double-count."""
-        gs = make_game_state()
+        gs = _make_gs()
         await self._setup_near_miss(gs)
         await gs.end_round()
         gs.set_title_artist_override("Alice:title", True)
@@ -321,7 +321,7 @@ class TestRoundResultsShareGrid:
 
     async def test_all_exact_grid_is_not_missed(self):
         """Immediate-resolve path: both fields exact -> 'exact', not 'missed'."""
-        gs = make_game_state()
+        gs = _make_gs()
         await _start_round(gs)
         await gs.start_round()
         gs._challenge_manager.submit_title_artist_guess(
@@ -340,7 +340,7 @@ class TestRoundResultsShareGrid:
 
     async def test_title_only_correct_is_scored(self):
         """One field exact, other wrong (no near-miss) -> 'scored'."""
-        gs = make_game_state()
+        gs = _make_gs()
         await _start_round(gs)
         await gs.start_round()
         # Exact title, clearly-wrong artist (not a near-miss -> immediate resolve).
@@ -365,7 +365,7 @@ class TestRoundResultsShareGrid:
         round_results append must run AFTER the window resolves so it sees the
         promoted near_miss_accepted status.
         """
-        gs = make_game_state()
+        gs = _make_gs()
         await _start_round(gs)
         await gs.start_round()
         gs._challenge_manager.submit_title_artist_guess(
@@ -388,7 +388,7 @@ class TestRoundResultsShareGrid:
 
     async def test_rejected_near_miss_only_is_close(self):
         """A near-miss accepted with no other full-points field -> 'close'."""
-        gs = make_game_state()
+        gs = _make_gs()
         await _start_round(gs)
         await gs.start_round()
         # Alice: near-miss title AND wrong artist -> only the accepted title
@@ -408,7 +408,7 @@ class TestRoundResultsShareGrid:
 
     async def test_no_submission_is_missed(self):
         """A player who didn't guess in title/artist mode -> 'missed'."""
-        gs = make_game_state()
+        gs = _make_gs()
         await _start_round(gs)
         await gs.start_round()
         gs._challenge_manager.submit_title_artist_guess(
@@ -449,7 +449,7 @@ class TestVoteWindowFlagReset:
 
     async def test_end_game_clears_open_vote_flag(self):
         """Force-ending while the window is open must reset the flag."""
-        gs = make_game_state()
+        gs = _make_gs()
         await self._open_window(gs)
         # Admin force-ends the game mid vote-window.
         await gs.end_game()
@@ -463,7 +463,7 @@ class TestVoteWindowFlagReset:
         and asserts the next create_game scrubs it, so the new game keeps its
         REVEAL auto-advance and never double-scores.
         """
-        gs = make_game_state()
+        gs = _make_gs()
         # Pretend a prior game leaked the flag.
         gs._title_artist_voting_open = True
         gs._title_artist_vote_deadline = 123.0
@@ -479,7 +479,7 @@ class TestVoteWindowFlagReset:
 
     async def test_cancelled_window_task_clears_flag(self):
         """Cancelling the window task (defense in depth) clears the flag."""
-        gs = make_game_state()
+        gs = _make_gs()
         await self._open_window(gs)
         # Let the freshly-created window task actually enter its try-block so
         # the cancellation lands inside the except handler (not before start).
@@ -498,7 +498,7 @@ class TestVoteWindowFlagReset:
     async def test_next_year_game_keeps_reveal_auto_advance(self):
         """End-to-end: after a force-end mid-window, a plain year game still
         schedules REVEAL auto-advance (the leak previously disabled it)."""
-        gs = make_game_state()
+        gs = _make_gs()
         await self._open_window(gs)
         await gs.end_game()
         # Start a fresh plain year-mode game.
@@ -510,8 +510,8 @@ class TestVoteWindowFlagReset:
             title_artist_mode=False,
             reveal_auto_advance=5,
         )
-        # Stub the service after create_game, which nulls it for a fresh game (#1526).
-        gs._media_player_service = _stub_media_service()
+        # #2638: the injected factory rebuilds the stub for the fresh game, so
+        # the old "re-inject after create_game" step (#1526) is gone.
         gs.platform = "music_assistant"
         gs.add_player("Alice", MagicMock())
         for p in gs.players.values():

--- a/tests/unit/test_websocket.py
+++ b/tests/unit/test_websocket.py
@@ -59,6 +59,9 @@ def _make_handler_and_game(
     mock_hass.data = {DOMAIN: {"game": game_state}}
 
     handler = BeatifyWebSocketHandler(mock_hass)
+    # #2638: mirror the composition root — the handler owns the admin spectator
+    # socket and drops it when the game is torn down or rebuilt.
+    game_state.register_reset_callback(handler.clear_admin_socket)
     mock_ws = AsyncMock()
     mock_ws.send_json = AsyncMock()
     mock_ws.closed = False
@@ -828,7 +831,7 @@ class TestAdminConnect:
             ws, {"type": "admin_connect", "ha_token": "valid-ha-token"}
         )
 
-        assert game_state._admin_ws is ws
+        assert handler.admin_ws is ws
         # First call: ack, second call: state
         calls = ws.send_json.call_args_list
         assert calls[0][0][0]["type"] == "admin_connect_ack"
@@ -844,7 +847,7 @@ class TestAdminConnect:
             ws, {"type": "admin_connect", "ha_token": "wrong-token"}
         )
 
-        assert game_state._admin_ws is None
+        assert handler.admin_ws is None
         msg = ws.send_json.call_args[0][0]
         assert msg["type"] == "error"
         assert msg["code"] == ERR_UNAUTHORIZED
@@ -854,7 +857,7 @@ class TestAdminConnect:
 
         await handler._handle_message(ws, {"type": "admin_connect"})
 
-        assert game_state._admin_ws is None
+        assert handler.admin_ws is None
         msg = ws.send_json.call_args[0][0]
         assert msg["code"] == ERR_UNAUTHORIZED
 
@@ -900,19 +903,20 @@ class TestAdminConnect:
 
     async def test_disconnect_clears_admin_ws(self):
         handler, game_state, ws = _make_handler_and_game()
-        game_state._admin_ws = ws
+        handler.admin_ws = ws
 
         await handler._handle_disconnect(ws)
 
-        assert game_state._admin_ws is None
+        assert handler.admin_ws is None
 
     async def test_game_reset_clears_admin_ws(self):
+        """#2638: the teardown still drops the socket — via the reset callback."""
         handler, game_state, ws = _make_handler_and_game()
-        game_state._admin_ws = ws
+        handler.admin_ws = ws
 
         game_state._reset_game_internals()
 
-        assert game_state._admin_ws is None
+        assert handler.admin_ws is None
 
 
 class TestBroadcastDebounceSupersede:

--- a/tests/unit/test_ws_title_artist_vote.py
+++ b/tests/unit/test_ws_title_artist_vote.py
@@ -19,11 +19,11 @@ def _ta_songs(n: int = 3) -> list[dict]:
 
 
 def _stub_media_service() -> MagicMock:
-    """A fake MediaPlayerService that reports a healthy, playing speaker.
+    """A fake media-player service that reports a healthy, playing speaker.
 
-    Injected so _ensure_media_player_service skips constructing a real
-    (hass-less) service — tests stub the dependency instead of branching
-    production code on a None hass.
+    #2638: handed to ``make_game_state(media_player=...)`` as the game's
+    speaker factory, so the game builds it the same way production builds the
+    real one — no hass, and no ordering trap around ``create_game``.
     """
     svc = MagicMock()
     svc.is_available.return_value = True
@@ -34,7 +34,7 @@ def _stub_media_service() -> MagicMock:
 
 def _make_handler_game():
     mock_hass = MagicMock()
-    gs = make_game_state()
+    gs = make_game_state(media_player=lambda *_a, **_kw: _stub_media_service())
     gs.create_game(
         playlists=["t.json"],
         songs=_ta_songs(3),
@@ -42,10 +42,6 @@ def _make_handler_game():
         base_url="http://h",
         title_artist_mode=True,
     )
-    # Inject a truthy stub service so the lazy _ensure_media_player_service is a
-    # no-op and real (hass-less) playback never runs during start_round. Must be
-    # after create_game, which nulls _media_player_service for a fresh game (#1526).
-    gs._media_player_service = _stub_media_service()
     gs.platform = "music_assistant"  # skip the verify_responsive branch
     mock_hass.data = {DOMAIN: {"game": gs}}
     handler = BeatifyWebSocketHandler(mock_hass)


### PR DESCRIPTION
Closes #2638

`GameState` built its own Home Assistant services and held an aiohttp socket that belongs to the server. Both are gone. Behaviour is unchanged — this is a refactor.

## The shape, and why

**Constructor injection of factories, not of instances.** `game/protocols.py` already declared `MediaPlayerProtocol` and `PartyLightsProtocol` but nothing consumed them; it now also declares `TtsProtocol` (the TTS service had no protocol at all) plus three factory ports, bundled in a frozen `GameOutputFactories` dataclass. `GameState.__init__` takes it as a keyword-only argument.

Factories rather than ready-made instances, because none of the three can be built at composition time:

- the media-player service captures the entity, platform and provider **at construction**, so a mid-game speaker switch throws it away and builds a new one (#1516/#2143), and the LOBBY pre-warm (#1540) decides *when* to build it;
- party lights are rebuilt on every `configure_party_lights`, carrying the previous instance's saved states forward (#1402 B2);
- TTS is built per `configure_tts` from the game's own speaker entity (#793).

Handing over an instance would have meant either building three services per HA startup that no game may ever use, or pushing the rebuild logic out of the domain and into the server. A factory keeps the *when* and the *with what* in the game, and the *how* at the composition root.

`services/factories.py` — `ha_service_factories(hass)` — is the single place that names the concrete classes. It is imported only from `async_setup_entry` and from the defensive fallback in `StartGameView`. The three lazy `from custom_components.beatify.services...` imports inside `game/` are gone; the comments explaining that they existed to keep the import graph acyclic are gone with them, because there is no longer a cycle to break.

**No factory = no output.** A bare `GameState()` has no speaker, no lights and no voice. Every caller of those already guarded for `None` (`if self._media_player_service`, `if self._party_lights`, `if not self._tts_service`), so nothing new had to be defended. That default is what makes the game logic constructible without Home Assistant.

**The socket.** `_admin_ws` moves to `BeatifyWebSocketHandler` as a public `admin_ws`. The handler already opened it, already redacted per-recipient for it and already dropped it on disconnect; it just kept the reference on the game. All 14 reads from `server/` now go through the handler. `_send_state_to` changes signature from `(ws, state_msg, game_state)` to `(handler, ws, state_msg)` — it only ever needed `game_state` for that one field.

The one place the move was not mechanical is `_reset_game_internals`, which nulled the socket for both `end_game()` and `rematch_game()`. Six call sites reach those two methods, so clearing at each of them would have been a standing invitation to miss one. Instead `GameState` grows `register_reset_callback` — the same shape as the existing `register_state_callback` — and fires it at exactly the line that used to do the nulling. The composition root wires it to `clear_admin_socket`. Timing is identical by construction, not by care.

## Socket ownership on shutdown — how I checked

The admin spectator socket enters `self.connections` at `handle()` like any other WebSocket (`websocket.py:250`), so it was always covered by teardown; what was missing was the reference.

- **Normal disconnect:** `handle()`'s `finally` block discards from `connections` and calls `_handle_disconnect(ws)`, which now nulls `self.admin_ws`. Covered by `test_websocket.py::test_disconnect_clears_admin_ws`.
- **Integration unload:** `async_unload_entry` → `ws_handler.async_close_all()`, which iterates `self.connections` and sends each a `GOING_AWAY` close. The admin socket is in that set, so it was already being closed. I added `self.admin_ws = None` after `connections.clear()` so the owner closes it *and* forgets it — previously neither `GameState.async_shutdown()` nor `async_close_all` dropped the reference, and an orphaned handler kept a closed socket alive. New test `test_service_injection_2638.py::test_unload_closes_and_forgets_the_socket` asserts `ws.close` was awaited and both `connections` and `admin_ws` are empty afterwards.
- **Game teardown:** unchanged and deliberately still a de-reference, not a close — `end_game()` must not hang up on a host who is about to start a rematch. `test_game_reset_clears_admin_ws` still passes, now through the callback.

## Which tests got simpler

The point of the issue was the mock layer, so here is what actually came off:

| | before | after |
|---|---|---|
| lazy `services.*` imports in `game/` | 3 | 0 (3 remain, all `TYPE_CHECKING`-only `StatsService` hints) |
| `game_state._admin_ws` reads from `server/` | 14 | 0 |
| files in `game/` using `self._hass` in code | 6 | 4 (`state_media.py` and `state_tts.py` no longer touch it) |
| `_hass` references in `test_state.py` | 5 | 3 |

- **`TestConfigurePartyLightsPreservesStates`** (`test_state.py`) — both tests dropped `state._hass = MagicMock()` **and** `patch("...services.lights.PartyLightsService", FakeService)`. They now pass a one-line factory and read what it built. Net −18 lines, and the fake no longer has to fake a `hass` constructor argument it never used.
- **`test_state_title_artist_window.py` / `test_ws_title_artist_vote.py`** — both carried the same trap in a comment: *"Must come **after** create_game, which nulls `_media_player_service` so a fresh game rebuilds it (#1526) — injecting before would be wiped out."* With the stub supplied as a factory, `create_game` rebuilds it exactly like production does, and the ordering requirement disappears. One of them re-injected the stub mid-test for the same reason; that is gone too.
- **`TestStartRoundGhostRoundGuard._setup`** (`test_state.py`) — dropped `state._ensure_media_player_service = MagicMock()  # keep our mock service`. Monkey-patching a production method to stop it overwriting the test's own mock is exactly the smell the issue names; the round path now picks up the injected mock on its own.
- **`test_no_auto_end_when_two_remain`** — `with patch.object(state, "_ensure_media_player_service"):` deleted. With no factory there is nothing to stub.
- **`test_prewarm_is_idempotent_with_ensure`** — was standing up a `MagicMock` hass with `hass.states.get.return_value = None` so a real `MediaPlayerService` could be constructed and then bail gracefully inside `verify_responsive`. It now counts factory calls, which is what the test was actually asking.
- **`test_the_new_service_inherits_what_the_old_one_owed`** (`test_ma_queue_restore_2143.py`) — was building a real `MediaPlayerService` with `hass=None` and reaching into its private `_inherited_states`. It now reads the kwargs the factory was handed.

`test_service_injection_2638.py` is new (12 tests) and pins the contract: a bare `GameState` has no outputs and no path through it touches HA, the factories receive the right game context, the media-player service is built once per game, and the socket's ownership and teardown live on the handler.

**Mocks I left in place, and why.** `test_media_player_prewarm.py` still builds a `MagicMock` hass in eight tests. Those are about *task scheduling* — `hass.async_create_background_task`, the bare-`asyncio.create_task` fallback, cancellation on `end_game`/`create_game`. That is a second, separate dependency on HA and out of scope here; the issue is about service construction and the socket. The ~148 `MagicMock`s in `test_state.py` are overwhelmingly `add_player("Alice", MagicMock())` — stand-in WebSockets, which is inherent to `PlayerRegistry`'s API, not an HA mock layer.

## Found on the way, not fixed here

`StartGameView` builds a fallback `GameState()` when `hass.data[DOMAIN]["game"]` is missing (`game_views.py:376`) but never calls `set_hass()` on it. Before this change that GameState would have constructed a `MediaPlayerService(None, ...)` — a service that fails on first playback. It is a dead branch in practice (`async_setup_entry` always seeds the key), so I left it alone beyond wiring the factories, which is what a composition point owes. Worth its own issue if the branch is meant to be reachable at all.

## Checks

- `pytest tests/unit tests/integration -q` → **2345 passed, 2 skipped**
- `npm test` → **828 passed (87 files)**
- `npm run build:check` → **all 18 artifacts and 77 .gz siblings match source** (no frontend source touched)
- `python3 -m ruff format --check .` → **219 files already formatted**, `ruff check .` → **All checks passed**

Rebased onto `origin/main` after #2670 and #2671 landed. #2670 removed the `GameService` facade, so the new dataclass is named `GameOutputFactories` rather than reviving that name — the two are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKsEKt68KHSqmi617XNCVi
