### PR TITLE
Derive the speaker platform, and keep the podium on the REST end path

### DIFF
--- a/custom_components/beatify/game/state_tts.py
+++ b/custom_components/beatify/game/state_tts.py
@@ -60,6 +60,11 @@ class TtsAnnouncerMixin:
         # Issue #447: TTS announcement service
         # #2638: built by the injected TTS factory (see game/protocols.py).
         self._tts_service: TtsProtocol | None = None
+        # #2724: the announcement tasks still waiting for their turn at the
+        # speaker. `_bg_tasks` also holds party-light flashes and media work,
+        # so a caller that wants to wait for *speech* — the REST end-game
+        # teardown — needs the narrower set. Tasks remove themselves when done.
+        self._announce_tasks: set[asyncio.Task] = set()
         self._tts_announce_game_start: bool = True
         self._tts_announce_winner: bool = True
         # Issue #471 Phase 1: Game Flow announcements
@@ -188,6 +193,47 @@ class TtsAnnouncerMixin:
     async def disable_tts(self) -> None:
         """Disable TTS announcements."""
         self._tts_service = None
+
+    #: How long :meth:`drain_announcements` will wait at most (#2724). Two
+    #: queued phrases can reserve at most 2 x ``_TTS_MAX_ESTIMATE_S`` of
+    #: speaker time, so this never truncates a real end-game ceremony; it
+    #: exists so a wedged TTS provider cannot hold an HTTP request open.
+    _ANNOUNCE_DRAIN_TIMEOUT_S = 26.0
+
+    async def drain_announcements(self, timeout: float | None = None) -> bool:
+        """Wait until every queued announcement has reached the speaker (#2724).
+
+        ``_tts_announce`` does not speak inline: it reserves a slot in the
+        estimated speaker timeline and hands the phrase to a background task
+        that sleeps until its turn. So right after ``advance_to_end`` has
+        called ``announce_winner`` and ``announce_podium``, both phrases are
+        still only *queued* — the podium one typically sleeps out the winner's
+        estimate first.
+
+        Anything that tears the game down in the same breath therefore has to
+        wait here first. ``end_game`` calls ``disable_tts`` (``_tts_service =
+        None``) and then ``_reset_game_internals`` (which moves ``self.round``,
+        tripping the staleness guard): a podium task that wakes after either of
+        those is dropped, or dies on ``None.speak`` and is swallowed as "TTS
+        announcement failed" — silently, which is how #2724 stayed invisible.
+
+        Returns:
+            True when the queue drained, False when ``timeout`` cut it short.
+        """
+        pending = {t for t in self._announce_tasks if not t.done()}
+        if not pending:
+            return True
+        limit = self._ANNOUNCE_DRAIN_TIMEOUT_S if timeout is None else timeout
+        _, still_pending = await asyncio.wait(pending, timeout=limit)
+        if still_pending:
+            _LOGGER.warning(
+                "Announcement queue did not drain within %.1fs — %d phrase(s) "
+                "may be lost (#2724)",
+                limit,
+                len(still_pending),
+            )
+            return False
+        return True
 
     def _lang(self) -> str:
         """Resolve the game's TTS language, defaulting to English.
@@ -336,6 +382,10 @@ class TtsAnnouncerMixin:
             task = asyncio.create_task(_run())
             self._bg_tasks.add(task)
             task.add_done_callback(self._bg_tasks.discard)
+            # #2724: also tracked on their own so a teardown can wait for
+            # speech alone, without waiting on light flashes or media work.
+            self._announce_tasks.add(task)
+            task.add_done_callback(self._announce_tasks.discard)
         except Exception:  # noqa: BLE001
             _LOGGER.warning("TTS announcement failed")
 

--- a/custom_components/beatify/server/game_views.py
+++ b/custom_components/beatify/server/game_views.py
@@ -59,6 +59,7 @@ from custom_components.beatify.services.factories import ha_service_factories
 from custom_components.beatify.services.media_player import (
     async_get_native_twin_remap,
     get_platform_capabilities,
+    resolve_entity_platform,
 )
 
 if TYPE_CHECKING:
@@ -570,6 +571,16 @@ class StartGameView(RateLimitMixin, HomeAssistantView):
                     if isinstance(mp, str) and mp and self.hass.states.get(mp):
                         if gs.media_player != mp:
                             gs.media_player = mp
+                            # #2693: the speaker and its platform are one fact.
+                            # This hook used to move only the entity_id, so a
+                            # stored Sonos speaker kept the platform of the one
+                            # it replaced. `build_strategy` dispatches on the
+                            # platform (#2636) and the factory now derives it
+                            # per entity, so playback is safe either way — but
+                            # `start_round` and the pre-warm still read
+                            # `gs.platform` to decide whether to run the
+                            # non-MA responsiveness probe. Keep the pair honest.
+                            gs.platform = resolve_entity_platform(self.hass, mp)
                             # #2143: same release-instead-of-null as the lobby
                             # switch below. This path runs pre-start, so there
                             # is usually nothing captured yet — but a force-
@@ -579,7 +590,11 @@ class StartGameView(RateLimitMixin, HomeAssistantView):
                             if callable(_cp):
                                 with contextlib.suppress(Exception):
                                     _cp()
-                            _LOGGER.info("Pre-start: media_player -> %s", mp)
+                            _LOGGER.info(
+                                "Pre-start: media_player -> %s (platform %s)",
+                                mp,
+                                gs.platform,
+                            )
                     if "tts" in out:
                         with contextlib.suppress(Exception):
                             applied = await _apply_tts_config(gs, out["tts"])
@@ -745,6 +760,29 @@ class EndGameView(BeatifyAdminView):
                 await ws_handler.broadcast_state()
             else:
                 await game_state.advance_to_end()
+
+            # #2724: advance_to_end has QUEUED the winner and podium phrases,
+            # not spoken them — `_tts_announce` reserves a slot on the
+            # estimated speaker timeline and lets a background task sleep
+            # until its turn. `end_game()` below calls `disable_tts()` and
+            # then resets the round counter, so a podium task that wakes
+            # afterwards either finds `_tts_service is None` (the exception is
+            # swallowed as "TTS announcement failed") or is dropped by the
+            # staleness guard. Either way the host hears nothing.
+            #
+            # The WebSocket path does not need this: it leaves the game in END
+            # and only tears down on Dismiss, by which time the ceremony is
+            # over. This endpoint is the fallback for a CLOSED admin socket —
+            # the host is not looking at a screen, which is exactly when the
+            # spoken podium is the whole point. So wait for it here.
+            drain = getattr(game_state, "drain_announcements", None)
+            if callable(drain):
+                try:
+                    await drain()
+                except Exception as err:  # noqa: BLE001 — teardown must run
+                    _LOGGER.warning(
+                        "Waiting for the end-game announcements failed: %s", err
+                    )
 
         await game_state.end_game()
 

--- a/custom_components/beatify/services/factories.py
+++ b/custom_components/beatify/services/factories.py
@@ -11,6 +11,7 @@ import cycle.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 from custom_components.beatify.game.protocols import (
@@ -21,11 +22,13 @@ from custom_components.beatify.game.protocols import (
 )
 
 from .lights import PartyLightsService
-from .media_player import MediaPlayerService
+from .media_player import MediaPlayerService, resolve_entity_platform
 from .tts import TTSService
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def ha_service_factories(hass: HomeAssistant) -> GameOutputFactories:
@@ -38,10 +41,34 @@ def ha_service_factories(hass: HomeAssistant) -> GameOutputFactories:
         provider: str = "spotify",
         inherited_states: dict[str, dict[str, Any]] | None = None,
     ) -> MediaPlayerProtocol:
+        # #2693: the platform is DERIVED here, not taken on trust. Since #2636
+        # it is the key `build_strategy` dispatches on, so a caller that
+        # changes the speaker but forgets the platform (the Crate Digger
+        # pre-start hook did exactly that) would route a Sonos entity through
+        # `MusicAssistantStrategy` — the game starts, the first song times out,
+        # and nothing in the log points at the cause.
+        #
+        # This factory already closes over `hass`, so the registry that owns
+        # the answer is one call away. Deriving it here means the platform can
+        # only ever describe the entity this very service is being built for,
+        # whatever the caller believed.
+        resolved = resolve_entity_platform(hass, entity_id)
+        if resolved == "unknown":
+            # No registry entry (YAML-only player, test double). Fall back to
+            # what the caller passed rather than downgrading a known platform.
+            resolved = platform
+        elif resolved != platform and platform != "unknown":
+            _LOGGER.warning(
+                "Media player %s is on platform %s, not %s — using the "
+                "registry (#2693)",
+                entity_id,
+                resolved,
+                platform,
+            )
         return MediaPlayerService(
             hass,
             entity_id,
-            platform=platform,
+            platform=resolved,
             provider=provider,
             inherited_states=inherited_states,
         )

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -104,6 +104,35 @@ def get_platform_capabilities(platform: str) -> dict[str, Any]:
     )
 
 
+def resolve_entity_platform(hass: HomeAssistant, entity_id: str) -> str:
+    """The integration that owns ``entity_id``, straight from the entity registry.
+
+    #2693: the platform is what :func:`~.playback.build_strategy` dispatches on,
+    so it must describe the speaker that is actually about to play — not
+    whatever was written next to a previous selection. Reading it from the
+    registry at the moment the speaker is used makes it impossible for the two
+    to disagree.
+
+    Returns ``"unknown"`` when the entity has no registry entry (a YAML-only
+    player, a test double) or when the registry is unreadable; every caller
+    treats that the same way it always has.
+    """
+    # Late import: mirrors async_get_media_players — entity_registry is not
+    # importable in the unit-test env without a full HA setup. (noqa: PLC0415)
+    from homeassistant.helpers import entity_registry as er
+
+    try:
+        entry = er.async_get(hass).async_get(entity_id)
+    except Exception as err:  # noqa: BLE001 — a registry read must never abort a game
+        _LOGGER.warning(
+            "Entity registry lookup for %s raised %s; platform unknown",
+            entity_id,
+            err,
+        )
+        return "unknown"
+    return entry.platform if entry else "unknown"
+
+
 # Timeout for pre-flight connectivity check (seconds)
 PREFLIGHT_TIMEOUT = 3.0
 # Timeout for waiting for metadata to update after playing (seconds)

--- a/tests/unit/test_end_game_rest_podium_2724.py
+++ b/tests/unit/test_end_game_rest_podium_2724.py
@@ -1,0 +1,181 @@
+"""Ending the game over REST must not swallow the podium announcement (#2724).
+
+``advance_to_end`` does not SPEAK the winner and podium phrases — it queues
+them. ``_tts_announce`` reserves a slot on the estimated speaker timeline and
+hands each phrase to a background task that sleeps until its turn, so the
+podium is typically still waiting out the winner's estimate when
+``advance_to_end`` returns.
+
+``EndGameView`` called ``end_game()`` right after. That runs ``disable_tts()``
+(``_tts_service = None``) and then resets the round counter, so the podium task
+woke to either a ``None`` service — the exception swallowed as "TTS
+announcement failed" — or the staleness guard. Nothing reached the speaker, and
+nothing said so.
+
+The WebSocket path is unaffected: it leaves the game in END and only tears down
+on Dismiss. Which means the loss happened exactly on the fallback path — the
+one taken when the admin socket is closed and the host is not looking at a
+screen, so the spoken podium is all there is.
+
+These tests run the real ``GameState`` with a recording TTS service and assert
+on the phrases that actually reached ``speak()``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.beatify.const import DOMAIN
+from custom_components.beatify.game.state import GamePhase
+from custom_components.beatify.game.state_tts import TtsAnnouncerMixin
+from custom_components.beatify.server.game_views import EndGameView
+from tests.conftest import make_game_state, make_player, make_songs
+
+# Long enough that end_game() would comfortably finish first on origin/main,
+# short enough to keep the test instant. The real values are seconds.
+_FAKE_PHRASE_SECONDS = 0.25
+
+
+class _RecordingTts:
+    """Stands in for TTSService; remembers what actually reached the speaker."""
+
+    def __init__(self) -> None:
+        self.spoken: list[str] = []
+
+    async def speak(self, message: str, language: str | None = None) -> None:
+        self.spoken.append(message)
+
+
+@pytest.fixture
+def game_with_tts():
+    """A running game with three scoring players and a recording TTS."""
+    tts = _RecordingTts()
+    state = make_game_state(tts=lambda **_kwargs: tts)
+    state.create_game(
+        playlists=["test.json"],
+        songs=make_songs(3),
+        media_player="media_player.test",
+        base_url="http://localhost:8123",
+    )
+    state.players = {
+        "p1": make_player("Alice", 30),
+        "p2": make_player("Bob", 20),
+        "p3": make_player("Cara", 10),
+    }
+    state._set_phase(GamePhase.PLAYING)
+    return state, tts
+
+
+def _hass(state):
+    hass = MagicMock()
+    # No ws_handler: the closed-admin-socket case this endpoint exists for.
+    hass.data = {DOMAIN: {"game": state}}
+    return hass
+
+
+def _request():
+    request = MagicMock()
+    request.remote = "1.2.3.4"
+    return request
+
+
+@pytest.fixture
+def authorized():
+    with patch(
+        "custom_components.beatify.server.game_views.is_authorized_http",
+        return_value=True,
+    ):
+        yield
+
+
+@pytest.fixture
+def fast_phrases():
+    """Shrink the estimated speech time so the queue drains in milliseconds."""
+    with patch.object(
+        TtsAnnouncerMixin,
+        "_estimate_speech_seconds",
+        classmethod(lambda cls, message: _FAKE_PHRASE_SECONDS),
+    ):
+        yield
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("authorized", "fast_phrases")
+class TestRestEndGameKeepsThePodium:
+    async def test_both_ceremony_phrases_reach_the_speaker(self, game_with_tts):
+        """The regression: on origin/main only the winner phrase arrives."""
+        state, tts = game_with_tts
+        await state.configure_tts("tts.google_en")
+
+        resp = await EndGameView(_hass(state)).post(_request())
+
+        assert resp.status == 200
+        assert len(tts.spoken) == 2, f"only these were spoken: {tts.spoken}"
+        winner, podium = tts.spoken
+        assert "Alice" in winner
+        # Bottom-up, the way a host reads an awards list: Cara, Bob, Alice.
+        assert "Cara" in podium
+        assert "Bob" in podium
+        assert "Alice" in podium
+
+    async def test_the_game_is_still_torn_down(self, game_with_tts):
+        """Waiting for the podium must not leave a live game behind."""
+        state, _tts = game_with_tts
+        await state.configure_tts("tts.google_en")
+
+        resp = await EndGameView(_hass(state)).post(_request())
+
+        assert resp.status == 200
+        assert state.game_id is None
+        assert state.phase is GamePhase.LOBBY
+        assert state._tts_service is None
+
+    async def test_no_tts_configured_still_ends_promptly(self, game_with_tts):
+        """Nothing queued, nothing to wait for."""
+        state, tts = game_with_tts
+
+        resp = await EndGameView(_hass(state)).post(_request())
+
+        assert resp.status == 200
+        assert tts.spoken == []
+        assert state.game_id is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("fast_phrases")
+class TestDrainAnnouncements:
+    async def test_drain_waits_for_a_queued_phrase(self, game_with_tts):
+        state, tts = game_with_tts
+        await state.configure_tts("tts.google_en")
+
+        await state.announce_winner()
+        await state.announce_podium()
+        # Both are still only queued at this point.
+        assert tts.spoken == []
+
+        assert await state.drain_announcements() is True
+        assert len(tts.spoken) == 2
+
+    async def test_drain_is_a_no_op_with_an_empty_queue(self, game_with_tts):
+        state, _tts = game_with_tts
+        assert await state.drain_announcements() is True
+
+    async def test_drain_reports_a_timeout_instead_of_hanging(self, game_with_tts):
+        """A wedged provider must not hold the HTTP request open forever."""
+        state, tts = game_with_tts
+        await state.configure_tts("tts.google_en")
+
+        with patch.object(
+            TtsAnnouncerMixin,
+            "_estimate_speech_seconds",
+            classmethod(lambda cls, message: 30.0),
+        ):
+            # The first phrase goes out at once; the second one reserves the
+            # speaker for half a minute and is what the drain waits on.
+            await state.announce_winner()
+            await state.announce_podium()
+            assert await state.drain_announcements(timeout=0.01) is False
+        assert len(tts.spoken) < 2
+        state.async_shutdown()

--- a/tests/unit/test_pre_start_speaker_platform_2693.py
+++ b/tests/unit/test_pre_start_speaker_platform_2693.py
@@ -1,0 +1,228 @@
+"""The pre-start hook must move the speaker AND its platform (#2693).
+
+Since #2636 the platform is the key :func:`build_strategy` dispatches on, so a
+speaker and a platform that disagree do not fail loudly — they pick the wrong
+strategy. The game starts, the first song times out, and nothing in the log
+points at the cause.
+
+The pre-start hook (``StartGameView`` -> ``_regen_library_songs``) re-applies
+the persisted output settings, which hold ``media_player`` but no platform. It
+used to assign the entity alone.
+
+The fix has two halves and both are pinned here:
+
+* the factory DERIVES the platform from the entity registry, so no caller can
+  build a service whose strategy disagrees with the speaker (the class of bug);
+* the hook writes ``gs.platform`` as well, so the round path's non-MA
+  responsiveness probe reads the truth too (this instance of it).
+
+Every assertion below is on the strategy that is actually SELECTED, not on the
+attribute — an attribute test would have passed with the routing still broken.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.beatify.const import DOMAIN, PROVIDER_MA_LIBRARY
+from custom_components.beatify.game.state import GameState
+from custom_components.beatify.services.factories import ha_service_factories
+from custom_components.beatify.services.playback import (
+    MusicAssistantStrategy,
+    SonosStrategy,
+)
+from custom_components.beatify.server.game_views import StartGameView
+
+MA_SPEAKER = "media_player.ma_speaker"
+SONOS_SPEAKER = "media_player.sonos_kitchen"
+
+_PLATFORM_BY_ENTITY = {
+    MA_SPEAKER: "music_assistant",
+    SONOS_SPEAKER: "sonos",
+}
+
+
+def _registry() -> MagicMock:
+    """An entity registry that knows both speakers and their platforms."""
+
+    def _lookup(entity_id: str):
+        platform = _PLATFORM_BY_ENTITY.get(entity_id)
+        if platform is None:
+            return None
+        entry = MagicMock()
+        entry.platform = platform
+        return entry
+
+    reg = MagicMock()
+    reg.async_get.side_effect = _lookup
+    return reg
+
+
+def _hass() -> MagicMock:
+    hass = MagicMock()
+    hass.states.get.return_value = MagicMock(state="playing")
+    return hass
+
+
+def _library_songs(n: int = 5) -> list[dict[str, Any]]:
+    return [
+        {
+            "year": 1980 + i,
+            "title": f"Song {i}",
+            "artist": f"Artist {i}",
+            "uri_ma_library": f"library://track/{i}",
+        }
+        for i in range(n)
+    ]
+
+
+def _selected_strategy(game_state: GameState):
+    """Build the media-player service the way a round does, return its strategy."""
+    game_state._media_player_service = None
+    game_state._ensure_media_player_service()
+    assert game_state._media_player_service is not None
+    return game_state._media_player_service._strategy
+
+
+class TestFactoryDerivesThePlatform:
+    """The class of bug: a caller cannot hand the factory a wrong platform."""
+
+    def test_stale_platform_does_not_choose_the_strategy(self):
+        hass = _hass()
+        with patch(
+            "homeassistant.helpers.entity_registry.async_get", return_value=_registry()
+        ):
+            service = ha_service_factories(hass).media_player(
+                SONOS_SPEAKER, platform="music_assistant"
+            )
+        assert isinstance(service._strategy, SonosStrategy)
+
+    def test_the_other_direction_too(self):
+        hass = _hass()
+        with patch(
+            "homeassistant.helpers.entity_registry.async_get", return_value=_registry()
+        ):
+            service = ha_service_factories(hass).media_player(
+                MA_SPEAKER, platform="sonos"
+            )
+        assert isinstance(service._strategy, MusicAssistantStrategy)
+
+    def test_unregistered_entity_keeps_what_the_caller_passed(self):
+        """A YAML-only player has no registry entry — don't downgrade it."""
+        hass = _hass()
+        with patch(
+            "homeassistant.helpers.entity_registry.async_get", return_value=_registry()
+        ):
+            service = ha_service_factories(hass).media_player(
+                "media_player.not_in_registry", platform="sonos"
+            )
+        assert isinstance(service._strategy, SonosStrategy)
+
+
+@pytest.fixture
+def library_game():
+    """A started Crate Digger game whose pre-start hook is installed.
+
+    Returns ``(game_state, hass)``. The game was created on the Music Assistant
+    speaker; the persisted output settings point at the Sonos one, which is the
+    switch the hook exists to apply.
+    """
+    hass = _hass()
+    game_state = GameState(service_factories=ha_service_factories(hass))
+    game_state._hass = hass
+    hass.data = {DOMAIN: {"game": game_state}}
+
+    body = {
+        "playlists": [],
+        "media_player": MA_SPEAKER,
+        "provider": PROVIDER_MA_LIBRARY,
+    }
+    request = MagicMock()
+    request.remote = "1.2.3.4"
+    request.json = AsyncMock(return_value=body)
+
+    with (
+        patch(
+            "custom_components.beatify.server.game_views.is_authorized_http",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.helpers.entity_registry.async_get", return_value=_registry()
+        ),
+        patch(
+            "custom_components.beatify.server.game_views._generate_library_songs",
+            new=AsyncMock(return_value=(_library_songs(), None)),
+        ),
+        patch(
+            "custom_components.beatify.server.game_views.async_get_native_twin_remap",
+            new=AsyncMock(return_value={}),
+        ),
+    ):
+        yield StartGameView(hass), request, game_state, hass
+
+
+@pytest.mark.asyncio
+class TestPreStartHookMovesBoth:
+    async def _start(self, view, request):
+        resp = await view.post(request)
+        assert resp.status == 200, resp.body
+        return resp
+
+    async def test_hook_is_installed_for_a_library_game(self, library_game):
+        view, request, game_state, _hass_ = library_game
+        with (
+            patch(
+                "homeassistant.helpers.entity_registry.async_get",
+                return_value=_registry(),
+            ),
+            patch(
+                "custom_components.beatify.server.game_views._generate_library_songs",
+                new=AsyncMock(return_value=(_library_songs(), None)),
+            ),
+            patch(
+                "custom_components.beatify.server.game_views.async_get_native_twin_remap",
+                new=AsyncMock(return_value={}),
+            ),
+        ):
+            await self._start(view, request)
+        assert callable(game_state.pre_start_hook)
+        # Baseline: created on MA, so MA is what the game would play through.
+        assert game_state.platform == "music_assistant"
+        assert isinstance(_selected_strategy(game_state), MusicAssistantStrategy)
+
+    async def test_stored_sonos_speaker_gets_the_sonos_strategy(self, library_game):
+        """The regression. Before the fix this built MusicAssistantStrategy."""
+        view, request, game_state, _hass_ = library_game
+        stored = {"media_player": SONOS_SPEAKER}
+        with (
+            patch(
+                "homeassistant.helpers.entity_registry.async_get",
+                return_value=_registry(),
+            ),
+            patch(
+                "custom_components.beatify.server.game_views._generate_library_songs",
+                new=AsyncMock(return_value=(_library_songs(), None)),
+            ),
+            patch(
+                "custom_components.beatify.server.game_views.async_get_native_twin_remap",
+                new=AsyncMock(return_value={}),
+            ),
+            patch(
+                "custom_components.beatify.server.library_views."
+                "async_load_game_output_settings",
+                new=AsyncMock(return_value=stored),
+            ),
+        ):
+            await self._start(view, request)
+            hook = game_state.pre_start_hook
+            await hook(game_state)
+
+            assert game_state.media_player == SONOS_SPEAKER
+            # What actually matters, asserted first: the strategy the next
+            # round will use. On origin/main this is MusicAssistantStrategy.
+            assert isinstance(_selected_strategy(game_state), SonosStrategy)
+            # The attribute — necessary, but on its own it proves nothing.
+            assert game_state.platform == "sonos"


### PR DESCRIPTION
Two bugs in `custom_components/beatify/server/game_views.py`, a few hundred lines apart.

## #2693 — the pre-start hook moved the speaker but not its platform

`StartGameView`'s Crate Digger pre-start hook re-applies the persisted output settings before the first round. It assigned `gs.media_player = mp`, released the media-player service and cancelled the pre-warm — but never touched `gs.platform`. The store it reads holds only `media_player`, `tts` and `party_lights`, and the lobby switch two blocks further down sets both.

Since #2636 the platform is the key `build_strategy()` dispatches on. A stored Sonos speaker therefore kept the platform of the speaker it replaced and ran through `MusicAssistantStrategy`. What a host sees: the game starts fine, the first song times out, and nothing in the log points at the cause — from the code's point of view nothing was wrong.

### Direction chosen: derive the platform, not a setter

The issue offered two: derive the platform in the factory, or give `GameState` one `set_speaker()` that is the only writer of the three fields.

**This PR derives it.** `ha_service_factories._media_player` already closes over `hass`, so the entity registry that owns the answer is one call away. Reading it there means the platform can only ever describe the entity the service is being built for, whatever the caller believed — which removes the *class* of bug. A `set_speaker()` would only remove this instance of it: it fixes the one writer that forgot, and the next writer can forget again in exactly the same way. It also costs nothing at the seam — the factory is the single construction site for `MediaPlayerService` in the codebase, so there is no second door.

The registry value wins only when there is one; an entity with no registry entry (a YAML-only player, a test double) keeps whatever the caller passed rather than being downgraded to `"unknown"`. A disagreement is logged.

Deriving in the factory fixes playback, but `gs.platform` is read in two more places (`state_lifecycle.py:351` and `:965`) to decide whether a speaker gets the non-MA responsiveness probe. So the hook now writes `gs.platform` too — the pair stays honest for the readers that are not the dispatch.

## #2724 — ending over REST loses the podium announcement

`EndGameView` called `finalize_and_end` and then `end_game()` immediately. `advance_to_end` has only *queued* `announce_winner` / `announce_podium` at that point: `_tts_announce` reserves a slot on the estimated speaker timeline and hands the phrase to a background task that sleeps until its turn. `end_game()` runs `disable_tts()` (`_tts_service = None`) and then `_reset_game_internals()` (which moves `self.round`, tripping the staleness guard), so the podium task woke to a `None` service and the exception was swallowed as "TTS announcement failed".

Only the REST fallback path is affected — the one taken when the admin socket has closed, i.e. exactly when nobody is looking at a screen and the announcement is all there is. The WebSocket path defers `end_game` to Dismiss and is fine.

Fixed with `GameState.drain_announcements()`: announcement tasks are now tracked in their own set (`_bg_tasks` also carries light flashes and media work), and the drain awaits them before the view tears the game down. It is bounded at 26s — above the 2 × 12s a pair of queued phrases can ever reserve, so it never truncates a real ceremony, but a wedged TTS provider cannot hold the HTTP request open either. A timeout is logged and returns `False` rather than being silent.

## Tests, and what red looked like

`tests/unit/test_pre_start_speaker_platform_2693.py` — asserts on the strategy the game **actually selects** after the hook runs, not on the attribute. Reverting the source and re-running gives:

```
>       assert isinstance(service._strategy, SonosStrategy)
>       assert isinstance(service._strategy, MusicAssistantStrategy)
>           assert isinstance(_selected_strategy(game_state), SonosStrategy)
3 failed, 2 passed
```

The two that still pass are the baseline (a game created on an MA speaker gets `MusicAssistantStrategy`) and the unregistered-entity fallback — both true before and after, by design.

`tests/unit/test_end_game_rest_podium_2724.py` — drives the real `GameState` through `EndGameView` with a recording TTS service. Reverted:

```
E       AssertionError: only these were spoken: []
WARNING  custom_components.beatify.game.state_tts: TTS announcement failed
4 failed, 2 passed
```

Note that on `main` **neither** phrase reaches the speaker, not just the podium — `end_game()` completes before the winner task gets its first turn — and the log line is the exact swallowed exception from the issue.

Both files pass green with the fix in place (11 tests).

## Checks

| | |
|---|---|
| `pytest tests/unit tests/integration -q` | 2472 passed, 2 skipped |
| `npm test` | 912 passed (93 files) |
| `npm run build:check` | 16 artifacts + 76 .gz siblings match source |
| `ruff format --check .` | 234 files already formatted |

`ruff check .` is clean as well; `npm run lint` reports the same 307 pre-existing warnings and 0 errors as `main`.

Closes #2693
Closes #2724

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKsEKt68KHSqmi617XNCVi
