### PR TITLE
fix(admin-ws): End ends the game, and a phone rematch keeps its own socket

### DIFF
--- a/custom_components/beatify/server/ws_handlers/admin.py
+++ b/custom_components/beatify/server/ws_handlers/admin.py
@@ -355,7 +355,17 @@ async def admin_end_game(
 
     # #1702: record + end ceremony run once per game (shared claim with the
     # next_round terminal path).
-    await finalize_and_end(handler, game_state)
+    #
+    # #2689: allow_playoff=False, mirroring the REST EndGameView. End is the
+    # host saying "stop now", not a game reaching its natural end, and this WS
+    # path is the one the admin page actually uses. With the finale tiebreaker
+    # armed and a tie for first during REVEAL, the default allow_playoff=True
+    # made maybe_start_finale_playoff freeze every non-leader as a playoff
+    # spectator and start another song — so End visibly continued the game and
+    # only a second tap ended it, with the spectator flags on the end screen.
+    # The finale tiebreaker still fires on the paths it was written for: the
+    # last-round next_round branch and the REVEAL auto-advance.
+    await finalize_and_end(handler, game_state, allow_playoff=False)
     _LOGGER.info(
         "Admin ended game early at round %d - players preserved for rematch",
         game_state.round,
@@ -450,20 +460,41 @@ async def admin_rematch_game(
     await handler.cleanup_game_tasks()
 
     player_count = len(game_state.players)
+    # #2706: remember the spectator socket before rematch_game() runs — its
+    # reset callback (clear_admin_socket) nulls handler.admin_ws.
+    previous_admin_ws = handler.admin_ws
+    # #2706: decide on the socket identity BEFORE the rebuild, while the player
+    # records are guaranteed intact.
+    sender_is_participant = game_state.get_player_by_ws(ws) is not None
     game_state.rematch_game()
     # Issue #841 Phase 3: announce the rematch (use case 20). TTS survives
     # rematch_game() — only end_game() tears the service down.
     await game_state.announce_rematch()
     _LOGGER.info("Rematch started with %d players", player_count)
 
-    handler.admin_ws = ws
-    await ws.send_json(
-        {
-            "type": "admin_token_update",
-            "admin_token": game_state.admin_token,
-            "game_id": game_state.game_id,
-        }
-    )
+    # #2706: this action is reachable from EITHER admin-capable socket, and
+    # www/js/player-end.js sends it over the host's PARTICIPANT socket. Handing
+    # that phone the admin slot gave it the unredacted broadcast (answers,
+    # admin_song) for the whole rematch — exactly what _send_state_to forbids —
+    # while the admin page, which only sends admin_connect once on open, was
+    # left with the redacted copy and blank reveal fields. Only a genuine
+    # spectator socket may claim the slot; a phone-initiated rematch restores
+    # the spectator socket rematch_game() just cleared, if it is still open.
+    if not sender_is_participant:
+        handler.admin_ws = ws
+    elif previous_admin_ws is not None and not previous_admin_ws.closed:
+        handler.admin_ws = previous_admin_ws
+
+    # The new admin_token belongs to whoever holds the admin slot; the
+    # requesting socket gets it too, since it asked for the rematch.
+    token_msg = {
+        "type": "admin_token_update",
+        "admin_token": game_state.admin_token,
+        "game_id": game_state.game_id,
+    }
+    await ws.send_json(token_msg)
+    if handler.admin_ws is not None and handler.admin_ws is not ws:
+        await handler.admin_ws.send_json(token_msg)
     await handler.broadcast({"type": "rematch_started"})
     await handler.broadcast_state()
 

--- a/tests/unit/test_finale_1725.py
+++ b/tests/unit/test_finale_1725.py
@@ -20,7 +20,12 @@ from custom_components.beatify.game.state import (
     FINALE_PLAYOFF_MAX_ROUNDS,
     GamePhase,
 )
+from custom_components.beatify.server.ws_handlers import (
+    admin_end_game,
+    admin_next_round,
+)
 from tests.conftest import make_game_state, make_songs
+from tests.unit.test_websocket import _make_handler_and_game
 
 
 # ---------------------------------------------------------------------------
@@ -322,3 +327,74 @@ class TestFinalePlumbing:
         assert gs.finale_tiebreaker_enabled is True
         assert gs._finale_playoff_rounds == 0
         assert gs._finale_playoff_active is False
+
+
+# ---------------------------------------------------------------------------
+# #2689 — the End button ends the game; it never arms a playoff
+# ---------------------------------------------------------------------------
+
+
+async def _handler_game_in_reveal_tie():
+    """A tiebreaker-armed game sitting in REVEAL on a two-way tie for first.
+
+    Round 1 of a five-song game, so four unplayed songs remain — every
+    precondition ``maybe_start_finale_playoff`` looks for is satisfied.
+    """
+    handler, game_state, ws = _make_handler_and_game(
+        songs=make_songs(5), finale_tiebreaker_enabled=True
+    )
+    game_state._media_player_service = _stub_media_service()
+    game_state.platform = "music_assistant"
+    for name in ("Alice", "Bob", "Carol"):
+        _add_live_player(game_state, name)
+    await game_state.start_round()
+    _reveal_with_scores(game_state, {"Alice": 10, "Bob": 10, "Carol": 4})
+    assert game_state.songs_remaining >= 1
+
+    game_state.advance_to_end = AsyncMock()
+    game_state.finalize_game = MagicMock(return_value={})
+    handler.broadcast_state = AsyncMock()
+    return handler, game_state, ws
+
+
+class TestEndGameNeverStartsAPlayoff:
+    """#2689 — ``test_no_trigger_outside_reveal`` above covers PLAYING only.
+
+    From REVEAL the gate is meant to fire, which is exactly why the host's End
+    button has to say so explicitly. Before the fix the WebSocket path — the
+    one the admin page uses — ran with the default ``allow_playoff=True``, so
+    End during REVEAL froze every non-leader as a playoff spectator and started
+    another song instead of ending the game.
+    """
+
+    async def test_end_during_reveal_ends_instead_of_arming_a_playoff(self):
+        handler, game_state, ws = await _handler_game_in_reveal_tie()
+        round_before = game_state.round
+
+        await admin_end_game(handler, ws, {"action": "end_game"}, game_state)
+
+        # The end ceremony ran — the game really ended on this one tap.
+        game_state.advance_to_end.assert_awaited_once()
+        # No playoff was armed.
+        assert game_state._finale_playoff_active is False
+        assert game_state._finale_playoff_rounds == 0
+        assert game_state.round == round_before
+        # Nobody was benched — the end screen carries no spectator flags.
+        for name in ("Alice", "Bob", "Carol"):
+            assert game_state.get_player(name).playoff_spectator is False
+
+    async def test_the_natural_end_path_still_arms_the_playoff(self):
+        """The door that must stay open: the last-round ``next_round`` branch.
+
+        Only the host's explicit End opts out; the game reaching its own end
+        still offers the sudden-death round.
+        """
+        handler, game_state, ws = await _handler_game_in_reveal_tie()
+        game_state.last_round = True
+
+        await admin_next_round(handler, ws, {"action": "next_round"}, game_state)
+
+        assert game_state._finale_playoff_active is True
+        assert game_state._finale_playoff_rounds == 1
+        assert game_state.get_player("Carol").playoff_spectator is True
+        game_state.advance_to_end.assert_not_awaited()

--- a/tests/unit/test_rematch_admin_socket_2706.py
+++ b/tests/unit/test_rematch_admin_socket_2706.py
@@ -1,0 +1,154 @@
+"""#2706 — a rematch from the host's phone must not claim the admin socket.
+
+``rematch_game`` is reachable from either admin-capable socket, and
+``www/js/player-end.js`` sends it over the host's **participant** socket. The
+handler used to assign ``handler.admin_ws = ws`` unconditionally, so after a
+phone-initiated rematch the phone was the spectator admin: ``broadcast()`` sent
+it the unredacted payload (the year answer, the fun fact, the library URI) for
+the whole rematch, while the admin page — which sends ``admin_connect`` once on
+open and has no ``rematch_started`` handler — was left with the redacted copy
+and blank reveal fields.
+
+The slot now only changes hands to a genuine spectator socket. A rematch tapped
+on a phone keeps the spectator socket the rebuild just cleared, as long as it is
+still open.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+from custom_components.beatify.game.state import GamePhase
+from custom_components.beatify.server.ws_handlers import admin_rematch_game
+from tests.conftest import make_songs
+from tests.unit.test_websocket import _make_handler_and_game, _make_ws
+
+
+async def _game_at_end_with_both_sockets():
+    """END phase, host seated on a phone, admin page on the spectator socket."""
+    handler, game_state, phone_ws = _make_handler_and_game(songs=make_songs(5))
+    game_state.add_player("Host", phone_ws)
+    game_state.set_admin("Host")
+    game_state.add_player("Guest", _make_ws())
+    game_state.phase = GamePhase.END
+
+    admin_page_ws = _make_ws()
+    handler.admin_ws = admin_page_ws
+
+    handler.cleanup_game_tasks = AsyncMock()
+    game_state.announce_rematch = AsyncMock()
+    handler.broadcast = AsyncMock()
+    handler.broadcast_state = AsyncMock()
+    return handler, game_state, phone_ws, admin_page_ws
+
+
+def _token_updates(ws) -> list[dict]:
+    return [
+        call.args[0]
+        for call in ws.send_json.call_args_list
+        if call.args and call.args[0].get("type") == "admin_token_update"
+    ]
+
+
+class TestPhoneInitiatedRematch:
+    async def test_the_phone_does_not_take_over_the_admin_socket(self):
+        (
+            handler,
+            game_state,
+            phone_ws,
+            admin_page_ws,
+        ) = await _game_at_end_with_both_sockets()
+
+        await admin_rematch_game(
+            handler, phone_ws, {"action": "rematch_game"}, game_state
+        )
+
+        assert handler.admin_ws is admin_page_ws
+        assert handler.admin_ws is not phone_ws
+
+    async def test_the_phone_keeps_getting_the_redacted_broadcast(self):
+        """The harm the socket swap caused, asserted at the broadcast."""
+        (
+            handler,
+            game_state,
+            phone_ws,
+            admin_page_ws,
+        ) = await _game_at_end_with_both_sockets()
+        handler.connections.add(phone_ws)
+
+        await admin_rematch_game(
+            handler, phone_ws, {"action": "rematch_game"}, game_state
+        )
+
+        # The real broadcast, not the stub the fixture installs.
+        handler.broadcast = type(handler).broadcast.__get__(handler)
+        await handler.broadcast(
+            {
+                "type": "state",
+                "phase": "PLAYING",
+                "admin_song": {"year": 1984, "fun_fact": "the answer"},
+            }
+        )
+
+        phone_payload = json.loads(phone_ws.send_str.call_args[0][0])
+        admin_payload = json.loads(admin_page_ws.send_str.call_args[0][0])
+        assert "admin_song" not in phone_payload
+        assert admin_payload["admin_song"]["year"] == 1984
+
+    async def test_the_admin_page_is_told_about_the_new_token(self):
+        (
+            handler,
+            game_state,
+            phone_ws,
+            admin_page_ws,
+        ) = await _game_at_end_with_both_sockets()
+
+        await admin_rematch_game(
+            handler, phone_ws, {"action": "rematch_game"}, game_state
+        )
+
+        for socket in (phone_ws, admin_page_ws):
+            updates = _token_updates(socket)
+            assert len(updates) == 1
+            assert updates[0]["admin_token"] == game_state.admin_token
+            assert updates[0]["game_id"] == game_state.game_id
+
+    async def test_a_closed_spectator_socket_is_not_replaced_by_the_phone(self):
+        (
+            handler,
+            game_state,
+            phone_ws,
+            admin_page_ws,
+        ) = await _game_at_end_with_both_sockets()
+        admin_page_ws.closed = True
+
+        await admin_rematch_game(
+            handler, phone_ws, {"action": "rematch_game"}, game_state
+        )
+
+        # Nothing to restore, but the phone still must not inherit the slot.
+        assert handler.admin_ws is None
+
+
+class TestSpectatorInitiatedRematch:
+    async def test_the_admin_page_still_claims_the_slot(self):
+        """The door that must stay open: rematch tapped on the admin page.
+
+        ``rematch_game`` nulls ``handler.admin_ws`` via its reset callback, so
+        the spectator socket has to re-claim it here or the TV/admin view loses
+        the unredacted feed for the whole rematch.
+        """
+        (
+            handler,
+            game_state,
+            _phone_ws,
+            admin_page_ws,
+        ) = await _game_at_end_with_both_sockets()
+
+        await admin_rematch_game(
+            handler, admin_page_ws, {"action": "rematch_game"}, game_state
+        )
+
+        assert handler.admin_ws is admin_page_ws
+        assert len(_token_updates(admin_page_ws)) == 1


### PR DESCRIPTION
Two bugs, both in `server/ws_handlers/admin.py`. One PR because separate branches would collide on the same file.

## #2689 — End during REVEAL started a playoff instead of ending the game

`admin_end_game` called `finalize_and_end(handler, game_state)` with the default `allow_playoff=True`, while the REST `EndGameView` passes `allow_playoff=False` explicitly with a comment explaining why. The WebSocket path is the one the admin page uses, so the guarded path was the one nobody took.

With the finale tiebreaker on and a tie for first, tapping End during REVEAL marked every non-leader `playoff_spectator=True`, started a new song, and returned without ending anything. The other guests' phones answered every tap with "You are sitting out this playoff", and a second End tap ended the game with the spectator flags still on the end screen.

**Chosen fix: mirror the REST view (`allow_playoff=False`), not a `last_round` gate on `maybe_start_finale_playoff`.** End is the host saying "stop now", not the game reaching its natural end, so the opt-out belongs to that one caller. Gating the state method on `last_round` would also suppress two legitimate natural-end paths: the `start_round()`-returned-False fallback in `admin_next_round`, and single-song games, where `last_round` is deliberately never raised (`total_rounds > 1` guard in `state_lifecycle.py`). That would trade this bug for a silent regression of #1725.

The tiebreaker still fires where it was written to: the last-round `next_round` branch and the REVEAL auto-advance.

## #2706 — a rematch from the host's phone hijacked the admin socket

`admin_rematch_game` assigned `handler.admin_ws = ws` unconditionally, but the action is accepted on either admin-capable socket and `www/js/player-end.js` sends it over the host's **participant** socket — after `rematch_game()` → `clear_admin_socket()` has just nulled the real spectator socket.

The phone therefore became `admin_ws`: `broadcast()` sent it the unredacted `admin_json` (year answer, fun fact, library URI) for the whole rematch, and the admin page — which sends `admin_connect` once on open and has no `rematch_started` handler — was left with the redacted copy, so its reveal fields went blank.

The slot now only changes hands to a genuine spectator socket (`get_player_by_ws(ws) is None`, evaluated before the rebuild while the player records are intact). A phone-initiated rematch restores the spectator socket the rebuild cleared, as long as it is still open. The new `admin_token` is delivered to that socket as well as to the requester.

## Tests

Both are regression tests, each verified by reverting the fix and watching it go red.

- `tests/unit/test_finale_1725.py` — extended rather than duplicated, since `test_no_trigger_outside_reveal` covered PLAYING only, which is how #2689 slipped through. `TestEndGameNeverStartsAPlayoff` drives a real game into REVEAL on a two-way tie with songs remaining and asserts End ends it: `advance_to_end` awaited once, no playoff armed, no `playoff_spectator` flags. A companion test asserts the last-round `next_round` path still arms the playoff.
- `tests/unit/test_rematch_admin_socket_2706.py` — a phone rematch leaves `admin_ws` on the admin page; the phone still receives the redacted broadcast (asserted through the real `broadcast()`, `admin_song` absent for the phone and present for the admin page); both sockets get the token update; a closed spectator socket is not replaced by the phone; and a rematch from the admin page still claims the slot.

Red-then-green: with `allow_playoff=False` reverted, 1 of the 21 finale tests fails. With the socket guard reverted, 4 of the 5 rematch tests fail — the spectator-initiated one keeps passing, which is the door that must stay open.

## Checks (from the worktree)

- `pytest tests/unit tests/integration -q` — 2468 passed, 2 skipped
- `npm test` — 93 files, 912 tests passed
- `npm run build:check` — 16 artifacts and 76 .gz siblings match source
- `python3 -m ruff format --check .` — 233 files already formatted (`ruff check .` also clean)

No frontend source touched, so no build artifacts to commit.

Closes #2689
Closes #2706

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKsEKt68KHSqmi617XNCVi