### PR TITLE
perf(library): keep Crate Digger's playlist build off the event loop

### DIFF
--- a/custom_components/beatify/library/__init__.py
+++ b/custom_components/beatify/library/__init__.py
@@ -27,6 +27,7 @@ unit-testable without Home Assistant installed.
 
 from __future__ import annotations
 
+import functools
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -45,6 +46,7 @@ __all__ = [
     "async_build_pool",
     "async_generate_library_playlist",
     "async_load_pool",
+    "async_load_pool_cached",
     "pool_path",
     "pool_stats",
 ]
@@ -57,7 +59,13 @@ def __getattr__(name: str) -> Any:
     breaks standalone use/tests of the pure logic. PEP 562 module __getattr__
     defers that import until one of these names is actually accessed.
     """
-    if name in ("async_build_pool", "async_load_pool", "pool_path", "pool_stats"):
+    if name in (
+        "async_build_pool",
+        "async_load_pool",
+        "async_load_pool_cached",
+        "pool_path",
+        "pool_stats",
+    ):
         from . import pool as _pool
 
         return getattr(_pool, name)
@@ -91,20 +99,19 @@ async def async_generate_library_playlist(
     """
     from . import pool as _pool
 
-    cached = await _pool.async_load_pool(hass)
+    # #2694: read-only, cached parse. This runs twice per game — at game
+    # creation and again from the pre-start hook that fires on the host's
+    # "Start" tap — and re-parsing an 11 MB pool blocked the event loop both
+    # times. The cache keys on the file's mtime+size, so a scan or correction
+    # invalidates it by itself. NOTHING below may mutate `cached`.
+    #
+    # The familiarity_band recompute that used to sit here (older pools stored
+    # an absolute, miscalibrated band) now happens once per pool version
+    # inside pool.prepare_pool_for_generate, in the executor.
+    cached = await _pool.async_load_pool_cached(hass)
     if not cached or not cached.get("songs"):
         _LOGGER.warning("No library pool built yet; run beatify.build_library_pool")
         return None
-
-    # Older pools stored an absolute (miscalibrated) familiarity_band. If the
-    # percentiles are present, recompute the band from them so existing pools
-    # get the corrected difficulty split without requiring a rescan.
-    from .popularity import percentile_band as _pband
-
-    for _s in cached["songs"]:
-        _pct = _s.get("popularity_percentile")
-        if _pct is not None:
-            _s["familiarity_band"] = _pband(_pct)
 
     band = slider_to_target_band(difficulty_slider)
 
@@ -117,15 +124,23 @@ async def async_generate_library_playlist(
         p = max(1, min(100, int(popularity_percent)))
         pop_min_pct = 1.0 - (p / 100.0)
 
-    playlist = generate_playlist(
-        cached["songs"],
-        size=size,
-        difficulty_band=band,
-        popularity_min_percentile=pop_min_pct,
-        genres=set(genres) if genres else None,
-        min_confidence=min_confidence,
-        balance_decades=balance_decades,
-        exclude_uris=exclude_uris,
+    # #2694: generate_playlist is pure and CPU-bound (dedupe + filtering +
+    # decade balancing over the whole pool). On an 18k-song library it blocked
+    # the event loop for ~40 ms here on Apple Silicon and several hundred on a
+    # Raspberry Pi, immediately in front of the first play_song. Off to a
+    # worker thread it goes.
+    playlist = await hass.async_add_executor_job(
+        functools.partial(
+            generate_playlist,
+            cached["songs"],
+            size=size,
+            difficulty_band=band,
+            popularity_min_percentile=pop_min_pct,
+            genres=set(genres) if genres else None,
+            min_confidence=min_confidence,
+            balance_decades=balance_decades,
+            exclude_uris=exclude_uris,
+        )
     )
     # Observability: one INFO line per generation so setting/effect mismatches
     # are visible in the HA log instead of needing UI archaeology.

--- a/custom_components/beatify/library/corrections.py
+++ b/custom_components/beatify/library/corrections.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import time
 from typing import Any
 
+from .generator import NORM_KEY_FIELD
 from .year_resolver import YearConfidence, _norm
 
 # Marks an entry a human has fixed. Enrichment and refresh both skip these, so
@@ -141,6 +142,10 @@ def apply_correction(
         updated["year_source"] = CORRECTION_SOURCE
 
     if identity_changed:
+        # The precomputed dedupe key (#2694) was derived from the OLD name.
+        # Drop it; entry_key falls back to computing one until the next
+        # finalize_pool writes a fresh one.
+        updated.pop(NORM_KEY_FIELD, None)
         # Genres inferred for the wrong track are wrong too; let the next
         # enrichment pass redo them for the corrected identity.
         updated["genres_checked"] = 0

--- a/custom_components/beatify/library/generator.py
+++ b/custom_components/beatify/library/generator.py
@@ -50,22 +50,43 @@ _BAND_SPILL_ORDER = {
 }
 
 
+# Precompiled once at import: `_norm_key` runs twice per song, so on an 18k
+# pool these two patterns were looked up 72,000 times per generated playlist.
+_VERSION_SUFFIX_RE = re.compile(
+    r"\s*[\(\[-].*?(remaster|remastered|live|mono|stereo|version|"
+    r"edit|mix|deluxe|feat\.?|featuring|explicit|radio).*?[\)\]]?$"
+)
+_NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
+
+#: Pool entries carry the precomputed dedupe key under this field (written by
+#: :func:`custom_components.beatify.library.pool.finalize_pool`). Pools built
+#: before that existed simply lack it and are recomputed on the fly.
+NORM_KEY_FIELD = "_norm_key"
+
+
+def _clean_part(s: str) -> str:
+    s = unicodedata.normalize("NFKD", s)
+    s = "".join(c for c in s if not unicodedata.combining(c))
+    s = s.lower()
+    s = _VERSION_SUFFIX_RE.sub("", s)
+    return _NON_ALNUM_RE.sub(" ", s).strip()
+
+
 def _norm_key(artist: str, title: str) -> str:
     """Normalized dedupe key: lowercased, accent-stripped, version-suffix-free."""
+    return f"{_clean_part(artist)}|{_clean_part(title)}"
 
-    def clean(s: str) -> str:
-        s = unicodedata.normalize("NFKD", s)
-        s = "".join(c for c in s if not unicodedata.combining(c))
-        s = s.lower()
-        s = re.sub(
-            r"\s*[\(\[-].*?(remaster|remastered|live|mono|stereo|version|"
-            r"edit|mix|deluxe|feat\.?|featuring|explicit|radio).*?[\)\]]?$",
-            "",
-            s,
-        )
-        return re.sub(r"[^a-z0-9]+", " ", s).strip()
 
-    return f"{clean(artist)}|{clean(title)}"
+def entry_key(entry: dict[str, Any]) -> str:
+    """Dedupe key for a pool entry — precomputed if the pool has it.
+
+    Older pools (written before ``_norm_key`` was stored) have no such field;
+    they fall back to computing it, so nothing breaks on an existing install.
+    """
+    key = entry.get(NORM_KEY_FIELD)
+    if isinstance(key, str) and key:
+        return key
+    return _norm_key(entry.get("artist") or "", entry.get("title") or "")
 
 
 def _decade(year: int) -> int:
@@ -153,7 +174,7 @@ def count_eligible(
     seen: set[str] = set()
     deduped: list[dict[str, Any]] = []
     for s_ in usable:
-        key = _norm_key(s_.get("artist") or "", s_.get("title") or "")
+        key = entry_key(s_)
         if key in seen:
             continue
         seen.add(key)
@@ -228,7 +249,7 @@ def generate_playlist(
     # 2) Dedupe by normalized (artist, title); keep the higher-confidence copy.
     by_key: dict[str, dict[str, Any]] = {}
     for s in trusted:
-        key = _norm_key(s.get("artist", ""), s.get("title", ""))
+        key = entry_key(s)
         prev = by_key.get(key)
         if prev is None or int(s.get("year_confidence", 0)) > int(
             prev.get("year_confidence", 0)

--- a/custom_components/beatify/library/matcher.py
+++ b/custom_components/beatify/library/matcher.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .generator import _norm_key, _to_song_entry
+from .generator import _norm_key, _to_song_entry, entry_key
 from .year_resolver import YearConfidence
 
 
@@ -49,7 +49,7 @@ def build_pool_index(
             continue
         if not s.get("uri_ma_library"):
             continue
-        key = _norm_key(s.get("artist", ""), s.get("title", ""))
+        key = entry_key(s)
         prev = index.get(key)
         if prev is None or int(s.get("year_confidence", 0)) > int(
             prev.get("year_confidence", 0)

--- a/custom_components/beatify/library/pool.py
+++ b/custom_components/beatify/library/pool.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from . import corrections
+from .generator import NORM_KEY_FIELD, _norm_key
 from .ma_client import (
     async_fetch_track_genres,
     async_iter_all_library_tracks,
@@ -70,6 +71,16 @@ _LOGGER = logging.getLogger(__name__)
 # **/*.json under that tree and would list the pool as a broken playlist in
 # the "Mine" tab. The pool is engine data, not a playlist.
 POOL_RELATIVE_PATH = "beatify/library_pool.json"
+
+# Parsed-pool cache (issue #2694). An 18k-song pool is a ~11 MB JSON document
+# and Crate Digger loads it TWICE per game — once at create, once from the
+# pre-start hook that fires on the host's "Start" tap. The parse is keyed by
+# the file's (path, mtime_ns, size), so any write — a scan checkpoint, a year
+# correction, a manual edit — produces a new key and the next load re-reads.
+# Held for a while, then dropped: a Raspberry Pi should not carry the pool in
+# RAM between parties.
+_POOL_CACHE_KEY = "library_pool_cache"
+_POOL_CACHE_TTL = 900.0  # seconds
 
 # Concurrency for popularity lookups (Deezer tolerates a few in flight).
 # MusicBrainz is serialized separately by its 1 req/s throttle.
@@ -137,6 +148,98 @@ async def async_load_pool(hass: HomeAssistant) -> dict[str, Any] | None:
         return None
 
 
+def _pool_signature(path: Path) -> tuple[str, int, int] | None:
+    """(path, mtime_ns, size) of the pool file, or None when it is unreadable.
+
+    Any write to the pool — scan checkpoint, refresh, correction, or a manual
+    edit — changes at least the mtime, so a stale parse can never be served.
+    """
+    try:
+        st = path.stat()
+    except OSError:
+        return None
+    return (str(path), st.st_mtime_ns, st.st_size)
+
+
+def prepare_pool_for_generate(pool: dict[str, Any]) -> dict[str, Any]:
+    """Do the per-song fix-ups the generate path needs, once. Blocking.
+
+    Both of these used to run on the event loop on EVERY generate call:
+
+    * ``familiarity_band`` — older pools stored an absolute (miscalibrated)
+      band; recomputing it from the stored percentile gives existing pools the
+      corrected difficulty split without a rescan.
+    * ``_norm_key`` — pools written before #2694 have no precomputed dedupe
+      key. Filling it here means the generator computes it once per pool
+      version instead of twice per song per game.
+
+    Call it from an executor. Mutates ``pool`` in place and returns it.
+    """
+    for entry in pool.get("songs") or ():
+        pct = entry.get("popularity_percentile")
+        if pct is not None:
+            entry["familiarity_band"] = percentile_band(pct)
+        if not entry.get(NORM_KEY_FIELD):
+            entry[NORM_KEY_FIELD] = _norm_key(
+                entry.get("artist") or "", entry.get("title") or ""
+            )
+    return pool
+
+
+def _cache_store(hass: HomeAssistant) -> dict[str, Any]:
+    from custom_components.beatify.const import DOMAIN
+
+    return hass.data.setdefault(DOMAIN, {})
+
+
+def invalidate_pool_cache(hass: HomeAssistant) -> None:
+    """Forget the cached parse (and cancel its eviction timer)."""
+    cached = _cache_store(hass).pop(_POOL_CACHE_KEY, None)
+    if cached is not None:
+        with contextlib.suppress(Exception):
+            cached["evict"].cancel()
+
+
+async def async_load_pool_cached(hass: HomeAssistant) -> dict[str, Any] | None:
+    """Load the pool for READ-ONLY use, reusing the previous parse.
+
+    Crate Digger loads the pool twice per game (game creation, then the
+    pre-start hook on the host's "Start" tap) and an 18k-song pool is ~11 MB
+    of JSON — a parse that blocked the event loop both times (#2694). The
+    parse is cached under ``hass.data`` keyed by the file's mtime and size, so
+    the second load is a dict lookup and any write invalidates it by itself.
+
+    THE RETURNED DICT IS SHARED. Callers must not mutate it; anything that
+    writes the pool back (build, refresh, corrections) must keep using
+    :func:`async_load_pool`, which always returns a fresh parse.
+    """
+    path = pool_path(hass)
+    store = _cache_store(hass)
+    signature = await hass.async_add_executor_job(_pool_signature, path)
+
+    cached = store.get(_POOL_CACHE_KEY)
+    if cached is not None and signature is not None and cached["sig"] == signature:
+        return cached["pool"]
+
+    invalidate_pool_cache(hass)
+    pool = await async_load_pool(hass)
+    if pool is None:
+        return None
+    await hass.async_add_executor_job(prepare_pool_for_generate, pool)
+
+    if signature is not None:
+        # Drop it again after a while: an idle Raspberry Pi should not hold
+        # the whole library in RAM between parties.
+        store[_POOL_CACHE_KEY] = {
+            "sig": signature,
+            "pool": pool,
+            "evict": hass.loop.call_later(
+                _POOL_CACHE_TTL, lambda: store.pop(_POOL_CACHE_KEY, None)
+            ),
+        }
+    return pool
+
+
 def finalize_pool(
     entries: dict[str, dict[str, Any]],
     *,
@@ -157,6 +260,13 @@ def finalize_pool(
         # Band by percentile within THIS library (fair + robust across
         # libraries); keep the absolute score only as an info hint.
         x["familiarity_band"] = percentile_band(pct)
+        # Precomputed dedupe key (#2694): the generator needed it twice per
+        # song per game, each time re-running NFKD + two regex passes. Written
+        # once here, when the entry is created. Recomputed only for entries
+        # that lack it (a rebuild does not redo the whole pool) or whose
+        # artist/title changed (async_build_pool drops the field in that case).
+        if not x.get(NORM_KEY_FIELD):
+            x[NORM_KEY_FIELD] = _norm_key(x.get("artist") or "", x.get("title") or "")
     usable = sum(
         1 for x in songs if int(x.get("year_confidence", 0)) >= DEFAULT_MIN_CONFIDENCE
     )
@@ -266,9 +376,12 @@ async def async_build_pool(
         if entry is None:
             new_tracks.append(t)
             continue
+        _prev_name = (entry.get("artist"), entry.get("title"))
         entry["title"] = t.get("title") or entry.get("title")
         entry["artist"] = t.get("artist") or entry.get("artist")
         entry["album"] = t.get("album") or entry.get("album")
+        if (entry.get("artist"), entry.get("title")) != _prev_name:
+            entry.pop(NORM_KEY_FIELD, None)  # stale; finalize_pool recomputes
         if t.get("genres"):
             entry["genres"] = t["genres"]
         refreshed += 1
@@ -481,6 +594,10 @@ async def async_build_pool(
 
 async def _write_pool(hass: HomeAssistant, pool: dict[str, Any]) -> None:
     path = pool_path(hass)
+    # The read cache keys on mtime+size, which already covers this; dropping it
+    # explicitly closes the window where a rewrite happens to land on the same
+    # mtime_ns AND the same byte count.
+    invalidate_pool_cache(hass)
 
     def _write() -> None:
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/custom_components/beatify/library/version.py
+++ b/custom_components/beatify/library/version.py
@@ -7,6 +7,32 @@ end-to-end on real hardware.
 
 CHANGELOG
 ---------
+0.9.3  The pool stops blocking the event loop on the way to the first song.
+       - Sampling a game's songs ran ENTIRELY on the event loop, twice per
+         game: once at create, once from the pre-start hook that fires on the
+         host's "Start" tap. Nothing else could run — no WebSocket frame, no
+         game timer, no unrelated Home Assistant automation — and it sat
+         directly in front of the first play_song, whose budget #2682 already
+         measured at 14.6 s of 15.
+       - Three changes, measured on an 18k-song / 10.5 MB pool:
+         * generate_playlist is pure, so it moved to async_add_executor_job.
+         * The parsed pool is cached under hass.data, keyed by the file's
+           mtime and size, so the pre-start load is a dict lookup instead of
+           an 11 MB json.loads. Any write — scan checkpoint, refresh, host
+           correction — changes the key and the next load re-reads. The cache
+           is dropped again after 15 idle minutes; a Pi should not hold the
+           library in RAM between parties.
+         * The dedupe key (NFKD + two regex passes, previously run twice per
+           song per game) is precomputed at build time and stored on the
+           entry as `_norm_key`. Entries written before this simply lack the
+           field and are computed on the fly, so no rescan is needed and
+           POOL_SCHEMA_VERSION stays at 1. An identity correction drops the
+           stale key; so does a scan that refreshes an entry's artist/title.
+       - generate_playlist: 38.2 ms -> 3.8 ms on that pool (and 32.7 ms on a
+         pre-0.9.3 pool, from precompiling the two regexes). Event-loop time
+         on the generate path: ~73 ms x2 -> 0.
+       - +14 checks (test_library_pool_cache.py).
+
 0.9.2  Players flag, the host fixes — no more reports about private libraries.
        - A player tapping "Wrong year?" on a Crate Digger song was still
          taking the public path: appending to the shared data-quality file
@@ -1109,7 +1135,7 @@ CHANGELOG
        - Beatify-schema output via uri_ma_library; const.py + playlist.py wired.
 """
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 __author__ = "DMW"
 __mode_name__ = "Crate Digger"
 

--- a/tests/unit/test_library_pool_cache.py
+++ b/tests/unit/test_library_pool_cache.py
@@ -1,0 +1,175 @@
+"""Crate Digger — the pool parse and playlist sampling must stay off the loop.
+
+Issue #2694: Crate Digger loaded and re-parsed an ~11 MB pool file and then
+sampled a playlist from it on the event loop, twice per game — once at game
+creation, once from the pre-start hook on the host's "Start" tap. Nothing
+else could run for the duration, and it sat directly in front of the first
+play_song.
+
+Three guards live here:
+
+* the dedupe key is stored on the entry at build time (and recomputed for
+  pools written before it existed, so an existing install keeps working),
+* the parse is cached under ``hass.data`` and re-read when the file changes,
+* the generate path uses the executor rather than the loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from custom_components.beatify.library import corrections, pool as pool_mod
+from custom_components.beatify.library.generator import (
+    NORM_KEY_FIELD,
+    _norm_key,
+    entry_key,
+)
+
+COMPONENT = Path(__file__).resolve().parents[2] / "custom_components" / "beatify"
+
+
+def make_entry(i: int, **over):
+    entry = {
+        "title": f"Song {i}",
+        "artist": f"Artist {i}",
+        "uri_ma_library": f"library://track/{i}",
+        "year": 1990 + (i % 30),
+        "year_confidence": 3,
+        "global_score": float(i % 100),
+    }
+    entry.update(over)
+    return entry
+
+
+class FakeHass:
+    """Enough Home Assistant to exercise the pool loader."""
+
+    def __init__(self, root: Path):
+        self.data: dict = {}
+        self.config = type("C", (), {"path": lambda _s, p: str(root / p)})()
+        self.executor_calls = 0
+
+    @property
+    def loop(self):
+        return asyncio.get_running_loop()
+
+    async def async_add_executor_job(self, target, *args):
+        self.executor_calls += 1
+        return target(*args)
+
+
+@pytest.fixture
+def hass(tmp_path):
+    return FakeHass(tmp_path)
+
+
+def write_pool(hass, songs):
+    path = pool_mod.pool_path(hass)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"songs": songs}), encoding="utf-8")
+    return path
+
+
+class TestPrecomputedDedupeKey:
+    def test_finalize_pool_stores_the_key(self):
+        out = pool_mod.finalize_pool(
+            {"u": make_entry(1, artist="Björk", title="Jóga (Remastered)")},
+            built_at=0,
+            config_entry_id=None,
+            library_total=1,
+            target_size=None,
+        )
+        assert out["songs"][0][NORM_KEY_FIELD] == _norm_key(
+            "Björk", "Jóga (Remastered)"
+        )
+
+    def test_finalize_pool_does_not_recompute_an_existing_key(self):
+        entry = make_entry(1)
+        entry[NORM_KEY_FIELD] = "sentinel|value"
+        out = pool_mod.finalize_pool(
+            {"u": entry},
+            built_at=0,
+            config_entry_id=None,
+            library_total=1,
+            target_size=None,
+        )
+        assert out["songs"][0][NORM_KEY_FIELD] == "sentinel|value"
+
+    def test_entry_key_falls_back_for_pools_built_before_2694(self):
+        """An existing install must not need a rescan to keep working."""
+        old = make_entry(1, artist="Motörhead", title="Ace of Spades (Live)")
+        assert NORM_KEY_FIELD not in old
+        assert entry_key(old) == _norm_key("Motörhead", "Ace of Spades (Live)")
+
+    def test_entry_key_prefers_the_stored_value(self):
+        entry = make_entry(1)
+        entry[NORM_KEY_FIELD] = "stored|key"
+        assert entry_key(entry) == "stored|key"
+
+    def test_identity_correction_drops_the_stale_key(self):
+        """The stored key was derived from the wrong name."""
+        entry = make_entry(1, artist="Wrong", title="Wrong Title")
+        entry[NORM_KEY_FIELD] = _norm_key("Wrong", "Wrong Title")
+        fixed = corrections.apply_correction(entry, title="Right Title")
+        assert NORM_KEY_FIELD not in fixed
+        assert entry_key(fixed) == _norm_key("Wrong", "Right Title")
+
+    def test_year_only_correction_keeps_the_key(self):
+        entry = make_entry(1)
+        entry[NORM_KEY_FIELD] = "stored|key"
+        fixed = corrections.apply_correction(entry, year=1977)
+        assert fixed[NORM_KEY_FIELD] == "stored|key"
+
+    def test_prepare_backfills_missing_keys(self):
+        pool = {"songs": [make_entry(i) for i in range(5)]}
+        pool["songs"][0]["popularity_percentile"] = 0.99
+        pool_mod.prepare_pool_for_generate(pool)
+        assert all(s[NORM_KEY_FIELD] for s in pool["songs"])
+        assert pool["songs"][0]["familiarity_band"] is not None
+
+
+class TestParsedPoolCache:
+    async def test_second_load_reuses_the_parse(self, hass):
+        write_pool(hass, [make_entry(i) for i in range(3)])
+        first = await pool_mod.async_load_pool_cached(hass)
+        second = await pool_mod.async_load_pool_cached(hass)
+        assert first is second, "the pre-start hook must not re-parse the pool"
+
+    async def test_a_rewrite_invalidates_the_cache(self, hass):
+        path = write_pool(hass, [make_entry(i) for i in range(3)])
+        first = await pool_mod.async_load_pool_cached(hass)
+        path.write_text(
+            json.dumps({"songs": [make_entry(i) for i in range(9)]}), encoding="utf-8"
+        )
+        second = await pool_mod.async_load_pool_cached(hass)
+        assert second is not first
+        assert len(second["songs"]) == 9
+
+    async def test_missing_pool_is_not_cached(self, hass):
+        assert await pool_mod.async_load_pool_cached(hass) is None
+
+    async def test_load_and_prepare_run_in_the_executor(self, hass):
+        write_pool(hass, [make_entry(i) for i in range(3)])
+        await pool_mod.async_load_pool_cached(hass)
+        assert hass.executor_calls >= 3  # stat, read, prepare
+
+    async def test_cached_pool_is_prepared(self, hass):
+        write_pool(hass, [make_entry(i) for i in range(3)])
+        cached = await pool_mod.async_load_pool_cached(hass)
+        assert all(s[NORM_KEY_FIELD] for s in cached["songs"])
+
+
+class TestGenerationIsOffTheLoop:
+    def test_generate_path_uses_the_executor(self):
+        code = (COMPONENT / "library" / "__init__.py").read_text(encoding="utf-8")
+        assert "async_add_executor_job" in code, "#2694: generate_playlist is pure"
+        assert "async_load_pool_cached" in code
+
+    def test_write_pool_invalidates_the_cache(self):
+        code = (COMPONENT / "library" / "pool.py").read_text(encoding="utf-8")
+        body = code.split("async def _write_pool", 1)[1]
+        assert "invalidate_pool_cache" in body.split("def _get_session", 1)[0]


### PR DESCRIPTION
Crate Digger loaded, re-parsed and sampled an ~11 MB library pool **on the event loop, twice per game**: once at game creation (`server/game_views.py:182`) and once from the pre-start hook that fires on the host's "Start" tap (`:550-600`). For the duration nothing else ran — no WebSocket frame, no game timer, no unrelated Home Assistant automation — and it sat directly in front of the first `play_song`, whose budget #2682 already measured at 14.6 s of 15.

All three directions from the issue are implemented.

## 1. `generate_playlist` → `async_add_executor_job`

It is pure (seedable RNG, no I/O), so it moved to a worker thread verbatim. The `familiarity_band` recompute loop that sat next to it (`library/__init__.py:95-98`, a walk over every song in the pool) went with it.

## 2. Parsed pool cached in `hass.data`

`pool.async_load_pool_cached()` keys the parse on the pool file's `(path, mtime_ns, size)`. Any write — scan checkpoint, refresh pass, host correction, a manual edit — produces a new key, so a stale parse cannot be served; `_write_pool` also drops the entry explicitly, closing the window where a rewrite lands on the same mtime *and* the same byte count.

Two deliberate limits:

- **Read-only.** The returned dict is shared. Only `async_generate_library_playlist` uses it. Everything that writes the pool back (build, refresh, corrections) keeps calling `async_load_pool`, which always returns a fresh parse. `generate_playlist` and `count_eligible` do not mutate pool entries — `_to_song_entry` builds new dicts.
- **Not resident forever.** The cache is dropped after 15 idle minutes. A Raspberry Pi should not carry the whole library in RAM between parties.

## 3. `_norm_key` precomputed at build time

`finalize_pool` now writes the dedupe key onto each entry as `_norm_key`. It previously ran twice per song per generated playlist — NFKD normalisation plus two regex substitutions, 72,000 regex calls on an 18k pool.

**How pools built by an older version are handled:** `generator.entry_key(entry)` returns the stored key if the field is present and falls back to computing it otherwise, so an existing install keeps working unchanged and needs no rescan. `POOL_SCHEMA_VERSION` stays at **1** — the field is additive, and an old Beatify reading a new pool simply ignores it. On top of that, `prepare_pool_for_generate` backfills the field in memory when a pre-#2694 pool is first loaded, so even an un-rescanned install pays the cost once per pool version instead of twice per game. The key is dropped whenever it could go stale: an identity correction (`corrections.apply_correction`) and a scan that refreshes an entry's artist/title both `pop` it, and `finalize_pool` recomputes it on the next write.

The two regexes in `_norm_key` are now compiled once at module import rather than looked up per call, which speeds up the fallback path as well.

## Measurements

18k synthetic entries, written the way `pool.py` writes them (`indent=1`), 10.5 MB before / 11.4 MB after. Apple Silicon, `.venv` Python 3.13, best of 7 runs.

**`generate_playlist` alone**

| pool | before | after |
|---|---|---|
| top-30% window | 38.2 ms | **3.8 ms** |
| no window (band path) | 40.6 ms | **5.2 ms** |
| genre + top-10% | 40.5 ms | **5.2 ms** |
| top-30%, pool built *before* this PR (fallback path) | 38.2 ms | **32.7 ms** |

**Both generate calls of one game, with a 2 ms heartbeat task measuring how long the event loop was actually starved**

| | wall | worst loop stall | loop blocked > 5 ms |
|---|---|---|---|
| main — call 1 (create) | 70.5 ms | 38.2 ms | 73.1 ms |
| main — call 2 (Start tap) | 71.2 ms | 38.0 ms | 71.0 ms |
| branch — call 1 (create) | 42.6 ms | 36.8 ms | 42.5 ms |
| branch — call 2 (Start tap) | **4.3 ms** | **4.3 ms** | **0.0 ms** |

The call that matters is the second one — it lands on the host's "Start" tap with the guests watching, immediately before the first `play_song`: **~70 ms of blocked event loop → 0**, and 71 ms wall → 4.3 ms. On a Raspberry Pi 4 the issue's own extrapolation puts that saving at roughly half a second.

**Honest note on the first call.** It still shows a ~37 ms stall: `json.loads` on an 11 MB document holds the GIL for its whole run, so putting it in the executor (where it already was, on main) does not free the loop. That is unchanged by this PR — what changed is that it now happens **once per pool version instead of twice per game**. Storing `_norm_key` grows the file by 8.6% (~3 ms more parse) and saves ~34 ms of generate per call plus ~43 ms of one-time backfill, so the cold path comes out ahead too.

## Not touched: `server/game_views.py`

Another agent is editing it for #2693/#2724, so I left it alone — and it turned out not to need a change. Both call sites funnel through `_generate_library_songs` → `async_generate_library_playlist`, so both pick up the executor hop and the cache without any edit at the call sites.

## Checks

- `pytest tests/unit tests/integration -q` — 2475 passed, 2 skipped (was 2461; +14 in `tests/unit/test_library_pool_cache.py`)
- `npm test` — 912 passed, 93 files
- `npm run build:check` — 16 artifacts and 76 .gz siblings match source
- `python3 -m ruff format --check .` — 233 files already formatted

Closes #2694

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKsEKt68KHSqmi617XNCVi
