### PR TITLE
release: v4.4.3 — Closing Time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
-## [4.4.3-rc1] - 2026-09-06
+## [4.4.3] - 2026-09-06
 
 Die Woche 2026-W38: zweiunddreissig Eintraege aus der Redaktionskonferenz, alle gebaut und gemergt —
-am Sonntag statt am Mittwoch. Der Kandidat traegt sie vollstaendig.
+am Sonntag statt am Mittwoch. Der Live-Test gegen den Kandidaten war sauber; **`main` lag beim Cut
+exakt auf dem getesteten Tag** (`ahead_by 0`), das Stable traegt also genau den geprueften Stand.
+Ein Befund steht offen und haelt das Release nicht auf: bei einer von 23 Wiedergaben blieben unter
+Apple-Music-Drosselung nur 0,4 s bis zum Timeout ([#2682](https://github.com/mholzi/beatify/issues/2682)).
 
 ### Fixed
 - **Der Lautsprecher spielte nach dem Spielende weiter (#2605).** Zweiter Anlauf: der Fix aus rc3 der

--- a/docs/release-notes-v4.4.3.md
+++ b/docs/release-notes-v4.4.3.md
@@ -1,0 +1,17 @@
+## 4.4.3 — Closing Time
+
+The end of a game finally behaves like an ending, and the screens that spoke half English stopped doing it.
+
+### 🔇 When it's over, it's over
+
+The speaker kept playing after the last round. That was fixed once and came back, so this time the pause is held and re-applied for a few seconds rather than checked once — and the final round that ends on its own, with nobody touching the host phone, now stops the music too. Spectators sitting out a finale playoff no longer score or guess.
+
+### 🗣️ Every screen, your language
+
+The host's setup line, the statistics on the TV, the end screen on your phone and the reveal all mixed German into English. They don't now. A guest joining on party wifi with no internet also gets the join button straight away, instead of waiting out a download that was never going to arrive.
+
+---
+
+**66 playlists · 8,432 songs · 6 music platforms · 6 languages**
+
+[Report a Bug](https://github.com/mholzi/beatify/issues) · [Discussions](https://github.com/mholzi/beatify/discussions) · [Full Changelog](https://github.com/mholzi/beatify/blob/main/CHANGELOG.md)


### PR DESCRIPTION
Promotes `v4.4.3-rc1` to stable.

The manifest already carries `4.4.3`, so this only merges the CHANGELOG section and adds the stable release notes.

**All six abort conditions of `release-cut` were checked before anything was written:**

| # | Condition | Result |
|---|---|---|
| 1 | `live_test.bestanden` false | passed — both runs clean |
| 2 | no live test ran | ran today, backend and frontend |
| 3 | `veto: true` | not set |
| 4 | another gate condition red | all 32 plan entries merged |
| 5 | no rc tagged | `v4.4.3-rc1` |
| 6 | `main` ahead of the tested rc | **`ahead_by 0`** via the compare API |

Condition 6 is the one that caught a real problem on 2026-09-05, when a commit reached `main` after the rc tag and no test had ever seen it. Here `main` sits exactly on the tested tag, so the stable carries the tested code and nothing else.

**One finding is open and does not hold the release** ([#2682](https://github.com/mholzi/beatify/issues/2682)): one of 23 playback starts in the live test took 14.6 s of the 15 s budget while Apple Music was throttling. Nothing failed; the margin is a measurement, not a safety margin.

README counts were recomputed from the repo (66 playlists, 8,432 songs) and already matched, so nothing there was touched.