### PR TITLE
data: remove dead YT Music + Tidal URIs from koelner-karneval — Räuber Op dem Maat (#2686)

### DIFF
--- a/custom_components/beatify/playlists/community/koelner-karneval.json
+++ b/custom_components/beatify/playlists/community/koelner-karneval.json
@@ -1,6 +1,6 @@
 {
   "name": "Cologne Carnival 🎭",
-  "version": "1.15",
+  "version": "1.16",
   "tags": [
     "german",
     "carnival",
@@ -2640,9 +2640,7 @@
         "nl": "applemusic://track/202229994",
         "it": "applemusic://track/202229994"
       },
-      "uri_tidal": "tidal://track/2117520",
-      "uri_deezer": "deezer://track/2473722",
-      "uri_youtube_music": "https://music.youtube.com/watch?v=uc8WS_pXXtM"
+      "uri_deezer": "deezer://track/2473722"
     },
     {
       "year": 1957,


### PR DESCRIPTION
Closes #2686

Removes 2 dead URIs from Räuber 'Op dem Maat' in the Köln Karneval playlist. The song has no licensed release on YouTube Music or Tidal (only unofficial fan uploads exist on YT); both URIs have been deny-listed since 2026-04-22 (#768). Song remains playable via Spotify, Apple Music, and Deezer.

Also cleans up all 4 now-orphaned entries from `known_bad_uris.json` (Spotify + Apple Music were already fixed in the playlist post-#768; YT + Tidal now removed by this PR).

- Removed `uri_youtube_music: https://music.youtube.com/watch?v=uc8WS_pXXtM`
- Removed `uri_tidal: tidal://track/2117520`
- Bumped version 1.15 → 1.16