### PR TITLE
Keep watching a restore whose track never started, and stop the guard from mislabelling a timeout

### DIFF
--- a/custom_components/beatify/services/playback/queue_restore.py
+++ b/custom_components/beatify/services/playback/queue_restore.py
@@ -14,15 +14,32 @@ first speaker its queue back, and that debt is settled through
 it — so it lives here, taking an entity id and a snapshot, and asks nothing
 about platforms.
 
-The #2605 guard (:meth:`MaQueueRestorer.pause_and_confirm`) is the second fix
-for a bug that came back once. It is reproduced here unchanged; its behaviour
-is pinned by ``tests/unit/test_queue_restore_stays_paused_2605.py``.
+The #2605 guard (:meth:`MaQueueRestorer.pause_and_confirm`) is the third fix
+for a bug that came back twice. Its behaviour is pinned by
+``tests/unit/test_queue_restore_stays_paused_2605.py``.
+
+The two corrections in that third round are both about what the guard could
+*not* see:
+
+* #2691 — the guard used to confirm silence on a track that had never started.
+  ``media_pause`` on an idle player is a no-op, and the ``idle`` left behind by
+  ``advance_to_end``'s ``media_stop`` reads exactly like a settled pause. When
+  Music Assistant started the track afterwards — Apple Music throttles and
+  retries at roughly 15.7s, and #2682 measured 14.6s live — nobody was
+  watching. A restore that never saw ``playing`` now holds the watch for the
+  whole window instead of accepting the pre-play ``idle`` as proof.
+* #2707 — ``_stays_quiet`` reported a relapse and a deadline expiry with the
+  same ``False``, so the caller could not tell them apart and the closing
+  WARNING claimed the speaker was still playing while it was in fact paused.
+  It now returns a :class:`QuietOutcome`, and the window is sized from the
+  attempt budget rather than guessed at.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.exceptions import HomeAssistantError, ServiceNotFound
@@ -55,15 +72,66 @@ MA_QUEUE_RESTORE_POLL = 0.25
 # owns.
 MA_PAUSE_CONFIRM_WAIT = 2.0
 MA_PAUSE_SETTLE_HOLD = 5.0
-MA_PAUSE_GUARD_WINDOW = 12.0
 MA_PAUSE_MAX_ATTEMPTS = 3
 MA_PAUSE_POLL = 0.25
+# #2707: the window used to be a round 12.0 that had nothing to do with what an
+# attempt costs. One attempt can spend a full MA_PAUSE_CONFIRM_WAIT waiting for
+# the speaker to go quiet plus a full MA_PAUSE_SETTLE_HOLD holding the silence,
+# so a second attempt could not fit and MA_PAUSE_MAX_ATTEMPTS was decoration.
+# The window is therefore derived from the attempt cost instead of guessed at:
+# two worst-case attempts always fit, and a third fits whenever the relapse
+# arrives before the hold is over — which is the shape every live run has had
+# (the speaker restarts itself about five seconds after the pause).
+MA_PAUSE_ATTEMPT_COST = MA_PAUSE_CONFIRM_WAIT + MA_PAUSE_SETTLE_HOLD
+MA_PAUSE_GUARD_WINDOW = 2 * MA_PAUSE_ATTEMPT_COST
+
+# #2691: a restore whose track never reported `playing` gets a LONGER watch,
+# because it has nothing to confirm — the `idle` it is reading predates the
+# `play_media` and proves only that nothing has started YET.
+#
+# The number has to outlive Music Assistant's Apple Music provider, which
+# throttles and retries on its own backoff: roughly 15.7s, documented in
+# `game/state_lifecycle.py`, and 14.6s measured on the live installation in
+# #2682. Counted from the end of MA_QUEUE_RESTORE_WAIT, this covers
+# 5 + 18 = 23s after the `play_media` went out.
+#
+# It is bought with teardown latency — the admin's end-game round trip can sit
+# here for the whole 18s — and that is the deliberate trade: a spinner the host
+# is already looking at, against the host's own music coming back up in a room
+# where the game is over. #2605 has now been reopened twice for the second one.
+MA_LATE_START_WATCH = 18.0
 
 # #2605: "not playing" is too generous. MA reports `buffering` while a track
 # loads, and a reading that lands there looks exactly like a successful pause —
 # the track starts a second later anyway. Both states therefore count as "still
 # going".
 MA_ACTIVE_STATES = frozenset({"playing", "buffering"})
+
+
+class QuietOutcome(Enum):
+    """Why :meth:`MaQueueRestorer._stays_quiet` stopped watching (#2707).
+
+    The three cases used to be two booleans, and the two that mattered shared
+    the ``False``. A relapse means the speaker started itself again and has to
+    be paused once more; an expiry means the guard ran out of window while the
+    room was silent. Reporting the second as the first is what produced the
+    WARNING "it is still playing the host's queue" over a paused speaker — the
+    exact line the live test read to identify the mechanism behind #2605.
+    """
+
+    HELD = "held"
+    """The silence lasted the full hold. The pause is confirmed."""
+
+    RELAPSED = "relapsed"
+    """Active playback was reported again. Pause it once more."""
+
+    WINDOW_EXPIRED = "window-expired"
+    """The guard window ran out while the speaker was quiet.
+
+    Not a confirmation and not a failure: the room is silent, the guard simply
+    stopped being allowed to look. The teardown counts it as paused and says so
+    in the log rather than claiming either more or less than it saw.
+    """
 
 
 class MaQueueRestorer:
@@ -97,7 +165,15 @@ class MaQueueRestorer:
             # the still-playing Beatify track would move the wrong song. Wait
             # for the speaker to report a position, bounded, then give up and
             # leave it playing from the start rather than hang the teardown.
-            if not await self._wait_for_playing(entity_id):
+            started = await self._wait_for_playing(entity_id)
+            if not started:
+                # #2691: this is NOT a cosmetic miss. The seek is skipped
+                # below, which was always right, but the pause that follows is
+                # then aimed at a player that is still idle from
+                # `advance_to_end`'s `media_stop` — where `media_pause` is a
+                # no-op and the reading that comes back is the state from
+                # BEFORE the `play_media`. The guard has to be told, or it
+                # confirms a silence nothing has disturbed yet.
                 _LOGGER.debug(
                     "Queue restore on %s: track loaded but never confirmed", entity_id
                 )
@@ -138,7 +214,7 @@ class MaQueueRestorer:
             # after the pause and start Sonos playing again. Rather than guess
             # which call did it, `_pause_and_confirm` holds the silence instead
             # of measuring it once.
-            paused = await self.pause_and_confirm(entity_id)
+            paused = await self.pause_and_confirm(entity_id, started=started)
         except (HomeAssistantError, ServiceNotFound) as err:
             _LOGGER.warning("Queue restore on %s failed: %s", entity_id, err)
             return False
@@ -148,13 +224,27 @@ class MaQueueRestorer:
                 entity_id,
                 queue.get("name") or queue["uri"],
                 queue.get("elapsed_time", 0),
-                "paused"
-                if paused
-                else "PAUSE NOT CONFIRMED — see the warning above (#2605)",
+                self._outcome_label(paused=paused, started=started),
             )
             return True
 
-    async def pause_and_confirm(self, entity_id: str) -> bool:
+    @staticmethod
+    def _outcome_label(*, paused: bool, started: bool) -> str:
+        """What the closing restore line says about the speaker (#2691/#2707).
+
+        Three states, not two. A restore whose track never reported ``playing``
+        did not confirm a pause — it watched an idle speaker and can only say
+        the room stayed quiet, whether that is because nothing ever started or
+        because a late start was caught and stopped. Printing either as
+        ``(paused)`` is what let #2691 hide inside a green log line.
+        """
+        if not paused:
+            return "PAUSE NOT CONFIRMED — see the warning above (#2605)"
+        if not started:
+            return "quiet after the late-start watch, not a confirmed pause (#2691)"
+        return "paused"
+
+    async def pause_and_confirm(self, entity_id: str, *, started: bool = True) -> bool:
         """Pause, read it back — and then keep looking (#2605).
 
         A `media_pause` with ``blocking=False`` is a request, not a fact. That
@@ -178,11 +268,30 @@ class MaQueueRestorer:
         ``MA_PAUSE_GUARD_WINDOW`` caps the whole thing so a speaker something
         else owns cannot hang the ``end-game`` teardown.
 
+        Args:
+            entity_id: the speaker to hold quiet.
+            started: whether the caller actually saw the restored track reach
+                ``playing``. False switches the guard into its #2691 mode: the
+                window becomes ``MA_LATE_START_WATCH`` and step 3 runs to the
+                end of it instead of stopping after ``MA_PAUSE_SETTLE_HOLD``,
+                because a speaker that has not started yet produces exactly the
+                same ``idle`` reading as one that has settled. Silence is only
+                evidence once there was something to silence.
+
         Returns:
-            True when the speaker actually held the silence (or the entity is
-            gone). False means unconfirmed — the warning in the log says why.
+            True when the speaker actually held the silence, when the window
+            ran out with the room quiet, or when the entity is gone. False
+            means it was still playing when the guard had to stop — the
+            warning in the log says so, and only then.
         """
-        deadline = asyncio.get_event_loop().time() + MA_PAUSE_GUARD_WINDOW
+        loop = asyncio.get_event_loop()
+        window = MA_PAUSE_GUARD_WINDOW if started else MA_LATE_START_WATCH
+        deadline = loop.time() + window
+        # Flips the moment the speaker is seen playing — including a late start
+        # caught inside the #2691 watch. From then on this is an ordinary
+        # relapse and gets the ordinary MA_PAUSE_SETTLE_HOLD, not another full
+        # window of waiting.
+        seen_playing = started
         for versuch in range(1, MA_PAUSE_MAX_ATTEMPTS + 1):
             await self._hass.services.async_call(
                 "media_player",
@@ -191,36 +300,70 @@ class MaQueueRestorer:
                 blocking=False,
             )
             if not await self._wait_until_quiet(entity_id, deadline):
+                # `_wait_until_quiet` only gives up on a reading that is still
+                # active, so this branch is always a genuinely playing speaker.
+                seen_playing = True
                 _LOGGER.debug(
                     "Queue restore on %s: still playing after pause attempt %d",
                     entity_id,
                     versuch,
                 )
-            elif await self._stays_quiet(entity_id, deadline):
-                if versuch > 1:
-                    _LOGGER.info(
-                        "Queue restore on %s: speaker stayed paused after "
-                        "attempt %d (#2605)",
-                        entity_id,
-                        versuch,
-                    )
-                return True
             else:
+                hold = MA_PAUSE_SETTLE_HOLD if seen_playing else None
+                outcome = await self._stays_quiet(entity_id, deadline, hold)
+                if outcome is QuietOutcome.HELD:
+                    if versuch > 1:
+                        _LOGGER.info(
+                            "Queue restore on %s: speaker stayed paused after "
+                            "attempt %d (#2605)",
+                            entity_id,
+                            versuch,
+                        )
+                    return True
+                if outcome is QuietOutcome.WINDOW_EXPIRED:
+                    # #2707: quiet room, spent window. The old code fell
+                    # through to the WARNING here and told the maintainer the
+                    # speaker was still playing the host's queue.
+                    if seen_playing:
+                        _LOGGER.info(
+                            "Queue restore on %s: %.0fs guard window ran out "
+                            "with the speaker quiet after attempt %d — pause "
+                            "held, though not for the full %.0fs (#2707)",
+                            entity_id,
+                            window,
+                            versuch,
+                            MA_PAUSE_SETTLE_HOLD,
+                        )
+                    else:
+                        # #2691: the track never started at all. Worth an INFO
+                        # rather than silence, because the host's music did not
+                        # actually come back — the restore returns True for the
+                        # room, not for the promise.
+                        _LOGGER.info(
+                            "Queue restore on %s: the track never started "
+                            "within %.0fs and the speaker stayed quiet for all "
+                            "of it (#2691)",
+                            entity_id,
+                            window,
+                        )
+                    return True
                 # This is the observation #2606 could not make: the pause
                 # arrived, and the speaker started itself again afterwards.
+                # Under #2691 it is the late start finally landing.
+                seen_playing = True
                 _LOGGER.info(
                     "Queue restore on %s: speaker started playing again after "
                     "pause attempt %d — pausing once more (#2605)",
                     entity_id,
                     versuch,
                 )
-            if asyncio.get_event_loop().time() >= deadline:
+            if loop.time() >= deadline:
                 break
         _LOGGER.warning(
             "Queue restore on %s: could not get the speaker to stay paused "
             "within %.0fs — it is still playing the host's queue (#2605)",
             entity_id,
-            MA_PAUSE_GUARD_WINDOW,
+            window,
         )
         return False
 
@@ -234,6 +377,11 @@ class MaQueueRestorer:
 
         ``None`` means the entity is gone. There is nothing left to pause then,
         and waiting on it would only stall the teardown.
+
+        Returns:
+            True as soon as the speaker is not reporting active playback.
+            False only ever after a reading that WAS active — which is why the
+            caller may treat it as "still playing" without a second check.
         """
         loop = asyncio.get_event_loop()
         limit = min(loop.time() + MA_PAUSE_CONFIRM_WAIT, deadline)
@@ -245,31 +393,45 @@ class MaQueueRestorer:
                 return False
             await asyncio.sleep(MA_PAUSE_POLL)
 
-    async def _stays_quiet(self, entity_id: str, deadline: float) -> bool:
-        """Read the silence back for ``MA_PAUSE_SETTLE_HOLD`` seconds (#2605).
+    async def _stays_quiet(
+        self, entity_id: str, deadline: float, hold: float | None
+    ) -> QuietOutcome:
+        """Read the silence back and say why the watch ended (#2605/#2707).
 
-        This is precisely the step #2606 was missing. There the first quiet
-        reading counted as proof — and because it fell inside a two-second
-        window, it was a reading of a speaker that had not finished settling.
+        Holding the silence is precisely the step #2606 was missing. There the
+        first quiet reading counted as proof — and because it fell inside a
+        two-second window, it was a reading of a speaker that had not finished
+        settling.
+
+        Args:
+            entity_id: the speaker to watch.
+            deadline: the guard window's end; never watched past it.
+            hold: how many seconds of unbroken silence count as proof, or
+                ``None`` to watch until the deadline. ``None`` is the #2691
+                case: a track that never started has no settling to outlive,
+                so no length of quiet is proof and the guard simply watches
+                for as long as it is allowed to.
 
         Returns:
-            False as soon as playback is reported again, or when the guard
-            window runs out before the silence has held long enough.
+            The reason the watch stopped. ``RELAPSED`` and ``WINDOW_EXPIRED``
+            used to share a ``False``, and the caller has to tell them apart —
+            one needs another pause, the other needs the guard to stop lying
+            about a silent room (#2707).
         """
         loop = asyncio.get_event_loop()
-        hold_until = loop.time() + MA_PAUSE_SETTLE_HOLD
+        hold_until = None if hold is None else loop.time() + hold
         while True:
             now = loop.time()
-            if now >= hold_until:
-                return True
+            if hold_until is not None and now >= hold_until:
+                return QuietOutcome.HELD
             if now >= deadline:
-                return False
+                return QuietOutcome.WINDOW_EXPIRED
             await asyncio.sleep(MA_PAUSE_POLL)
             state = self._hass.states.get(entity_id)
             if state is None:
-                return True
+                return QuietOutcome.HELD
             if state.state in MA_ACTIVE_STATES:
-                return False
+                return QuietOutcome.RELAPSED
 
     async def _wait_for_playing(self, entity_id: str) -> bool:
         """Poll until the speaker reports playback, at most MA_QUEUE_RESTORE_WAIT."""

--- a/tests/unit/test_ma_queue_restore_2143.py
+++ b/tests/unit/test_ma_queue_restore_2143.py
@@ -44,6 +44,11 @@ def _fast_pause_guard(monkeypatch):
     monkeypatch.setattr(queue_restore, "MA_PAUSE_CONFIRM_WAIT", 0.05)
     monkeypatch.setattr(queue_restore, "MA_PAUSE_SETTLE_HOLD", 0.05)
     monkeypatch.setattr(queue_restore, "MA_PAUSE_GUARD_WINDOW", 0.30)
+    # #2691: the restore that never sees `playing` gets the longer late-start
+    # watch instead of the guard window. One fixture in this file (the idle
+    # speaker in the seek test) takes that path and would otherwise sit here
+    # for the full production 18s.
+    monkeypatch.setattr(queue_restore, "MA_LATE_START_WATCH", 0.30)
     monkeypatch.setattr(queue_restore, "MA_PAUSE_POLL", 0.01)
 
 

--- a/tests/unit/test_queue_restore_stays_paused_2605.py
+++ b/tests/unit/test_queue_restore_stays_paused_2605.py
@@ -46,16 +46,27 @@ ENTITY = "media_player.esszimmer"
 
 
 @pytest.fixture(autouse=True)
-def _fast_guard(monkeypatch):
+def _fast_guard(monkeypatch, request):
     """Run the real guard on a compressed clock.
 
-    The production budget is 5s of hold inside a 12s window — correct for a
-    Sonos, unbearable in a unit suite. Only the durations shrink; the logic
-    under test is untouched.
+    The production budget is 5s of hold inside a 14s window, and an 18s watch
+    for a track that never started — correct for a Sonos behind Apple Music,
+    unbearable in a unit suite. Only the durations shrink; the logic under test
+    is untouched.
+
+    A class can set ``real_clock = True`` to opt out. Exactly one does: the
+    arithmetic between the constants (#2707) is only worth asserting on the
+    numbers that ship.
     """
+    if getattr(request.cls, "real_clock", False):
+        return
     monkeypatch.setattr(queue_restore, "MA_PAUSE_CONFIRM_WAIT", 0.20)
     monkeypatch.setattr(queue_restore, "MA_PAUSE_SETTLE_HOLD", 0.30)
     monkeypatch.setattr(queue_restore, "MA_PAUSE_GUARD_WINDOW", 2.0)
+    # Kept clearly longer than the guard window, the way production keeps it
+    # (18s against 14s): a test that only passes because the two are equal
+    # would prove nothing about #2691.
+    monkeypatch.setattr(queue_restore, "MA_LATE_START_WATCH", 3.0)
     monkeypatch.setattr(queue_restore, "MA_PAUSE_POLL", 0.02)
     monkeypatch.setattr(queue_restore, "MA_QUEUE_RESTORE_WAIT", 0.20)
     monkeypatch.setattr(queue_restore, "MA_QUEUE_RESTORE_POLL", 0.02)
@@ -69,27 +80,76 @@ class Speaker:
     seconds later the device is playing once more. #2606 stopped looking two
     seconds after the pause, so from where it stood the teardown had worked.
 
+    ``starts_after`` adds the case #2691 found missing. Without it the fake is
+    playing from the first read, which is the one thing a restored track is
+    NOT: ``advance_to_end`` stopped the speaker, ``play_media`` is submitted
+    non-blocking, and Music Assistant's Apple Music provider throttles and
+    retries on its own backoff — 15.7s in this codebase's own notes, 14.6s
+    measured live in #2682. Until it starts, the device answers ``idle``, which
+    reads exactly like a settled pause, and **a pause sent in that stretch does
+    nothing at all**. That last part is the defect: the guard used to confirm
+    silence against a track that had not begun, and by the time it did begin
+    nobody was looking.
+
     Args:
         resume_after: seconds between an accepted pause and the relapse.
-        obeys_from: the pause command number from which the speaker stays
-            quiet for good. ``None`` means it never settles.
+        obeys_from: the number of EFFECTIVE pauses (see ``pause``) from which
+            the speaker stays quiet for good. ``None`` means it never settles.
+        starts_after: seconds from the first state read until Music Assistant
+            actually starts the track. ``None`` means it is already playing.
     """
 
-    def __init__(self, *, resume_after: float, obeys_from: int | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        resume_after: float,
+        obeys_from: int | None = None,
+        starts_after: float | None = None,
+    ) -> None:
         self.resume_after = resume_after
         self.obeys_from = obeys_from
+        self.starts_after = starts_after
+        # Every pause command HA sent, including the ones that hit an idle
+        # player and did nothing.
         self.pause_count = 0
+        # The pauses that actually stopped something. A guard that only ever
+        # pauses a player that has not started yet scores zero here — which is
+        # #2691 in one number.
+        self.effective_pauses = 0
         self.paused_at: float | None = None
+        self._playing = starts_after is None
+        self._born: float | None = None
+
+    def _tick(self) -> None:
+        """Let the clock start the track if its moment has come."""
+        now = asyncio.get_event_loop().time()
+        if self._born is None:
+            self._born = now
+        if self._playing or self.starts_after is None:
+            return
+        if now - self._born >= self.starts_after:
+            self._playing = True
+            # A pause that arrived before the track existed did not survive it.
+            self.paused_at = None
 
     def pause(self) -> None:
+        self._tick()
         self.pause_count += 1
+        if not self._playing:
+            # `media_pause` on an idle player is a no-op. Counting it as one
+            # would hide the very thing #2691 is about.
+            return
+        self.effective_pauses += 1
         self.paused_at = asyncio.get_event_loop().time()
 
     @property
     def state(self) -> str:
+        self._tick()
+        if not self._playing:
+            return "idle"
         if self.paused_at is None:
             return "playing"
-        if self.obeys_from is not None and self.pause_count >= self.obeys_from:
+        if self.obeys_from is not None and self.effective_pauses >= self.obeys_from:
             # `idle`, not `paused`: that is what Sonos through Music Assistant
             # actually settles to — measured 05.09.2026, visible in the service
             # response as playing → idle.
@@ -279,3 +339,211 @@ class TestOrderingStillHolds:
             assert calls.index((domain, service)) < pause_at, (
                 f"{service} runs after the pause and can undo it"
             )
+
+
+class TestATrackThatStartsLate:
+    """#2691 — the third layer of #2605, and the one the fake could not reach.
+
+    ``restore_on`` waits ``MA_QUEUE_RESTORE_WAIT`` for the restored track to
+    report ``playing`` and then goes on to the guard whether it saw it or not.
+    Everything downstream of that then agrees, wrongly: ``media_pause`` on an
+    idle player is a no-op, the ``idle`` that ``advance_to_end``'s ``media_stop``
+    left behind reads as a settled pause, the hold watches five seconds of that
+    same untouched idle, and the log says ``(paused)``.
+
+    Then Music Assistant starts the track. 15.7s is what this codebase records
+    for Apple Music's throttle-and-retry (``game/state_lifecycle.py``); 14.6s is
+    what #2682 measured on the live installation. Both are past the 5s wait, and
+    the old 12s guard window did not reach them either.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_track_that_starts_after_the_wait_is_still_paused(self):
+        """The room must end up quiet even when the track begins late.
+
+        Against the guard as it shipped in v4.4.3 this fails twice over: the
+        speaker is never effectively paused, and it is playing when the restore
+        claims to be done.
+        """
+        speaker = Speaker(resume_after=99.0, obeys_from=1, starts_after=1.0)
+        hass = _hass_for(speaker)
+        guard = _guard(hass)
+
+        assert await guard.restore_on(ENTITY, QUEUE) is True
+
+        assert speaker.effective_pauses >= 1, (
+            "the track started after the restore stopped watching and was "
+            "never actually paused — this is #2691"
+        )
+        assert speaker.state != "playing"
+
+    @pytest.mark.asyncio
+    async def test_the_pre_play_idle_is_not_accepted_as_a_settled_pause(self):
+        """The guard alone, told the track never started.
+
+        ``pause_and_confirm(started=False)`` must keep watching for the whole
+        late-start window rather than take the first quiet reading as proof.
+        The speaker here starts halfway through it.
+        """
+        speaker = Speaker(resume_after=99.0, obeys_from=1, starts_after=1.0)
+        hass = _hass_for(speaker)
+        guard = _guard(hass)
+
+        assert await guard.pause_and_confirm(ENTITY, started=False) is True
+
+        assert speaker.effective_pauses >= 1
+        assert speaker.state != "playing"
+
+    @pytest.mark.asyncio
+    async def test_the_log_does_not_call_an_unstarted_track_paused(
+        self, caplog, monkeypatch
+    ):
+        """A track that never started was not paused, and the line must say so.
+
+        The v4.4.3 line reads ``Queue restored on … (paused)`` here, over a
+        speaker nothing has been done to. That is the same green-log failure
+        mode that let #2605 survive two live tests.
+        """
+        monkeypatch.setattr(queue_restore, "MA_LATE_START_WATCH", 0.30)
+        speaker = Speaker(resume_after=99.0, obeys_from=1, starts_after=99.0)
+        hass = _hass_for(speaker)
+        guard = _guard(hass)
+
+        with caplog.at_level("INFO"):
+            assert await guard.restore_on(ENTITY, QUEUE) is True
+
+        restored = [r for r in caplog.records if "Queue restored on" in r.getMessage()]
+        assert restored, "no restore line was logged at all"
+        assert "(paused)" not in restored[-1].getMessage(), (
+            "the restore reports a pause it never performed — the track had "
+            "not started (#2691)"
+        )
+        assert "2691" in restored[-1].getMessage()
+
+    @pytest.mark.asyncio
+    async def test_a_late_start_does_not_get_a_second_full_window(self):
+        """Once the speaker has been seen playing, it is an ordinary relapse.
+
+        The long watch exists because silence proves nothing before the track
+        starts. After it starts, ``MA_PAUSE_SETTLE_HOLD`` is the right hold
+        again — otherwise every late start would cost a second full window of
+        teardown.
+        """
+        speaker = Speaker(resume_after=99.0, obeys_from=1, starts_after=0.1)
+        hass = _hass_for(speaker)
+        guard = _guard(hass)
+
+        loop = asyncio.get_event_loop()
+        began = loop.time()
+        assert await guard.pause_and_confirm(ENTITY, started=False) is True
+        spent = loop.time() - began
+
+        assert spent < queue_restore.MA_LATE_START_WATCH / 2, (
+            "the guard sat out the whole late-start window after the speaker "
+            "had already been caught and paused"
+        )
+
+
+class TestTheLogTellsRelapseFromTimeout:
+    """#2707 — ``_stays_quiet`` used to answer both questions with ``False``.
+
+    A relapse and an expired window are opposite findings: one means the
+    speaker started itself again, the other means the room was silent and the
+    guard simply ran out of permission to look. Merging them produced the
+    WARNING "it is still playing the host's queue" over a paused speaker —
+    and that WARNING is the line the live test read to identify the mechanism
+    behind #2605.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_quiet_speaker_at_the_deadline_is_not_reported_as_playing(
+        self, caplog, monkeypatch
+    ):
+        """Window shorter than the hold: the guard must run out, not accuse.
+
+        This is the shape of the real thing — attempt 1 spends its full budget
+        and the window ends underneath it — compressed into one attempt.
+        """
+        monkeypatch.setattr(queue_restore, "MA_PAUSE_SETTLE_HOLD", 0.60)
+        monkeypatch.setattr(queue_restore, "MA_PAUSE_GUARD_WINDOW", 0.15)
+        speaker = Speaker(resume_after=99.0, obeys_from=1)
+        hass = _hass_for(speaker)
+        guard = _guard(hass)
+
+        with caplog.at_level("INFO"):
+            assert await guard.pause_and_confirm(ENTITY) is True
+
+        assert not [
+            r
+            for r in caplog.records
+            if "still playing the host's queue" in r.getMessage()
+        ], "the guard ran out of window over a silent speaker and called it playing"
+
+    @pytest.mark.asyncio
+    async def test_a_real_relapse_still_warns(self, caplog):
+        """The other half of #2707: the WARNING has to keep meaning something.
+
+        A speaker that genuinely will not stay paused must still produce it —
+        the fix is about the false positive, not about softening the line.
+        """
+        speaker = Speaker(resume_after=0.08)  # never settles
+        hass = _hass_for(speaker)
+        guard = _guard(hass)
+
+        with caplog.at_level("INFO"):
+            assert await guard.pause_and_confirm(ENTITY) is False
+
+        assert [
+            r
+            for r in caplog.records
+            if "still playing the host's queue" in r.getMessage()
+        ], "a speaker that never stayed paused was reported as fine"
+
+    @pytest.mark.asyncio
+    async def test_the_second_attempt_fits_inside_the_window(self, monkeypatch):
+        """Attempt 2 must be able to run to the end, not be cut off by the cap.
+
+        With the window sized at exactly two worst-case attempts, a speaker
+        that relapses once and then settles is confirmed on attempt 2 rather
+        than falling out of the loop with a warning.
+        """
+        cost = queue_restore.MA_PAUSE_CONFIRM_WAIT + queue_restore.MA_PAUSE_SETTLE_HOLD
+        monkeypatch.setattr(queue_restore, "MA_PAUSE_GUARD_WINDOW", 2 * cost)
+        speaker = Speaker(resume_after=0.25, obeys_from=2)
+        hass = _hass_for(speaker)
+        guard = _guard(hass)
+
+        assert await guard.pause_and_confirm(ENTITY) is True
+        assert speaker.pause_count == 2
+
+
+class TestTheProductionBudget:
+    """The numbers that ship, not the compressed ones (#2707).
+
+    ``MA_PAUSE_MAX_ATTEMPTS = 3`` was decoration: one attempt can cost a full
+    ``MA_PAUSE_CONFIRM_WAIT`` plus a full ``MA_PAUSE_SETTLE_HOLD``, and the
+    window was a round 12.0 that fitted one of those and a bit.
+    """
+
+    real_clock = True
+
+    def test_the_window_fits_at_least_two_worst_case_attempts(self):
+        cost = queue_restore.MA_PAUSE_CONFIRM_WAIT + queue_restore.MA_PAUSE_SETTLE_HOLD
+        assert queue_restore.MA_PAUSE_GUARD_WINDOW >= 2 * cost, (
+            "a second pause attempt cannot finish inside the guard window, so "
+            "MA_PAUSE_MAX_ATTEMPTS is a number the loop can never reach (#2707)"
+        )
+
+    def test_the_late_start_watch_outlives_apple_musics_backoff(self):
+        """15.7s is the documented throttle-and-retry, 14.6s the measured one.
+
+        Both are counted from the ``play_media``, so the watch only has to
+        cover what is left after ``MA_QUEUE_RESTORE_WAIT`` — with margin,
+        because neither number is a guarantee.
+        """
+        cover = queue_restore.MA_QUEUE_RESTORE_WAIT + queue_restore.MA_LATE_START_WATCH
+        assert cover >= 20.0, (
+            "a track that starts on Apple Music's own backoff (15.7s "
+            "documented, 14.6s measured in #2682) finishes outside the watch "
+            "and plays into an ended game (#2691)"
+        )


### PR DESCRIPTION
Third round on #2605. The guard shipped in v4.4.3 — pause, wait for quiet, hold the silence, re-pause on relapse — is untouched: the live test on real hardware saw it fire on 4 of 6 game endings, always with a `media_seek` in flight, always recovering inside the window. These are the two cases it still missed.

## #2691 — silence confirmed on a track that had not started

`restore_on` sends a non-blocking `play_media`, waits at most `MA_QUEUE_RESTORE_WAIT` (5s) for `playing`, and went on to `pause_and_confirm` whether or not it ever saw the track start. From there everything agreed, wrongly: `media_pause` on an idle player is a no-op, the `idle` that `advance_to_end`'s `media_stop` left behind reads exactly like a settled pause, the hold watched five seconds of that same untouched state, and the log said `(paused)`.

Then Music Assistant starts the track. Apple Music's throttle-and-retry is ~15.7s in this codebase's own notes (`game/state_lifecycle.py`), and #2682 measured 14.6s on the live installation. Both are past the 5s wait, and the old 12s window did not reach them either.

`restore_on` now tells the guard what it saw. A restore that never observed `playing` runs in a different mode:

- the window becomes `MA_LATE_START_WATCH` (18s, so 23s of cover counted from the `play_media`),
- the hold runs to the end of that window instead of stopping after `MA_PAUSE_SETTLE_HOLD`, because before the track starts no length of quiet is evidence of anything,
- a late start caught inside the watch is paused and then treated as an ordinary relapse, so it does not cost a second full window,
- the closing restore line stops calling an unstarted track `(paused)`.

The cost is teardown latency on that path, and it is deliberate: a spinner the host is already looking at, against their own music coming back up in a room where the game is over.

## #2707 — a timeout reported as a relapse

`_stays_quiet` returned `False` both when the speaker started itself again and when the guard window expired, so the caller could not tell them apart. If attempt 1 spent its full budget, attempt 2 could not fit, and the run ended on the WARNING "it is still playing the host's queue" over a speaker that was in fact paused — the exact line the live test read to identify the mechanism behind #2605.

It now returns a `QuietOutcome`: `HELD`, `RELAPSED`, or `WINDOW_EXPIRED`. A spent window over a silent room is logged at INFO for what it is and counts as paused; the WARNING fires only after a reading that was genuinely active.

`MA_PAUSE_GUARD_WINDOW` was a round 12.0 with no relation to what an attempt costs (`MA_PAUSE_CONFIRM_WAIT` + `MA_PAUSE_SETTLE_HOLD` = 7s), which is why `MA_PAUSE_MAX_ATTEMPTS = 3` was unreachable. It is now derived — two worst-case attempts always fit (14s), and a third fits whenever the relapse arrives before the hold is over, which is the shape every live run has had.

## Tests

The `Speaker` fake modelled "obeys, then relapses" and nothing else, which is why #2691 passed its tests. It gains `starts_after`: idle until Music Assistant starts the track, with pauses sent during that stretch counted separately because they do nothing at all.

Every new test was verified by breaking the production code on purpose and watching the right one go red:

| Break | Red |
|---|---|
| `restore_on` stops passing `started` | `test_a_track_that_starts_after_the_wait_is_still_paused` |
| hold fixed at `MA_PAUSE_SETTLE_HOLD` | the two late-start behaviour tests |
| label always `paused` | `test_the_log_does_not_call_an_unstarted_track_paused` |
| `WINDOW_EXPIRED` → `RELAPSED` | `test_a_quiet_speaker_at_the_deadline_is_not_reported_as_playing` |
| window back to `12.0` | `test_the_window_fits_at_least_two_worst_case_attempts` |
| watch cut to `12.0` | `test_the_late_start_watch_outlives_apple_musics_backoff` |

Green: `pytest tests/unit tests/integration` 2470 passed / 2 skipped · `npm test` 912 passed · `npm run build:check` 16 artifacts match · `ruff format --check` clean.

## Not covered

A start later than `MA_QUEUE_RESTORE_WAIT + MA_LATE_START_WATCH` (23s after the `play_media`) is still unwatched — the guard cannot outlive the teardown without running in the background, which would risk pausing the next game. Worth watching for in the next live test.

Closes #2691
Closes #2707

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKsEKt68KHSqmi617XNCVi