### PR TITLE
release: v4.4.3-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [4.4.3-rc1] - 2026-09-06
+
+Die Woche 2026-W38: zweiunddreissig Eintraege aus der Redaktionskonferenz, alle gebaut und gemergt —
+am Sonntag statt am Mittwoch. Der Kandidat traegt sie vollstaendig.
+
+### Fixed
+- **Der Lautsprecher spielte nach dem Spielende weiter (#2605).** Zweiter Anlauf: der Fix aus rc3 der
+  Vorwoche sah nach dem Pausieren zwei Sekunden lang nach und bekam die Bestaetigung beim ersten
+  Blick. Die Pause wird jetzt gehalten und bei einem Rueckfall erneut geschickt, `buffering` zaehlt
+  als spielend. Dabei kam ein **zweites Loch mit demselben Titel** heraus: endete die letzte Runde
+  unbeaufsichtigt ueber den REVEAL-Timer statt per Knopf, hat niemand den Lautsprecher gestoppt.
+- **Der Fernseher fror ein, statt den Pausen-Screen zu zeigen (#2617).**
+- **Zuschauer im Finale wurden gewertet und durften raten (#2612).**
+- **Auto-Advance beendete das Spiel ohne Broadcast (#2613).**
+- **Die Jahres-Pruefung ignorierte den geweiteten Schieberegler (#2623).**
+- **Zwei Songs mit gleichem Titel liefen hintereinander (#2616).**
+- **Der Fehlerzaehler ueberlebte das Spielende (#2614)**, das Deferral-Flag den Reset (#2615).
+- **Ein spaeter Gast liess sich nicht mehr einladen (#2621).**
+- **Halb deutsche, halb englische Zeilen** auf Startkarte, Fernseher, Endbild und im Reveal
+  (#2620, #2618, #2619, #2624).
+- **Ein totes Rate-Limit-Attribut** liess zwei Library-Views auf dem 5/min-Default laufen (#2628).
+
+### Changed
+- **Geteilte Konstanten haben je eine Definition** statt drei bis acht Kopien — Punktetabelle,
+  Auto-Advance-Werte, Namenslaenge, Spieloptionen (#2625, #2626, #2627, #2635).
+- **`MediaPlayerService` 2526 -> 1196 Zeilen**, je ein Modul pro Plattform hinter einer
+  Dispatch-Stelle (#2636).
+- **`admin.js` und seine Sektionen haengen nicht mehr im Kreis** ueber 14 `window`-Globals; sechs
+  davon waren tot (#2637).
+- **`GameState` baut sich seine HA-Dienste nicht mehr selbst** und haelt keinen Server-Socket mehr
+  (#2638).
+- **Der Spieler-Zustand ist eine Allowlist** statt einer Denylist ueber ~59 Felder (#2634).
+- **Statische Dateien werden vorkomprimiert ausgeliefert** (#2640); das Konfetti-Skript blockiert den
+  Beitritt nicht mehr (#2641).
+- **`main` hat Branch-Schutz** — 13 Pflicht-Checks (#2644).
+
+### Removed
+- Tote `GameService`-Fassade (#2629), `async_musicbrainz_year` (#2631), ein dokumentierter Fallback
+  ohne Verdrahtung (#2632), `PartyLightsService.strobe` (#2633), drei Animationshelfer ohne Aufrufer
+  (#2630).
+
 ## [4.4.2] - 2026-09-05
 
 Die Woche 2026-W37: fuenfzehn Eintraege aus der Redaktionskonferenz, alle gebaut, getestet und

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -20,5 +20,5 @@
     "num2words==0.5.14"
   ],
   "single_config_entry": true,
-  "version": "4.4.2"
+  "version": "4.4.3"
 }

--- a/docs/release-notes-v4.4.3-rc1.md
+++ b/docs/release-notes-v4.4.3-rc1.md
@@ -1,0 +1,17 @@
+## 4.4.3-rc1 — Closing Time
+
+The end of a game finally behaves like an ending, and the screens that spoke half English stopped doing it.
+
+### 🔇 When it's over, it's over
+
+The speaker kept playing after the last round. That was fixed once and came back, so this time the pause is held and re-applied for a few seconds rather than checked once — and the final round that ends on its own, with nobody touching the host phone, now stops the music too. Spectators sitting out a finale playoff no longer score or guess.
+
+### 🗣️ Every screen, your language
+
+The host's setup line, the statistics on the TV, the end screen on your phone and the reveal all mixed German into English. They don't now. A guest joining on party wifi with no internet also gets the join button straight away, instead of waiting out a download that was never going to arrive.
+
+---
+
+**66 playlists · 8,432 songs · 6 music platforms · 6 languages**
+
+[Report a Bug](https://github.com/mholzi/beatify/issues) · [Discussions](https://github.com/mholzi/beatify/discussions) · [Full Changelog](https://github.com/mholzi/beatify/blob/main/CHANGELOG.md)


### PR DESCRIPTION
Cuts the release candidate for the week 2026-W38. All **32 entries** of the editorial plan are merged — on Sunday rather than Wednesday.

**Playlist version check (step 3 of `rc-cut`):** one playlist file changed since `v4.4.2` — `community/100-greatest-rock-songs.json` — and its `version` field went `0.15` → `0.16` in the same commit. The change therefore reaches existing installations; `_copy_bundled_playlists` only overwrites on a strictly higher version.

**Gates run locally on this branch:** pytest 2461 passed / 2 skipped, vitest 912 passed across 93 files, `build:check` 16 artifacts and 76 `.gz` siblings match, `ruff format --check` 232 files clean.

Contents: 27 commits, listed in the CHANGELOG section this PR adds.

Two things this candidate does **not** yet prove, both for Thursday's live test:
- Which of the two mechanisms actually caused the speaker to resume after the game ended (#2605). A new INFO line names it when it fires.
- Whether five seconds of holding the pause is enough, and what happens with grouped speakers — the guard watches only the entity Beatify was given.