### PR TITLE
refactor(media-player): one module per platform behind one dispatch point

### DIFF
--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -1,4 +1,11 @@
-"""Media player discovery and control service for Beatify."""
+"""Media player discovery and control service for Beatify.
+
+Playback itself lives in :mod:`custom_components.beatify.services.playback` —
+one strategy per platform behind one dispatch point (#2636). What stays here is
+what is not per-platform: discovery, the album-art proxy, analytics, volume
+save/restore, the metadata wait, the pre-flight check, and the game-lifecycle
+bookkeeping that decides WHEN the host's queue is captured and handed back.
+"""
 
 from __future__ import annotations
 
@@ -6,7 +13,6 @@ import asyncio
 import hashlib
 import hmac
 import logging
-import re
 import secrets
 from asyncio import timeout as async_timeout
 from datetime import datetime, timezone
@@ -17,6 +23,14 @@ from homeassistant.exceptions import HomeAssistantError, ServiceNotFound
 from homeassistant.helpers.event import async_track_state_change_event
 
 from custom_components.beatify.game.playlist import get_playback_uri
+
+from .playback import (
+    MaQueueRestorer,
+    PlayerContext,
+    build_strategy,
+    uri_match_tokens,
+)
+from .playback.base import PLAYBACK_TIMEOUT
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -92,202 +106,6 @@ def get_platform_capabilities(platform: str) -> dict[str, Any]:
 
 # Timeout for pre-flight connectivity check (seconds)
 PREFLIGHT_TIMEOUT = 3.0
-
-# Timeout for play_song service calls (seconds) - prevents long hangs (#179)
-PLAYBACK_TIMEOUT = 8.0
-
-# Music Assistant playback timeout. Higher than PLAYBACK_TIMEOUT because MA
-# routes through the speaker's own buffering layer and AirPlay (HomePods,
-# Denon AirPlay, some MA-wrapped Sonos setups) can take 10-12s to acknowledge
-# a new track on the first round. #777 showed 8s was too aggressive — rounds
-# advanced before the track had actually swapped on the speaker.
-MA_PLAYBACK_TIMEOUT = 15.0
-
-# #1936: the FIRST play of a game gets a third more time (15.0s → 20.0s). A
-# speaker idle for a while was measured at 10.1s to first audio (Sonos via MA,
-# Apple Music) — close enough to the deadline that a cold start regularly lost
-# the race and the game paused before a single note had played. Later rounds
-# keep the shorter deadline: by then the speaker is warm and a longer wait is
-# just silence in front of the players.
-#
-# Expressed as a FACTOR, not a second absolute constant, so the one existing
-# patch point still governs both budgets — eight tests patch
-# MA_PLAYBACK_TIMEOUT down to keep the suite fast, and a separate absolute
-# constant would have silently made each of them wait the full 20s.
-MA_FIRST_PLAY_TIMEOUT_FACTOR = 4 / 3
-
-# #2143: how long the queue restore waits for the host's track to actually
-# start before it seeks to the saved position. Deliberately far below
-# MA_PLAYBACK_TIMEOUT: this runs during game teardown, where every second is a
-# second the admin UI sits on a dead screen. Missing the window costs the
-# position, not the track — the song comes back either way, just from 0:00.
-MA_QUEUE_RESTORE_WAIT = 5.0
-MA_QUEUE_RESTORE_POLL = 0.25
-# #2605: the pause at the end of the queue restore is read back — and the check
-# has to OUTLIVE the device settling rather than fit inside it.
-#
-# The first attempt (#2606) looked once, inside a two-second window, and then
-# stopped looking. On the real installation (Sonos through Music Assistant) the
-# speaker reported `idle` inside exactly that window, the pause counted as
-# confirmed — and from second five onwards it was playing again, for three
-# minutes. The window was the defect, not the state check.
-#
-# So now: confirm, and then KEEP WATCHING. The teardown only counts as done
-# once the speaker has stayed quiet for MA_PAUSE_SETTLE_HOLD seconds in a row;
-# if it starts again before that, it is paused again. MA_PAUSE_GUARD_WINDOW
-# caps the whole thing so `end-game` cannot hang on a speaker something else
-# owns.
-MA_PAUSE_CONFIRM_WAIT = 2.0
-MA_PAUSE_SETTLE_HOLD = 5.0
-MA_PAUSE_GUARD_WINDOW = 12.0
-MA_PAUSE_MAX_ATTEMPTS = 3
-MA_PAUSE_POLL = 0.25
-
-# #2605: "not playing" is too generous. MA reports `buffering` while a track
-# loads, and a reading that lands there looks exactly like a successful pause —
-# the track starts a second later anyway. Both states therefore count as "still
-# going".
-MA_ACTIVE_STATES = frozenset({"playing", "buffering"})
-
-# #1381: Fast-path Path 2 (title-advanced-without-exact-match) must not
-# instant-accept an *arbitrary* title change. If a requested URI fails to
-# resolve in MA while the speaker's prior queue naturally auto-advances to its
-# next track within the wait window, the title changes to an unrelated song and
-# the old code confirmed it as success in ~1s — silently running a round whose
-# audio is the wrong track (the #795 failure class). Path 2 now requires cheap
-# evidence that the new title is plausibly OUR track: either a token overlap
-# with the expected title (remaster/translation tolerance, e.g. "Das Modell"
-# vs "The Model" share no tokens but the artist matches) OR the expected artist
-# appearing in the speaker's media_artist. The unbounded "any new title"
-# acceptance is reserved for the post-timeout #345 branch, where it is logged.
-_TITLE_TOKEN_MIN_LEN = 3
-
-# Providers whose missing/failed URI may be retried by asking Music Assistant to
-# resolve the track from name + artist. `ma_library` has done this since the
-# Crate Digger work; `tidal` joins because its URIs can no longer be refreshed —
-# Odesli's public API, the only source they ever came from, was retired on
-# 2026-07-31 and now answers 401.
-_NAME_FALLBACK_PROVIDERS = frozenset({"ma_library", "tidal", "ytmusic_free"})
-
-# Words that mark a *different recording of the same song*. A name search is
-# free to return any of them, which is exactly the risk this fallback carries:
-# measured against ~2000 catalogue tracks with a known Deezer id, a plain
-# "artist title" search returned the wrong edition for 2 % of mainstream tracks
-# but 19 % of EDM ones ("Satisfaction" → "Satisfaction (Uk Radio Edit)",
-# "Scary Monsters and Nice Sprites" → "… (Zedd Remix)").
-#
-# `_titles_plausibly_match` does NOT catch these: it accepts a normalized
-# prefix, and the expected title is always a prefix of its own remix. That
-# leniency is deliberate and load-bearing for #1381 ("Das Modell" vs "The
-# Model"), so it stays — the stricter check below is applied only on the name
-# fallback path, where the extra risk actually lives.
-_EDITION_MARKERS = re.compile(
-    r"\b("
-    r"radio edit|extended|club mix|original mix|dub mix|"
-    r"remix|re-?edit|mixed|karaoke|instrumental|acapella|a cappella|"
-    r"acoustic|unplugged|live|demo|cover|tribute|playback|"
-    r"edit|mix|version"
-    r")\b",
-    re.IGNORECASE,
-)
-
-
-def _edition_markers(text: str) -> set[str]:
-    """Edition words present in a title, lower-cased."""
-    return {m.group(0).lower() for m in _EDITION_MARKERS.finditer(text or "")}
-
-
-def _edition_matches(expected_title: str, played_title: str) -> bool:
-    """False when the played title carries an edition the expected title lacks.
-
-    Deliberately one-directional. A catalogue entry named "Waves - Robin Schulz
-    Radio Edit" may legitimately play back as plain "Waves" (the provider drops
-    the suffix), so markers the *expected* side has are not required on the
-    played side. The reverse is the failure we are guarding against: plain
-    "Burn" must not be satisfied by "Burn (Aybsent Mynded Remix)".
-
-    This matters more for Beatify than it would for a music player. The game
-    asks players to guess the release *year*; a 2014 remix standing in for a
-    1998 original does not merely sound different, it makes the round's correct
-    answer wrong — and nothing on screen reveals that.
-    """
-    if not expected_title or not played_title:
-        return True
-    return not (_edition_markers(played_title) - _edition_markers(expected_title))
-
-
-def _normalize_for_match(text: str) -> str:
-    """Lower-case and strip non-alphanumeric to ASCII-ish tokens for matching."""
-    return "".join(c if c.isalnum() else " " for c in text.lower())
-
-
-def _title_tokens(text: str) -> set[str]:
-    """Significant word tokens of a title (drops short noise words/suffixes)."""
-    return {
-        tok
-        for tok in _normalize_for_match(text).split()
-        if len(tok) >= _TITLE_TOKEN_MIN_LEN
-    }
-
-
-def _titles_plausibly_match(expected_title: str, current_title: str) -> bool:
-    """Cheap similarity gate for fast-path Path 2 (#1381).
-
-    True when the two titles share at least one significant token, or one
-    normalized title is a prefix of the other (covers "(Remastered)" suffixes
-    and minor punctuation differences). False for genuinely unrelated titles
-    (e.g. the prior queue auto-advancing to a different song).
-    """
-    exp_norm = _normalize_for_match(expected_title).strip()
-    cur_norm = _normalize_for_match(current_title).strip()
-    if not exp_norm or not cur_norm:
-        return False
-    if cur_norm.startswith(exp_norm) or exp_norm.startswith(cur_norm):
-        return True
-    return bool(_title_tokens(expected_title) & _title_tokens(current_title))
-
-
-def _artist_matches(expected_artist: str, media_artist: str) -> bool:
-    """True when the expected artist is plausibly present in media_artist (#1381)."""
-    exp = _normalize_for_match(expected_artist).strip()
-    cur = _normalize_for_match(media_artist).strip()
-    if not exp or not cur:
-        return False
-    if exp in cur or cur in exp:
-        return True
-    return bool(_title_tokens(expected_artist) & _title_tokens(media_artist))
-
-
-def _content_id_advanced(
-    content_id: str, content_id_before: str, match_tokens: list[str]
-) -> bool:
-    """True when media_content_id proves the REQUESTED track is now loaded (#2616).
-
-    `media_title` is not a track identity. Two different songs can share one
-    title — round N plays "Hello" (Adele), round N+1 draws "Hello" (Lionel
-    Richie) — and the title-must-change invariant (#2333/#795) then reads a
-    perfectly successful switch as "the speaker never left the prior track".
-
-    `media_content_id` IS an identity, and `_uri_match_tokens` already knows
-    how to recognise our URI inside it (#1380). Two conditions, both required:
-
-      * the id contains a token of the URI we just asked for — so an unrelated
-        auto-advance of the prior queue cannot qualify, and
-      * the id differs from the one playing before the call — so the #2333
-        failure (MA never switched, prior track keeps running) still cannot
-        qualify, not even when the prior round happened to play this same URI.
-
-    Anything the speaker does not report (`media_content_id` missing on this
-    platform) yields False and leaves the title comparison in sole charge, as
-    before.
-    """
-    if not content_id or not match_tokens:
-        return False
-    if content_id == content_id_before:
-        return False
-    return any(token in content_id for token in match_tokens)
-
-
 # Timeout for waiting for metadata to update after playing (seconds)
 # Wait up to 2s for MA to push fresh metadata (album art, etc.) after a
 # playback transition. Reduced from 5s — that earlier value was the
@@ -313,44 +131,6 @@ ENTITY_PICTURE_WAIT = 1.0
 # placeholder before the real cover loads — Phase 2 must NOT treat that
 # transient as "the new art has arrived" (issue #1260 follow-up).
 NO_ARTWORK_PLACEHOLDER = "/beatify/static/img/no-artwork.svg"
-
-# Candidate URI fields on a song, by user-selected provider (#805).
-#
-# Each provider lists its own playable URI fields in priority order. The
-# fallback cascade in `_get_ma_uri_candidates` only walks the fields for
-# `self._provider` — never tries a different provider's URI.
-#
-# Why: prior to #805 the cascade walked ALL six URI fields regardless of
-# which provider the user picked in the wizard. On Levtos's Apple-Music-only
-# MA setup, every round paid 4×15s of timeouts on Spotify/YT/Tidal URIs that
-# his MA had no provider configured for, before getting to the Apple Music
-# URI that actually worked. After 3 cumulative play_song failures the game
-# was force-paused and the admin couldn't recover.
-#
-# The "fall through to other providers when primary fails" intent of #768
-# only makes sense when the user's MA actually has those other providers
-# configured — which the wizard already gates. If the user picked Apple
-# Music, they're saying "this is the provider MA is set up for". Trust
-# them.
-_PROVIDER_URI_FIELDS: dict[str, tuple[str, ...]] = {
-    "spotify": ("uri_spotify", "uri"),
-    "apple_music": ("uri_apple_music",),
-    "youtube_music": ("uri_youtube_music",),
-    "tidal": ("uri_tidal",),
-    "deezer": ("uri_deezer",),
-    # Crate Digger: URIs come from the user's own MA library.
-    "ma_library": ("uri_ma_library",),
-    # Amazon Music uses Alexa text search — no URI fields; playback via
-    # _play_via_alexa() with content_type="AMAZON_MUSIC".
-    "amazon_music": (),
-    # #2426: the ytmusic_free URI is DERIVED from uri_youtube_music by
-    # get_song_uri(), so there is no catalogue field to walk. The empty tuple
-    # is deliberate rather than an omission: a missing key would log the
-    # "unknown provider" warning below and imply a mapping bug, while an empty
-    # one says the provider has no stored fields and lets _resolved_uri — which
-    # already holds the derived URI — do the work.
-    "ytmusic_free": (),
-}
 
 
 # Process-global key used to sign the absolute URLs that the album-art proxy
@@ -433,55 +213,28 @@ class MediaPlayerService:
         """
         self._hass = hass
         self._entity_id = entity_id
-        self._platform = platform
-        self._provider = provider
         self._analytics: AnalyticsStorage | None = None
         self._preflight_verified: bool = False
-        # Which URI field last succeeded against MA — used to reorder the
-        # candidate list so subsequent songs don't pay the primary-attempt
-        # timeout on every round (#768).
-        self._ma_preferred_uri_field: str | None = None
-        # #1381: which acceptance path confirmed the most recent successful
-        # _try_ma_play. 1 = expected-title substring (Path 1, strongest), 2 =
-        # similarity/artist gate (Path 2), 0 = post-timeout #345 tolerance.
-        # Only Path 1 is strong enough to promote a URI field to preferred.
-        self._last_confirm_path: int = 0
-        # #808 follow-up: classify the most recent failure mode so the
-        # caller (game/state.py:start_round) can decide whether to count
-        # this against MAX_SONG_RETRIES (real failure) or skip silently
-        # (track unavailable in the user's catalog/storefront).
+
+        # #2636: everything platform-specific now lives behind one interface.
+        # The context is the speaker; the strategy is the platform; the
+        # dispatch happened once, in `build_strategy`, instead of in an
+        # `if self._platform ==` chain spread over five methods.
         #
-        # Values:
-        #   None         — last call succeeded or hasn't been called yet
-        #   "unavailable" — MA accepted the URI but speaker stayed on the
-        #                   prior track. Almost always means the track ID
-        #                   isn't in the user's Apple Music storefront, or
-        #                   MA's provider needs re-authentication for this
-        #                   track. Skipping silently lets the game continue
-        #                   with whatever subset IS playable.
-        #   "error"       — speaker idle/off/unavailable, or hard speaker
-        #                   problem. Counts toward MAX_SONG_RETRIES so the
-        #                   game pauses on systemic issues (offline speaker,
-        #                   broken provider auth across the board).
-        self.last_failure_reason: str | None = None
-
-        # #1927 follow-up: the URI actually handed to the player for the most
-        # recent attempt. `state_lifecycle` used to log `song["uri"]` on a
-        # playback failure — the song's Spotify base field — so an Apple Music
-        # attempt was reported as `spotify:track:…` and every reader was sent
-        # hunting in the wrong provider. None until the first attempt.
-        self.last_attempted_uri: str | None = None
-
-        # #1936: True until the first playback attempt of this game has been
-        # made. Drives the longer cold-start budget in _try_ma_play.
-        self._first_play_pending: bool = True
-
-        # #1363: set when Beatify itself issues a same-song media_stop after a
-        # stale-title detect (line ~729). The stop forces the speaker to
-        # 'idle'; if the NEXT cascade candidate also fails to resolve, the
-        # idle-failure branch must NOT misread that self-induced idle as a
-        # systemic 'error' (which pauses the game). Reset before each song.
-        self._stopped_for_cascade: bool = False
+        # `save_queue` is handed over as a callback rather than called from
+        # here because only the strategy knows the moment the host's queue is
+        # about to be replaced (#2143) — while the bookkeeping around it
+        # (capture once, hand back at game end, survive a speaker switch) is
+        # game lifecycle and stays below.
+        self._context = PlayerContext(
+            hass,
+            entity_id,
+            platform=platform,
+            provider=provider,
+            save_queue=self.save_queue,
+        )
+        self._strategy = build_strategy(self._context)
+        self._restorer = MaQueueRestorer(hass)
 
         # #1516: the speaker's volume as it was BEFORE Beatify first changed it
         # this game. Captured once (via save_volume) on the first in-game volume
@@ -490,7 +243,7 @@ class MediaPlayerService:
         self._saved_volume: float | None = None
 
         # #2143: what the speaker was playing before Beatify claimed the queue.
-        # `_try_ma_play` sends `enqueue: "replace"`, which wipes whatever the
+        # The MA strategy sends `enqueue: "replace"`, which wipes whatever the
         # host had queued — in EVERY round, for every Music Assistant user,
         # whether or not they use Crate Digger. Captured once per game (like
         # `_saved_volume`) and handed back at game end.
@@ -519,6 +272,60 @@ class MediaPlayerService:
         if own_snapshot:
             self._saved_volume = own_snapshot.get("volume")
             self._saved_queue = own_snapshot.get("queue")
+
+    @property
+    def _platform(self) -> str:
+        """The speaker's platform. Lives on the context so the strategy and the
+        shell can never disagree about which speaker this is."""
+        return self._context.platform
+
+    @property
+    def _provider(self) -> str:
+        """The music provider the wizard settled on."""
+        return self._context.provider
+
+    @property
+    def last_failure_reason(self) -> str | None:
+        """Why the most recent play failed — set by whichever strategy ran.
+
+        #808 follow-up: classify the most recent failure mode so the caller
+        (``game/state.py:start_round``) can decide whether to count this
+        against MAX_SONG_RETRIES (real failure) or skip silently (track
+        unavailable in the user's catalog/storefront).
+
+        Values:
+          None          — last call succeeded or hasn't been called yet
+          "unavailable" — MA accepted the URI but speaker stayed on the prior
+                          track. Almost always means the track ID isn't in the
+                          user's Apple Music storefront, or MA's provider needs
+                          re-authentication for this track. Skipping silently
+                          lets the game continue with whatever subset IS
+                          playable.
+          "error"       — speaker idle/off/unavailable, or hard speaker
+                          problem. Counts toward MAX_SONG_RETRIES so the game
+                          pauses on systemic issues (offline speaker, broken
+                          provider auth across the board).
+        """
+        return self._context.last_failure_reason
+
+    @last_failure_reason.setter
+    def last_failure_reason(self, value: str | None) -> None:
+        self._context.last_failure_reason = value
+
+    @property
+    def last_attempted_uri(self) -> str | None:
+        """The URI actually handed to the player for the most recent attempt.
+
+        #1927 follow-up: `state_lifecycle` used to log `song["uri"]` on a
+        playback failure — the song's Spotify base field — so an Apple Music
+        attempt was reported as `spotify:track:…` and every reader was sent
+        hunting in the wrong provider. None until the first attempt.
+        """
+        return self._context.last_attempted_uri
+
+    @last_attempted_uri.setter
+    def last_attempted_uri(self, value: str | None) -> None:
+        self._context.last_attempted_uri = value
 
     def snapshot_saved_states(self) -> dict[str, dict[str, Any]]:
         """Everything this game still owes the user's speakers (#1516/#2143).
@@ -582,61 +389,19 @@ class MediaPlayerService:
         per game captures. Round two would otherwise "capture" Beatify's own
         track and hand the host that instead of their music.
 
-        Music Assistant only — the snapshot is read from ``get_queue``, which
-        no other platform provides. A failure here is deliberately swallowed:
-        not being able to remember the queue must never stop the round from
-        playing.
+        WHAT is remembered is the platform's business — only Music Assistant
+        can report it, and only its strategy overrides
+        :meth:`~.playback.base.PlaybackStrategy.capture_queue`. WHEN it is
+        remembered is this shell's, which is why the guard below stayed here
+        (#2636). A strategy that reports None (every platform but MA, and a
+        platform Beatify cannot play on at all) leaves ``_saved_queue`` unset,
+        so ``restore_queue`` hands nothing back — exactly as before.
         """
-        if self._platform != "music_assistant" or self._saved_queue is not None:
+        if self._saved_queue is not None or self._strategy is None:
             return
-        try:
-            response = await self._hass.services.async_call(
-                "music_assistant",
-                "get_queue",
-                {"entity_id": self._entity_id},
-                blocking=True,
-                return_response=True,
-            )
-        except (HomeAssistantError, ServiceNotFound, TypeError) as err:
-            # TypeError guards older MA versions whose get_queue takes no
-            # response — there is nothing to remember then, and pretending
-            # otherwise would make restore_queue play a phantom track.
-            _LOGGER.debug("Queue snapshot unavailable on %s: %s", self._entity_id, err)
-            self._saved_queue = {}
-            return
-
-        # HA hands back None when a service has no response payload, and older
-        # cores ignore `return_response` outright — neither is an error worth a
-        # log line, but both must not be walked as if they were the mapping.
-        if not isinstance(response, dict):
-            self._saved_queue = {}
-            return
-        data = response.get(self._entity_id)
-        if not isinstance(data, dict):
-            self._saved_queue = {}
-            return
-        media_item = (data.get("current_item") or {}).get("media_item") or {}
-        uri = media_item.get("uri")
-        if not uri:
-            # Idle speaker: captured, but there is nothing to hand back. Stored
-            # as {} rather than None so round two doesn't try again.
-            self._saved_queue = {}
-            _LOGGER.debug("Queue snapshot on %s: speaker idle", self._entity_id)
-            return
-
-        self._saved_queue = {
-            "uri": uri,
-            "name": media_item.get("name") or "",
-            "elapsed_time": float(data.get("elapsed_time") or 0),
-            "shuffle": bool(data.get("shuffle_enabled")),
-            "repeat_mode": data.get("repeat_mode"),
-        }
-        _LOGGER.debug(
-            "Queue snapshot on %s: %s at %.0fs",
-            self._entity_id,
-            uri,
-            self._saved_queue["elapsed_time"],
-        )
+        snapshot = await self._strategy.capture_queue()
+        if snapshot is not None:
+            self._saved_queue = snapshot
 
     async def restore_queue(self) -> bool:
         """Hand the speaker back what it was playing before the game (#2143).
@@ -655,218 +420,12 @@ class MediaPlayerService:
         restored = False
         for entity_id, snapshot in list(self._inherited_states.items()):
             queue = snapshot.pop("queue", None)
-            if await self._restore_queue_on(entity_id, queue):
+            if await self._restorer.restore_on(entity_id, queue):
                 restored = True
         queue = self._saved_queue
         # Clear BEFORE the awaits so a re-entrant call can't double-restore.
         self._saved_queue = None
-        return await self._restore_queue_on(self._entity_id, queue) or restored
-
-    async def _restore_queue_on(
-        self, entity_id: str, queue: dict[str, Any] | None
-    ) -> bool:
-        """Replay one captured queue snapshot onto one speaker."""
-        if not queue or not queue.get("uri"):
-            return False
-        try:
-            await self._hass.services.async_call(
-                "music_assistant",
-                "play_media",
-                {
-                    "media_id": queue["uri"],
-                    "media_type": "track",
-                    "enqueue": "replace",
-                },
-                target={"entity_id": entity_id},
-                blocking=False,
-            )
-            # The seek below needs the track actually loaded — a seek against
-            # the still-playing Beatify track would move the wrong song. Wait
-            # for the speaker to report a position, bounded, then give up and
-            # leave it playing from the start rather than hang the teardown.
-            if not await self._wait_for_playing(entity_id):
-                _LOGGER.debug(
-                    "Queue restore on %s: track loaded but never confirmed", entity_id
-                )
-            elif queue.get("elapsed_time", 0) >= 1:
-                await self._hass.services.async_call(
-                    "media_player",
-                    "media_seek",
-                    {
-                        "entity_id": entity_id,
-                        "seek_position": queue["elapsed_time"],
-                    },
-                    blocking=False,
-                )
-            if queue.get("shuffle") is not None:
-                await self._hass.services.async_call(
-                    "media_player",
-                    "shuffle_set",
-                    {"entity_id": entity_id, "shuffle": bool(queue["shuffle"])},
-                    blocking=False,
-                )
-            if queue.get("repeat_mode"):
-                await self._hass.services.async_call(
-                    "media_player",
-                    "repeat_set",
-                    {"entity_id": entity_id, "repeat": queue["repeat_mode"]},
-                    blocking=False,
-                )
-            # #2605: the pause runs LAST, and it is guarded.
-            #
-            # It originally sat before `shuffle_set`/`repeat_set` and was fired
-            # with `blocking=False` with nobody looking. Measured 2026-09-05:
-            # the speaker read `playing` afterwards three times in a row — the
-            # host's old queue playing on over the podium, at party volume.
-            #
-            # Every call above is deliberately `blocking=False` (MA hangs on
-            # `blocking=True` for `play_media`, see `play_song`). Submission
-            # order is therefore NOT execution order: the `media_seek` can land
-            # after the pause and start Sonos playing again. Rather than guess
-            # which call did it, `_pause_and_confirm` holds the silence instead
-            # of measuring it once.
-            paused = await self._pause_and_confirm(entity_id)
-        except (HomeAssistantError, ServiceNotFound) as err:
-            _LOGGER.warning("Queue restore on %s failed: %s", entity_id, err)
-            return False
-        else:
-            _LOGGER.info(
-                "Queue restored on %s: %s at %.0fs (%s)",
-                entity_id,
-                queue.get("name") or queue["uri"],
-                queue.get("elapsed_time", 0),
-                "paused"
-                if paused
-                else "PAUSE NOT CONFIRMED — see the warning above (#2605)",
-            )
-            return True
-
-    async def _pause_and_confirm(self, entity_id: str) -> bool:
-        """Pause, read it back — and then keep looking (#2605).
-
-        A `media_pause` with ``blocking=False`` is a request, not a fact. That
-        was the finding of #2605, and #2606 answered it by reading the state
-        back. On the real installation that still did not hold: the pause
-        landed, was confirmed, and from second five the speaker was playing
-        again. The check sat in a two-second window; the device takes longer
-        than that to settle.
-
-        So the pause is not merely confirmed here, it is **held**:
-
-        1. pause,
-        2. wait until the speaker no longer reports active playback,
-        3. then watch it for ``MA_PAUSE_SETTLE_HOLD`` seconds in a row.
-
-        If it starts again during step 3 — whether from a ``media_seek`` still
-        in flight, a ``play_media`` that had not finished loading, or Music
-        Assistant resuming its own queue — it is paused again. The guard is
-        deliberately blind to the mechanism; it reacts to what the room does.
-
-        ``MA_PAUSE_GUARD_WINDOW`` caps the whole thing so a speaker something
-        else owns cannot hang the ``end-game`` teardown.
-
-        Returns:
-            True when the speaker actually held the silence (or the entity is
-            gone). False means unconfirmed — the warning in the log says why.
-        """
-        deadline = asyncio.get_event_loop().time() + MA_PAUSE_GUARD_WINDOW
-        for versuch in range(1, MA_PAUSE_MAX_ATTEMPTS + 1):
-            await self._hass.services.async_call(
-                "media_player",
-                "media_pause",
-                {"entity_id": entity_id},
-                blocking=False,
-            )
-            if not await self._wait_until_quiet(entity_id, deadline):
-                _LOGGER.debug(
-                    "Queue restore on %s: still playing after pause attempt %d",
-                    entity_id,
-                    versuch,
-                )
-            elif await self._stays_quiet(entity_id, deadline):
-                if versuch > 1:
-                    _LOGGER.info(
-                        "Queue restore on %s: speaker stayed paused after "
-                        "attempt %d (#2605)",
-                        entity_id,
-                        versuch,
-                    )
-                return True
-            else:
-                # This is the observation #2606 could not make: the pause
-                # arrived, and the speaker started itself again afterwards.
-                _LOGGER.info(
-                    "Queue restore on %s: speaker started playing again after "
-                    "pause attempt %d — pausing once more (#2605)",
-                    entity_id,
-                    versuch,
-                )
-            if asyncio.get_event_loop().time() >= deadline:
-                break
-        _LOGGER.warning(
-            "Queue restore on %s: could not get the speaker to stay paused "
-            "within %.0fs — it is still playing the host's queue (#2605)",
-            entity_id,
-            MA_PAUSE_GUARD_WINDOW,
-        )
-        return False
-
-    async def _wait_until_quiet(self, entity_id: str, deadline: float) -> bool:
-        """Wait until the speaker stops reporting active playback (#2605).
-
-        ``media_pause`` settles Sonos-through-Music-Assistant to ``idle``, not
-        to ``paused`` — measured 2026-09-05, visible in the service response as
-        playing → idle. So this tests for "not active" rather than for one
-        particular target state.
-
-        ``None`` means the entity is gone. There is nothing left to pause then,
-        and waiting on it would only stall the teardown.
-        """
-        loop = asyncio.get_event_loop()
-        limit = min(loop.time() + MA_PAUSE_CONFIRM_WAIT, deadline)
-        while True:
-            state = self._hass.states.get(entity_id)
-            if state is None or state.state not in MA_ACTIVE_STATES:
-                return True
-            if loop.time() >= limit:
-                return False
-            await asyncio.sleep(MA_PAUSE_POLL)
-
-    async def _stays_quiet(self, entity_id: str, deadline: float) -> bool:
-        """Read the silence back for ``MA_PAUSE_SETTLE_HOLD`` seconds (#2605).
-
-        This is precisely the step #2606 was missing. There the first quiet
-        reading counted as proof — and because it fell inside a two-second
-        window, it was a reading of a speaker that had not finished settling.
-
-        Returns:
-            False as soon as playback is reported again, or when the guard
-            window runs out before the silence has held long enough.
-        """
-        loop = asyncio.get_event_loop()
-        hold_until = loop.time() + MA_PAUSE_SETTLE_HOLD
-        while True:
-            now = loop.time()
-            if now >= hold_until:
-                return True
-            if now >= deadline:
-                return False
-            await asyncio.sleep(MA_PAUSE_POLL)
-            state = self._hass.states.get(entity_id)
-            if state is None:
-                return True
-            if state.state in MA_ACTIVE_STATES:
-                return False
-
-    async def _wait_for_playing(self, entity_id: str) -> bool:
-        """Poll until the speaker reports playback, at most MA_QUEUE_RESTORE_WAIT."""
-        deadline = asyncio.get_event_loop().time() + MA_QUEUE_RESTORE_WAIT
-        while asyncio.get_event_loop().time() < deadline:
-            state = self._hass.states.get(entity_id)
-            if state is not None and state.state == "playing":
-                return True
-            await asyncio.sleep(MA_QUEUE_RESTORE_POLL)
-        return False
+        return await self._restorer.restore_on(self._entity_id, queue) or restored
 
     def set_analytics(self, analytics: AnalyticsStorage) -> None:
         """
@@ -890,51 +449,19 @@ class MediaPlayerService:
         if self._analytics:
             self._analytics.record_error(error_type, message)
 
-    def _safe_state(self):
-        """Read entity state, return None on any exception.
-
-        Resilience for the playback-confirmation read sites in `_play_via_ma`.
-        A transient exception from `hass.states.get()` (rare but possible during
-        HA restarts / state-machine reload) used to propagate up and abort the
-        whole song play, even though the existing code paths gracefully handle
-        a None return. Catching here lets the flow downgrade to "state unknown"
-        and continue. (#777 follow-up — the polling-resilience scope flagged in
-        TestMAPollingResilience.)
-        """
-        try:
-            return self._hass.states.get(self._entity_id)
-        except Exception as err:  # noqa: BLE001 — defensive read of HA state
-            _LOGGER.warning(
-                "hass.states.get(%s) raised %s; treating as unknown",
-                self._entity_id,
-                err,
-            )
-            return None
-
-    async def _safe_state_with_retry(self, retries: int = 3, delay: float = 0.5):
-        """Read entity state with short retry loop; for the post-timeout site
-        where having a state is critical for the title-advance check.
-
-        Most reads succeed on attempt 1; this only kicks in when HA's state
-        machine is briefly unreadable (HA restart edge, MA reload). Returns
-        None if all attempts return None.
-        """
-        for attempt in range(retries):
-            state = self._safe_state()
-            if state is not None:
-                return state
-            if attempt < retries - 1:
-                await asyncio.sleep(delay)
-        return None
-
     async def play_song(self, song: dict[str, Any]) -> bool:
         """
         Play a song using appropriate method for platform.
 
-        Routes playback based on platform:
+        The platform was resolved once, at construction, into a
+        :class:`~.playback.base.PlaybackStrategy` (#2636):
+
         - music_assistant: Uses music_assistant.play_media with URI
         - sonos: Uses media_player.play_media with Spotify URI
         - alexa_media: Uses media_player.play_media with text search
+
+        What is left here is what every platform shares: the URI precondition,
+        the timeout and error log lines, and the analytics record.
 
         Args:
             song: Song dict with _resolved_uri, artist, title keys
@@ -957,15 +484,12 @@ class MediaPlayerService:
             self._record_error("PLAYBACK_FAILURE", "Song has no URI")
             return False
 
-        try:
-            if self._platform == "music_assistant":
-                return await self._play_via_music_assistant(song)
-            if self._platform == "sonos":
-                return await self._play_via_sonos(song)
-            if self._platform in ("alexa_media", "alexa"):
-                return await self._play_via_alexa(song)
+        if self._strategy is None:
             _LOGGER.error("Unsupported platform: %s", self._platform)
             return False
+
+        try:
+            return await self._strategy.play(song)
         except (TimeoutError, asyncio.TimeoutError):
             _LOGGER.error(
                 "Playback timed out after %ss for %s: %s",
@@ -979,860 +503,6 @@ class MediaPlayerService:
             _LOGGER.error("Playback failed for %s: %s", uri, err)  # noqa: TRY400
             self._record_error("PLAYBACK_FAILURE", f"Failed to play {uri}: {err}")
             return False
-
-    @staticmethod
-    def _convert_uri_for_ma(uri: str) -> str:
-        """
-        Convert Beatify-internal URIs to formats Music Assistant understands.
-
-        Beatify playlists store URIs in internal formats:
-        - applemusic://track/<id>  → apple_music://track/<id>  (MA native, #772)
-        - deezer://track/<id>      → unchanged (MA native, #797)
-        - tidal://track/<id>       → https://tidal.com/browse/track/<id>
-        - spotify:track:<id>       → unchanged (MA native format)
-        - https://music.youtube.com/... → unchanged (already a URL)
-
-        Args:
-            uri: Beatify-internal URI string
-
-        Returns:
-            URI converted to a format Music Assistant can resolve
-
-        """
-        if not uri:
-            return uri
-
-        if uri.startswith("deezer://track/"):
-            # MA's Deezer provider has domain "deezer". The previous
-            # https://www.deezer.com/track/<id> form was being routed to the
-            # "builtin" provider via MA's generic http(s):// branch — and
-            # builtin doesn't know Deezer, so playback failed with
-            # "No playable items found". Pass through the native form. (#797)
-            return uri
-
-        if uri.startswith("applemusic://track/"):
-            # MA's Apple Music provider has domain "apple_music". Use MA's native
-            # provider-URI form; the short "music.apple.com/song/<id>" URL fails
-            # MA's parser (needs storefront+slug, 6+ path parts). (#772)
-            track_id = uri.removeprefix("applemusic://track/")
-            return f"apple_music://track/{track_id}"
-
-        if uri.startswith("tidal://track/"):
-            track_id = uri.removeprefix("tidal://track/")
-            return f"https://tidal.com/browse/track/{track_id}"
-
-        if uri.startswith("https://music.youtube.com/watch?v="):
-            track_id = uri.removeprefix("https://music.youtube.com/watch?v=")
-            return f"ytmusic://track/{track_id}"
-
-        # spotify:track:<id> and https:// URLs are passed through unchanged
-        return uri
-
-    @classmethod
-    def _uri_match_tokens(cls, uri: str) -> list[str]:
-        """Tokens to look for in MA's media_content_id to confirm playback.
-
-        Issue #1380: the raw Beatify-internal URI is not what MA reports in
-        media_content_id — MA echoes the _convert_uri_for_ma form. To reliably
-        detect that the requested track started, match against BOTH the
-        MA-converted URI and the bare track ID (last path/ID segment), which is
-        identical across the internal and the MA-converted form for every
-        provider (Spotify, Apple Music, Tidal, YT Music, Deezer).
-
-        Args:
-            uri: The Beatify-internal URI that was requested.
-
-        Returns:
-            Ordered, deduped, non-empty substring tokens.
-
-        """
-        tokens: list[str] = []
-
-        def _add(token: str | None) -> None:
-            if token and token not in tokens:
-                tokens.append(token)
-
-        # The form MA actually reports.
-        _add(cls._convert_uri_for_ma(uri))
-        # The raw form too, in case a provider echoes the internal URI verbatim.
-        _add(uri)
-
-        # Bare track ID — stable across both forms.
-        if uri.startswith("spotify:"):
-            _add(uri.split(":")[-1])
-        elif "watch?v=" in uri:
-            # https://music.youtube.com/watch?v=<id>[&extra]
-            _add(uri.split("watch?v=", 1)[-1].split("&", 1)[0])
-        elif "://" in uri:
-            # applemusic://track/<id>, tidal://track/<id>, deezer://track/<id>,
-            # and plain https URLs — the bare ID is the last "/"-segment.
-            tail = uri.rstrip("/").rsplit("/", 1)[-1]
-            _add(tail.split("?", 1)[0])
-
-        return tokens
-
-    def _get_ma_uri_candidates(
-        self, song: dict[str, Any]
-    ) -> list[tuple[str | None, str]]:
-        """
-        Build the ordered list of MA-ready URIs to try for this song (#805).
-
-        Only walks URI fields belonging to the user's selected provider
-        (`self._provider`). The wizard's provider choice represents what's
-        actually configured in MA — trying URIs from other providers when
-        the user said "Apple Music only" just buys 15s timeouts per
-        unsupported provider before MA reports `MediaNotFoundError`.
-
-        Order: the user's selected URI (`_resolved_uri`, storefront-resolved by
-        the caller) ALWAYS first, then the previously-successful field (if any),
-        then any remaining provider URI fields. URIs are converted for MA and
-        deduped by their converted form.
-
-        For apple_music, the legacy `uri_apple_music` field (a single,
-        historically US-storefront ID) is dropped from the alternates whenever
-        the song carries a `uri_apple_music_by_region` map — otherwise a non-US
-        user would re-pay the wrong-storefront timeout #808 eliminated, and a
-        cross-storefront-lucky US hit could become the learned preferred field
-        and bypass region-correct resolution for the rest of the session (#1379).
-
-        Returns:
-            List of `(field_name, converted_uri)`. `field_name` is `None` for
-            the `_resolved_uri` entry, a `uri_*` field name otherwise.
-
-        """
-        seen: set[str] = set()
-        candidates: list[tuple[str | None, str]] = []
-        # Validate the dispatch key explicitly (#1276). An unknown provider
-        # (key absent from the table) is a config-level mismatch — the wizard
-        # is supposed to gate it, but if it slips through, `.get(..., ())`
-        # would silently yield zero candidates and playback would fail with
-        # no actionable diagnostic. This is the silent-fail pattern behind
-        # #768/#808. A KNOWN provider mapped to `()` (e.g. amazon_music, which
-        # plays via Alexa text-search, not URIs) is intentional and stays
-        # quiet. `_resolved_uri` is still honored below as a last resort so an
-        # unexpected provider doesn't hard-fail when the song does carry a URI.
-        provider_fields = _PROVIDER_URI_FIELDS.get(self._provider)
-        if provider_fields is None:
-            _LOGGER.warning(
-                "MA dispatch: unknown provider %r — no URI field mapping; "
-                "falling back to _resolved_uri only for %s - %s (#1276)",
-                self._provider,
-                song.get("artist"),
-                song.get("title"),
-            )
-            provider_fields = ()
-
-        def _add(field: str | None, raw: str | None) -> None:
-            if not raw:
-                return
-            converted = self._convert_uri_for_ma(raw)
-            if not converted or converted in seen:
-                return
-            seen.add(converted)
-            candidates.append((field, converted))
-
-        # #1379: storefront-unaware fallback guard. For apple_music, the legacy
-        # `uri_apple_music` field holds a single (historically US-storefront)
-        # track ID. The caller (`get_song_uri`) already resolves `_resolved_uri`
-        # storefront-aware from `uri_apple_music_by_region` when that map exists.
-        # Appending the legacy US field as an alternate for a non-US user
-        # re-introduces exactly the wrong-storefront 15s stale-title timeout that
-        # #808 eliminated — and if that US ID ever resolves cross-storefront, it
-        # becomes the learned preferred field and systematically outranks the
-        # region-correct URI for the rest of the session. When a regional map is
-        # present, drop the legacy field entirely so only `_resolved_uri` (the
-        # region-correct ID, or None when unavailable) is tried.
-        skip_legacy_apple = self._provider == "apple_music" and bool(
-            song.get("uri_apple_music_by_region")
-        )
-
-        def _field_eligible(field: str) -> bool:
-            return not (skip_legacy_apple and field == "uri_apple_music")
-
-        # #1379: `_resolved_uri` is ALWAYS tried first — it is the URI Beatify
-        # resolved for the user's selected provider AND storefront. The learned
-        # preference must never outrank it (a US ID that resolved once must not
-        # systematically bypass storefront-correct resolution); the preference is
-        # used only to order the REMAINING alternates below.
-        _add(None, song.get("_resolved_uri"))
-
-        # Learned preference — but only if it's a field belonging to the
-        # current provider (the cache survives across games where provider
-        # may have changed) and not a legacy field we're skipping for storefront
-        # reasons (#1379). Ordered ahead of the other alternates, behind primary.
-        if (
-            self._ma_preferred_uri_field
-            and self._ma_preferred_uri_field in provider_fields
-            and _field_eligible(self._ma_preferred_uri_field)
-        ):
-            _add(self._ma_preferred_uri_field, song.get(self._ma_preferred_uri_field))
-
-        # Remaining alternates within the same provider.
-        for field in provider_fields:
-            if field != self._ma_preferred_uri_field and _field_eligible(field):
-                _add(field, song.get(field))
-
-        return candidates
-
-    async def _play_via_music_assistant(self, song: dict[str, Any]) -> bool:
-        """
-        Play via Music Assistant, walking the user-provider's URI fields (#805).
-
-        Only candidates from `_PROVIDER_URI_FIELDS[self._provider]` are tried —
-        the wizard's provider choice represents what MA is configured for, so
-        attempting other providers' URIs just burns 15s timeouts per
-        unsupported provider before MA reports `MediaNotFoundError`. This was
-        the originating bug for #805 (Levtos's Apple-Music-only setup paid
-        4×15s of Spotify/YT/Tidal timeouts on every failed round).
-        """
-        # #808 follow-up: clear stale failure classification before each
-        # attempt so start_round reads only the result of THIS song.
-        self.last_failure_reason = None
-        # #1363: clear the cascade-stop flag at the start of each song so a
-        # stop from a PRIOR song never leaks into this song's classification.
-        self._stopped_for_cascade = False
-
-        candidates = self._get_ma_uri_candidates(song)
-        expected_title = song.get("title") or ""
-        expected_artist = song.get("artist") or ""
-
-        # The name fallback below needs both fields; without them there is
-        # nothing to search for and nothing to verify the result against.
-        name_fallback = bool(
-            self._provider in _NAME_FALLBACK_PROVIDERS
-            and expected_title
-            and expected_artist
-        )
-
-        if not candidates and not name_fallback:
-            # #1276: surface the provider so a missing-URI miss is debuggable
-            # (which provider was selected vs. which fields the song carries).
-            _LOGGER.warning(
-                "MA playback: no playable URI for provider %r — %s - %s (#1276)",
-                self._provider,
-                song.get("artist"),
-                song.get("title"),
-            )
-            self.last_failure_reason = "unavailable"
-            return False
-
-        if not expected_title:
-            _LOGGER.warning(
-                "MA playback: no expected title — skipping title verification"
-            )
-
-        for idx, (field, uri) in enumerate(candidates):
-            if idx > 0:
-                _LOGGER.info(
-                    "MA fallback %d/%d: trying %s (prior URI did not resolve) (#768)",
-                    idx + 1,
-                    len(candidates),
-                    uri,
-                )
-            success = await self._try_ma_play(uri, expected_title, expected_artist)
-            if success:
-                # #1381: only learn a candidate's URI field as the new preferred
-                # one when an EXPECTED-TITLE substring match (Path 1) confirmed
-                # it. A weaker confirmation (artist/token gate, or the
-                # post-timeout #345 tolerance) is not strong enough proof that
-                # THIS field actually resolved our track — promoting it would
-                # reorder future candidates wrongly for a field that never
-                # really worked.
-                if (
-                    field
-                    and field != self._ma_preferred_uri_field
-                    and self._last_confirm_path == 1
-                ):
-                    _LOGGER.debug("MA preferred URI field now: %s (#768)", field)
-                    self._ma_preferred_uri_field = field
-                self.last_failure_reason = None
-                return True
-
-        # Last resort: let MA resolve the track from name + artist.
-        #
-        # `ma_library`: the stored URI is normally exact, but the item may have
-        # moved or changed since the pool was built.
-        # `tidal`: the URI may be absent entirely and can no longer be obtained
-        # — Odesli, the only source Beatify ever had for Tidal ids, retired its
-        # public API on 2026-07-31. This path is a safety net *behind* the
-        # stored URIs, never a replacement for them: the loop above has already
-        # run, so a song that carries a working `uri_tidal` never reaches here.
-        if name_fallback:
-            _LOGGER.info(
-                "MA name fallback (%s): resolving by name -- %s - %s",
-                self._provider,
-                expected_artist,
-                expected_title,
-            )
-            if await self._try_ma_play(
-                expected_title,
-                expected_title,
-                expected_artist,
-                artist_filter=expected_artist,
-            ):
-                # A name search can land on a remix, a live take or a karaoke
-                # version of the right song. `_try_ma_play` will happily accept
-                # those (its title gate is a prefix/token check by design), so
-                # the edition is checked here instead.
-                state = self._safe_state()
-                played_title = (
-                    state.attributes.get("media_title", "") if state else ""
-                ) or ""
-                if not _edition_matches(expected_title, played_title):
-                    _LOGGER.warning(
-                        "MA name fallback: rejecting wrong edition — wanted %r, "
-                        "got %r (%s)",
-                        expected_title,
-                        played_title,
-                        expected_artist,
-                    )
-                    self.last_failure_reason = "wrong_track"
-                    return False
-                self.last_failure_reason = None
-                return True
-
-        _LOGGER.error(
-            "MA playback: all %d URI candidate(s) failed for %s - %s (#768)",
-            len(candidates),
-            song.get("artist"),
-            song.get("title"),
-        )
-        # last_failure_reason carries the classification of the last
-        # _try_ma_play attempt (set by that method); start_round reads it.
-        return False
-
-    async def _try_ma_play(
-        self,
-        uri: str,
-        expected_title: str,
-        expected_artist: str = "",
-        artist_filter: str | None = None,
-    ) -> bool:
-        """
-        Attempt a single MA `play_media` call and wait for playback confirmation.
-
-        Returns False on hard failure (speaker idle/unavailable, or the track
-        clearly never swapped on the speaker) so the caller can try the next
-        URI. Returns True both when playback is confirmed AND when the speaker
-        is showing ambiguous-but-changing state (MA may still be buffering —
-        preserving the #345 tolerance so we don't chase flaky retries).
-
-        `expected_artist` (#1381) feeds the fast-path Path 2 similarity gate so
-        an arbitrary title change from the prior queue auto-advancing is not
-        instant-accepted as our track.
-        """
-        # #1927 follow-up: remember what we are about to play, so a failure is
-        # reported with the URI that was really tried.
-        self.last_attempted_uri = uri
-        # #1936: cold-start budget for the very first attempt of a game only.
-        timeout = MA_PLAYBACK_TIMEOUT * (
-            MA_FIRST_PLAY_TIMEOUT_FACTOR if self._first_play_pending else 1
-        )
-        self._first_play_pending = False
-        _LOGGER.debug(
-            "MA playback: %s on %s (budget %.0fs)", uri, self._entity_id, timeout
-        )
-
-        # Snapshot speaker state before the call — we need both fields to
-        # distinguish #345 slow-buffer (one of them changed during the wait)
-        # from #777 silent failure (neither changed, speaker still on prior
-        # track).
-        state_before = self._safe_state()
-        if state_before is not None:
-            title_before = state_before.attributes.get("media_title", "")
-            position_updated_before = state_before.attributes.get(
-                "media_position_updated_at"
-            )
-            # #2616: the title alone cannot tell "same song still playing"
-            # apart from "different song, same title". The content id can.
-            content_id_before = state_before.attributes.get("media_content_id") or ""
-        else:
-            title_before = ""
-            position_updated_before = None
-            content_id_before = ""
-
-        # #2616: the substrings that identify THIS uri inside MA's
-        # media_content_id — the same tokens wait_for_metadata_update matches
-        # on (#1380).
-        match_tokens = self._uri_match_tokens(uri)
-
-        # #2143: remember the host's own queue BEFORE the replace below wipes
-        # it. Idempotent, so this only costs a get_queue call in round one.
-        await self.save_queue()
-
-        # Fire-and-forget the service call — blocking=True hangs on MA+YTMusic
-        # enqueue=replace: each round's track REPLACES the queue. Without it
-        # MA keeps prior rounds queued, and after a TTS announcement the queue
-        # resume can advance into stale entries — observed as the player
-        # returning to PREVIOUS rounds' songs, sometimes mid-round.
-        service_data: dict[str, Any] = {
-            "media_id": uri,
-            "media_type": "track",
-            "enqueue": "replace",
-        }
-        # Crate Digger name fallback: when a stored library URI no longer
-        # resolves (library rebuilds change item ids), media_id carries the
-        # track NAME and the artist disambiguates it inside MA's resolver.
-        if artist_filter:
-            service_data["artist"] = artist_filter
-        await self._hass.services.async_call(
-            "music_assistant",
-            "play_media",
-            service_data,
-            target={"entity_id": self._entity_id},
-            blocking=False,
-        )
-
-        # Wait for the EXPECTED song to actually play on the speaker:
-        # - media_title contains expected title (the strongest single signal —
-        #   speaker explicitly identifies our requested track)
-        # - media_position_updated_at changed (MA is actively reporting state)
-        #
-        # We used to also require media_position >= 1 here as a guard against
-        # MA reporting `state=playing` while a track was only queued. In
-        # practice that case shows itself by `media_position_updated_at`
-        # *not* changing — the queued track's position never updates. So
-        # `position_fresh` already filters it out, and the position-value
-        # check was needlessly delaying confirmation.
-        #
-        # Ziigmund84 reported (#803) on cold MA start the speaker shows
-        # state=playing + correct title within seconds, but media_position
-        # lags at 0 for 10-15s. Old fast-path didn't fire; user heard music
-        # while UI sat in REVEAL waiting for the timeout.
-        expected_lower = expected_title.lower()
-
-        confirmed = asyncio.Event()
-        start_time = asyncio.get_event_loop().time()
-
-        def _check_state(state) -> bool:
-            """Return True if the state confirms expected playback.
-
-            Two acceptance paths:
-              1. Title contains expected (substring) — the strongest signal.
-              2. Title moved to a *plausibly-our-track* new title — MA is
-                 making progress on a new track that shares a token with the
-                 expected title, or whose artist matches the expected artist.
-
-            Path 2 was previously only reachable via the 15-second slow-buffer
-            tolerance below. Levtos reported that pressing "next" caused the
-            UI to lag while the music had already started: the playlist had
-            a song with a slightly different title format (e.g. German
-            "Das Modell" vs MA's English "The Model", or "(Remastered)"
-            suffix mismatches) so the substring-match in path 1 failed and
-            the wait timed out. With path 2 in the fast-path, the UI now
-            returns within ~1s of MA actually starting playback.
-
-            #1381 tightened Path 2: it used to accept ANY title that differed
-            from `title_before`. If the requested URI failed to resolve in MA
-            while the speaker's prior queue auto-advanced to its next track
-            during the 15s window, that unrelated title was instant-confirmed
-            as success — the #795 "guess the year of SongX with no SongX audio"
-            class, but silently. Path 2 now requires a cheap similarity gate
-            (token overlap / normalized-prefix vs expected_title, OR expected
-            artist present in media_artist). The unbounded "any new title"
-            acceptance is reserved for the post-timeout #345 branch, where it
-            is logged.
-
-            #795 invariant still holds: if the title is unchanged from
-            before the call (`title_before`), neither path fires and we
-            fall through to the title-must-advance hard-failure check.
-            """
-            if not state or state.state != "playing":
-                return False
-            try:
-                current_title = state.attributes.get("media_title", "") or ""
-                current_artist = state.attributes.get("media_artist", "") or ""
-                position_updated = state.attributes.get("media_position_updated_at")
-
-                position_fresh = position_updated != position_updated_before
-                if not position_fresh:
-                    return False
-
-                # #2333: the track has to have actually changed. The
-                # docstring above promised this of BOTH paths, and Path 2
-                # honoured it while Path 1 did not — it accepted a substring
-                # match against whatever was playing, including the song from
-                # the previous round still running.
-                #
-                # `position_fresh` above is no help: a track that simply keeps
-                # playing keeps advancing its own position.
-                #
-                # The failure it allowed: round N plays "Stay With Me", round
-                # N+1 draws "Stay" whose URI is missing from the household's
-                # storefront, MA never switches, and `"stay" in "stay with
-                # me"` confirms success within a second. The room then guesses
-                # a song they already heard.
-                #
-                # Substring containment makes that reachable well beyond one
-                # example — covers, "One", "Hurt", remaster suffixes.
-                #
-                # An empty `title_before` (nothing was playing) still passes,
-                # which is the cold-start case and genuinely a change.
-                title_changed = current_title != title_before
-
-                # #2616: a changed title is sufficient proof of a new track,
-                # but it is not necessary. Two different songs can carry the
-                # same title ("Hello" by Adele, then "Hello" by Lionel
-                # Richie), and #2333's title check then rejects a switch that
-                # actually happened. `media_content_id` settles it: if it now
-                # carries the id of the URI we requested AND differs from what
-                # was loaded before, the speaker demonstrably moved to OUR
-                # track. The #2333 failure stays rejected — there MA never
-                # switched, so the content id never changes either.
-                content_id = state.attributes.get("media_content_id") or ""
-                track_changed = title_changed or _content_id_advanced(
-                    content_id, content_id_before, match_tokens
-                )
-
-                # Path 1: exact-ish title match (substring) — strongest signal,
-                # the only path strong enough to learn a preferred URI field.
-                if (
-                    track_changed
-                    and expected_lower
-                    and expected_lower in current_title.lower()
-                ):
-                    self._last_confirm_path = 1
-                    return True
-                # If no expected title was supplied, position-fresh alone is
-                # all the signal we have — accept (matches old behavior).
-                if not expected_lower:
-                    self._last_confirm_path = 2
-                    return True
-
-                # Path 2 (#1381): title moved to a DIFFERENT title AND that
-                # title is plausibly our track (shared token / prefix) OR the
-                # artist matches. A bare "any different title" no longer
-                # qualifies — that is the prior-queue auto-advance trap.
-                if current_title and track_changed:
-                    if _titles_plausibly_match(
-                        expected_title, current_title
-                    ) or _artist_matches(expected_artist, current_artist):
-                        self._last_confirm_path = 2
-                        return True
-
-                return False
-            except (AttributeError, KeyError):
-                return False
-
-        def _state_changed(ev):
-            new_state = ev.data.get("new_state")
-            if _check_state(new_state):
-                confirmed.set()
-
-        unsub = async_track_state_change_event(
-            self._hass, [self._entity_id], _state_changed
-        )
-        try:
-            # Check current state first — may already be playing
-            current = self._safe_state()
-            if _check_state(current):
-                elapsed = asyncio.get_event_loop().time() - start_time
-                _LOGGER.debug(
-                    "MA playback confirmed after %.1fs: %s (pos=%.1f)",
-                    elapsed,
-                    current.attributes.get("media_title", ""),
-                    current.attributes.get("media_position", 0),
-                )
-                return True
-
-            await asyncio.wait_for(confirmed.wait(), timeout=timeout)
-            elapsed = asyncio.get_event_loop().time() - start_time
-            final = self._safe_state()
-            _LOGGER.debug(
-                "MA playback confirmed after %.1fs: %s (pos=%.1f)",
-                elapsed,
-                final.attributes.get("media_title", "") if final else "?",
-                final.attributes.get("media_position", 0) if final else 0,
-            )
-            return True
-        except asyncio.TimeoutError:
-            pass
-        finally:
-            unsub()
-
-        current_state = await self._safe_state_with_retry()
-        speaker_state = current_state.state if current_state else "unknown"
-
-        # Hard failure: speaker is idle/unavailable/off — song won't play
-        if speaker_state in ("idle", "unavailable", "off", "unknown"):
-            # #1363: if the speaker is 'idle' only because WE stopped it after a
-            # prior same-song stale-title detect, this is a storefront-gap
-            # cascade (e.g. apple_music's `_resolved_uri` and a differing
-            # `uri_apple_music` both point at an unavailable catalog entry), NOT
-            # a systemic speaker/provider failure. Misclassifying it as 'error'
-            # makes state_lifecycle pause the whole game on a per-track gap —
-            # the exact #805/#808 regression. Keep it 'unavailable' so the game
-            # skips the song silently and tries the next one.
-            if self._stopped_for_cascade and speaker_state == "idle":
-                _LOGGER.warning(
-                    "MA playback failed after %.1fs for %s — speaker idle, but "
-                    "Beatify stopped it after a same-song stale-title detect. "
-                    "Treating as a storefront/catalog gap (unavailable), not a "
-                    "systemic error — game will skip this song silently. (#1363)",
-                    timeout,
-                    uri,
-                )
-                self.last_failure_reason = "unavailable"
-                return False
-            _LOGGER.error(
-                "MA playback failed after %.1fs for %s (state: %s). "
-                "Either the speaker is offline, MA's provider is unauthenticated, "
-                "or the track is not available in your provider's catalog. If this "
-                "happens for many tracks, re-authenticate your music provider in MA. "
-                "A rate-limiting provider looks the same from here — Music "
-                "Assistant then retries the track after its own backoff, which "
-                "can outlast this budget. (#1936)",
-                timeout,
-                uri,
-                speaker_state,
-            )
-            # Conservative: speaker-idle failures could be systemic (provider
-            # broken across the board) so we keep counting them toward
-            # MAX_SONG_RETRIES. The recovery banner will guide the user to
-            # the re-auth fix once 3 land in a row.
-            self.last_failure_reason = "error"
-            return False
-
-        # Hard failure: speaker title did not advance. If the title field is
-        # identical to what it was before we called play_media, the new track
-        # never started on the speaker — even if media_position_updated_at
-        # changed (that just means the *prior* track is still ticking).
-        #
-        # #777 originally caught only "title unchanged AND position unchanged"
-        # (everything frozen), but #795 surfaced the more common pattern:
-        # the prior track keeps playing, position advances, and the #345
-        # tolerance below would falsely return True. Levtos's playthrough
-        # had the speaker stuck on 'Sugar, Sugar' then 'Lazy Sunday (Mono)'
-        # for multiple rounds while UI advanced into "guess the year of
-        # SongX" with no actual SongX audio.
-        #
-        # Title-must-advance is the right invariant: if a new track really
-        # started, the title field must eventually become *something*
-        # different. Position alone is not proof of a new track.
-        title_after = (
-            current_state.attributes.get("media_title", "") if current_state else ""
-        )
-        position_updated_after = (
-            current_state.attributes.get("media_position_updated_at")
-            if current_state
-            else None
-        )
-        content_id_after = (
-            (current_state.attributes.get("media_content_id") or "")
-            if current_state
-            else ""
-        )
-        title_advanced = title_after != title_before
-        # #2616: same reasoning as in the fast path — an unchanged title is
-        # only evidence of a stuck speaker when the content id has not moved
-        # to the track we asked for. Stopping the speaker here is what made
-        # the collision audible: the room heard the correct song for the full
-        # budget, then silence, then a different song.
-        track_advanced = title_advanced or _content_id_advanced(
-            content_id_after, content_id_before, match_tokens
-        )
-        if not track_advanced:
-            position_changed = position_updated_after != position_updated_before
-            # #808 follow-up: this is the storefront/region-mismatch
-            # signature — MA accepted the URI but couldn't resolve a stream
-            # for it, so the speaker just keeps playing the prior track.
-            # @Levtos hit this for `apple_music://track/302229811` (US-only
-            # 'All Together Now' on a DE-storefront MA), and the iTunes
-            # Lookup confirmed: track in US catalog, NOT in DE catalog.
-            _LOGGER.warning(
-                "MA playback failed after %.1fs for %s — speaker still on "
-                "prior track %r (position timestamp %s). Track is likely "
-                "not available in your provider's catalog/storefront, OR "
-                "your provider needs re-authentication in MA. Skipping "
-                "this song silently — game will try the next one. (#795)",
-                timeout,
-                uri,
-                title_before,
-                "advanced — prior track still playing"
-                if position_changed
-                else "also unchanged",
-            )
-            # #801: Hard-stop the speaker so the prior track doesn't keep
-            # playing while the fallback cascade tries the next URI. Without
-            # this, Levtos's setup heard 'Kill Bill' continuing for multiple
-            # rounds while the UI advanced — strict-detection was rejecting
-            # candidates correctly but nobody was telling the speaker to
-            # actually stop. Best-effort: failure here doesn't change the
-            # outcome (we're already returning False).
-            try:
-                await self._hass.services.async_call(
-                    "media_player",
-                    "media_stop",
-                    {"entity_id": self._entity_id},
-                    blocking=False,
-                )
-                # #1363: record that the next cascade candidate will see an
-                # 'idle' speaker WE caused, so its idle-failure isn't
-                # misclassified as a systemic 'error'.
-                self._stopped_for_cascade = True
-            except (HomeAssistantError, ServiceNotFound, ConnectionError, OSError):
-                _LOGGER.debug(
-                    "media_stop call after stale-title detect failed for %s",
-                    self._entity_id,
-                )
-            # #808 follow-up: classify as "unavailable" so start_round skips
-            # silently without counting against MAX_SONG_RETRIES. Storefront
-            # gaps shouldn't pause the game — the user can't fix individual
-            # track availability and the game should keep playing whatever
-            # subset IS in their catalog.
-            self.last_failure_reason = "unavailable"
-            return False
-
-        if not title_advanced:
-            _LOGGER.debug(
-                "MA playback: title stayed %r for %s, but media_content_id "
-                "moved to %r — the requested track IS loaded, the two songs "
-                "merely share a title. Not a stale-title failure. (#2616)",
-                title_before,
-                uri,
-                content_id_after,
-            )
-
-        # #1863: "still buffering" requires that Music Assistant actually owns
-        # this player. An MA-platform entity reports the queue it is playing
-        # from in `active_queue`; while MA is buffering a track it has already
-        # taken the queue, so `active_queue` is set. A *null* `active_queue`
-        # means MA never accepted the play_media call for this player at all —
-        # the entity is only mirroring whatever the underlying speaker was
-        # doing before the game (in the report: a leftover Spotify context,
-        # `state: paused`, `media_position: 0`). That is a silent failure, not
-        # slow buffering, and the #345 tolerance below would wave it through as
-        # success: the round then starts, the timer arms, and the players get a
-        # silent PLAYING phase with no music and no error.
-        #
-        # Deliberately narrow: only when the attribute is PRESENT and falsy. If
-        # a Music Assistant / HA version does not expose `active_queue` at all
-        # the key is missing, and we keep the old tolerance rather than turning
-        # every slow buffer on that version into a failure.
-        attrs_after = current_state.attributes if current_state else {}
-        if "active_queue" in attrs_after and not attrs_after.get("active_queue"):
-            _LOGGER.error(
-                "MA playback failed after %.1fs for %s — the player reports no "
-                "active Music Assistant queue (state: %s, title %r → %r). MA "
-                "never took ownership of this speaker, so nothing was ever "
-                "dispatched. Check that the speaker is exposed to Music "
-                "Assistant and that your provider is authenticated there. "
-                "(#1863)",
-                timeout,
-                uri,
-                speaker_state,
-                title_before,
-                title_after,
-            )
-            # Systemic, not a per-track catalog gap: MA declined the whole
-            # play_media call, so the next song would fail identically.
-            # Classify as "error" so start_round pauses the game and shows the
-            # recovery banner within seconds instead of silently burning
-            # through the playlist one unplayable song at a time.
-            self.last_failure_reason = "error"
-            return False
-
-        # #345 slow-buffer tolerance, narrowed to "title genuinely changed":
-        # title is now different from what it was before the call, so MA is
-        # making progress on *some* new track. We still don't require the
-        # title to match expected_title (AirPlay sometimes delivers
-        # remasters/alternates with mismatched-but-valid titles), but we do
-        # require title evidence of forward motion. Returning False here
-        # would re-trigger the race condition #345 was originally filed for.
-        _LOGGER.warning(
-            "MA playback not confirmed after %.1fs for %s (state: %s). "
-            "Title moved %r → %r. Continuing anyway — MA may still be "
-            "buffering. (#345)",
-            timeout,
-            uri,
-            speaker_state,
-            title_before,
-            title_after,
-        )
-        # #1381: a post-timeout #345 tolerance confirmation is the weakest
-        # acceptance — it must NOT promote this candidate's URI field to
-        # preferred (it never proved THIS field actually resolved our track).
-        self._last_confirm_path = 0
-        return True
-
-    async def _play_via_sonos(self, song: dict[str, Any]) -> bool:
-        """Play via Sonos (URI-based)."""
-        uri = song.get("_resolved_uri")
-        _LOGGER.debug("Sonos playback: %s on %s", uri, self._entity_id)
-
-        async with async_timeout(PLAYBACK_TIMEOUT):
-            await self._hass.services.async_call(
-                "media_player",
-                "play_media",
-                {
-                    "entity_id": self._entity_id,
-                    "media_content_id": uri,
-                    "media_content_type": "music",
-                },
-                blocking=True,
-            )
-        return True
-
-    async def _play_via_alexa(self, song: dict[str, Any]) -> bool:
-        """Play via Alexa (text search-based)."""
-        search_text = self._get_alexa_search_text(song)
-        if self._provider == "spotify":
-            content_type = "SPOTIFY"
-        elif self._provider == "amazon_music":
-            content_type = "AMAZON_MUSIC"
-        elif self._provider == "apple_music":
-            content_type = "APPLE_MUSIC"
-        else:
-            # Unknown provider slipped past the wizard gate. Previously every
-            # non-spotify/non-amazon provider was silently mapped to
-            # APPLE_MUSIC, so a deezer/tidal/ytmusic mismatch played the wrong
-            # catalog with no diagnostic — the same silent-fail class as
-            # #768/#808. Surface it (mirrors the #1276 dispatch warning) before
-            # falling back to APPLE_MUSIC. (#1402)
-            _LOGGER.warning(
-                "Alexa dispatch: unexpected provider %r — no Alexa content-type "
-                "mapping; falling back to APPLE_MUSIC for %s - %s (#1402)",
-                self._provider,
-                song.get("artist"),
-                song.get("title"),
-            )
-            content_type = "APPLE_MUSIC"
-
-        _LOGGER.debug(
-            "Alexa playback: '%s' (%s) on %s",
-            search_text,
-            content_type,
-            self._entity_id,
-        )
-
-        async with async_timeout(PLAYBACK_TIMEOUT):
-            await self._hass.services.async_call(
-                "media_player",
-                "play_media",
-                {
-                    "entity_id": self._entity_id,
-                    "media_content_id": search_text,
-                    "media_content_type": content_type,
-                },
-                blocking=True,
-            )
-        return True
-
-    def _get_alexa_search_text(self, song: dict[str, Any]) -> str:
-        """Generate Alexa-compatible search text from song metadata."""
-        artist = song.get("artist", "")
-        title = song.get("title", "")
-
-        # Playlists may store multiple artists as "A;B" — use only the first.
-        if artist and ";" in artist:
-            artist = artist.split(";")[0].strip()
-
-        if artist and title:
-            return f"{title} by {artist}"
-        if title:
-            return title
-        _LOGGER.warning("Song missing artist/title for Alexa search")
-        return "unknown song"
 
     async def get_metadata(self) -> dict[str, Any]:
         """
@@ -1892,7 +562,7 @@ class MediaPlayerService:
         # https://tidal.com/browse/track/123, ytmusic://track/ABC). Match
         # against the MA-converted URI AND the bare track ID (the last path/ID
         # segment), which is stable across both forms.
-        match_tokens = self._uri_match_tokens(uri)
+        match_tokens = uri_match_tokens(uri)
 
         # Get initial state for comparison
         initial_state = self._hass.states.get(self._entity_id)
@@ -2178,7 +848,7 @@ class MediaPlayerService:
         song has finished — the player drops out of "playing" once the
         track ends.
         """
-        state = self._safe_state()
+        state = self._context.state()
         return state.state if state else None
 
     async def verify_responsive(self) -> tuple[bool, str]:

--- a/custom_components/beatify/services/playback/__init__.py
+++ b/custom_components/beatify/services/playback/__init__.py
@@ -14,12 +14,14 @@ from __future__ import annotations
 
 from .base import PLAYBACK_TIMEOUT, PlaybackStrategy
 from .context import PlayerContext
+from .sonos import SonosStrategy
 from .uris import convert_uri_for_ma, uri_match_tokens
 
 __all__ = [
     "PLAYBACK_TIMEOUT",
     "PlaybackStrategy",
     "PlayerContext",
+    "SonosStrategy",
     "convert_uri_for_ma",
     "uri_match_tokens",
 ]

--- a/custom_components/beatify/services/playback/__init__.py
+++ b/custom_components/beatify/services/playback/__init__.py
@@ -1,0 +1,25 @@
+"""Per-platform playback, and the one place that picks between them (#2636).
+
+``MediaPlayerService`` answers "how do I play this?" with an
+``if self._platform ==`` chain inside a 2300-line class, so Music Assistant,
+Sonos and Alexa share one class body, one test file and one blast radius.
+
+This package is where each platform is getting its own module behind one
+interface. It starts with what they have in common: the speaker
+(:class:`~.context.PlayerContext`) and the contract
+(:class:`~.base.PlaybackStrategy`).
+"""
+
+from __future__ import annotations
+
+from .base import PLAYBACK_TIMEOUT, PlaybackStrategy
+from .context import PlayerContext
+from .uris import convert_uri_for_ma, uri_match_tokens
+
+__all__ = [
+    "PLAYBACK_TIMEOUT",
+    "PlaybackStrategy",
+    "PlayerContext",
+    "convert_uri_for_ma",
+    "uri_match_tokens",
+]

--- a/custom_components/beatify/services/playback/__init__.py
+++ b/custom_components/beatify/services/playback/__init__.py
@@ -1,16 +1,24 @@
 """Per-platform playback, and the one place that picks between them (#2636).
 
-``MediaPlayerService`` answers "how do I play this?" with an
+``MediaPlayerService`` used to answer "how do I play this?" with an
 ``if self._platform ==`` chain inside a 2300-line class, so Music Assistant,
-Sonos and Alexa share one class body, one test file and one blast radius.
+Sonos and Alexa shared one class body, one test file and one blast radius.
 
-This package is where each platform is getting its own module behind one
-interface. It starts with what they have in common: the speaker
-(:class:`~.context.PlayerContext`) and the contract
-(:class:`~.base.PlaybackStrategy`).
+Now each platform is a :class:`~.base.PlaybackStrategy` in its own module, and
+the choice between them happens exactly once, in :func:`build_strategy`. A
+strategy claims its platform identifiers itself (``platforms`` on the class),
+so adding Plex or Jellyfin is a new module plus one entry in ``_STRATEGIES`` —
+no existing method is cut open, and nothing about the other platforms is
+touched.
+
+The service shell keeps what is genuinely not per-platform: timeouts and
+analytics, volume save/restore, the metadata wait, the pre-flight check and the
+game-lifecycle bookkeeping around the queue snapshot.
 """
 
 from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from .alexa import AlexaStrategy
 from .base import PLAYBACK_TIMEOUT, PlaybackStrategy
@@ -20,6 +28,47 @@ from .queue_restore import MaQueueRestorer
 from .sonos import SonosStrategy
 from .uris import convert_uri_for_ma, uri_match_tokens
 
+if TYPE_CHECKING:
+    pass
+
+#: Every platform Beatify can play on. Order is irrelevant — a platform
+#: identifier belongs to exactly one strategy, which the assertion below keeps
+#: true at import time.
+_STRATEGIES: tuple[type[PlaybackStrategy], ...] = (
+    MusicAssistantStrategy,
+    SonosStrategy,
+    AlexaStrategy,
+)
+
+_BY_PLATFORM: dict[str, type[PlaybackStrategy]] = {}
+for _strategy in _STRATEGIES:
+    for _platform in _strategy.platforms:
+        if _platform in _BY_PLATFORM:  # pragma: no cover - guards a typo
+            raise RuntimeError(f"two strategies claim platform {_platform!r}")
+        _BY_PLATFORM[_platform] = _strategy
+del _strategy, _platform
+
+
+def build_strategy(context: PlayerContext) -> PlaybackStrategy | None:
+    """The dispatch point — the only place a platform name picks an implementation.
+
+    Args:
+        context: the speaker to play on, carrying its platform identifier.
+
+    Returns:
+        The strategy for that platform, or None when Beatify cannot play on it
+        (Cast without Music Assistant, an unknown entity type). The caller logs
+        that; deciding it is this function's whole job.
+    """
+    strategy = _BY_PLATFORM.get(context.platform)
+    return strategy(context) if strategy else None
+
+
+def supported_platforms() -> tuple[str, ...]:
+    """Every platform identifier some strategy answers to."""
+    return tuple(_BY_PLATFORM)
+
+
 __all__ = [
     "PLAYBACK_TIMEOUT",
     "AlexaStrategy",
@@ -28,6 +77,8 @@ __all__ = [
     "PlaybackStrategy",
     "PlayerContext",
     "SonosStrategy",
+    "build_strategy",
     "convert_uri_for_ma",
+    "supported_platforms",
     "uri_match_tokens",
 ]

--- a/custom_components/beatify/services/playback/__init__.py
+++ b/custom_components/beatify/services/playback/__init__.py
@@ -12,6 +12,7 @@ interface. It starts with what they have in common: the speaker
 
 from __future__ import annotations
 
+from .alexa import AlexaStrategy
 from .base import PLAYBACK_TIMEOUT, PlaybackStrategy
 from .context import PlayerContext
 from .sonos import SonosStrategy
@@ -19,6 +20,7 @@ from .uris import convert_uri_for_ma, uri_match_tokens
 
 __all__ = [
     "PLAYBACK_TIMEOUT",
+    "AlexaStrategy",
     "PlaybackStrategy",
     "PlayerContext",
     "SonosStrategy",

--- a/custom_components/beatify/services/playback/__init__.py
+++ b/custom_components/beatify/services/playback/__init__.py
@@ -16,12 +16,14 @@ from .alexa import AlexaStrategy
 from .base import PLAYBACK_TIMEOUT, PlaybackStrategy
 from .context import PlayerContext
 from .music_assistant import MusicAssistantStrategy
+from .queue_restore import MaQueueRestorer
 from .sonos import SonosStrategy
 from .uris import convert_uri_for_ma, uri_match_tokens
 
 __all__ = [
     "PLAYBACK_TIMEOUT",
     "AlexaStrategy",
+    "MaQueueRestorer",
     "MusicAssistantStrategy",
     "PlaybackStrategy",
     "PlayerContext",

--- a/custom_components/beatify/services/playback/__init__.py
+++ b/custom_components/beatify/services/playback/__init__.py
@@ -15,12 +15,14 @@ from __future__ import annotations
 from .alexa import AlexaStrategy
 from .base import PLAYBACK_TIMEOUT, PlaybackStrategy
 from .context import PlayerContext
+from .music_assistant import MusicAssistantStrategy
 from .sonos import SonosStrategy
 from .uris import convert_uri_for_ma, uri_match_tokens
 
 __all__ = [
     "PLAYBACK_TIMEOUT",
     "AlexaStrategy",
+    "MusicAssistantStrategy",
     "PlaybackStrategy",
     "PlayerContext",
     "SonosStrategy",

--- a/custom_components/beatify/services/playback/alexa.py
+++ b/custom_components/beatify/services/playback/alexa.py
@@ -1,0 +1,84 @@
+"""Alexa playback (#2636).
+
+Alexa has no URI: the Echo is asked, in words, for "<title> by <artist>", and
+the content type tells it which service to look in. That voice search is the
+platform's whole character — and the reason its failure modes have nothing in
+common with the Music Assistant path's.
+"""
+
+from __future__ import annotations
+
+import logging
+from asyncio import timeout as async_timeout
+from typing import Any, ClassVar
+
+from .base import PLAYBACK_TIMEOUT, PlaybackStrategy
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AlexaStrategy(PlaybackStrategy):
+    """Play via Alexa (text search-based)."""
+
+    platforms: ClassVar[tuple[str, ...]] = ("alexa_media", "alexa")
+
+    async def play(self, song: dict[str, Any]) -> bool:
+        """Play via Alexa (text search-based)."""
+        search_text = self._get_alexa_search_text(song)
+        if self._provider == "spotify":
+            content_type = "SPOTIFY"
+        elif self._provider == "amazon_music":
+            content_type = "AMAZON_MUSIC"
+        elif self._provider == "apple_music":
+            content_type = "APPLE_MUSIC"
+        else:
+            # Unknown provider slipped past the wizard gate. Previously every
+            # non-spotify/non-amazon provider was silently mapped to
+            # APPLE_MUSIC, so a deezer/tidal/ytmusic mismatch played the wrong
+            # catalog with no diagnostic — the same silent-fail class as
+            # #768/#808. Surface it (mirrors the #1276 dispatch warning) before
+            # falling back to APPLE_MUSIC. (#1402)
+            _LOGGER.warning(
+                "Alexa dispatch: unexpected provider %r — no Alexa content-type "
+                "mapping; falling back to APPLE_MUSIC for %s - %s (#1402)",
+                self._provider,
+                song.get("artist"),
+                song.get("title"),
+            )
+            content_type = "APPLE_MUSIC"
+
+        _LOGGER.debug(
+            "Alexa playback: '%s' (%s) on %s",
+            search_text,
+            content_type,
+            self._entity_id,
+        )
+
+        async with async_timeout(PLAYBACK_TIMEOUT):
+            await self._hass.services.async_call(
+                "media_player",
+                "play_media",
+                {
+                    "entity_id": self._entity_id,
+                    "media_content_id": search_text,
+                    "media_content_type": content_type,
+                },
+                blocking=True,
+            )
+        return True
+
+    def _get_alexa_search_text(self, song: dict[str, Any]) -> str:
+        """Generate Alexa-compatible search text from song metadata."""
+        artist = song.get("artist", "")
+        title = song.get("title", "")
+
+        # Playlists may store multiple artists as "A;B" — use only the first.
+        if artist and ";" in artist:
+            artist = artist.split(";")[0].strip()
+
+        if artist and title:
+            return f"{title} by {artist}"
+        if title:
+            return title
+        _LOGGER.warning("Song missing artist/title for Alexa search")
+        return "unknown song"

--- a/custom_components/beatify/services/playback/base.py
+++ b/custom_components/beatify/services/playback/base.py
@@ -1,0 +1,98 @@
+"""The interface every platform answers to (#2636).
+
+Before this, ``MediaPlayerService`` carried Music Assistant, Sonos and Alexa in
+one class body, so a Sonos change was one indentation level away from the Music
+Assistant path. A strategy is that platform and nothing else: it is handed a
+:class:`~.context.PlayerContext`, it answers :meth:`play`, and it says on its
+own behalf what it can remember of the host's queue.
+
+Adding a platform (Plex, Jellyfin) is a new file plus one entry in
+``_STRATEGIES`` — no existing method is cut open.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, ClassVar
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from .context import PlayerContext
+
+# Timeout for play_song service calls (seconds) - prevents long hangs (#179).
+# Shared by the two strategies that make a single blocking play_media call;
+# Music Assistant runs on its own, much longer budget (see MA_PLAYBACK_TIMEOUT).
+PLAYBACK_TIMEOUT = 8.0
+
+
+class PlaybackStrategy(ABC):
+    """One platform's answer to "play this song on this speaker"."""
+
+    #: platform identifiers from the entity registry that this strategy serves.
+    #: The dispatch table in :mod:`..playback` is built from these, so a
+    #: platform is claimed in exactly one place — the strategy that implements
+    #: it — instead of in an ``if self._platform ==`` chain.
+    platforms: ClassVar[tuple[str, ...]] = ()
+
+    def __init__(self, context: PlayerContext) -> None:
+        self.context = context
+
+    # Convenience aliases. Properties rather than copies so a context that is
+    # re-pointed (tests do this) stays authoritative.
+    @property
+    def _hass(self) -> HomeAssistant:
+        return self.context.hass
+
+    @property
+    def _entity_id(self) -> str:
+        return self.context.entity_id
+
+    @property
+    def _provider(self) -> str:
+        return self.context.provider
+
+    @property
+    def last_attempted_uri(self) -> str | None:
+        """The URI actually handed to the player for the most recent attempt."""
+        return self.context.last_attempted_uri
+
+    @last_attempted_uri.setter
+    def last_attempted_uri(self, value: str | None) -> None:
+        self.context.last_attempted_uri = value
+
+    @property
+    def last_failure_reason(self) -> str | None:
+        """Why the most recent attempt failed — ``"unavailable"``, ``"error"``,
+        ``"wrong_track"`` — or None when it succeeded. Read by
+        ``game/state_lifecycle.py`` to decide whether a failure counts against
+        ``MAX_SONG_RETRIES``."""
+        return self.context.last_failure_reason
+
+    @last_failure_reason.setter
+    def last_failure_reason(self, value: str | None) -> None:
+        self.context.last_failure_reason = value
+
+    @abstractmethod
+    async def play(self, song: dict[str, Any]) -> bool:
+        """Play one song on this platform.
+
+        Args:
+            song: song dict with ``_resolved_uri``, ``artist``, ``title``.
+
+        Returns:
+            True if playback started, False otherwise. Timeouts and
+            ``HomeAssistantError`` are allowed to escape — the service shell
+            owns the analytics and the log line for those.
+        """
+
+    async def capture_queue(self) -> dict[str, Any] | None:
+        """What the speaker was playing before Beatify claimed it (#2143).
+
+        Returns:
+            ``None`` when the platform cannot report it — the default, and the
+            reason the shell then remembers nothing and hands nothing back.
+            ``{}`` means "asked, and there was nothing playing". A dict is the
+            track, its position, shuffle and repeat mode.
+        """
+        return None

--- a/custom_components/beatify/services/playback/context.py
+++ b/custom_components/beatify/services/playback/context.py
@@ -1,0 +1,116 @@
+"""The speaker a playback strategy talks to, and the reads it may make.
+
+Split out of :mod:`custom_components.beatify.services.media_player` for #2636.
+
+A strategy needs surprisingly little: which Home Assistant, which entity, and
+which music provider the user picked. Everything else the old 2300-line class
+carried around — analytics, the pre-flight cache, volume bookkeeping, the
+metadata wait — belongs to the service shell and is deliberately NOT reachable
+from here. That is what makes a strategy testable on its own: a unit test
+builds a ``PlayerContext`` over a mock ``hass`` and never constructs a
+``MediaPlayerService`` at all.
+
+The two state reads live here rather than on the strategies because both the
+shell and every strategy need them, and because their defensiveness (an
+exception out of ``hass.states.get`` must degrade to "unknown", not abort a
+round) is a property of reading THIS entity, not of any one platform.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def _no_queue_capture() -> None:
+    """Default #2143 hook: a context nobody wired remembers no queue."""
+    return None
+
+
+class PlayerContext:
+    """One speaker, plus the handful of things a strategy may ask of it.
+
+    Args:
+        hass: Home Assistant instance.
+        entity_id: the media player entity this context speaks for.
+        platform: platform identifier from the entity registry — read by the
+            dispatch in :func:`..playback.build_strategy`, not by strategies.
+        provider: the music provider the wizard settled on.
+        save_queue: the #2143 hook. Music Assistant's ``enqueue: "replace"``
+            wipes whatever the host had queued, so the strategy calls this
+            immediately before the first replace of a game. The bookkeeping
+            (capture once, hand back at game end, carry across a speaker
+            switch) stays in the service shell, which is where the game
+            lifecycle lives; the hook is only the "now is the moment" signal.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entity_id: str,
+        platform: str = "unknown",
+        provider: str = "spotify",
+        *,
+        save_queue: Callable[[], Awaitable[Any]] | None = None,
+    ) -> None:
+        self.hass = hass
+        self.entity_id = entity_id
+        self.platform = platform
+        self.provider = provider
+        self._save_queue = save_queue or _no_queue_capture
+
+        # #1927 follow-up / #808 follow-up: the attempt record. Both the shell
+        # (which seeds it from the dispatcher's URI) and the Music Assistant
+        # strategy (which overwrites it per candidate) write these, and
+        # ``state_lifecycle`` reads them off the service. One owner, two
+        # writers — so they live on the thing both sides already share.
+        self.last_attempted_uri: str | None = None
+        self.last_failure_reason: str | None = None
+
+    async def save_queue(self) -> None:
+        """Tell the shell that the host's queue is about to be replaced."""
+        await self._save_queue()
+
+    def state(self):
+        """Read entity state, return None on any exception.
+
+        Resilience for the playback-confirmation read sites in the Music
+        Assistant strategy. A transient exception from ``hass.states.get()``
+        (rare but possible during HA restarts / state-machine reload) used to
+        propagate up and abort the whole song play, even though the existing
+        code paths gracefully handle a None return. Catching here lets the flow
+        downgrade to "state unknown" and continue. (#777 follow-up — the
+        polling-resilience scope flagged in TestMAPollingResilience.)
+        """
+        try:
+            return self.hass.states.get(self.entity_id)
+        except Exception as err:  # noqa: BLE001 — defensive read of HA state
+            _LOGGER.warning(
+                "hass.states.get(%s) raised %s; treating as unknown",
+                self.entity_id,
+                err,
+            )
+            return None
+
+    async def state_with_retry(self, retries: int = 3, delay: float = 0.5):
+        """Read entity state with short retry loop; for the post-timeout site
+        where having a state is critical for the title-advance check.
+
+        Most reads succeed on attempt 1; this only kicks in when HA's state
+        machine is briefly unreadable (HA restart edge, MA reload). Returns
+        None if all attempts return None.
+        """
+        for attempt in range(retries):
+            state = self.state()
+            if state is not None:
+                return state
+            if attempt < retries - 1:
+                await asyncio.sleep(delay)
+        return None

--- a/custom_components/beatify/services/playback/music_assistant.py
+++ b/custom_components/beatify/services/playback/music_assistant.py
@@ -1,0 +1,993 @@
+"""Music Assistant playback (#2636).
+
+By far the largest of the three strategies, and the reason the split was worth
+doing: everything below — the URI cascade of #768/#805/#1379, the confirmation
+paths of #345/#795/#1381/#2333/#2616, the cold-start budget of #1936, the
+failure classification of #808/#1363/#1863 — is Music Assistant's alone. In the
+old 2300-line ``MediaPlayerService`` it shared a class body with Sonos and
+Alexa, so a Sonos change was reviewed against all of it.
+
+Split out of :mod:`custom_components.beatify.services.media_player`; the code
+moved unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from typing import Any, ClassVar
+
+from homeassistant.exceptions import HomeAssistantError, ServiceNotFound
+from homeassistant.helpers.event import async_track_state_change_event
+
+from .base import PlaybackStrategy
+from .uris import convert_uri_for_ma, uri_match_tokens
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# Music Assistant playback timeout. Higher than PLAYBACK_TIMEOUT because MA
+# routes through the speaker's own buffering layer and AirPlay (HomePods,
+# Denon AirPlay, some MA-wrapped Sonos setups) can take 10-12s to acknowledge
+# a new track on the first round. #777 showed 8s was too aggressive — rounds
+# advanced before the track had actually swapped on the speaker.
+MA_PLAYBACK_TIMEOUT = 15.0
+
+# #1936: the FIRST play of a game gets a third more time (15.0s → 20.0s). A
+# speaker idle for a while was measured at 10.1s to first audio (Sonos via MA,
+# Apple Music) — close enough to the deadline that a cold start regularly lost
+# the race and the game paused before a single note had played. Later rounds
+# keep the shorter deadline: by then the speaker is warm and a longer wait is
+# just silence in front of the players.
+#
+# Expressed as a FACTOR, not a second absolute constant, so the one existing
+# patch point still governs both budgets — eight tests patch
+# MA_PLAYBACK_TIMEOUT down to keep the suite fast, and a separate absolute
+# constant would have silently made each of them wait the full 20s.
+MA_FIRST_PLAY_TIMEOUT_FACTOR = 4 / 3
+
+# #1381: Fast-path Path 2 (title-advanced-without-exact-match) must not
+# instant-accept an *arbitrary* title change. If a requested URI fails to
+# resolve in MA while the speaker's prior queue naturally auto-advances to its
+# next track within the wait window, the title changes to an unrelated song and
+# the old code confirmed it as success in ~1s — silently running a round whose
+# audio is the wrong track (the #795 failure class). Path 2 now requires cheap
+# evidence that the new title is plausibly OUR track: either a token overlap
+# with the expected title (remaster/translation tolerance, e.g. "Das Modell"
+# vs "The Model" share no tokens but the artist matches) OR the expected artist
+# appearing in the speaker's media_artist. The unbounded "any new title"
+# acceptance is reserved for the post-timeout #345 branch, where it is logged.
+_TITLE_TOKEN_MIN_LEN = 3
+
+# Providers whose missing/failed URI may be retried by asking Music Assistant to
+# resolve the track from name + artist. `ma_library` has done this since the
+# Crate Digger work; `tidal` joins because its URIs can no longer be refreshed —
+# Odesli's public API, the only source they ever came from, was retired on
+# 2026-07-31 and now answers 401.
+_NAME_FALLBACK_PROVIDERS = frozenset({"ma_library", "tidal", "ytmusic_free"})
+
+# Words that mark a *different recording of the same song*. A name search is
+# free to return any of them, which is exactly the risk this fallback carries:
+# measured against ~2000 catalogue tracks with a known Deezer id, a plain
+# "artist title" search returned the wrong edition for 2 % of mainstream tracks
+# but 19 % of EDM ones ("Satisfaction" → "Satisfaction (Uk Radio Edit)",
+# "Scary Monsters and Nice Sprites" → "… (Zedd Remix)").
+#
+# `_titles_plausibly_match` does NOT catch these: it accepts a normalized
+# prefix, and the expected title is always a prefix of its own remix. That
+# leniency is deliberate and load-bearing for #1381 ("Das Modell" vs "The
+# Model"), so it stays — the stricter check below is applied only on the name
+# fallback path, where the extra risk actually lives.
+_EDITION_MARKERS = re.compile(
+    r"\b("
+    r"radio edit|extended|club mix|original mix|dub mix|"
+    r"remix|re-?edit|mixed|karaoke|instrumental|acapella|a cappella|"
+    r"acoustic|unplugged|live|demo|cover|tribute|playback|"
+    r"edit|mix|version"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+def _edition_markers(text: str) -> set[str]:
+    """Edition words present in a title, lower-cased."""
+    return {m.group(0).lower() for m in _EDITION_MARKERS.finditer(text or "")}
+
+
+def _edition_matches(expected_title: str, played_title: str) -> bool:
+    """False when the played title carries an edition the expected title lacks.
+
+    Deliberately one-directional. A catalogue entry named "Waves - Robin Schulz
+    Radio Edit" may legitimately play back as plain "Waves" (the provider drops
+    the suffix), so markers the *expected* side has are not required on the
+    played side. The reverse is the failure we are guarding against: plain
+    "Burn" must not be satisfied by "Burn (Aybsent Mynded Remix)".
+
+    This matters more for Beatify than it would for a music player. The game
+    asks players to guess the release *year*; a 2014 remix standing in for a
+    1998 original does not merely sound different, it makes the round's correct
+    answer wrong — and nothing on screen reveals that.
+    """
+    if not expected_title or not played_title:
+        return True
+    return not (_edition_markers(played_title) - _edition_markers(expected_title))
+
+
+def _normalize_for_match(text: str) -> str:
+    """Lower-case and strip non-alphanumeric to ASCII-ish tokens for matching."""
+    return "".join(c if c.isalnum() else " " for c in text.lower())
+
+
+def _title_tokens(text: str) -> set[str]:
+    """Significant word tokens of a title (drops short noise words/suffixes)."""
+    return {
+        tok
+        for tok in _normalize_for_match(text).split()
+        if len(tok) >= _TITLE_TOKEN_MIN_LEN
+    }
+
+
+def _titles_plausibly_match(expected_title: str, current_title: str) -> bool:
+    """Cheap similarity gate for fast-path Path 2 (#1381).
+
+    True when the two titles share at least one significant token, or one
+    normalized title is a prefix of the other (covers "(Remastered)" suffixes
+    and minor punctuation differences). False for genuinely unrelated titles
+    (e.g. the prior queue auto-advancing to a different song).
+    """
+    exp_norm = _normalize_for_match(expected_title).strip()
+    cur_norm = _normalize_for_match(current_title).strip()
+    if not exp_norm or not cur_norm:
+        return False
+    if cur_norm.startswith(exp_norm) or exp_norm.startswith(cur_norm):
+        return True
+    return bool(_title_tokens(expected_title) & _title_tokens(current_title))
+
+
+def _artist_matches(expected_artist: str, media_artist: str) -> bool:
+    """True when the expected artist is plausibly present in media_artist (#1381)."""
+    exp = _normalize_for_match(expected_artist).strip()
+    cur = _normalize_for_match(media_artist).strip()
+    if not exp or not cur:
+        return False
+    if exp in cur or cur in exp:
+        return True
+    return bool(_title_tokens(expected_artist) & _title_tokens(media_artist))
+
+
+def _content_id_advanced(
+    content_id: str, content_id_before: str, match_tokens: list[str]
+) -> bool:
+    """True when media_content_id proves the REQUESTED track is now loaded (#2616).
+
+    `media_title` is not a track identity. Two different songs can share one
+    title — round N plays "Hello" (Adele), round N+1 draws "Hello" (Lionel
+    Richie) — and the title-must-change invariant (#2333/#795) then reads a
+    perfectly successful switch as "the speaker never left the prior track".
+
+    `media_content_id` IS an identity, and `_uri_match_tokens` already knows
+    how to recognise our URI inside it (#1380). Two conditions, both required:
+
+      * the id contains a token of the URI we just asked for — so an unrelated
+        auto-advance of the prior queue cannot qualify, and
+      * the id differs from the one playing before the call — so the #2333
+        failure (MA never switched, prior track keeps running) still cannot
+        qualify, not even when the prior round happened to play this same URI.
+
+    Anything the speaker does not report (`media_content_id` missing on this
+    platform) yields False and leaves the title comparison in sole charge, as
+    before.
+    """
+    if not content_id or not match_tokens:
+        return False
+    if content_id == content_id_before:
+        return False
+    return any(token in content_id for token in match_tokens)
+
+
+# Candidate URI fields on a song, by user-selected provider (#805).
+#
+# Each provider lists its own playable URI fields in priority order. The
+# fallback cascade in `uri_candidates` only walks the fields for the user's
+# provider — never tries a different provider's URI.
+#
+# Why: prior to #805 the cascade walked ALL six URI fields regardless of
+# which provider the user picked in the wizard. On Levtos's Apple-Music-only
+# MA setup, every round paid 4×15s of timeouts on Spotify/YT/Tidal URIs that
+# his MA had no provider configured for, before getting to the Apple Music
+# URI that actually worked. After 3 cumulative play_song failures the game
+# was force-paused and the admin couldn't recover.
+#
+# The "fall through to other providers when primary fails" intent of #768
+# only makes sense when the user's MA actually has those other providers
+# configured — which the wizard already gates. If the user picked Apple
+# Music, they're saying "this is the provider MA is set up for". Trust
+# them.
+_PROVIDER_URI_FIELDS: dict[str, tuple[str, ...]] = {
+    "spotify": ("uri_spotify", "uri"),
+    "apple_music": ("uri_apple_music",),
+    "youtube_music": ("uri_youtube_music",),
+    "tidal": ("uri_tidal",),
+    "deezer": ("uri_deezer",),
+    # Crate Digger: URIs come from the user's own MA library.
+    "ma_library": ("uri_ma_library",),
+    # Amazon Music uses Alexa text search — no URI fields; playback via
+    # AlexaStrategy with content_type="AMAZON_MUSIC".
+    "amazon_music": (),
+    # #2426: the ytmusic_free URI is DERIVED from uri_youtube_music by
+    # get_song_uri(), so there is no catalogue field to walk. The empty tuple
+    # is deliberate rather than an omission: a missing key would log the
+    # "unknown provider" warning below and imply a mapping bug, while an empty
+    # one says the provider has no stored fields and lets _resolved_uri — which
+    # already holds the derived URI — do the work.
+    "ytmusic_free": (),
+}
+
+
+class MusicAssistantStrategy(PlaybackStrategy):
+    """Play through Music Assistant, and prove the speaker actually followed."""
+
+    platforms: ClassVar[tuple[str, ...]] = ("music_assistant",)
+
+    def __init__(self, context) -> None:
+        super().__init__(context)
+        # Which URI field last succeeded against MA — used to reorder the
+        # candidate list so subsequent songs don't pay the primary-attempt
+        # timeout on every round (#768).
+        self._ma_preferred_uri_field: str | None = None
+        # #1381: which acceptance path confirmed the most recent successful
+        # try_play. 1 = expected-title substring (Path 1, strongest), 2 =
+        # similarity/artist gate (Path 2), 0 = post-timeout #345 tolerance.
+        # Only Path 1 is strong enough to promote a URI field to preferred.
+        self._last_confirm_path: int = 0
+        # #1936: True until the first playback attempt of this game has been
+        # made. Drives the longer cold-start budget in try_play.
+        self._first_play_pending: bool = True
+        # #1363: set when Beatify itself issues a same-song media_stop after a
+        # stale-title detect. The stop forces the speaker to 'idle'; if the
+        # NEXT cascade candidate also fails to resolve, the idle-failure branch
+        # must NOT misread that self-induced idle as a systemic 'error' (which
+        # pauses the game). Reset before each song.
+        self._stopped_for_cascade: bool = False
+
+    def uri_candidates(self, song: dict[str, Any]) -> list[tuple[str | None, str]]:
+        """
+        Build the ordered list of MA-ready URIs to try for this song (#805).
+
+        Only walks URI fields belonging to the user's selected provider
+        (`self._provider`). The wizard's provider choice represents what's
+        actually configured in MA — trying URIs from other providers when
+        the user said "Apple Music only" just buys 15s timeouts per
+        unsupported provider before MA reports `MediaNotFoundError`.
+
+        Order: the user's selected URI (`_resolved_uri`, storefront-resolved by
+        the caller) ALWAYS first, then the previously-successful field (if any),
+        then any remaining provider URI fields. URIs are converted for MA and
+        deduped by their converted form.
+
+        For apple_music, the legacy `uri_apple_music` field (a single,
+        historically US-storefront ID) is dropped from the alternates whenever
+        the song carries a `uri_apple_music_by_region` map — otherwise a non-US
+        user would re-pay the wrong-storefront timeout #808 eliminated, and a
+        cross-storefront-lucky US hit could become the learned preferred field
+        and bypass region-correct resolution for the rest of the session (#1379).
+
+        Returns:
+            List of `(field_name, converted_uri)`. `field_name` is `None` for
+            the `_resolved_uri` entry, a `uri_*` field name otherwise.
+
+        """
+        seen: set[str] = set()
+        candidates: list[tuple[str | None, str]] = []
+        # Validate the dispatch key explicitly (#1276). An unknown provider
+        # (key absent from the table) is a config-level mismatch — the wizard
+        # is supposed to gate it, but if it slips through, `.get(..., ())`
+        # would silently yield zero candidates and playback would fail with
+        # no actionable diagnostic. This is the silent-fail pattern behind
+        # #768/#808. A KNOWN provider mapped to `()` (e.g. amazon_music, which
+        # plays via Alexa text-search, not URIs) is intentional and stays
+        # quiet. `_resolved_uri` is still honored below as a last resort so an
+        # unexpected provider doesn't hard-fail when the song does carry a URI.
+        provider_fields = _PROVIDER_URI_FIELDS.get(self._provider)
+        if provider_fields is None:
+            _LOGGER.warning(
+                "MA dispatch: unknown provider %r — no URI field mapping; "
+                "falling back to _resolved_uri only for %s - %s (#1276)",
+                self._provider,
+                song.get("artist"),
+                song.get("title"),
+            )
+            provider_fields = ()
+
+        def _add(field: str | None, raw: str | None) -> None:
+            if not raw:
+                return
+            converted = convert_uri_for_ma(raw)
+            if not converted or converted in seen:
+                return
+            seen.add(converted)
+            candidates.append((field, converted))
+
+        # #1379: storefront-unaware fallback guard. For apple_music, the legacy
+        # `uri_apple_music` field holds a single (historically US-storefront)
+        # track ID. The caller (`get_song_uri`) already resolves `_resolved_uri`
+        # storefront-aware from `uri_apple_music_by_region` when that map exists.
+        # Appending the legacy US field as an alternate for a non-US user
+        # re-introduces exactly the wrong-storefront 15s stale-title timeout that
+        # #808 eliminated — and if that US ID ever resolves cross-storefront, it
+        # becomes the learned preferred field and systematically outranks the
+        # region-correct URI for the rest of the session. When a regional map is
+        # present, drop the legacy field entirely so only `_resolved_uri` (the
+        # region-correct ID, or None when unavailable) is tried.
+        skip_legacy_apple = self._provider == "apple_music" and bool(
+            song.get("uri_apple_music_by_region")
+        )
+
+        def _field_eligible(field: str) -> bool:
+            return not (skip_legacy_apple and field == "uri_apple_music")
+
+        # #1379: `_resolved_uri` is ALWAYS tried first — it is the URI Beatify
+        # resolved for the user's selected provider AND storefront. The learned
+        # preference must never outrank it (a US ID that resolved once must not
+        # systematically bypass storefront-correct resolution); the preference is
+        # used only to order the REMAINING alternates below.
+        _add(None, song.get("_resolved_uri"))
+
+        # Learned preference — but only if it's a field belonging to the
+        # current provider (the cache survives across games where provider
+        # may have changed) and not a legacy field we're skipping for storefront
+        # reasons (#1379). Ordered ahead of the other alternates, behind primary.
+        if (
+            self._ma_preferred_uri_field
+            and self._ma_preferred_uri_field in provider_fields
+            and _field_eligible(self._ma_preferred_uri_field)
+        ):
+            _add(self._ma_preferred_uri_field, song.get(self._ma_preferred_uri_field))
+
+        # Remaining alternates within the same provider.
+        for field in provider_fields:
+            if field != self._ma_preferred_uri_field and _field_eligible(field):
+                _add(field, song.get(field))
+
+        return candidates
+
+    async def capture_queue(self) -> dict[str, Any] | None:
+        """Read what the speaker is playing right now (#2143).
+
+        The snapshot comes from MA's ``get_queue``, which no other platform
+        provides — hence the base class default of None and this override.
+        Idempotence ("capture only once per game") is NOT decided here: it is a
+        game-lifecycle question and lives with the shell, which calls this at
+        most once.
+
+        A failure is deliberately swallowed and reported as ``{}``: not being
+        able to remember the queue must never stop the round from playing.
+        """
+        try:
+            response = await self._hass.services.async_call(
+                "music_assistant",
+                "get_queue",
+                {"entity_id": self._entity_id},
+                blocking=True,
+                return_response=True,
+            )
+        except (HomeAssistantError, ServiceNotFound, TypeError) as err:
+            # TypeError guards older MA versions whose get_queue takes no
+            # response — there is nothing to remember then, and pretending
+            # otherwise would make restore_queue play a phantom track.
+            _LOGGER.debug("Queue snapshot unavailable on %s: %s", self._entity_id, err)
+            return {}
+
+        # HA hands back None when a service has no response payload, and older
+        # cores ignore `return_response` outright — neither is an error worth a
+        # log line, but both must not be walked as if they were the mapping.
+        if not isinstance(response, dict):
+            return {}
+        data = response.get(self._entity_id)
+        if not isinstance(data, dict):
+            return {}
+        media_item = (data.get("current_item") or {}).get("media_item") or {}
+        uri = media_item.get("uri")
+        if not uri:
+            # Idle speaker: captured, but there is nothing to hand back.
+            # Reported as {} rather than None so the shell records the capture
+            # and round two doesn't try again.
+            _LOGGER.debug("Queue snapshot on %s: speaker idle", self._entity_id)
+            return {}
+
+        snapshot = {
+            "uri": uri,
+            "name": media_item.get("name") or "",
+            "elapsed_time": float(data.get("elapsed_time") or 0),
+            "shuffle": bool(data.get("shuffle_enabled")),
+            "repeat_mode": data.get("repeat_mode"),
+        }
+        _LOGGER.debug(
+            "Queue snapshot on %s: %s at %.0fs",
+            self._entity_id,
+            uri,
+            snapshot["elapsed_time"],
+        )
+        return snapshot
+
+    async def play(self, song: dict[str, Any]) -> bool:
+        """
+        Play via Music Assistant, walking the user-provider's URI fields (#805).
+
+        Only candidates from `_PROVIDER_URI_FIELDS[self._provider]` are tried —
+        the wizard's provider choice represents what MA is configured for, so
+        attempting other providers' URIs just burns 15s timeouts per
+        unsupported provider before MA reports `MediaNotFoundError`. This was
+        the originating bug for #805 (Levtos's Apple-Music-only setup paid
+        4×15s of Spotify/YT/Tidal timeouts on every failed round).
+        """
+        # #808 follow-up: clear stale failure classification before each
+        # attempt so start_round reads only the result of THIS song.
+        self.last_failure_reason = None
+        # #1363: clear the cascade-stop flag at the start of each song so a
+        # stop from a PRIOR song never leaks into this song's classification.
+        self._stopped_for_cascade = False
+
+        candidates = self.uri_candidates(song)
+        expected_title = song.get("title") or ""
+        expected_artist = song.get("artist") or ""
+
+        # The name fallback below needs both fields; without them there is
+        # nothing to search for and nothing to verify the result against.
+        name_fallback = bool(
+            self._provider in _NAME_FALLBACK_PROVIDERS
+            and expected_title
+            and expected_artist
+        )
+
+        if not candidates and not name_fallback:
+            # #1276: surface the provider so a missing-URI miss is debuggable
+            # (which provider was selected vs. which fields the song carries).
+            _LOGGER.warning(
+                "MA playback: no playable URI for provider %r — %s - %s (#1276)",
+                self._provider,
+                song.get("artist"),
+                song.get("title"),
+            )
+            self.last_failure_reason = "unavailable"
+            return False
+
+        if not expected_title:
+            _LOGGER.warning(
+                "MA playback: no expected title — skipping title verification"
+            )
+
+        for idx, (field, uri) in enumerate(candidates):
+            if idx > 0:
+                _LOGGER.info(
+                    "MA fallback %d/%d: trying %s (prior URI did not resolve) (#768)",
+                    idx + 1,
+                    len(candidates),
+                    uri,
+                )
+            success = await self.try_play(uri, expected_title, expected_artist)
+            if success:
+                # #1381: only learn a candidate's URI field as the new preferred
+                # one when an EXPECTED-TITLE substring match (Path 1) confirmed
+                # it. A weaker confirmation (artist/token gate, or the
+                # post-timeout #345 tolerance) is not strong enough proof that
+                # THIS field actually resolved our track — promoting it would
+                # reorder future candidates wrongly for a field that never
+                # really worked.
+                if (
+                    field
+                    and field != self._ma_preferred_uri_field
+                    and self._last_confirm_path == 1
+                ):
+                    _LOGGER.debug("MA preferred URI field now: %s (#768)", field)
+                    self._ma_preferred_uri_field = field
+                self.last_failure_reason = None
+                return True
+
+        # Last resort: let MA resolve the track from name + artist.
+        #
+        # `ma_library`: the stored URI is normally exact, but the item may have
+        # moved or changed since the pool was built.
+        # `tidal`: the URI may be absent entirely and can no longer be obtained
+        # — Odesli, the only source Beatify ever had for Tidal ids, retired its
+        # public API on 2026-07-31. This path is a safety net *behind* the
+        # stored URIs, never a replacement for them: the loop above has already
+        # run, so a song that carries a working `uri_tidal` never reaches here.
+        if name_fallback:
+            _LOGGER.info(
+                "MA name fallback (%s): resolving by name -- %s - %s",
+                self._provider,
+                expected_artist,
+                expected_title,
+            )
+            if await self.try_play(
+                expected_title,
+                expected_title,
+                expected_artist,
+                artist_filter=expected_artist,
+            ):
+                # A name search can land on a remix, a live take or a karaoke
+                # version of the right song. `try_play` will happily accept
+                # those (its title gate is a prefix/token check by design), so
+                # the edition is checked here instead.
+                state = self.context.state()
+                played_title = (
+                    state.attributes.get("media_title", "") if state else ""
+                ) or ""
+                if not _edition_matches(expected_title, played_title):
+                    _LOGGER.warning(
+                        "MA name fallback: rejecting wrong edition — wanted %r, "
+                        "got %r (%s)",
+                        expected_title,
+                        played_title,
+                        expected_artist,
+                    )
+                    self.last_failure_reason = "wrong_track"
+                    return False
+                self.last_failure_reason = None
+                return True
+
+        _LOGGER.error(
+            "MA playback: all %d URI candidate(s) failed for %s - %s (#768)",
+            len(candidates),
+            song.get("artist"),
+            song.get("title"),
+        )
+        # last_failure_reason carries the classification of the last
+        # try_play attempt (set by that method); start_round reads it.
+        return False
+
+    async def try_play(
+        self,
+        uri: str,
+        expected_title: str,
+        expected_artist: str = "",
+        artist_filter: str | None = None,
+    ) -> bool:
+        """
+        Attempt a single MA `play_media` call and wait for playback confirmation.
+
+        Returns False on hard failure (speaker idle/unavailable, or the track
+        clearly never swapped on the speaker) so the caller can try the next
+        URI. Returns True both when playback is confirmed AND when the speaker
+        is showing ambiguous-but-changing state (MA may still be buffering —
+        preserving the #345 tolerance so we don't chase flaky retries).
+
+        `expected_artist` (#1381) feeds the fast-path Path 2 similarity gate so
+        an arbitrary title change from the prior queue auto-advancing is not
+        instant-accepted as our track.
+        """
+        # #1927 follow-up: remember what we are about to play, so a failure is
+        # reported with the URI that was really tried.
+        self.last_attempted_uri = uri
+        # #1936: cold-start budget for the very first attempt of a game only.
+        timeout = MA_PLAYBACK_TIMEOUT * (
+            MA_FIRST_PLAY_TIMEOUT_FACTOR if self._first_play_pending else 1
+        )
+        self._first_play_pending = False
+        _LOGGER.debug(
+            "MA playback: %s on %s (budget %.0fs)", uri, self._entity_id, timeout
+        )
+
+        # Snapshot speaker state before the call — we need both fields to
+        # distinguish #345 slow-buffer (one of them changed during the wait)
+        # from #777 silent failure (neither changed, speaker still on prior
+        # track).
+        state_before = self.context.state()
+        if state_before is not None:
+            title_before = state_before.attributes.get("media_title", "")
+            position_updated_before = state_before.attributes.get(
+                "media_position_updated_at"
+            )
+            # #2616: the title alone cannot tell "same song still playing"
+            # apart from "different song, same title". The content id can.
+            content_id_before = state_before.attributes.get("media_content_id") or ""
+        else:
+            title_before = ""
+            position_updated_before = None
+            content_id_before = ""
+
+        # #2616: the substrings that identify THIS uri inside MA's
+        # media_content_id — the same tokens wait_for_metadata_update matches
+        # on (#1380).
+        match_tokens = uri_match_tokens(uri)
+
+        # #2143: remember the host's own queue BEFORE the replace below wipes
+        # it. Idempotent, so this only costs a get_queue call in round one.
+        await self.context.save_queue()
+
+        # Fire-and-forget the service call — blocking=True hangs on MA+YTMusic
+        # enqueue=replace: each round's track REPLACES the queue. Without it
+        # MA keeps prior rounds queued, and after a TTS announcement the queue
+        # resume can advance into stale entries — observed as the player
+        # returning to PREVIOUS rounds' songs, sometimes mid-round.
+        service_data: dict[str, Any] = {
+            "media_id": uri,
+            "media_type": "track",
+            "enqueue": "replace",
+        }
+        # Crate Digger name fallback: when a stored library URI no longer
+        # resolves (library rebuilds change item ids), media_id carries the
+        # track NAME and the artist disambiguates it inside MA's resolver.
+        if artist_filter:
+            service_data["artist"] = artist_filter
+        await self._hass.services.async_call(
+            "music_assistant",
+            "play_media",
+            service_data,
+            target={"entity_id": self._entity_id},
+            blocking=False,
+        )
+
+        # Wait for the EXPECTED song to actually play on the speaker:
+        # - media_title contains expected title (the strongest single signal —
+        #   speaker explicitly identifies our requested track)
+        # - media_position_updated_at changed (MA is actively reporting state)
+        #
+        # We used to also require media_position >= 1 here as a guard against
+        # MA reporting `state=playing` while a track was only queued. In
+        # practice that case shows itself by `media_position_updated_at`
+        # *not* changing — the queued track's position never updates. So
+        # `position_fresh` already filters it out, and the position-value
+        # check was needlessly delaying confirmation.
+        #
+        # Ziigmund84 reported (#803) on cold MA start the speaker shows
+        # state=playing + correct title within seconds, but media_position
+        # lags at 0 for 10-15s. Old fast-path didn't fire; user heard music
+        # while UI sat in REVEAL waiting for the timeout.
+        expected_lower = expected_title.lower()
+
+        confirmed = asyncio.Event()
+        start_time = asyncio.get_event_loop().time()
+
+        def _check_state(state) -> bool:
+            """Return True if the state confirms expected playback.
+
+            Two acceptance paths:
+              1. Title contains expected (substring) — the strongest signal.
+              2. Title moved to a *plausibly-our-track* new title — MA is
+                 making progress on a new track that shares a token with the
+                 expected title, or whose artist matches the expected artist.
+
+            Path 2 was previously only reachable via the 15-second slow-buffer
+            tolerance below. Levtos reported that pressing "next" caused the
+            UI to lag while the music had already started: the playlist had
+            a song with a slightly different title format (e.g. German
+            "Das Modell" vs MA's English "The Model", or "(Remastered)"
+            suffix mismatches) so the substring-match in path 1 failed and
+            the wait timed out. With path 2 in the fast-path, the UI now
+            returns within ~1s of MA actually starting playback.
+
+            #1381 tightened Path 2: it used to accept ANY title that differed
+            from `title_before`. If the requested URI failed to resolve in MA
+            while the speaker's prior queue auto-advanced to its next track
+            during the 15s window, that unrelated title was instant-confirmed
+            as success — the #795 "guess the year of SongX with no SongX audio"
+            class, but silently. Path 2 now requires a cheap similarity gate
+            (token overlap / normalized-prefix vs expected_title, OR expected
+            artist present in media_artist). The unbounded "any new title"
+            acceptance is reserved for the post-timeout #345 branch, where it
+            is logged.
+
+            #795 invariant still holds: if the title is unchanged from
+            before the call (`title_before`), neither path fires and we
+            fall through to the title-must-advance hard-failure check.
+            """
+            if not state or state.state != "playing":
+                return False
+            try:
+                current_title = state.attributes.get("media_title", "") or ""
+                current_artist = state.attributes.get("media_artist", "") or ""
+                position_updated = state.attributes.get("media_position_updated_at")
+
+                position_fresh = position_updated != position_updated_before
+                if not position_fresh:
+                    return False
+
+                # #2333: the track has to have actually changed. The
+                # docstring above promised this of BOTH paths, and Path 2
+                # honoured it while Path 1 did not — it accepted a substring
+                # match against whatever was playing, including the song from
+                # the previous round still running.
+                #
+                # `position_fresh` above is no help: a track that simply keeps
+                # playing keeps advancing its own position.
+                #
+                # The failure it allowed: round N plays "Stay With Me", round
+                # N+1 draws "Stay" whose URI is missing from the household's
+                # storefront, MA never switches, and `"stay" in "stay with
+                # me"` confirms success within a second. The room then guesses
+                # a song they already heard.
+                #
+                # Substring containment makes that reachable well beyond one
+                # example — covers, "One", "Hurt", remaster suffixes.
+                #
+                # An empty `title_before` (nothing was playing) still passes,
+                # which is the cold-start case and genuinely a change.
+                title_changed = current_title != title_before
+
+                # #2616: a changed title is sufficient proof of a new track,
+                # but it is not necessary. Two different songs can carry the
+                # same title ("Hello" by Adele, then "Hello" by Lionel
+                # Richie), and #2333's title check then rejects a switch that
+                # actually happened. `media_content_id` settles it: if it now
+                # carries the id of the URI we requested AND differs from what
+                # was loaded before, the speaker demonstrably moved to OUR
+                # track. The #2333 failure stays rejected — there MA never
+                # switched, so the content id never changes either.
+                content_id = state.attributes.get("media_content_id") or ""
+                track_changed = title_changed or _content_id_advanced(
+                    content_id, content_id_before, match_tokens
+                )
+
+                # Path 1: exact-ish title match (substring) — strongest signal,
+                # the only path strong enough to learn a preferred URI field.
+                if (
+                    track_changed
+                    and expected_lower
+                    and expected_lower in current_title.lower()
+                ):
+                    self._last_confirm_path = 1
+                    return True
+                # If no expected title was supplied, position-fresh alone is
+                # all the signal we have — accept (matches old behavior).
+                if not expected_lower:
+                    self._last_confirm_path = 2
+                    return True
+
+                # Path 2 (#1381): title moved to a DIFFERENT title AND that
+                # title is plausibly our track (shared token / prefix) OR the
+                # artist matches. A bare "any different title" no longer
+                # qualifies — that is the prior-queue auto-advance trap.
+                if current_title and track_changed:
+                    if _titles_plausibly_match(
+                        expected_title, current_title
+                    ) or _artist_matches(expected_artist, current_artist):
+                        self._last_confirm_path = 2
+                        return True
+
+                return False
+            except (AttributeError, KeyError):
+                return False
+
+        def _state_changed(ev):
+            new_state = ev.data.get("new_state")
+            if _check_state(new_state):
+                confirmed.set()
+
+        unsub = async_track_state_change_event(
+            self._hass, [self._entity_id], _state_changed
+        )
+        try:
+            # Check current state first — may already be playing
+            current = self.context.state()
+            if _check_state(current):
+                elapsed = asyncio.get_event_loop().time() - start_time
+                _LOGGER.debug(
+                    "MA playback confirmed after %.1fs: %s (pos=%.1f)",
+                    elapsed,
+                    current.attributes.get("media_title", ""),
+                    current.attributes.get("media_position", 0),
+                )
+                return True
+
+            await asyncio.wait_for(confirmed.wait(), timeout=timeout)
+            elapsed = asyncio.get_event_loop().time() - start_time
+            final = self.context.state()
+            _LOGGER.debug(
+                "MA playback confirmed after %.1fs: %s (pos=%.1f)",
+                elapsed,
+                final.attributes.get("media_title", "") if final else "?",
+                final.attributes.get("media_position", 0) if final else 0,
+            )
+            return True
+        except asyncio.TimeoutError:
+            pass
+        finally:
+            unsub()
+
+        current_state = await self.context.state_with_retry()
+        speaker_state = current_state.state if current_state else "unknown"
+
+        # Hard failure: speaker is idle/unavailable/off — song won't play
+        if speaker_state in ("idle", "unavailable", "off", "unknown"):
+            # #1363: if the speaker is 'idle' only because WE stopped it after a
+            # prior same-song stale-title detect, this is a storefront-gap
+            # cascade (e.g. apple_music's `_resolved_uri` and a differing
+            # `uri_apple_music` both point at an unavailable catalog entry), NOT
+            # a systemic speaker/provider failure. Misclassifying it as 'error'
+            # makes state_lifecycle pause the whole game on a per-track gap —
+            # the exact #805/#808 regression. Keep it 'unavailable' so the game
+            # skips the song silently and tries the next one.
+            if self._stopped_for_cascade and speaker_state == "idle":
+                _LOGGER.warning(
+                    "MA playback failed after %.1fs for %s — speaker idle, but "
+                    "Beatify stopped it after a same-song stale-title detect. "
+                    "Treating as a storefront/catalog gap (unavailable), not a "
+                    "systemic error — game will skip this song silently. (#1363)",
+                    timeout,
+                    uri,
+                )
+                self.last_failure_reason = "unavailable"
+                return False
+            _LOGGER.error(
+                "MA playback failed after %.1fs for %s (state: %s). "
+                "Either the speaker is offline, MA's provider is unauthenticated, "
+                "or the track is not available in your provider's catalog. If this "
+                "happens for many tracks, re-authenticate your music provider in MA. "
+                "A rate-limiting provider looks the same from here — Music "
+                "Assistant then retries the track after its own backoff, which "
+                "can outlast this budget. (#1936)",
+                timeout,
+                uri,
+                speaker_state,
+            )
+            # Conservative: speaker-idle failures could be systemic (provider
+            # broken across the board) so we keep counting them toward
+            # MAX_SONG_RETRIES. The recovery banner will guide the user to
+            # the re-auth fix once 3 land in a row.
+            self.last_failure_reason = "error"
+            return False
+
+        # Hard failure: speaker title did not advance. If the title field is
+        # identical to what it was before we called play_media, the new track
+        # never started on the speaker — even if media_position_updated_at
+        # changed (that just means the *prior* track is still ticking).
+        #
+        # #777 originally caught only "title unchanged AND position unchanged"
+        # (everything frozen), but #795 surfaced the more common pattern:
+        # the prior track keeps playing, position advances, and the #345
+        # tolerance below would falsely return True. Levtos's playthrough
+        # had the speaker stuck on 'Sugar, Sugar' then 'Lazy Sunday (Mono)'
+        # for multiple rounds while UI advanced into "guess the year of
+        # SongX" with no actual SongX audio.
+        #
+        # Title-must-advance is the right invariant: if a new track really
+        # started, the title field must eventually become *something*
+        # different. Position alone is not proof of a new track.
+        title_after = (
+            current_state.attributes.get("media_title", "") if current_state else ""
+        )
+        position_updated_after = (
+            current_state.attributes.get("media_position_updated_at")
+            if current_state
+            else None
+        )
+        content_id_after = (
+            (current_state.attributes.get("media_content_id") or "")
+            if current_state
+            else ""
+        )
+        title_advanced = title_after != title_before
+        # #2616: same reasoning as in the fast path — an unchanged title is
+        # only evidence of a stuck speaker when the content id has not moved
+        # to the track we asked for. Stopping the speaker here is what made
+        # the collision audible: the room heard the correct song for the full
+        # budget, then silence, then a different song.
+        track_advanced = title_advanced or _content_id_advanced(
+            content_id_after, content_id_before, match_tokens
+        )
+        if not track_advanced:
+            position_changed = position_updated_after != position_updated_before
+            # #808 follow-up: this is the storefront/region-mismatch
+            # signature — MA accepted the URI but couldn't resolve a stream
+            # for it, so the speaker just keeps playing the prior track.
+            # @Levtos hit this for `apple_music://track/302229811` (US-only
+            # 'All Together Now' on a DE-storefront MA), and the iTunes
+            # Lookup confirmed: track in US catalog, NOT in DE catalog.
+            _LOGGER.warning(
+                "MA playback failed after %.1fs for %s — speaker still on "
+                "prior track %r (position timestamp %s). Track is likely "
+                "not available in your provider's catalog/storefront, OR "
+                "your provider needs re-authentication in MA. Skipping "
+                "this song silently — game will try the next one. (#795)",
+                timeout,
+                uri,
+                title_before,
+                "advanced — prior track still playing"
+                if position_changed
+                else "also unchanged",
+            )
+            # #801: Hard-stop the speaker so the prior track doesn't keep
+            # playing while the fallback cascade tries the next URI. Without
+            # this, Levtos's setup heard 'Kill Bill' continuing for multiple
+            # rounds while the UI advanced — strict-detection was rejecting
+            # candidates correctly but nobody was telling the speaker to
+            # actually stop. Best-effort: failure here doesn't change the
+            # outcome (we're already returning False).
+            try:
+                await self._hass.services.async_call(
+                    "media_player",
+                    "media_stop",
+                    {"entity_id": self._entity_id},
+                    blocking=False,
+                )
+                # #1363: record that the next cascade candidate will see an
+                # 'idle' speaker WE caused, so its idle-failure isn't
+                # misclassified as a systemic 'error'.
+                self._stopped_for_cascade = True
+            except (HomeAssistantError, ServiceNotFound, ConnectionError, OSError):
+                _LOGGER.debug(
+                    "media_stop call after stale-title detect failed for %s",
+                    self._entity_id,
+                )
+            # #808 follow-up: classify as "unavailable" so start_round skips
+            # silently without counting against MAX_SONG_RETRIES. Storefront
+            # gaps shouldn't pause the game — the user can't fix individual
+            # track availability and the game should keep playing whatever
+            # subset IS in their catalog.
+            self.last_failure_reason = "unavailable"
+            return False
+
+        if not title_advanced:
+            _LOGGER.debug(
+                "MA playback: title stayed %r for %s, but media_content_id "
+                "moved to %r — the requested track IS loaded, the two songs "
+                "merely share a title. Not a stale-title failure. (#2616)",
+                title_before,
+                uri,
+                content_id_after,
+            )
+
+        # #1863: "still buffering" requires that Music Assistant actually owns
+        # this player. An MA-platform entity reports the queue it is playing
+        # from in `active_queue`; while MA is buffering a track it has already
+        # taken the queue, so `active_queue` is set. A *null* `active_queue`
+        # means MA never accepted the play_media call for this player at all —
+        # the entity is only mirroring whatever the underlying speaker was
+        # doing before the game (in the report: a leftover Spotify context,
+        # `state: paused`, `media_position: 0`). That is a silent failure, not
+        # slow buffering, and the #345 tolerance below would wave it through as
+        # success: the round then starts, the timer arms, and the players get a
+        # silent PLAYING phase with no music and no error.
+        #
+        # Deliberately narrow: only when the attribute is PRESENT and falsy. If
+        # a Music Assistant / HA version does not expose `active_queue` at all
+        # the key is missing, and we keep the old tolerance rather than turning
+        # every slow buffer on that version into a failure.
+        attrs_after = current_state.attributes if current_state else {}
+        if "active_queue" in attrs_after and not attrs_after.get("active_queue"):
+            _LOGGER.error(
+                "MA playback failed after %.1fs for %s — the player reports no "
+                "active Music Assistant queue (state: %s, title %r → %r). MA "
+                "never took ownership of this speaker, so nothing was ever "
+                "dispatched. Check that the speaker is exposed to Music "
+                "Assistant and that your provider is authenticated there. "
+                "(#1863)",
+                timeout,
+                uri,
+                speaker_state,
+                title_before,
+                title_after,
+            )
+            # Systemic, not a per-track catalog gap: MA declined the whole
+            # play_media call, so the next song would fail identically.
+            # Classify as "error" so start_round pauses the game and shows the
+            # recovery banner within seconds instead of silently burning
+            # through the playlist one unplayable song at a time.
+            self.last_failure_reason = "error"
+            return False
+
+        # #345 slow-buffer tolerance, narrowed to "title genuinely changed":
+        # title is now different from what it was before the call, so MA is
+        # making progress on *some* new track. We still don't require the
+        # title to match expected_title (AirPlay sometimes delivers
+        # remasters/alternates with mismatched-but-valid titles), but we do
+        # require title evidence of forward motion. Returning False here
+        # would re-trigger the race condition #345 was originally filed for.
+        _LOGGER.warning(
+            "MA playback not confirmed after %.1fs for %s (state: %s). "
+            "Title moved %r → %r. Continuing anyway — MA may still be "
+            "buffering. (#345)",
+            timeout,
+            uri,
+            speaker_state,
+            title_before,
+            title_after,
+        )
+        # #1381: a post-timeout #345 tolerance confirmation is the weakest
+        # acceptance — it must NOT promote this candidate's URI field to
+        # preferred (it never proved THIS field actually resolved our track).
+        self._last_confirm_path = 0
+        return True

--- a/custom_components/beatify/services/playback/queue_restore.py
+++ b/custom_components/beatify/services/playback/queue_restore.py
@@ -1,0 +1,282 @@
+"""Handing the host's speaker back at the end of a game (#2143), and making
+the pause stick (#2605/#2671).
+
+Split out of :mod:`custom_components.beatify.services.media_player` for #2636.
+
+Deliberately NOT a playback strategy, although every line of it is Music
+Assistant's. The distinction matters and it is the one place where #2636's
+"three strategies" framing does not fit the code: a restore is keyed on the
+SNAPSHOT, not on the speaker Beatify happens to be pointed at now. A game that
+starts on a Music Assistant speaker and switches to a Sonos one still owes the
+first speaker its queue back, and that debt is settled through
+``music_assistant.play_media`` even though the service's current platform is
+``sonos``. Routing the restore through the current strategy would silently drop
+it — so it lives here, taking an entity id and a snapshot, and asks nothing
+about platforms.
+
+The #2605 guard (:meth:`MaQueueRestorer.pause_and_confirm`) is the second fix
+for a bug that came back once. It is reproduced here unchanged; its behaviour
+is pinned by ``tests/unit/test_queue_restore_stays_paused_2605.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.exceptions import HomeAssistantError, ServiceNotFound
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+# #2143: how long the queue restore waits for the host's track to actually
+# start before it seeks to the saved position. Deliberately far below
+# MA_PLAYBACK_TIMEOUT: this runs during game teardown, where every second is a
+# second the admin UI sits on a dead screen. Missing the window costs the
+# position, not the track — the song comes back either way, just from 0:00.
+MA_QUEUE_RESTORE_WAIT = 5.0
+MA_QUEUE_RESTORE_POLL = 0.25
+# #2605: the pause at the end of the queue restore is read back — and the check
+# has to OUTLIVE the device settling rather than fit inside it.
+#
+# The first attempt (#2606) looked once, inside a two-second window, and then
+# stopped looking. On the real installation (Sonos through Music Assistant) the
+# speaker reported `idle` inside exactly that window, the pause counted as
+# confirmed — and from second five onwards it was playing again, for three
+# minutes. The window was the defect, not the state check.
+#
+# So now: confirm, and then KEEP WATCHING. The teardown only counts as done
+# once the speaker has stayed quiet for MA_PAUSE_SETTLE_HOLD seconds in a row;
+# if it starts again before that, it is paused again. MA_PAUSE_GUARD_WINDOW
+# caps the whole thing so `end-game` cannot hang on a speaker something else
+# owns.
+MA_PAUSE_CONFIRM_WAIT = 2.0
+MA_PAUSE_SETTLE_HOLD = 5.0
+MA_PAUSE_GUARD_WINDOW = 12.0
+MA_PAUSE_MAX_ATTEMPTS = 3
+MA_PAUSE_POLL = 0.25
+
+# #2605: "not playing" is too generous. MA reports `buffering` while a track
+# loads, and a reading that lands there looks exactly like a successful pause —
+# the track starts a second later anyway. Both states therefore count as "still
+# going".
+MA_ACTIVE_STATES = frozenset({"playing", "buffering"})
+
+
+class MaQueueRestorer:
+    """Replays one captured queue snapshot onto one speaker.
+
+    Holds a ``hass`` and nothing else — no entity, no provider, no service. A
+    unit test builds one over a mock ``hass`` and exercises the whole #2605
+    guard without standing up a ``MediaPlayerService``, a strategy or a game.
+    """
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self._hass = hass
+
+    async def restore_on(self, entity_id: str, queue: dict[str, Any] | None) -> bool:
+        """Replay one captured queue snapshot onto one speaker."""
+        if not queue or not queue.get("uri"):
+            return False
+        try:
+            await self._hass.services.async_call(
+                "music_assistant",
+                "play_media",
+                {
+                    "media_id": queue["uri"],
+                    "media_type": "track",
+                    "enqueue": "replace",
+                },
+                target={"entity_id": entity_id},
+                blocking=False,
+            )
+            # The seek below needs the track actually loaded — a seek against
+            # the still-playing Beatify track would move the wrong song. Wait
+            # for the speaker to report a position, bounded, then give up and
+            # leave it playing from the start rather than hang the teardown.
+            if not await self._wait_for_playing(entity_id):
+                _LOGGER.debug(
+                    "Queue restore on %s: track loaded but never confirmed", entity_id
+                )
+            elif queue.get("elapsed_time", 0) >= 1:
+                await self._hass.services.async_call(
+                    "media_player",
+                    "media_seek",
+                    {
+                        "entity_id": entity_id,
+                        "seek_position": queue["elapsed_time"],
+                    },
+                    blocking=False,
+                )
+            if queue.get("shuffle") is not None:
+                await self._hass.services.async_call(
+                    "media_player",
+                    "shuffle_set",
+                    {"entity_id": entity_id, "shuffle": bool(queue["shuffle"])},
+                    blocking=False,
+                )
+            if queue.get("repeat_mode"):
+                await self._hass.services.async_call(
+                    "media_player",
+                    "repeat_set",
+                    {"entity_id": entity_id, "repeat": queue["repeat_mode"]},
+                    blocking=False,
+                )
+            # #2605: the pause runs LAST, and it is guarded.
+            #
+            # It originally sat before `shuffle_set`/`repeat_set` and was fired
+            # with `blocking=False` with nobody looking. Measured 2026-09-05:
+            # the speaker read `playing` afterwards three times in a row — the
+            # host's old queue playing on over the podium, at party volume.
+            #
+            # Every call above is deliberately `blocking=False` (MA hangs on
+            # `blocking=True` for `play_media`, see `play_song`). Submission
+            # order is therefore NOT execution order: the `media_seek` can land
+            # after the pause and start Sonos playing again. Rather than guess
+            # which call did it, `_pause_and_confirm` holds the silence instead
+            # of measuring it once.
+            paused = await self.pause_and_confirm(entity_id)
+        except (HomeAssistantError, ServiceNotFound) as err:
+            _LOGGER.warning("Queue restore on %s failed: %s", entity_id, err)
+            return False
+        else:
+            _LOGGER.info(
+                "Queue restored on %s: %s at %.0fs (%s)",
+                entity_id,
+                queue.get("name") or queue["uri"],
+                queue.get("elapsed_time", 0),
+                "paused"
+                if paused
+                else "PAUSE NOT CONFIRMED — see the warning above (#2605)",
+            )
+            return True
+
+    async def pause_and_confirm(self, entity_id: str) -> bool:
+        """Pause, read it back — and then keep looking (#2605).
+
+        A `media_pause` with ``blocking=False`` is a request, not a fact. That
+        was the finding of #2605, and #2606 answered it by reading the state
+        back. On the real installation that still did not hold: the pause
+        landed, was confirmed, and from second five the speaker was playing
+        again. The check sat in a two-second window; the device takes longer
+        than that to settle.
+
+        So the pause is not merely confirmed here, it is **held**:
+
+        1. pause,
+        2. wait until the speaker no longer reports active playback,
+        3. then watch it for ``MA_PAUSE_SETTLE_HOLD`` seconds in a row.
+
+        If it starts again during step 3 — whether from a ``media_seek`` still
+        in flight, a ``play_media`` that had not finished loading, or Music
+        Assistant resuming its own queue — it is paused again. The guard is
+        deliberately blind to the mechanism; it reacts to what the room does.
+
+        ``MA_PAUSE_GUARD_WINDOW`` caps the whole thing so a speaker something
+        else owns cannot hang the ``end-game`` teardown.
+
+        Returns:
+            True when the speaker actually held the silence (or the entity is
+            gone). False means unconfirmed — the warning in the log says why.
+        """
+        deadline = asyncio.get_event_loop().time() + MA_PAUSE_GUARD_WINDOW
+        for versuch in range(1, MA_PAUSE_MAX_ATTEMPTS + 1):
+            await self._hass.services.async_call(
+                "media_player",
+                "media_pause",
+                {"entity_id": entity_id},
+                blocking=False,
+            )
+            if not await self._wait_until_quiet(entity_id, deadline):
+                _LOGGER.debug(
+                    "Queue restore on %s: still playing after pause attempt %d",
+                    entity_id,
+                    versuch,
+                )
+            elif await self._stays_quiet(entity_id, deadline):
+                if versuch > 1:
+                    _LOGGER.info(
+                        "Queue restore on %s: speaker stayed paused after "
+                        "attempt %d (#2605)",
+                        entity_id,
+                        versuch,
+                    )
+                return True
+            else:
+                # This is the observation #2606 could not make: the pause
+                # arrived, and the speaker started itself again afterwards.
+                _LOGGER.info(
+                    "Queue restore on %s: speaker started playing again after "
+                    "pause attempt %d — pausing once more (#2605)",
+                    entity_id,
+                    versuch,
+                )
+            if asyncio.get_event_loop().time() >= deadline:
+                break
+        _LOGGER.warning(
+            "Queue restore on %s: could not get the speaker to stay paused "
+            "within %.0fs — it is still playing the host's queue (#2605)",
+            entity_id,
+            MA_PAUSE_GUARD_WINDOW,
+        )
+        return False
+
+    async def _wait_until_quiet(self, entity_id: str, deadline: float) -> bool:
+        """Wait until the speaker stops reporting active playback (#2605).
+
+        ``media_pause`` settles Sonos-through-Music-Assistant to ``idle``, not
+        to ``paused`` — measured 2026-09-05, visible in the service response as
+        playing → idle. So this tests for "not active" rather than for one
+        particular target state.
+
+        ``None`` means the entity is gone. There is nothing left to pause then,
+        and waiting on it would only stall the teardown.
+        """
+        loop = asyncio.get_event_loop()
+        limit = min(loop.time() + MA_PAUSE_CONFIRM_WAIT, deadline)
+        while True:
+            state = self._hass.states.get(entity_id)
+            if state is None or state.state not in MA_ACTIVE_STATES:
+                return True
+            if loop.time() >= limit:
+                return False
+            await asyncio.sleep(MA_PAUSE_POLL)
+
+    async def _stays_quiet(self, entity_id: str, deadline: float) -> bool:
+        """Read the silence back for ``MA_PAUSE_SETTLE_HOLD`` seconds (#2605).
+
+        This is precisely the step #2606 was missing. There the first quiet
+        reading counted as proof — and because it fell inside a two-second
+        window, it was a reading of a speaker that had not finished settling.
+
+        Returns:
+            False as soon as playback is reported again, or when the guard
+            window runs out before the silence has held long enough.
+        """
+        loop = asyncio.get_event_loop()
+        hold_until = loop.time() + MA_PAUSE_SETTLE_HOLD
+        while True:
+            now = loop.time()
+            if now >= hold_until:
+                return True
+            if now >= deadline:
+                return False
+            await asyncio.sleep(MA_PAUSE_POLL)
+            state = self._hass.states.get(entity_id)
+            if state is None:
+                return True
+            if state.state in MA_ACTIVE_STATES:
+                return False
+
+    async def _wait_for_playing(self, entity_id: str) -> bool:
+        """Poll until the speaker reports playback, at most MA_QUEUE_RESTORE_WAIT."""
+        deadline = asyncio.get_event_loop().time() + MA_QUEUE_RESTORE_WAIT
+        while asyncio.get_event_loop().time() < deadline:
+            state = self._hass.states.get(entity_id)
+            if state is not None and state.state == "playing":
+                return True
+            await asyncio.sleep(MA_QUEUE_RESTORE_POLL)
+        return False

--- a/custom_components/beatify/services/playback/sonos.py
+++ b/custom_components/beatify/services/playback/sonos.py
@@ -1,0 +1,42 @@
+"""Sonos playback (#2636).
+
+Sonos speaks plain ``media_player.play_media`` with a Spotify URI, and that is
+the whole platform. Its brevity next to
+:mod:`.music_assistant` is the point of the split: it used to sit in the same
+class body as 600 lines of Music Assistant confirmation logic, so a change here
+was one indentation level from that.
+"""
+
+from __future__ import annotations
+
+import logging
+from asyncio import timeout as async_timeout
+from typing import Any, ClassVar
+
+from .base import PLAYBACK_TIMEOUT, PlaybackStrategy
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SonosStrategy(PlaybackStrategy):
+    """Play via Sonos (URI-based)."""
+
+    platforms: ClassVar[tuple[str, ...]] = ("sonos",)
+
+    async def play(self, song: dict[str, Any]) -> bool:
+        """Play via Sonos (URI-based)."""
+        uri = song.get("_resolved_uri")
+        _LOGGER.debug("Sonos playback: %s on %s", uri, self._entity_id)
+
+        async with async_timeout(PLAYBACK_TIMEOUT):
+            await self._hass.services.async_call(
+                "media_player",
+                "play_media",
+                {
+                    "entity_id": self._entity_id,
+                    "media_content_id": uri,
+                    "media_content_type": "music",
+                },
+                blocking=True,
+            )
+        return True

--- a/custom_components/beatify/services/playback/uris.py
+++ b/custom_components/beatify/services/playback/uris.py
@@ -1,0 +1,101 @@
+"""URI shapes Music Assistant understands, and how to recognise them back.
+
+Split out of :mod:`custom_components.beatify.services.media_player` for #2636.
+Module-level functions rather than methods: neither depends on a speaker, a
+provider or any service state, and both are needed on two sides — the Music
+Assistant strategy when it plays, and the service shell when it waits for
+metadata to catch up (#1380).
+"""
+
+from __future__ import annotations
+
+
+def convert_uri_for_ma(uri: str) -> str:
+    """
+    Convert Beatify-internal URIs to formats Music Assistant understands.
+
+    Beatify playlists store URIs in internal formats:
+    - applemusic://track/<id>  → apple_music://track/<id>  (MA native, #772)
+    - deezer://track/<id>      → unchanged (MA native, #797)
+    - tidal://track/<id>       → https://tidal.com/browse/track/<id>
+    - spotify:track:<id>       → unchanged (MA native format)
+    - https://music.youtube.com/... → unchanged (already a URL)
+
+    Args:
+        uri: Beatify-internal URI string
+
+    Returns:
+        URI converted to a format Music Assistant can resolve
+
+    """
+    if not uri:
+        return uri
+
+    if uri.startswith("deezer://track/"):
+        # MA's Deezer provider has domain "deezer". The previous
+        # https://www.deezer.com/track/<id> form was being routed to the
+        # "builtin" provider via MA's generic http(s):// branch — and
+        # builtin doesn't know Deezer, so playback failed with
+        # "No playable items found". Pass through the native form. (#797)
+        return uri
+
+    if uri.startswith("applemusic://track/"):
+        # MA's Apple Music provider has domain "apple_music". Use MA's native
+        # provider-URI form; the short "music.apple.com/song/<id>" URL fails
+        # MA's parser (needs storefront+slug, 6+ path parts). (#772)
+        track_id = uri.removeprefix("applemusic://track/")
+        return f"apple_music://track/{track_id}"
+
+    if uri.startswith("tidal://track/"):
+        track_id = uri.removeprefix("tidal://track/")
+        return f"https://tidal.com/browse/track/{track_id}"
+
+    if uri.startswith("https://music.youtube.com/watch?v="):
+        track_id = uri.removeprefix("https://music.youtube.com/watch?v=")
+        return f"ytmusic://track/{track_id}"
+
+    # spotify:track:<id> and https:// URLs are passed through unchanged
+    return uri
+
+
+def uri_match_tokens(uri: str) -> list[str]:
+    """Tokens to look for in MA's media_content_id to confirm playback.
+
+    Issue #1380: the raw Beatify-internal URI is not what MA reports in
+    media_content_id — MA echoes the convert_uri_for_ma form. To reliably
+    detect that the requested track started, match against BOTH the
+    MA-converted URI and the bare track ID (last path/ID segment), which is
+    identical across the internal and the MA-converted form for every
+    provider (Spotify, Apple Music, Tidal, YT Music, Deezer).
+
+    Args:
+        uri: The Beatify-internal URI that was requested.
+
+    Returns:
+        Ordered, deduped, non-empty substring tokens.
+
+    """
+    tokens: list[str] = []
+
+    def _add(token: str | None) -> None:
+        if token and token not in tokens:
+            tokens.append(token)
+
+    # The form MA actually reports.
+    _add(convert_uri_for_ma(uri))
+    # The raw form too, in case a provider echoes the internal URI verbatim.
+    _add(uri)
+
+    # Bare track ID — stable across both forms.
+    if uri.startswith("spotify:"):
+        _add(uri.split(":")[-1])
+    elif "watch?v=" in uri:
+        # https://music.youtube.com/watch?v=<id>[&extra]
+        _add(uri.split("watch?v=", 1)[-1].split("&", 1)[0])
+    elif "://" in uri:
+        # applemusic://track/<id>, tidal://track/<id>, deezer://track/<id>,
+        # and plain https URLs — the bare ID is the last "/"-segment.
+        tail = uri.rstrip("/").rsplit("/", 1)[-1]
+        _add(tail.split("?", 1)[0])
+
+    return tokens

--- a/tests/unit/test_game_end_stops_the_speaker_2605.py
+++ b/tests/unit/test_game_end_stops_the_speaker_2605.py
@@ -1,7 +1,7 @@
 """#2605: every way a game can end has to stop the speaker.
 
 The reopened #2605 was two defects wearing one title. The loud one is in
-``MediaPlayerService._pause_and_confirm`` — see
+``MaQueueRestorer.pause_and_confirm`` — see
 ``test_queue_restore_stays_paused_2605.py``. The quiet one is here: not every
 route to the podium asked the speaker to stop.
 

--- a/tests/unit/test_library_regressions.py
+++ b/tests/unit/test_library_regressions.py
@@ -165,7 +165,7 @@ class TestAnnouncementsAndPlayback:
     def test_each_round_replaces_the_playback_queue(self):
         """Without enqueue=replace, rounds accumulated in MA's queue and a
         post-announcement resume advanced into earlier rounds' songs."""
-        assert '"enqueue": "replace"' in src("services/media_player.py")
+        assert '"enqueue": "replace"' in src("services/playback/music_assistant.py")
 
 
 class TestPlaybackWiring:
@@ -187,7 +187,7 @@ class TestPlaybackWiring:
         asserts on the guard that actually decides whether the fallback runs
         instead of on the wording of a log message.
         """
-        code = src("services/media_player.py")
+        code = src("services/playback/music_assistant.py")
         assert "_NAME_FALLBACK_PROVIDERS" in code
         assert '"ma_library"' in code
         assert "MA name fallback" in code

--- a/tests/unit/test_ma_path1_requires_title_change_2333.py
+++ b/tests/unit/test_ma_path1_requires_title_change_2333.py
@@ -60,9 +60,9 @@ class TestSubstringOfTheStillPlayingTrack:
             "custom_components.beatify.services.media_player.asyncio.wait_for",
             new=_instant_timeout,
         ):
-            await svc._try_ma_play("spotify:track:x", "Stay", "Rihanna")
+            await svc._strategy.try_play("spotify:track:x", "Stay", "Rihanna")
 
-        assert svc._last_confirm_path != 1, (
+        assert svc._strategy._last_confirm_path != 1, (
             "Weg 1 hat den weiterlaufenden Vorgaenger bestaetigt"
         )
 
@@ -91,9 +91,9 @@ class TestSubstringOfTheStillPlayingTrack:
             "custom_components.beatify.services.media_player.asyncio.wait_for",
             new=_instant_timeout,
         ):
-            await svc._try_ma_play("spotify:track:x", "One", "Metallica")
+            await svc._strategy.try_play("spotify:track:x", "One", "Metallica")
 
-        assert svc._last_confirm_path != 1
+        assert svc._strategy._last_confirm_path != 1
 
 
 class TestWhatMustKeepWorking:
@@ -117,10 +117,10 @@ class TestWhatMustKeepWorking:
         svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
         hass.states.get = MagicMock(side_effect=[before, current])
 
-        confirmed = await svc._try_ma_play("spotify:track:x", "Stay", "Rihanna")
+        confirmed = await svc._strategy.try_play("spotify:track:x", "Stay", "Rihanna")
 
         assert confirmed is True
-        assert svc._last_confirm_path == 1
+        assert svc._strategy._last_confirm_path == 1
 
     @pytest.mark.asyncio
     async def test_the_cold_start_still_confirms(self):
@@ -143,7 +143,7 @@ class TestWhatMustKeepWorking:
         svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
         hass.states.get = MagicMock(side_effect=[before, current])
 
-        confirmed = await svc._try_ma_play("spotify:track:x", "Stay", "Rihanna")
+        confirmed = await svc._strategy.try_play("spotify:track:x", "Stay", "Rihanna")
 
         assert confirmed is True
-        assert svc._last_confirm_path == 1
+        assert svc._strategy._last_confirm_path == 1

--- a/tests/unit/test_ma_queue_restore_2143.py
+++ b/tests/unit/test_ma_queue_restore_2143.py
@@ -26,7 +26,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from custom_components.beatify.services import media_player as mp
+from custom_components.beatify.services.playback import queue_restore
 from custom_components.beatify.services.media_player import MediaPlayerService
 from tests.conftest import make_game_state, make_songs
 
@@ -41,10 +41,10 @@ def _fast_pause_guard(monkeypatch):
     #2605 contract itself is tested in
     ``test_queue_restore_stays_paused_2605.py``.
     """
-    monkeypatch.setattr(mp, "MA_PAUSE_CONFIRM_WAIT", 0.05)
-    monkeypatch.setattr(mp, "MA_PAUSE_SETTLE_HOLD", 0.05)
-    monkeypatch.setattr(mp, "MA_PAUSE_GUARD_WINDOW", 0.30)
-    monkeypatch.setattr(mp, "MA_PAUSE_POLL", 0.01)
+    monkeypatch.setattr(queue_restore, "MA_PAUSE_CONFIRM_WAIT", 0.05)
+    monkeypatch.setattr(queue_restore, "MA_PAUSE_SETTLE_HOLD", 0.05)
+    monkeypatch.setattr(queue_restore, "MA_PAUSE_GUARD_WINDOW", 0.30)
+    monkeypatch.setattr(queue_restore, "MA_PAUSE_POLL", 0.01)
 
 
 QUEUE_RESPONSE = {
@@ -235,7 +235,7 @@ class TestQueueRestore:
                 new_callable=AsyncMock,
             ),
             patch(
-                "custom_components.beatify.services.media_player.MA_QUEUE_RESTORE_WAIT",
+                "custom_components.beatify.services.playback.queue_restore.MA_QUEUE_RESTORE_WAIT",
                 0.05,
             ),
         ):
@@ -393,11 +393,11 @@ class TestPlayPathTakesTheSnapshotFirst:
                 new_callable=AsyncMock,
             ),
             patch(
-                "custom_components.beatify.services.media_player.MA_PLAYBACK_TIMEOUT",
+                "custom_components.beatify.services.playback.music_assistant.MA_PLAYBACK_TIMEOUT",
                 0.05,
             ),
         ):
-            await svc._try_ma_play("spotify:track:abc", "New Song")
+            await svc._strategy.try_play("spotify:track:abc", "New Song")
 
         services = [c.args[:2] for c in hass.services.async_call.await_args_list]
         assert services.index(("music_assistant", "get_queue")) < services.index(

--- a/tests/unit/test_ma_same_title_different_track_2616.py
+++ b/tests/unit/test_ma_same_title_different_track_2616.py
@@ -83,12 +83,12 @@ class TestTitleCollisionBetweenRounds:
         svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
         hass.states.get = MagicMock(side_effect=[before, after])
 
-        confirmed = await svc._try_ma_play(RICHIE_URI, "Hello", "Lionel Richie")
+        confirmed = await svc._strategy.try_play(RICHIE_URI, "Hello", "Lionel Richie")
 
         assert confirmed is True, (
             "Gleicher Titel, andere content id — der Wechsel hat stattgefunden"
         )
-        assert svc._last_confirm_path == 1
+        assert svc._strategy._last_confirm_path == 1
         assert svc.last_failure_reason is None
 
     @pytest.mark.asyncio
@@ -119,7 +119,9 @@ class TestTitleCollisionBetweenRounds:
             "custom_components.beatify.services.media_player.asyncio.wait_for",
             new=_instant_timeout,
         ):
-            confirmed = await svc._try_ma_play(RICHIE_URI, "Hello", "Lionel Richie")
+            confirmed = await svc._strategy.try_play(
+                RICHIE_URI, "Hello", "Lionel Richie"
+            )
 
         assert confirmed is True
         assert svc.last_failure_reason != "unavailable"
@@ -160,10 +162,10 @@ class TestTheInvariantFrom2333StillHolds:
             "custom_components.beatify.services.media_player.asyncio.wait_for",
             new=_instant_timeout,
         ):
-            confirmed = await svc._try_ma_play(RICHIE_URI, "Stay", "Rihanna")
+            confirmed = await svc._strategy.try_play(RICHIE_URI, "Stay", "Rihanna")
 
         assert confirmed is False
-        assert svc._last_confirm_path != 1
+        assert svc._strategy._last_confirm_path != 1
         assert svc.last_failure_reason == "unavailable"
 
     @pytest.mark.asyncio
@@ -192,10 +194,12 @@ class TestTheInvariantFrom2333StillHolds:
             "custom_components.beatify.services.media_player.asyncio.wait_for",
             new=_instant_timeout,
         ):
-            confirmed = await svc._try_ma_play(RICHIE_URI, "Hello", "Lionel Richie")
+            confirmed = await svc._strategy.try_play(
+                RICHIE_URI, "Hello", "Lionel Richie"
+            )
 
         assert confirmed is False
-        assert svc._last_confirm_path != 1
+        assert svc._strategy._last_confirm_path != 1
 
     @pytest.mark.asyncio
     async def test_a_speaker_without_content_id_is_unaffected(self):
@@ -221,7 +225,9 @@ class TestTheInvariantFrom2333StillHolds:
             "custom_components.beatify.services.media_player.asyncio.wait_for",
             new=_instant_timeout,
         ):
-            confirmed = await svc._try_ma_play(RICHIE_URI, "Hello", "Lionel Richie")
+            confirmed = await svc._strategy.try_play(
+                RICHIE_URI, "Hello", "Lionel Richie"
+            )
 
         assert confirmed is False
         assert svc.last_failure_reason == "unavailable"

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -16,6 +16,9 @@ from custom_components.beatify.services.media_player import (
     async_get_native_twin_remap,
     proxy_album_art,
 )
+from custom_components.beatify.services.playback import (
+    uri_match_tokens,
+)
 
 
 def _make_state(
@@ -277,7 +280,7 @@ class TestMANonBlockingPlayback:
             new_callable=AsyncMock,
         ):
             with patch(
-                "custom_components.beatify.services.media_player.MA_PLAYBACK_TIMEOUT",
+                "custom_components.beatify.services.playback.music_assistant.MA_PLAYBACK_TIMEOUT",
                 1.0,
             ):
                 result = await svc.play_song(_make_song(title="New Song"))
@@ -324,7 +327,7 @@ class TestMANonBlockingPlayback:
             new_callable=AsyncMock,
         ):
             with patch(
-                "custom_components.beatify.services.media_player.MA_PLAYBACK_TIMEOUT",
+                "custom_components.beatify.services.playback.music_assistant.MA_PLAYBACK_TIMEOUT",
                 1.0,
             ):
                 result = await svc.play_song(_make_song(title="New Song"))
@@ -383,7 +386,7 @@ class TestMANonBlockingPlayback:
             new_callable=AsyncMock,
         ):
             with patch(
-                "custom_components.beatify.services.media_player.MA_PLAYBACK_TIMEOUT",
+                "custom_components.beatify.services.playback.music_assistant.MA_PLAYBACK_TIMEOUT",
                 1.0,
             ):
                 result = await svc.play_song(_make_song(title="New Song"))
@@ -437,7 +440,7 @@ class TestMANonBlockingPlayback:
             new_callable=AsyncMock,
         ):
             with patch(
-                "custom_components.beatify.services.media_player.MA_PLAYBACK_TIMEOUT",
+                "custom_components.beatify.services.playback.music_assistant.MA_PLAYBACK_TIMEOUT",
                 1.0,
             ):
                 result = await svc.play_song(_make_song(title="New Song"))
@@ -485,7 +488,7 @@ class TestMANonBlockingPlayback:
             new_callable=AsyncMock,
         ):
             with patch(
-                "custom_components.beatify.services.media_player.MA_PLAYBACK_TIMEOUT",
+                "custom_components.beatify.services.playback.music_assistant.MA_PLAYBACK_TIMEOUT",
                 1.0,
             ):
                 result = await svc.play_song(_make_song(title="New Song"))
@@ -539,7 +542,7 @@ class TestMANonBlockingPlayback:
             new_callable=AsyncMock,
         ):
             with patch(
-                "custom_components.beatify.services.media_player.MA_PLAYBACK_TIMEOUT",
+                "custom_components.beatify.services.playback.music_assistant.MA_PLAYBACK_TIMEOUT",
                 1.0,
             ):
                 result = await svc.play_song(_make_song(title="New Song"))
@@ -595,17 +598,19 @@ class TestMANonBlockingPlayback:
         hass = _make_hass("idle", media_title="Old Song")
         svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
         # Simulate the prior candidate's media_stop having already fired.
-        svc._stopped_for_cascade = True
+        svc._strategy._stopped_for_cascade = True
 
         with patch(
             "custom_components.beatify.services.media_player.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             with patch(
-                "custom_components.beatify.services.media_player.MA_PLAYBACK_TIMEOUT",
+                "custom_components.beatify.services.playback.music_assistant.MA_PLAYBACK_TIMEOUT",
                 1.0,
             ):
-                result = await svc._try_ma_play("apple_music://track/302229811", "X")
+                result = await svc._strategy.try_play(
+                    "apple_music://track/302229811", "X"
+                )
 
         assert result is False
         assert svc.last_failure_reason == "unavailable"
@@ -618,17 +623,19 @@ class TestMANonBlockingPlayback:
         """
         hass = _make_hass("idle", media_title="Old Song")
         svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
-        assert svc._stopped_for_cascade is False
+        assert svc._strategy._stopped_for_cascade is False
 
         with patch(
             "custom_components.beatify.services.media_player.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             with patch(
-                "custom_components.beatify.services.media_player.MA_PLAYBACK_TIMEOUT",
+                "custom_components.beatify.services.playback.music_assistant.MA_PLAYBACK_TIMEOUT",
                 1.0,
             ):
-                result = await svc._try_ma_play("apple_music://track/302229811", "X")
+                result = await svc._strategy.try_play(
+                    "apple_music://track/302229811", "X"
+                )
 
         assert result is False
         assert svc.last_failure_reason == "error"
@@ -640,13 +647,13 @@ class TestMANonBlockingPlayback:
         """
         hass = _make_hass("idle", media_title="Old Song")
         svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
-        svc._stopped_for_cascade = True  # leftover from a prior song
+        svc._strategy._stopped_for_cascade = True  # leftover from a prior song
 
         # _play_via_music_assistant must reset the flag before the cascade.
-        with patch.object(svc, "_try_ma_play", AsyncMock(return_value=False)):
-            await svc._play_via_music_assistant(_make_song())
+        with patch.object(svc._strategy, "try_play", AsyncMock(return_value=False)):
+            await svc._strategy.play(_make_song())
 
-        assert svc._stopped_for_cascade is False
+        assert svc._strategy._stopped_for_cascade is False
 
     @pytest.mark.asyncio
     async def test_sonos_still_uses_blocking_true(self):
@@ -794,17 +801,17 @@ class TestMANonBlockingPlayback:
             "custom_components.beatify.services.media_player.asyncio.wait_for",
             new=_instant_timeout,
         ):
-            confirmed = await svc._try_ma_play(
+            confirmed = await svc._strategy.try_play(
                 "spotify:track:our-song", "Sweet Child O' Mine", "Guns N' Roses"
             )
 
         # The fast-path (Path 2) must NOT have confirmed this unrelated track.
         # (It falls through to the post-timeout #345 tolerance, path 0.)
-        assert svc._last_confirm_path != 2
+        assert svc._strategy._last_confirm_path != 2
         # And whatever the final outcome, an unrelated auto-advance must never
         # be learned as a working URI field.
         assert confirmed is True  # #345 tolerance still returns True post-timeout
-        assert svc._last_confirm_path == 0
+        assert svc._strategy._last_confirm_path == 0
 
     @pytest.mark.asyncio
     async def test_fast_path_accepts_title_token_overlap(self):
@@ -831,12 +838,12 @@ class TestMANonBlockingPlayback:
         svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
         hass.states.get = MagicMock(side_effect=[before, current])
 
-        confirmed = await svc._try_ma_play(
+        confirmed = await svc._strategy.try_play(
             "spotify:track:x", "Sweet Child O' Mine", "Different Artist"
         )
 
         assert confirmed is True
-        assert svc._last_confirm_path == 2
+        assert svc._strategy._last_confirm_path == 2
 
     @pytest.mark.asyncio
     async def test_fast_path_accepts_artist_match_on_title_mismatch(self):
@@ -860,10 +867,12 @@ class TestMANonBlockingPlayback:
         svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
         hass.states.get = MagicMock(side_effect=[before, current])
 
-        confirmed = await svc._try_ma_play("spotify:track:x", "Das Modell", "Kraftwerk")
+        confirmed = await svc._strategy.try_play(
+            "spotify:track:x", "Das Modell", "Kraftwerk"
+        )
 
         assert confirmed is True
-        assert svc._last_confirm_path == 2
+        assert svc._strategy._last_confirm_path == 2
 
     @pytest.mark.asyncio
     async def test_preferred_uri_field_not_learned_on_path2_confirmation(self):
@@ -891,22 +900,24 @@ class TestMANonBlockingPlayback:
         ) -> bool:
             ok = uri == "spotify:track:legacy"
             if ok:
-                svc._last_confirm_path = 2  # weak (similarity-gate) confirmation
+                svc._strategy._last_confirm_path = (
+                    2  # weak (similarity-gate) confirmation
+                )
             return ok
 
-        with patch.object(svc, "_try_ma_play", side_effect=fake_try):
-            result = await svc._play_via_music_assistant(song)
+        with patch.object(svc._strategy, "try_play", side_effect=fake_try):
+            result = await svc._strategy.play(song)
 
         assert result is True
         # Path-2-only confirmation must not learn the field.
-        assert svc._ma_preferred_uri_field is None
+        assert svc._strategy._ma_preferred_uri_field is None
 
 
 class TestTitleSimilarityGate:
     """#1381: unit tests for the fast-path Path 2 similarity helpers."""
 
     def test_token_overlap_matches_suffix(self):
-        from custom_components.beatify.services.media_player import (
+        from custom_components.beatify.services.playback.music_assistant import (
             _titles_plausibly_match,
         )
 
@@ -914,14 +925,14 @@ class TestTitleSimilarityGate:
         assert _titles_plausibly_match("Sweet Child O' Mine", "Sweet Child o Mine")
 
     def test_prefix_matches_remaster_suffix(self):
-        from custom_components.beatify.services.media_player import (
+        from custom_components.beatify.services.playback.music_assistant import (
             _titles_plausibly_match,
         )
 
         assert _titles_plausibly_match("Africa", "Africa (Remastered 2020)")
 
     def test_unrelated_titles_do_not_match(self):
-        from custom_components.beatify.services.media_player import (
+        from custom_components.beatify.services.playback.music_assistant import (
             _titles_plausibly_match,
         )
 
@@ -932,7 +943,9 @@ class TestTitleSimilarityGate:
         assert not _titles_plausibly_match("Go", "No")
 
     def test_artist_match_helper(self):
-        from custom_components.beatify.services.media_player import _artist_matches
+        from custom_components.beatify.services.playback.music_assistant import (
+            _artist_matches,
+        )
 
         assert _artist_matches("Kraftwerk", "Kraftwerk")
         assert _artist_matches("The Beatles", "Beatles")
@@ -1023,7 +1036,7 @@ class TestMAProviderFallback:
         hass = _make_hass()
         svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
         song = {"uri": "spotify:track:abc", "_resolved_uri": "spotify:track:abc"}
-        candidates = svc._get_ma_uri_candidates(song)
+        candidates = svc._strategy.uri_candidates(song)
         assert candidates == [(None, "spotify:track:abc")]
 
     def test_candidates_skip_other_providers_when_apple_music_only(self):
@@ -1049,7 +1062,7 @@ class TestMAProviderFallback:
             "uri_deezer": "deezer://track/333",
             "_resolved_uri": "applemusic://track/111",
         }
-        uris = [uri for _, uri in svc._get_ma_uri_candidates(song)]
+        uris = [uri for _, uri in svc._strategy.uri_candidates(song)]
         # Only the Apple Music URI (converted to MA's native form) should be tried.
         assert uris == ["apple_music://track/111"]
 
@@ -1072,7 +1085,7 @@ class TestMAProviderFallback:
             "uri_apple_music": "applemusic://track/111",
             "uri_tidal": "tidal://track/222",
         }
-        uris = [uri for _, uri in svc._get_ma_uri_candidates(song)]
+        uris = [uri for _, uri in svc._strategy.uri_candidates(song)]
         assert "spotify:track:canonical" in uris
         assert "spotify:track:legacy" in uris
         # Apple Music + Tidal must be excluded.
@@ -1093,7 +1106,7 @@ class TestMAProviderFallback:
             "uri_spotify": "spotify:track:abc",  # same as uri
             "_resolved_uri": "spotify:track:abc",
         }
-        uris = [uri for _, uri in svc._get_ma_uri_candidates(song)]
+        uris = [uri for _, uri in svc._strategy.uri_candidates(song)]
         assert uris == ["spotify:track:abc"]
 
     def test_candidates_converts_apple_music(self):
@@ -1109,7 +1122,7 @@ class TestMAProviderFallback:
             "_resolved_uri": "applemusic://track/999",
             "uri_apple_music": "applemusic://track/999",
         }
-        candidates = svc._get_ma_uri_candidates(song)
+        candidates = svc._strategy.uri_candidates(song)
         assert candidates[0][1] == "apple_music://track/999"
 
     def test_candidates_keeps_deezer_native_form(self):
@@ -1132,7 +1145,7 @@ class TestMAProviderFallback:
             "_resolved_uri": "deezer://track/12345",
             "uri_deezer": "deezer://track/12345",
         }
-        candidates = svc._get_ma_uri_candidates(song)
+        candidates = svc._strategy.uri_candidates(song)
         assert candidates[0][1] == "deezer://track/12345"
 
     def test_candidates_learned_preference_within_same_provider(self):
@@ -1150,13 +1163,13 @@ class TestMAProviderFallback:
             provider="spotify",
         )
         # Cached: legacy `uri` field worked last time.
-        svc._ma_preferred_uri_field = "uri"
+        svc._strategy._ma_preferred_uri_field = "uri"
         song = {
             "uri": "spotify:track:legacy",
             "uri_spotify": "spotify:track:canonical",
             "_resolved_uri": "spotify:track:canonical",
         }
-        candidates = svc._get_ma_uri_candidates(song)
+        candidates = svc._strategy.uri_candidates(song)
         # Primary (`_resolved_uri`) is always first.
         assert candidates[0] == (None, "spotify:track:canonical")
         # Cached field is ordered ahead of the other alternates, behind primary.
@@ -1177,13 +1190,13 @@ class TestMAProviderFallback:
             platform="music_assistant",
             provider="apple_music",
         )
-        svc._ma_preferred_uri_field = "uri_spotify"  # stale cache
+        svc._strategy._ma_preferred_uri_field = "uri_spotify"  # stale cache
         song = {
             "uri_spotify": "spotify:track:abc",
             "uri_apple_music": "applemusic://track/111",
             "_resolved_uri": "applemusic://track/111",
         }
-        uris = [uri for _, uri in svc._get_ma_uri_candidates(song)]
+        uris = [uri for _, uri in svc._strategy.uri_candidates(song)]
         # Stale cached field is ignored; only Apple Music URI is tried.
         assert uris == ["apple_music://track/111"]
 
@@ -1191,7 +1204,7 @@ class TestMAProviderFallback:
         """Song with no URI fields yields no candidates."""
         hass = _make_hass()
         svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
-        assert svc._get_ma_uri_candidates({"title": "x", "artist": "y"}) == []
+        assert svc._strategy.uri_candidates({"title": "x", "artist": "y"}) == []
 
     def test_candidates_skip_legacy_us_field_when_regional_map_present(self):
         """#1379: non-US Apple-Music user must NOT get the legacy US ID appended.
@@ -1213,7 +1226,7 @@ class TestMAProviderFallback:
             "uri_apple_music_by_region": {"de": "applemusic://track/DE222"},
             "_resolved_uri": "applemusic://track/DE222",  # DE-resolved
         }
-        uris = [uri for _, uri in svc._get_ma_uri_candidates(song)]
+        uris = [uri for _, uri in svc._strategy.uri_candidates(song)]
         # Only the storefront-resolved DE URI is tried; the US legacy ID is gone.
         assert uris == ["apple_music://track/DE222"]
         assert "apple_music://track/US111" not in uris
@@ -1233,7 +1246,7 @@ class TestMAProviderFallback:
             "uri_apple_music": "applemusic://track/111",
             "_resolved_uri": "applemusic://track/111",
         }
-        uris = [uri for _, uri in svc._get_ma_uri_candidates(song)]
+        uris = [uri for _, uri in svc._strategy.uri_candidates(song)]
         assert uris == ["apple_music://track/111"]
 
     def test_candidates_learned_us_field_never_outranks_resolved_uri(self):
@@ -1249,13 +1262,13 @@ class TestMAProviderFallback:
             provider="apple_music",
         )
         # A prior song without a regional map "learned" the legacy US field.
-        svc._ma_preferred_uri_field = "uri_apple_music"
+        svc._strategy._ma_preferred_uri_field = "uri_apple_music"
         song = {
             "uri_apple_music": "applemusic://track/US111",  # wrong storefront
             "uri_apple_music_by_region": {"de": "applemusic://track/DE222"},
             "_resolved_uri": "applemusic://track/DE222",  # DE-resolved
         }
-        candidates = svc._get_ma_uri_candidates(song)
+        candidates = svc._strategy.uri_candidates(song)
         # Storefront-resolved URI first; learned US field dropped entirely.
         assert candidates == [(None, "apple_music://track/DE222")]
 
@@ -1281,7 +1294,7 @@ class TestMAProviderFallback:
             "_resolved_uri": "spotify:track:abc",
         }
         with caplog.at_level("WARNING"):
-            candidates = svc._get_ma_uri_candidates(song)
+            candidates = svc._strategy.uri_candidates(song)
         # _resolved_uri is still honored as a last resort.
         assert candidates == [(None, "spotify:track:abc")]
         # Warning names the unknown provider so the mismatch is debuggable.
@@ -1304,7 +1317,7 @@ class TestMAProviderFallback:
             provider="amazon_music",
         )
         with caplog.at_level("WARNING"):
-            svc._get_ma_uri_candidates({"artist": "A", "title": "T"})
+            svc._strategy.uri_candidates({"artist": "A", "title": "T"})
         assert not any("unknown provider" in rec.message for rec in caplog.records)
 
     @pytest.mark.asyncio
@@ -1320,7 +1333,7 @@ class TestMAProviderFallback:
         # Song has no apple_music URI → no candidates.
         song = {"artist": "Artist", "title": "Title", "uri_spotify": "spotify:track:x"}
         with caplog.at_level("WARNING"):
-            result = await svc._play_via_music_assistant(song)
+            result = await svc._strategy.play(song)
         assert result is False
         assert svc.last_failure_reason == "unavailable"
         assert any(
@@ -1356,15 +1369,15 @@ class TestMAProviderFallback:
             if ok:
                 # Simulate a Path-1 (expected-title substring) confirmation —
                 # the only path strong enough to learn a preferred URI field.
-                svc._last_confirm_path = 1
+                svc._strategy._last_confirm_path = 1
             return ok
 
-        with patch.object(svc, "_try_ma_play", side_effect=fake_try):
-            result = await svc._play_via_music_assistant(song)
+        with patch.object(svc._strategy, "try_play", side_effect=fake_try):
+            result = await svc._strategy.play(song)
 
         assert result is True
         assert calls == ["spotify:track:canonical", "spotify:track:legacy"]
-        assert svc._ma_preferred_uri_field == "uri"
+        assert svc._strategy._ma_preferred_uri_field == "uri"
 
     @pytest.mark.asyncio
     async def test_primary_success_does_not_update_preference(self):
@@ -1382,11 +1395,11 @@ class TestMAProviderFallback:
             "uri_spotify": "spotify:track:abc",
         }
 
-        with patch.object(svc, "_try_ma_play", AsyncMock(return_value=True)):
-            result = await svc._play_via_music_assistant(song)
+        with patch.object(svc._strategy, "try_play", AsyncMock(return_value=True)):
+            result = await svc._strategy.play(song)
 
         assert result is True
-        assert svc._ma_preferred_uri_field is None
+        assert svc._strategy._ma_preferred_uri_field is None
 
     @pytest.mark.asyncio
     async def test_all_candidates_fail_returns_false(self):
@@ -1404,11 +1417,11 @@ class TestMAProviderFallback:
             "uri_apple_music": "applemusic://track/111",
         }
 
-        with patch.object(svc, "_try_ma_play", AsyncMock(return_value=False)):
-            result = await svc._play_via_music_assistant(song)
+        with patch.object(svc._strategy, "try_play", AsyncMock(return_value=False)):
+            result = await svc._strategy.play(song)
 
         assert result is False
-        assert svc._ma_preferred_uri_field is None
+        assert svc._strategy._ma_preferred_uri_field is None
 
     @pytest.mark.asyncio
     async def test_learned_preference_orders_alternates_behind_primary(self):
@@ -1450,12 +1463,14 @@ class TestMAProviderFallback:
             # Canonical never works in this user's setup; legacy always does.
             ok = uri.endswith("-legacy")
             if ok:
-                svc._last_confirm_path = 1  # Path-1 confirmation learns the field
+                svc._strategy._last_confirm_path = (
+                    1  # Path-1 confirmation learns the field
+                )
             return ok
 
-        with patch.object(svc, "_try_ma_play", side_effect=fake_try):
-            assert await svc._play_via_music_assistant(song_a) is True
-            assert await svc._play_via_music_assistant(song_b) is True
+        with patch.object(svc._strategy, "try_play", side_effect=fake_try):
+            assert await svc._strategy.play(song_a) is True
+            assert await svc._strategy.play(song_b) is True
 
         # Song A: canonical (primary) fails, legacy succeeds → learns "uri".
         # Song B: #1379 — primary `_resolved_uri` is STILL tried first (fails),
@@ -1475,8 +1490,8 @@ class TestMAProviderFallback:
         svc = MediaPlayerService(hass, "media_player.test", platform="music_assistant")
 
         mock_try = AsyncMock(return_value=True)
-        with patch.object(svc, "_try_ma_play", mock_try):
-            result = await svc._play_via_music_assistant({"title": "x"})
+        with patch.object(svc._strategy, "try_play", mock_try):
+            result = await svc._strategy.play({"title": "x"})
 
         assert result is False
         mock_try.assert_not_awaited()
@@ -2143,7 +2158,7 @@ class TestUriMatchTokens:
         ],
     )
     def test_tokens_match_ma_content_id_and_bare_id(self, uri, ma_content_id, bare_id):
-        tokens = MediaPlayerService._uri_match_tokens(uri)
+        tokens = uri_match_tokens(uri)
         # The MA-converted form is always reproducible in content_id.
         assert any(tok in ma_content_id for tok in tokens), (
             f"{uri!r} tokens {tokens!r} don't match MA content_id {ma_content_id!r}"
@@ -2152,14 +2167,12 @@ class TestUriMatchTokens:
         assert bare_id in tokens
 
     def test_youtube_watch_url_strips_extra_query_params(self):
-        tokens = MediaPlayerService._uri_match_tokens(
-            "https://music.youtube.com/watch?v=XYZ&list=PL1"
-        )
+        tokens = uri_match_tokens("https://music.youtube.com/watch?v=XYZ&list=PL1")
         assert "XYZ" in tokens
         assert "XYZ&list=PL1" not in tokens
 
     def test_empty_uri_yields_no_tokens(self):
-        assert MediaPlayerService._uri_match_tokens("") == []
+        assert uri_match_tokens("") == []
 
 
 class TestWaitForMetadataUpdateCrossProvider:
@@ -2285,14 +2298,14 @@ class TestAlexaContentType:
     @pytest.mark.asyncio
     async def test_spotify_maps_to_spotify(self):
         svc, hass = self._service("spotify")
-        await svc._play_via_alexa(_make_song())
+        await svc._strategy.play(_make_song())
         call = hass.services.async_call.call_args
         assert call[0][2]["media_content_type"] == "SPOTIFY"
 
     @pytest.mark.asyncio
     async def test_amazon_maps_to_amazon_music(self):
         svc, hass = self._service("amazon_music")
-        await svc._play_via_alexa(_make_song())
+        await svc._strategy.play(_make_song())
         call = hass.services.async_call.call_args
         assert call[0][2]["media_content_type"] == "AMAZON_MUSIC"
 
@@ -2300,9 +2313,9 @@ class TestAlexaContentType:
     async def test_apple_music_maps_to_apple_music_no_warning(self):
         svc, hass = self._service("apple_music")
         with patch(
-            "custom_components.beatify.services.media_player._LOGGER"
+            "custom_components.beatify.services.playback.alexa._LOGGER"
         ) as mock_log:
-            await svc._play_via_alexa(_make_song())
+            await svc._strategy.play(_make_song())
         call = hass.services.async_call.call_args
         assert call[0][2]["media_content_type"] == "APPLE_MUSIC"
         assert not any(
@@ -2315,9 +2328,9 @@ class TestAlexaContentType:
         APPLE_MUSIC but logs a warning naming the provider (#1402)."""
         svc, hass = self._service("deezer")
         with patch(
-            "custom_components.beatify.services.media_player._LOGGER"
+            "custom_components.beatify.services.playback.alexa._LOGGER"
         ) as mock_log:
-            await svc._play_via_alexa(_make_song())
+            await svc._strategy.play(_make_song())
         call = hass.services.async_call.call_args
         assert call[0][2]["media_content_type"] == "APPLE_MUSIC"
         warnings = [str(c) for c in mock_log.warning.call_args_list]
@@ -2737,7 +2750,7 @@ class TestFirstPlayBudget:
     """#1936 — the first play of a game gets a third more time (cold speaker)."""
 
     def test_factor_is_derived_from_the_base_timeout(self):
-        from custom_components.beatify.services.media_player import (  # noqa: PLC0415
+        from custom_components.beatify.services.playback.music_assistant import (  # noqa: PLC0415
             MA_FIRST_PLAY_TIMEOUT_FACTOR,
             MA_PLAYBACK_TIMEOUT,
         )
@@ -2748,7 +2761,7 @@ class TestFirstPlayBudget:
         svc = MediaPlayerService(
             MagicMock(), "media_player.test", platform="music_assistant"
         )
-        assert svc._first_play_pending is True
+        assert svc._strategy._first_play_pending is True
 
     @pytest.mark.asyncio
     async def test_the_longer_budget_is_used_once_and_then_dropped(self):
@@ -2768,7 +2781,7 @@ class TestFirstPlayBudget:
 
         with (
             patch(
-                "custom_components.beatify.services.media_player.MA_PLAYBACK_TIMEOUT",
+                "custom_components.beatify.services.playback.music_assistant.MA_PLAYBACK_TIMEOUT",
                 1.0,
             ),
             patch(

--- a/tests/unit/test_playback_strategies_2636.py
+++ b/tests/unit/test_playback_strategies_2636.py
@@ -1,0 +1,242 @@
+"""#2636: one platform at a time.
+
+``MediaPlayerService`` used to hold Music Assistant, Sonos and Alexa in one
+2344-line class body, dispatched by ``if self._platform ==`` in five separate
+methods. Its mirror test file is 2787 lines, and a Sonos assertion sat in the
+same suite as the Music Assistant confirmation logic — so checking that Sonos
+sends one ``play_media`` meant importing the URI cascade, the provider table,
+the analytics hook and the queue bookkeeping along with it.
+
+Every test in this file builds ONE strategy over a mock ``hass`` and asserts
+against that platform alone. There is no ``MediaPlayerService`` anywhere in the
+file, and no game.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.beatify.services.playback import (
+    AlexaStrategy,
+    MusicAssistantStrategy,
+    PlaybackStrategy,
+    PlayerContext,
+    SonosStrategy,
+    build_strategy,
+    supported_platforms,
+)
+
+SONG = {
+    "artist": "Kraftwerk",
+    "title": "Das Modell",
+    "_resolved_uri": "spotify:track:ABC123",
+}
+
+
+def _hass(queue_response=None) -> MagicMock:
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock(return_value=queue_response)
+    hass.states.get = MagicMock(return_value=None)
+    return hass
+
+
+def _context(hass, platform: str, provider: str = "spotify") -> PlayerContext:
+    return PlayerContext(
+        hass, "media_player.esszimmer", platform=platform, provider=provider
+    )
+
+
+def _calls(hass) -> list[tuple[str, str]]:
+    return [c.args[:2] for c in hass.services.async_call.await_args_list]
+
+
+class TestTheDispatchHappensInOnePlace:
+    """The point of the split: adding a platform touches one table."""
+
+    @pytest.mark.parametrize(
+        ("platform", "expected"),
+        [
+            ("music_assistant", MusicAssistantStrategy),
+            ("sonos", SonosStrategy),
+            ("alexa_media", AlexaStrategy),
+            ("alexa", AlexaStrategy),
+        ],
+    )
+    def test_each_platform_reaches_its_own_strategy(self, platform, expected):
+        strategy = build_strategy(_context(_hass(), platform))
+        assert isinstance(strategy, expected)
+
+    @pytest.mark.parametrize("platform", ["cast", "unknown", "plex", ""])
+    def test_a_platform_beatify_cannot_play_gets_no_strategy(self, platform):
+        """Cast without Music Assistant, and anything unrecognised.
+
+        None rather than a raise: the service shell logs "Unsupported platform"
+        and returns False, exactly as the old ``if/elif`` chain fell through.
+        """
+        assert build_strategy(_context(_hass(), platform)) is None
+
+    def test_a_platform_belongs_to_exactly_one_strategy(self):
+        """The invariant the old chain could not state: no platform is served
+        by two implementations, and none is silently served by none."""
+        platforms = supported_platforms()
+        assert sorted(platforms) == sorted(set(platforms))
+        assert set(platforms) == {"music_assistant", "sonos", "alexa_media", "alexa"}
+
+    def test_every_strategy_answers_the_same_interface(self):
+        for platform in supported_platforms():
+            strategy = build_strategy(_context(_hass(), platform))
+            assert isinstance(strategy, PlaybackStrategy)
+
+
+class TestSonosOnItsOwn:
+    """Sonos, without a line of Music Assistant in the way."""
+
+    @pytest.mark.asyncio
+    async def test_it_sends_one_blocking_play_media_with_the_uri(self):
+        hass = _hass()
+        sonos = SonosStrategy(_context(hass, "sonos"))
+
+        assert await sonos.play(SONG) is True
+
+        assert _calls(hass) == [("media_player", "play_media")]
+        call = hass.services.async_call.await_args
+        assert call.args[2] == {
+            "entity_id": "media_player.esszimmer",
+            "media_content_id": "spotify:track:ABC123",
+            "media_content_type": "music",
+        }
+        assert call.kwargs["blocking"] is True
+
+    @pytest.mark.asyncio
+    async def test_it_never_touches_the_music_assistant_domain(self):
+        """The regression the split is meant to make impossible: a change to
+        the Music Assistant path cannot reach this one."""
+        hass = _hass()
+        await SonosStrategy(_context(hass, "sonos")).play(SONG)
+
+        assert all(domain != "music_assistant" for domain, _ in _calls(hass))
+
+    @pytest.mark.asyncio
+    async def test_it_remembers_nothing_of_the_host_queue(self):
+        """#2143 is Music Assistant's alone — Sonos cannot report a queue."""
+        sonos = SonosStrategy(_context(_hass(), "sonos"))
+        assert await sonos.capture_queue() is None
+
+
+class TestAlexaOnItsOwn:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("provider", "content_type"),
+        [
+            ("spotify", "SPOTIFY"),
+            ("amazon_music", "AMAZON_MUSIC"),
+            ("apple_music", "APPLE_MUSIC"),
+        ],
+    )
+    async def test_the_provider_picks_the_content_type(self, provider, content_type):
+        hass = _hass()
+        alexa = AlexaStrategy(_context(hass, "alexa_media", provider))
+
+        assert await alexa.play(SONG) is True
+
+        assert hass.services.async_call.await_args.args[2] == {
+            "entity_id": "media_player.esszimmer",
+            "media_content_id": "Das Modell by Kraftwerk",
+            "media_content_type": content_type,
+        }
+
+    @pytest.mark.asyncio
+    async def test_an_unmapped_provider_warns_and_falls_back(self, caplog):
+        """#1402: deezer has no Alexa mapping. It must not be silently mapped."""
+        hass = _hass()
+        alexa = AlexaStrategy(_context(hass, "alexa_media", "deezer"))
+
+        with caplog.at_level("WARNING"):
+            await alexa.play(SONG)
+
+        assert "unexpected provider" in caplog.text
+        assert "deezer" in caplog.text
+        assert (
+            hass.services.async_call.await_args.args[2]["media_content_type"]
+            == "APPLE_MUSIC"
+        )
+
+    def test_only_the_first_of_several_artists_is_spoken(self):
+        alexa = AlexaStrategy(_context(_hass(), "alexa_media"))
+        text = alexa._get_alexa_search_text({"artist": "A;B", "title": "T"})
+        assert text == "T by A"
+
+    @pytest.mark.asyncio
+    async def test_it_remembers_nothing_of_the_host_queue(self):
+        alexa = AlexaStrategy(_context(_hass(), "alexa_media"))
+        assert await alexa.capture_queue() is None
+
+
+class TestMusicAssistantOnItsOwn:
+    """Only the part of Music Assistant that the other two do not have."""
+
+    @pytest.mark.asyncio
+    async def test_it_is_the_only_platform_that_reports_a_queue(self):
+        """#2143: ``get_queue`` exists in Music Assistant and nowhere else."""
+        hass = _hass(
+            {
+                "media_player.esszimmer": {
+                    "current_item": {
+                        "media_item": {"uri": "apple_music://track/1", "name": "María"}
+                    },
+                    "elapsed_time": 42.0,
+                    "shuffle_enabled": True,
+                    "repeat_mode": "all",
+                }
+            }
+        )
+        ma = MusicAssistantStrategy(_context(hass, "music_assistant"))
+
+        assert await ma.capture_queue() == {
+            "uri": "apple_music://track/1",
+            "name": "María",
+            "elapsed_time": 42.0,
+            "shuffle": True,
+            "repeat_mode": "all",
+        }
+        assert _calls(hass) == [("music_assistant", "get_queue")]
+
+    @pytest.mark.asyncio
+    async def test_an_idle_speaker_reports_an_empty_snapshot_not_none(self):
+        """``{}`` and ``None`` are different answers: ``{}`` means "asked, and
+        there was nothing", which stops the shell asking again in round two."""
+        ma = MusicAssistantStrategy(_context(_hass({}), "music_assistant"))
+        assert await ma.capture_queue() == {}
+
+    def test_the_candidate_cascade_stays_inside_the_users_provider(self):
+        """#805, checkable without a speaker, a game or the other platforms."""
+        ma = MusicAssistantStrategy(_context(_hass(), "music_assistant", "apple_music"))
+        candidates = ma.uri_candidates(
+            {
+                "_resolved_uri": "applemusic://track/1",
+                "uri_apple_music": "applemusic://track/2",
+                "uri_spotify": "spotify:track:NOPE",
+            }
+        )
+        assert [uri for _, uri in candidates] == [
+            "apple_music://track/1",
+            "apple_music://track/2",
+        ]
+
+
+class TestTheAttemptRecordIsSharedNotDuplicated:
+    """``last_attempted_uri`` / ``last_failure_reason`` are read off the service
+    by ``game/state_lifecycle.py``, and written by whichever strategy ran. Both
+    sides therefore read one place — the context."""
+
+    def test_what_the_strategy_writes_the_context_reports(self):
+        context = _context(_hass(), "sonos")
+        strategy = build_strategy(context)
+
+        strategy.last_attempted_uri = "spotify:track:ABC123"
+        strategy.last_failure_reason = "unavailable"
+
+        assert context.last_attempted_uri == "spotify:track:ABC123"
+        assert context.last_failure_reason == "unavailable"

--- a/tests/unit/test_queue_restore_stays_paused_2605.py
+++ b/tests/unit/test_queue_restore_stays_paused_2605.py
@@ -31,8 +31,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from custom_components.beatify.services import media_player as mp
-from custom_components.beatify.services.media_player import MediaPlayerService
+from custom_components.beatify.services.playback import queue_restore
+from custom_components.beatify.services.playback.queue_restore import MaQueueRestorer
 
 QUEUE = {
     "uri": "apple_music://track/1705321808",
@@ -53,12 +53,12 @@ def _fast_guard(monkeypatch):
     Sonos, unbearable in a unit suite. Only the durations shrink; the logic
     under test is untouched.
     """
-    monkeypatch.setattr(mp, "MA_PAUSE_CONFIRM_WAIT", 0.20)
-    monkeypatch.setattr(mp, "MA_PAUSE_SETTLE_HOLD", 0.30)
-    monkeypatch.setattr(mp, "MA_PAUSE_GUARD_WINDOW", 2.0)
-    monkeypatch.setattr(mp, "MA_PAUSE_POLL", 0.02)
-    monkeypatch.setattr(mp, "MA_QUEUE_RESTORE_WAIT", 0.20)
-    monkeypatch.setattr(mp, "MA_QUEUE_RESTORE_POLL", 0.02)
+    monkeypatch.setattr(queue_restore, "MA_PAUSE_CONFIRM_WAIT", 0.20)
+    monkeypatch.setattr(queue_restore, "MA_PAUSE_SETTLE_HOLD", 0.30)
+    monkeypatch.setattr(queue_restore, "MA_PAUSE_GUARD_WINDOW", 2.0)
+    monkeypatch.setattr(queue_restore, "MA_PAUSE_POLL", 0.02)
+    monkeypatch.setattr(queue_restore, "MA_QUEUE_RESTORE_WAIT", 0.20)
+    monkeypatch.setattr(queue_restore, "MA_QUEUE_RESTORE_POLL", 0.02)
 
 
 class Speaker:
@@ -120,8 +120,15 @@ def _hass_for(speaker: Speaker | None = None, fixed_state: str = "playing"):
     return hass
 
 
-def _service(hass) -> MediaPlayerService:
-    return MediaPlayerService(hass, ENTITY, platform="music_assistant")
+def _guard(hass) -> MaQueueRestorer:
+    """The guard on its own — no service, no strategy, no game (#2636).
+
+    This used to read ``MediaPlayerService(hass, ENTITY,
+    platform="music_assistant")``, which dragged in the URI cascade, the
+    provider table, the analytics hook and the volume bookkeeping to test a
+    ``media_pause``. The guard now takes a ``hass`` and nothing else.
+    """
+    return MaQueueRestorer(hass)
 
 
 def _services_called(hass) -> list[tuple[str, str]]:
@@ -151,9 +158,9 @@ class TestTheGuardOutlivesTheSettling:
         """
         speaker = Speaker(resume_after=0.08, obeys_from=2)
         hass = _hass_for(speaker)
-        svc = _service(hass)
+        guard = _guard(hass)
 
-        assert await svc._restore_queue_on(ENTITY, QUEUE) is True
+        assert await guard.restore_on(ENTITY, QUEUE) is True
 
         assert speaker.pause_count >= 2, (
             "the speaker started playing again after the first pause and the "
@@ -170,19 +177,19 @@ class TestTheGuardOutlivesTheSettling:
         """
         speaker = Speaker(resume_after=0.08)  # never settles
         hass = _hass_for(speaker)
-        svc = _service(hass)
+        guard = _guard(hass)
 
-        assert await svc._pause_and_confirm(ENTITY) is False
+        assert await guard.pause_and_confirm(ENTITY) is False
         assert speaker.pause_count >= 2
 
     @pytest.mark.asyncio
     async def test_the_log_line_says_the_speaker_is_still_playing(self, caplog):
         speaker = Speaker(resume_after=0.08)
         hass = _hass_for(speaker)
-        svc = _service(hass)
+        guard = _guard(hass)
 
         with caplog.at_level("INFO"):
-            await svc._restore_queue_on(ENTITY, QUEUE)
+            await guard.restore_on(ENTITY, QUEUE)
 
         restored = [r for r in caplog.records if "Queue restored on" in r.getMessage()]
         assert restored, "no restore line was logged at all"
@@ -199,9 +206,9 @@ class TestTheGuardOutlivesTheSettling:
         half of why a single reading cannot be trusted.
         """
         hass = _hass_for(fixed_state="buffering")
-        svc = _service(hass)
+        guard = _guard(hass)
 
-        assert await svc._pause_and_confirm(ENTITY) is False
+        assert await guard.pause_and_confirm(ENTITY) is False
         assert _pause_calls(hass) >= 2
 
 
@@ -210,9 +217,9 @@ class TestTheCommonCaseDoesNotPayForIt:
     async def test_a_speaker_that_stays_paused_is_paused_once(self):
         speaker = Speaker(resume_after=99.0, obeys_from=1)
         hass = _hass_for(speaker)
-        svc = _service(hass)
+        guard = _guard(hass)
 
-        assert await svc._restore_queue_on(ENTITY, QUEUE) is True
+        assert await guard.restore_on(ENTITY, QUEUE) is True
         assert speaker.pause_count == 1
 
     @pytest.mark.asyncio
@@ -220,9 +227,9 @@ class TestTheCommonCaseDoesNotPayForIt:
         """``states.get`` returning None means there is nothing left to pause."""
         hass = _hass_for()
         hass.states.get = MagicMock(return_value=None)
-        svc = _service(hass)
+        guard = _guard(hass)
 
-        assert await svc._restore_queue_on(ENTITY, QUEUE) is True
+        assert await guard.restore_on(ENTITY, QUEUE) is True
 
     @pytest.mark.asyncio
     async def test_an_entity_that_vanishes_mid_hold_ends_the_watch(self):
@@ -240,9 +247,9 @@ class TestTheCommonCaseDoesNotPayForIt:
             return st
 
         hass.states.get = MagicMock(side_effect=_get)
-        svc = _service(hass)
+        guard = _guard(hass)
 
-        assert await svc._pause_and_confirm(ENTITY) is True
+        assert await guard.pause_and_confirm(ENTITY) is True
 
 
 class TestOrderingStillHolds:
@@ -258,9 +265,9 @@ class TestOrderingStillHolds:
         """
         speaker = Speaker(resume_after=99.0, obeys_from=1)
         hass = _hass_for(speaker)
-        svc = _service(hass)
+        guard = _guard(hass)
 
-        assert await svc._restore_queue_on(ENTITY, QUEUE) is True
+        assert await guard.restore_on(ENTITY, QUEUE) is True
 
         calls = _services_called(hass)
         pause_at = calls.index(("media_player", "media_pause"))

--- a/tests/unit/test_tidal_name_fallback.py
+++ b/tests/unit/test_tidal_name_fallback.py
@@ -17,8 +17,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from custom_components.beatify.services.media_player import (
-    MediaPlayerService,
+from custom_components.beatify.services.media_player import MediaPlayerService
+from custom_components.beatify.services.playback.music_assistant import (
     _edition_matches,
 )
 
@@ -114,8 +114,8 @@ class TestTidalNameFallback:
             calls.append(uri)
             return True
 
-        with patch.object(svc, "_try_ma_play", side_effect=fake_try):
-            assert await svc._play_via_music_assistant(song) is True
+        with patch.object(svc._strategy, "try_play", side_effect=fake_try):
+            assert await svc._strategy.play(song) is True
 
         # The stored id is normalised to a browse URL on the way out; what
         # matters is that exactly one call happened and it was not the name.
@@ -135,8 +135,8 @@ class TestTidalNameFallback:
             calls.append(uri)
             return True
 
-        with patch.object(svc, "_try_ma_play", side_effect=fake_try):
-            assert await svc._play_via_music_assistant(song) is True
+        with patch.object(svc._strategy, "try_play", side_effect=fake_try):
+            assert await svc._strategy.play(song) is True
 
         assert calls == ["Song"]
 
@@ -151,8 +151,8 @@ class TestTidalNameFallback:
             calls.append(uri)
             return uri == "Song"  # the stored URI is dead, the name works
 
-        with patch.object(svc, "_try_ma_play", side_effect=fake_try):
-            assert await svc._play_via_music_assistant(song) is True
+        with patch.object(svc._strategy, "try_play", side_effect=fake_try):
+            assert await svc._strategy.play(song) is True
 
         assert len(calls) == 2
         assert "999" in calls[0]  # stored URI first, normalised to a browse URL
@@ -167,8 +167,8 @@ class TestTidalNameFallback:
         )
         song = {"title": "Satisfaction", "artist": "Benny Benassi"}
 
-        with patch.object(svc, "_try_ma_play", AsyncMock(return_value=True)):
-            assert await svc._play_via_music_assistant(song) is False
+        with patch.object(svc._strategy, "try_play", AsyncMock(return_value=True)):
+            assert await svc._strategy.play(song) is False
 
         assert svc.last_failure_reason == "wrong_track"
 
@@ -179,8 +179,8 @@ class TestTidalNameFallback:
         song = {"title": "Song", "artist": "Artist"}
         try_ma = AsyncMock(return_value=True)
 
-        with patch.object(svc, "_try_ma_play", try_ma):
-            assert await svc._play_via_music_assistant(song) is False
+        with patch.object(svc._strategy, "try_play", try_ma):
+            assert await svc._strategy.play(song) is False
 
         try_ma.assert_not_called()
         assert svc.last_failure_reason == "unavailable"
@@ -192,8 +192,8 @@ class TestTidalNameFallback:
         song = {"title": "Song"}
         try_ma = AsyncMock(return_value=True)
 
-        with patch.object(svc, "_try_ma_play", try_ma):
-            assert await svc._play_via_music_assistant(song) is False
+        with patch.object(svc._strategy, "try_play", try_ma):
+            assert await svc._strategy.play(song) is False
 
         try_ma.assert_not_called()
         assert svc.last_failure_reason == "unavailable"


### PR DESCRIPTION
`services/media_player.py` held Music Assistant, Sonos and Alexa in one class
body and dispatched between them with `if self._platform ==`. Each platform is
now its own module behind one interface, and the choice between them happens in
exactly one function.

Closes #2636

## The shape

```
services/playback/
  __init__.py         build_strategy() — the only place a platform picks an implementation
  base.py             PlaybackStrategy: play(), capture_queue(), platforms
  context.py          PlayerContext: the speaker, and the reads a strategy may make
  uris.py             convert_uri_for_ma / uri_match_tokens (needed on both sides)
  music_assistant.py  993 lines that no other platform reads
  sonos.py            42
  alexa.py            84
  queue_restore.py    MaQueueRestorer — #2143 hand-back + the #2605/#2671 guard
```

`services/media_player.py`: **2526 → 1196 lines**. What stays is what is not
per-platform — discovery, the album-art proxy, analytics, volume save/restore,
the metadata wait, the pre-flight check, and the game-lifecycle bookkeeping
around the queue snapshot.

Adding Plex or Jellyfin is now a new module plus one entry in `_STRATEGIES`.
Before, it meant cutting open five methods.

## Where the issue's framing did not fit the code

#2636 describes three strategies behind `PLATFORM_CAPABILITIES` with
`play / save_queue / restore_queue / verify` on each. Two of those four are not
per-platform, and forcing them through the strategy would have introduced bugs:

* **`restore_queue` is keyed on the snapshot, not on the current platform.**
  A game that starts on a Music Assistant speaker and switches to a Sonos one
  still owes the first speaker its queue back, and settles that debt through
  `music_assistant.play_media` while `self._platform` is `"sonos"`. Routing it
  through the current strategy would silently drop the hand-back. It lives in
  `MaQueueRestorer`, which takes an entity id and a snapshot and asks nothing
  about platforms.
* **`verify_responsive` has no platform branch at all.** The issue cites one at
  `:2002` across 342 lines; the method is 78 lines of `volume_set` /
  `update_entity` with no `_platform` reference. Left where it is.
* **`save_queue` is two questions, not one.** WHAT can be remembered is the
  platform's (only MA has `get_queue`) — that became `capture_queue()`. WHEN it
  is remembered is the game's (once per game, #2143) — that guard stayed in the
  shell.

So: three playback strategies, plus one queue collaborator that is
Music-Assistant-only but not platform-dispatched.

## How I convinced myself behaviour is unchanged

Not by reading. I compared the AST of every moved function against
`origin/main`, with the renames applied and docstrings stripped: **24 of 29
bodies are identical statement for statement**. The five that differ do so only
in the rename itself — `self._safe_state()` → `self.context.state()`,
`self._restore_queue_on` → `self._restorer.restore_on`, and the
`@staticmethod` / `@classmethod` decorators dropped from the two URI helpers.

**The #2671 guard is in the identical set.** `pause_and_confirm`,
`_wait_until_quiet`, `_stays_quiet`, `_wait_for_playing`, `restore_on`,
`MA_PAUSE_SETTLE_HOLD`, `MA_PAUSE_GUARD_WINDOW` and `buffering` in
`MA_ACTIVE_STATES` all moved byte-for-byte into `queue_restore.py`. So did
`_try_ma_play` (454 lines), `_get_ma_uri_candidates`, both `_play_via_*`
methods and every match helper.

Its tests keep every assertion. Only the wiring changed: `_guard(hass)` now
returns `MaQueueRestorer(hass)` where it used to return
`MediaPlayerService(hass, ENTITY, platform="music_assistant")`.

## Testability, with numbers

* `test_queue_restore_stays_paused_2605.py` — 8 tests, unchanged assertions.
  Testing a `media_pause` no longer constructs a service that drags in the URI
  cascade, the provider table, the analytics hook and the volume bookkeeping.
* `test_playback_strategies_2636.py` — **new, 23 tests, 242 lines, 0.03s.**
  Covers the dispatch table and all three platforms. There is no
  `MediaPlayerService` and no game anywhere in the file; each test builds one
  strategy over a mock `hass`. `test_it_never_touches_the_music_assistant_domain`
  is the assertion the old layout could not make.
* The 2787-line `test_media_player.py` can now be split per platform. Not done
  here — this PR moves code, not tests, beyond what the move required.

## Worth a second look

1. **`last_attempted_uri` / `last_failure_reason` moved to the context.** Both
   the shell (seeds the record from the dispatcher's URI) and the MA strategy
   (overwrites it per candidate) write them, and `game/state_lifecycle.py`
   reads them off the service via `getattr`. They are properties on
   `MediaPlayerService` now, with setters, so external readers and writers are
   unaffected — but check the property pair.
2. **`PlayerContext.save_queue` is a callback.** The strategy knows the moment
   the host's queue is about to be replaced; the shell owns the bookkeeping. It
   is the one place the two are coupled, and I would rather a reviewer confirm
   the direction is right.
3. **`capture_queue` returning `None` vs `{}`.** `{}` means "asked, nothing was
   playing" and stops round two asking again; `None` means "this platform
   cannot say" and leaves `_saved_queue` unset. The old code expressed this as
   an early return on `self._platform != "music_assistant"`.
4. **Constants moved with the code they govern.** Tests patch them where they
   now live. A stale patch target now raises `AttributeError` rather than
   silently restoring a 15-second timeout — that is deliberate, but it means
   any patch of `media_player.MA_*` outside this PR will fail loudly.
5. **`PlayerContext.state()` logs under `services.playback.context`**, not
   `services.media_player`. Only affects the logger name on the defensive
   `hass.states.get` warning.

## Found on the way, not fixed here

* `PLATFORM_CAPABILITIES` and the strategies now both know which platforms
  exist, and they disagree: the table has a `cast` entry marked
  `supported: False`, while `build_strategy` expresses the same fact by
  returning `None`. Two sources of truth for one question. Deriving the table's
  `supported` flag from `supported_platforms()` is a small follow-up; it would
  have changed behaviour to do it here.
* `verify_responsive` caches `_preflight_verified` per service instance, so a
  mid-game speaker switch re-verifies from scratch while `_saved_volume` and
  `_saved_queue` are carried across. Probably intended, but the two lifetimes
  differ and nothing says so.

## Checks

| | |
|---|---|
| `pytest tests/unit tests/integration -q` | 2461 passed, 2 skipped |
| `npm test` | 886 passed (87 files) |
| `npm run build:check` | 18 artifacts + 78 .gz siblings match |
| `ruff format --check .` | 232 files already formatted |
| `ruff check .` | All checks passed |

Rebased onto `origin/main` at f317881f (after #2672 and #2674); no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKsEKt68KHSqmi617XNCVi
