### PR TITLE
refactor: put the TTS resume watchdog behind the media-player port

### DIFF
--- a/custom_components/beatify/game/protocols.py
+++ b/custom_components/beatify/game/protocols.py
@@ -17,13 +17,24 @@ instead of mocking Home Assistant.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Protocol, runtime_checkable
 
 
 @runtime_checkable
 class MediaPlayerProtocol(Protocol):
-    """Interface that GameState expects from a media-player service."""
+    """Interface that GameState expects from a media-player service.
+
+    #2711: this list is the whole contract, so it has to name everything the
+    domain actually calls. It did not: ``seek_forward``,
+    ``get_playback_state`` and the two failure-report attributes were called
+    without being declared, and a fake written against the Protocol therefore
+    raised on them. The reveal auto-advance swallows that exception as "still
+    playing" (``state_auto_advance.py``), so song-end auto-advance was
+    silently dead in every test that used such a fake. Anything the domain
+    reaches for belongs here.
+    """
 
     def set_analytics(self, analytics: Any) -> None: ...
     def is_available(self) -> bool: ...
@@ -38,6 +49,22 @@ class MediaPlayerProtocol(Protocol):
     async def restore_volume(self) -> bool: ...
     async def restore_queue(self) -> bool: ...
     def snapshot_saved_states(self) -> dict[str, dict[str, Any]]: ...
+    async def seek_forward(self, seconds: int) -> bool: ...
+    def get_playback_state(self) -> str | None: ...
+    async def resume_after_announcement(
+        self,
+        *,
+        lead_seconds: float,
+        should_continue: Callable[[], bool],
+    ) -> None: ...
+
+    # Why the last attempt failed, and which URI it used. Read by
+    # ``state_lifecycle`` to tell a storefront gap (#808: skip the song) from
+    # a systemic failure (#949/#1936: pause the game), and to name the URI
+    # that was really tried in the pause banner (#1927). Both are ``None``
+    # until the first attempt.
+    last_failure_reason: str | None
+    last_attempted_uri: str | None
 
 
 @runtime_checkable

--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -19,7 +19,9 @@ It **references** (does not own, receives from outside):
 * TTS announcer — optional, built from the injected factory (#2638)
 
 #2638: GameState does not import ``services.*`` and does not know Home
-Assistant exists when it builds these. It is handed a
+Assistant exists when it builds these — nor, since #2710, when it drives them:
+the post-announcement resume watchdog was the last place the game logic read
+``hass.states`` and called a ``media_player`` service itself. It is handed a
 ``GameOutputFactories`` bundle (game/protocols.py) at construction; the
 composition root fills it with HA-backed factories, a test fills it with fakes
 or leaves it empty. The admin spectator WebSocket used to live here too — it is

--- a/custom_components/beatify/game/state_lifecycle.py
+++ b/custom_components/beatify/game/state_lifecycle.py
@@ -90,6 +90,14 @@ methods that need it (``# noqa: PLC0415``) to avoid a top-level circular import
 back into ``state.py``. The concrete ``MediaPlayerService`` is no longer
 imported here at all (#2638) — ``_ensure_media_player_service`` calls the
 injected factory, so the import graph stays acyclic without a lazy import.
+
+#2710: the post-announcement resume watchdog used to run here too — 215 lines
+of ``hass.states.get`` / ``hass.services.async_call("media_player", …)`` inside
+``_start_round_locked``, which is why "the game logic does not know Home
+Assistant exists" was false on every round with TTS enabled. The loop now lives
+on the media-player port (``resume_after_announcement``), next to every other
+way this game presses play; what stays here is the announcement budget, the
+"was this stopped on purpose" answer only the game can give, and the task.
 """
 
 from __future__ import annotations
@@ -406,9 +414,11 @@ class RoundLifecycleMixin:
                 # "error" / unset → systemic failure (speaker offline, MA
                 # provider broken). Count toward MAX_SONG_RETRIES so the
                 # recovery banner kicks in for real problems.
-                failure_reason = getattr(
-                    self._media_player_service, "last_failure_reason", None
-                )
+                # #2711: a plain read. The port declares this attribute, so
+                # a `getattr(..., None)` guard would only hide a fake that
+                # does not — by classifying its failures as "error" and
+                # quietly disabling the skip logic below.
+                failure_reason = self._media_player_service.last_failure_reason
                 self._playlist_manager.mark_played(get_playback_uri(song))
 
                 if failure_reason == "unavailable":
@@ -476,9 +486,9 @@ class RoundLifecycleMixin:
                 # defect and sends the next reader into the wrong provider.
                 # Falls back to the base field when no attempt was recorded
                 # (e.g. the song carried no playable URI at all).
-                attempted_uri = getattr(
-                    self._media_player_service, "last_attempted_uri", None
-                ) or song.get("uri")
+                attempted_uri = (
+                    self._media_player_service.last_attempted_uri or song.get("uri")
+                )
                 # #1927: name the speaker too. The pause banner used to explain
                 # *what* failed and *which provider* to re-authenticate, but
                 # never *where* it was playing — the whole reason a game running
@@ -589,17 +599,20 @@ class RoundLifecycleMixin:
         # fail to auto-resume afterwards — the player sits "paused" until a
         # human presses play. Verify playback shortly after the announcement
         # chain and press play on the device's behalf if needed.
-        if self._tts_service and self._hass and self.media_player:
+        #
+        # #2710: the watching itself is a conversation with one speaker, so it
+        # lives on the media-player port (``resume_after_announcement``) next
+        # to every other way this game presses play. What stays here is what
+        # only the game knows — how long the announcements still run, whether
+        # playback stopped on purpose, and who owns the task.
+        #
+        # The old `self._hass` in this condition went with the old body. It
+        # meant "we are running under Home Assistant, so there is a state
+        # machine to poll"; nothing below polls one any more, and keeping it
+        # would have left the whole path reachable only from a `hass` stub —
+        # which is the #2638 complaint this change exists to answer.
+        if self._tts_service and self.media_player:
             import asyncio as _asyncio
-
-            # Snapshot the level BEFORE announcements duck/restore it, so the
-            # watchdog below can undo an upward ratchet.
-            _vol_before = None
-            with contextlib.suppress(Exception):
-                _st0 = self._hass.states.get(self.media_player)
-                _v = _st0.attributes.get("volume_level") if _st0 else None
-                if isinstance(_v, (int, float)):
-                    _vol_before = float(_v)
 
             # The song is (or is about to be) audible: start the round clock
             # from here rather than from initialize_round, so players get the
@@ -635,176 +648,58 @@ class RoundLifecycleMixin:
                     with contextlib.suppress(Exception):
                         self._notify_state_callbacks()
 
-            _LOGGER.info("TTS resume watchdog armed for %s", self.media_player)
+            # How long the speaker is still expected to be busy announcing.
+            # The TTS queue's own reservation, capped: the watchdog waits it
+            # out and then kicks immediately, rather than spending three more
+            # seconds confirming a hang we already expect.
+            lead = 0.0
+            _busy = getattr(self, "announcement_busy_seconds", None)
+            if callable(_busy):
+                with contextlib.suppress(Exception):
+                    lead = min(float(_busy()), 15.0)
 
-            async def _resume_watchdog() -> None:
-                # v0.7.22 — triggers verified on hardware via the narrating
-                # build:
-                # * VA satellites stick in state='idle' after an announcement
-                #   (HA never reports 'paused' even while MA's UI shows the
-                #   paused track) -> sustained idle WITH a loaded title is
-                #   the kick signature.
-                # * 'playing' is healthy, full stop: media_position on MA
-                #   entities is a snapshot+timestamp, not a live counter, so
-                #   the old frozen-position stall heuristic false-positived
-                #   on a perfectly playing ShieldTV. Removed.
-                # v0.7.30 — ANTICIPATE instead of observe. Playback starts
-                # BEFORE the announcements are fired, so every announcement
-                # interrupts the song and the device has to resume. Waiting
-                # for 3 consecutive idle ticks to prove that meant a 3-4s
-                # silence after "…3, 2, 1, go" (reported). We now know how
-                # long the announcements should take, so: wait out that
-                # window, then kick IMMEDIATELY if the speaker isn't playing,
-                # instead of spending three more seconds confirming what we
-                # already expect.
-                kicks = 0
-                idle_streak = 0
-                vol_restored = False
-                lead = 0.0
-                _busy = getattr(self, "announcement_busy_seconds", None)
-                if callable(_busy):
-                    with contextlib.suppress(Exception):
-                        lead = min(float(_busy()), 15.0)
-                if lead > 0:
-                    await _asyncio.sleep(lead + 0.4)
-                    st0 = self._hass.states.get(self.media_player)
-                    if st0 is not None and st0.state in ("idle", "paused"):
-                        kicks += 1
-                        _LOGGER.info(
-                            "Resume watchdog: announcement window over, resuming "
-                            "immediately (state=%s)",
-                            st0.state,
-                        )
-                        with contextlib.suppress(Exception):
-                            await self._hass.services.async_call(
-                                "media_player",
-                                "media_play",
-                                {"entity_id": self.media_player},
-                                blocking=True,
-                            )
-                    elif st0 is not None and st0.state == "playing":
-                        # Device resumed on its own (ShieldTV behaviour) —
-                        # nothing to do, but keep polling as a safety net.
-                        pass
-                for tick in range(20):
-                    await _asyncio.sleep(1.0)
-                    # #2576: der Wachhund darf nur wiederbeleben, was von allein
-                    # stehengeblieben ist — nie etwas, das jemand absichtlich
-                    # angehalten hat.
-                    #
-                    # Ohne diese Pruefung liest er zwei gewollte Zustaende als
-                    # Haenger: der Host tippt „Song stoppen" (media_stop laesst
-                    # einen MA-Player als `idle` MIT Titel zurueck — genau die
-                    # Signatur, die weiter unten als steckengeblieben gilt), und
-                    # das Spiel pausiert (pause_game stoppt den Lautsprecher).
-                    # In beiden Faellen startete er die Musik wieder: einmal
-                    # gegen den ausdruecklichen Wunsch des Gastgebers, einmal
-                    # unter dem Pause-Banner.
-                    from .state import GamePhase  # noqa: PLC0415 — Zirkelbezug
+            def _watchdog_should_continue() -> bool:
+                """False once playback stopped on purpose (#2576).
 
-                    if self.phase != GamePhase.PLAYING or getattr(
-                        self, "song_stopped", False
-                    ):
-                        _LOGGER.info(
-                            "Resume watchdog: phase=%s song_stopped=%s — exit "
-                            "(playback stopped on purpose)",
-                            self.phase,
-                            getattr(self, "song_stopped", None),
-                        )
-                        return
-                    st = self._hass.states.get(self.media_player)
-                    if st is None:
-                        _LOGGER.info("Resume watchdog: entity vanished — exit")
-                        return
-                    title = st.attributes.get("media_title")
+                Two *wanted* states are indistinguishable from a hang when you
+                only look at the speaker: the host taps "stop song"
+                (``media_stop`` leaves a Music Assistant player ``idle`` WITH a
+                title — exactly the stuck signature), and the game pauses
+                (``pause_game`` stops the speaker). Only the game can tell the
+                difference, so the port asks before every read.
+                """
+                from .state import GamePhase  # noqa: PLC0415 — Zirkelbezug
+
+                if self.phase != GamePhase.PLAYING or getattr(
+                    self, "song_stopped", False
+                ):
                     _LOGGER.info(
-                        "Resume watchdog[%02d]: state=%s title=%s",
-                        tick,
-                        st.state,
-                        title,
+                        "Resume watchdog: phase=%s song_stopped=%s — exit "
+                        "(playback stopped on purpose)",
+                        self.phase,
+                        getattr(self, "song_stopped", None),
                     )
+                    return False
+                return True
 
-                    # Volume ratchet guard. Music Assistant raises the volume
-                    # for an announcement and restores it afterwards; on a
-                    # ShieldTV feeding an AV receiver the restore wrote back a
-                    # HIGHER level each round, so the music grew painfully
-                    # loud within a few rounds. Beatify itself never changes
-                    # volume here, but it is the only component positioned to
-                    # notice — so undo an upward drift once per round, inside
-                    # the announcement window only, leaving the host's own
-                    # volume buttons alone for the rest of the round.
-                    if _vol_before is not None and not vol_restored and tick <= 10:
-                        cur = st.attributes.get("volume_level")
-                        if (
-                            isinstance(cur, (int, float))
-                            and float(cur) > _vol_before + 0.05
-                        ):
-                            vol_restored = True
-                            _LOGGER.warning(
-                                "Volume rose from %.2f to %.2f across the TTS "
-                                "announcement — restoring (announcement "
-                                "duck/restore ratchet)",
-                                _vol_before,
-                                float(cur),
-                            )
-                            with contextlib.suppress(Exception):
-                                await self._hass.services.async_call(
-                                    "media_player",
-                                    "volume_set",
-                                    {
-                                        "entity_id": self.media_player,
-                                        "volume_level": _vol_before,
-                                    },
-                                    blocking=True,
-                                )
-                    if st.state == "idle" and title:
-                        idle_streak += 1
-                    else:
-                        idle_streak = 0
-                    # 2 ticks, not 3: the anticipatory kick above handles the
-                    # normal case, so this fallback should react faster to the
-                    # cases it misses. Satellites flap idle<->playing for
-                    # SINGLE ticks during healthy playback, so 2 consecutive
-                    # remains the floor — and a spurious media_play on a
-                    # playing device is a no-op anyway.
-                    if st.state == "paused" or idle_streak >= 2:
-                        kicks += 1
-                        idle_streak = 0
-                        _LOGGER.warning(
-                            "Media player %s after TTS announcement — "
-                            "resuming playback (kick %d)",
-                            "paused" if st.state == "paused" else "idle-stuck",
-                            kicks,
-                        )
-                        try:
-                            await self._hass.services.async_call(
-                                "media_player",
-                                "media_play",
-                                {"entity_id": self.media_player},
-                                blocking=True,
-                            )
-                        except Exception as err:  # noqa: BLE001
-                            _LOGGER.warning(
-                                "Resume watchdog: media_play failed: %s", err
-                            )
-                            return
-                        if kicks >= 3:
-                            _LOGGER.info("Resume watchdog: 3 kicks — exit")
-                            return
-                    elif st.state == "off":
-                        _LOGGER.info("Resume watchdog: player off — exit")
-                        return
-                _LOGGER.info("Resume watchdog: 20s window elapsed — exit")
-
-            # Retain the task reference: asyncio's loop keeps only WEAK refs,
-            # so an unreferenced task can be garbage-collected before running.
-            prev = getattr(self, "_tts_resume_task", None)
-            if prev is not None and not prev.done():
-                prev.cancel()
-            self._tts_resume_task = _asyncio.create_task(_resume_watchdog())
-            self._tts_resume_task.add_done_callback(
-                lambda _t: setattr(self, "_tts_resume_task", None)
-            )
+            service = self._media_player_service
+            if service is not None:
+                _LOGGER.info("TTS resume watchdog armed for %s", self.media_player)
+                # Retain the task reference: asyncio's loop keeps only WEAK
+                # refs, so an unreferenced task can be garbage-collected before
+                # running.
+                prev = getattr(self, "_tts_resume_task", None)
+                if prev is not None and not prev.done():
+                    prev.cancel()
+                self._tts_resume_task = _asyncio.create_task(
+                    service.resume_after_announcement(
+                        lead_seconds=lead,
+                        should_continue=_watchdog_should_continue,
+                    )
+                )
+                self._tts_resume_task.add_done_callback(
+                    lambda _t: setattr(self, "_tts_resume_task", None)
+                )
 
         return True
 

--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -10,11 +10,13 @@ bookkeeping that decides WHEN the host's queue is captured and handed back.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import hmac
 import logging
 import secrets
 from asyncio import timeout as async_timeout
+from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
@@ -753,9 +755,15 @@ class MediaPlayerService:
             self._record_error("MEDIA_PLAYER_ERROR", f"Failed to stop: {err}")
             return False
 
-    async def play(self) -> bool:
+    async def play(self, *, blocking: bool = False) -> bool:
         """
         Resume playback (e.g. after intro pause).
+
+        Args:
+            blocking: wait for the service call to complete. The resume
+                watchdog (#2710) needs this — it re-reads the player one
+                second later and must not race its own kick. Everyone else
+                fires and forgets, which is what the call has always done.
 
         Returns:
             True if successful, False otherwise
@@ -766,12 +774,169 @@ class MediaPlayerService:
                 "media_player",
                 "media_play",
                 {"entity_id": self._entity_id},
+                blocking=blocking,
             )
             return True
         except (HomeAssistantError, ServiceNotFound) as err:
             _LOGGER.error("Failed to resume playback: %s", err)  # noqa: TRY400
             self._record_error("MEDIA_PLAYER_ERROR", f"Failed to resume: {err}")
             return False
+
+    async def resume_after_announcement(
+        self,
+        *,
+        lead_seconds: float,
+        should_continue: Callable[[], bool],
+    ) -> None:
+        """Watch the speaker through a TTS announcement and press play if it
+        does not resume on its own (#2710).
+
+        Announcements interrupt the just-started song, and some devices
+        (observed: Music Assistant voice satellites) never come back — the
+        player sits ``paused`` or ``idle``-with-a-title until a human presses
+        play. This walks a ~20 second window after the announcement chain and
+        kicks the speaker on its behalf, at most three times.
+
+        It lives here, not in ``game/state_lifecycle.py``, because every line
+        of it is a conversation with one speaker: read the state, press play,
+        undo a volume ratchet. Running it from the game logic meant a second,
+        analytics-free way to press play — a platform quirk fixed in
+        :meth:`play` was absent from the watchdog — and made the whole path
+        invisible to the injected fake from #2638.
+
+        Args:
+            lead_seconds: how long the announcements are still expected to
+                occupy the speaker. The caller owns that estimate (it is the
+                TTS queue's own reservation); we only wait it out and then
+                kick immediately instead of spending three more ticks
+                confirming what we already expect.
+            should_continue: asked once per tick, BEFORE the player is read.
+                False means playback stopped on purpose — the host tapped
+                "stop song", or the game paused — and the watchdog must not
+                undo that (#2576). Deciding after the read would still fire
+                one kick on the very tick the host stopped the song.
+
+        """
+        # v0.7.22 — triggers verified on hardware via the narrating build:
+        # * VA satellites stick in state='idle' after an announcement (HA
+        #   never reports 'paused' even while MA's UI shows the paused track)
+        #   -> sustained idle WITH a loaded title is the kick signature.
+        # * 'playing' is healthy, full stop: media_position on MA entities is
+        #   a snapshot+timestamp, not a live counter, so the old
+        #   frozen-position stall heuristic false-positived on a perfectly
+        #   playing ShieldTV. Removed.
+        # v0.7.30 — ANTICIPATE instead of observe. Playback starts BEFORE the
+        # announcements are fired, so every announcement interrupts the song
+        # and the device has to resume. Waiting for 3 consecutive idle ticks
+        # to prove that meant a 3-4s silence after "…3, 2, 1, go" (reported).
+
+        # The level as it is BEFORE the announcements duck and restore it, so
+        # the ratchet guard below can undo an upward drift.
+        vol_before: float | None = None
+        with contextlib.suppress(Exception):
+            st_before = self._hass.states.get(self._entity_id)
+            level = st_before.attributes.get("volume_level") if st_before else None
+            if isinstance(level, (int, float)):
+                vol_before = float(level)
+
+        kicks = 0
+        idle_streak = 0
+        vol_restored = False
+
+        if lead_seconds > 0:
+            await asyncio.sleep(lead_seconds + 0.4)
+            st0 = self._hass.states.get(self._entity_id)
+            if st0 is not None and st0.state in ("idle", "paused"):
+                kicks += 1
+                _LOGGER.info(
+                    "Resume watchdog: announcement window over, resuming "
+                    "immediately (state=%s)",
+                    st0.state,
+                )
+                with contextlib.suppress(Exception):
+                    await self.play(blocking=True)
+            elif st0 is not None and st0.state == "playing":
+                # Device resumed on its own (ShieldTV behaviour) — nothing to
+                # do, but keep polling as a safety net.
+                pass
+
+        for tick in range(20):
+            await asyncio.sleep(1.0)
+            # #2576: der Wachhund darf nur wiederbeleben, was von allein
+            # stehengeblieben ist — nie etwas, das jemand absichtlich
+            # angehalten hat. Der Aufrufer kennt den Unterschied, wir nicht.
+            if not should_continue():
+                return
+            st = self._hass.states.get(self._entity_id)
+            if st is None:
+                _LOGGER.info("Resume watchdog: entity vanished — exit")
+                return
+            title = st.attributes.get("media_title")
+            _LOGGER.info(
+                "Resume watchdog[%02d]: state=%s title=%s",
+                tick,
+                st.state,
+                title,
+            )
+
+            # Volume ratchet guard. Music Assistant raises the volume for an
+            # announcement and restores it afterwards; on a ShieldTV feeding
+            # an AV receiver the restore wrote back a HIGHER level each round,
+            # so the music grew painfully loud within a few rounds. Beatify
+            # itself never changes volume here, but it is the only component
+            # positioned to notice — so undo an upward drift once per round,
+            # inside the announcement window only, leaving the host's own
+            # volume buttons alone for the rest of the round.
+            if vol_before is not None and not vol_restored and tick <= 10:
+                cur = st.attributes.get("volume_level")
+                if isinstance(cur, (int, float)) and float(cur) > vol_before + 0.05:
+                    vol_restored = True
+                    _LOGGER.warning(
+                        "Volume rose from %.2f to %.2f across the TTS "
+                        "announcement — restoring (announcement "
+                        "duck/restore ratchet)",
+                        vol_before,
+                        float(cur),
+                    )
+                    with contextlib.suppress(Exception):
+                        await self._set_volume_on(
+                            self._entity_id, vol_before, blocking=True
+                        )
+            if st.state == "idle" and title:
+                idle_streak += 1
+            else:
+                idle_streak = 0
+            # 2 ticks, not 3: the anticipatory kick above handles the normal
+            # case, so this fallback should react faster to the cases it
+            # misses. Satellites flap idle<->playing for SINGLE ticks during
+            # healthy playback, so 2 consecutive remains the floor — and a
+            # spurious media_play on a playing device is a no-op anyway.
+            if st.state == "paused" or idle_streak >= 2:
+                kicks += 1
+                idle_streak = 0
+                _LOGGER.warning(
+                    "Media player %s after TTS announcement — "
+                    "resuming playback (kick %d)",
+                    "paused" if st.state == "paused" else "idle-stuck",
+                    kicks,
+                )
+                try:
+                    kicked = await self.play(blocking=True)
+                except Exception as err:  # noqa: BLE001
+                    _LOGGER.warning("Resume watchdog: media_play failed: %s", err)
+                    return
+                if not kicked:
+                    # play() has already logged it and recorded the analytics
+                    # event the old inline watchdog never produced.
+                    _LOGGER.warning("Resume watchdog: media_play failed — exit")
+                    return
+                if kicks >= 3:
+                    _LOGGER.info("Resume watchdog: 3 kicks — exit")
+                    return
+            elif st.state == "off":
+                _LOGGER.info("Resume watchdog: player off — exit")
+                return
+        _LOGGER.info("Resume watchdog: 20s window elapsed — exit")
 
     def get_volume(self) -> float:
         """
@@ -802,12 +967,15 @@ class MediaPlayerService:
         """
         return await self._set_volume_on(self._entity_id, level)
 
-    async def _set_volume_on(self, entity_id: str, level: float) -> bool:
+    async def _set_volume_on(
+        self, entity_id: str, level: float, *, blocking: bool = False
+    ) -> bool:
         """Set the volume of an explicit entity.
 
         Split out of :meth:`set_volume` so ``restore_volume`` can hand back a
         speaker the game has since switched away from (#2143) — that one is no
-        longer ``self._entity_id``.
+        longer ``self._entity_id``. ``blocking`` exists for the same reason as
+        on :meth:`play` (#2710).
         """
         try:
             await self._hass.services.async_call(
@@ -817,6 +985,7 @@ class MediaPlayerService:
                     "entity_id": entity_id,
                     "volume_level": max(0.0, min(1.0, level)),
                 },
+                blocking=blocking,
             )
             return True
         except (HomeAssistantError, ServiceNotFound) as err:

--- a/tests/unit/test_library_regressions.py
+++ b/tests/unit/test_library_regressions.py
@@ -150,11 +150,6 @@ class TestAnnouncementsAndPlayback:
             "game/state_lifecycle.py"
         )
 
-    def test_resume_watchdog_triggers_on_idle_not_only_paused(self):
-        """MA voice satellites stick in 'idle' with a title loaded; HA never
-        reports 'paused' for them."""
-        assert "idle_streak >= 2" in src("game/state_lifecycle.py")
-
     def test_announcement_is_not_mistaken_for_a_song_ending(self):
         """With auto-advance "Off" (= advance at song end), an announcement
         interruption read as a finished song and skipped the round."""
@@ -376,18 +371,12 @@ class TestRoundClockStartsWithTheMusic:
         assert "_notify_state_callbacks()" in src("game/state_lifecycle.py")
 
 
-class TestVolumeRatchetGuard:
-    def test_an_upward_drift_across_an_announcement_is_undone(self):
-        """MA's announce duck/restore wrote back a HIGHER level each round on
-        a ShieldTV feeding an AV receiver — painfully loud within a few
-        rounds."""
-        code = src("game/state_lifecycle.py")
-        assert "_vol_before" in code and "volume_set" in code
-
-    def test_the_guard_fires_once_and_only_during_the_announcement_window(self):
-        """The host's own volume buttons must keep working."""
-        code = src("game/state_lifecycle.py")
-        assert "not vol_restored" in code and "tick <= 10" in code
+# The resume watchdog's own guards — idle-streak detection and the volume
+# ratchet — used to be checked here by reading the source, because the loop was
+# a closure inside `_start_round_locked` that reached into `hass` directly and
+# could not be called. #2710 moved it onto the media-player port, so those
+# three checks are real behaviour tests now: see
+# tests/unit/test_watchdog_respects_deliberate_stop_2576.py.
 
 
 class TestClientClockIndependence:

--- a/tests/unit/test_service_injection_2638.py
+++ b/tests/unit/test_service_injection_2638.py
@@ -17,9 +17,13 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from custom_components.beatify.const import DOMAIN
-from custom_components.beatify.game.protocols import GameOutputFactories
+from custom_components.beatify.game.protocols import (
+    GameOutputFactories,
+    MediaPlayerProtocol,
+)
 from custom_components.beatify.game.state import GameState
 from custom_components.beatify.server.websocket import BeatifyWebSocketHandler
+from custom_components.beatify.services.media_player import MediaPlayerService
 from tests.conftest import make_game_state, make_songs
 
 
@@ -124,6 +128,61 @@ class TestFactoriesReceiveTheGameContext:
             "media_player_entity_id": "media_player.test",
         }
         assert state._tts_service is not None
+
+
+# ---------------------------------------------------------------------------
+# The Protocol is the whole contract (#2711)
+# ---------------------------------------------------------------------------
+
+
+class TestMediaPlayerProtocolConformance:
+    """A fake is only safe if the Protocol names everything the domain calls.
+
+    It did not. ``seek_forward``, ``get_playback_state`` and the two
+    failure-report attributes were called without being declared, so a fake
+    written against the Protocol raised on them — and the reveal auto-advance
+    swallows that as "still playing", which silently disabled song-end
+    auto-advance in every test using such a fake.
+    """
+
+    def test_the_real_service_satisfies_the_protocol(self):
+        service = MediaPlayerService(MagicMock(), "media_player.esszimmer")
+        assert isinstance(service, MediaPlayerProtocol)
+
+    @pytest.mark.parametrize(
+        "member",
+        [
+            "seek_forward",  # state_media.seek_forward
+            "get_playback_state",  # state_auto_advance._song_finished
+            "resume_after_announcement",  # state_lifecycle, #2710
+            "last_failure_reason",  # state_lifecycle, #808 skip logic
+            "last_attempted_uri",  # state_lifecycle, #1927 pause banner
+        ],
+    )
+    def test_a_fake_missing_one_of_them_is_rejected(self, member):
+        """Each is called by the domain, so each has to be part of the
+        contract — a fake without it must fail the check rather than fail at
+        3 a.m. inside an ``except Exception``."""
+
+        class Speaker:
+            """Answers to anything except the one member under test."""
+
+            def __getattr__(self, name):
+                if name == member:
+                    raise AttributeError(name)
+                return lambda *_a, **_kw: None
+
+        assert not isinstance(Speaker(), MediaPlayerProtocol)
+        assert hasattr(MediaPlayerService, member)
+
+    def test_a_bare_fake_is_not_mistaken_for_a_speaker(self):
+        """The isinstance check has to be worth something."""
+
+        class HalfASpeaker:
+            async def play(self) -> bool:
+                return True
+
+        assert not isinstance(HalfASpeaker(), MediaPlayerProtocol)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_watchdog_respects_deliberate_stop_2576.py
+++ b/tests/unit/test_watchdog_respects_deliberate_stop_2576.py
@@ -1,9 +1,10 @@
-"""#2576: the TTS resume watchdog must not undo a deliberate stop.
+"""The TTS resume watchdog: #2576 (do not undo a deliberate stop) and #2710
+(the loop lives on the media-player port, so it can finally be run).
 
-After every round start a watchdog runs for ~20 seconds and pushes `media_play`
-as soon as the player reports `paused`, or reports `idle` with a title twice in
-a row. It checked neither the game phase nor `song_stopped`, so it read two
-*wanted* states as a hang:
+After every round start a watchdog walks a ~20 second window and pushes
+`media_play` as soon as the player reports `paused`, or reports `idle` with a
+title twice in a row. It checked neither the game phase nor `song_stopped`, so
+it read two *wanted* states as a hang:
 
 * the host taps "stop song" — `media_stop` leaves a Music Assistant player as
   `idle` WITH a title, which is exactly the stuck signature; the watchdog
@@ -12,57 +13,270 @@ a row. It checked neither the game phase nor `song_stopped`, so it read two
   speaker, and the watchdog pushed play, so the music kept going under the
   PAUSED banner.
 
-The watchdog itself is a closure inside `_start_round_locked` and cannot be
-called directly, so this pins the guard in the source *and* the two inputs it
-relies on: that stopping sets `song_stopped`, and that pausing leaves PLAYING.
+Until #2710 this file could only assert the *source text*: the watchdog was a
+closure inside `_start_round_locked` that reached into `self._hass` directly,
+so there was nothing to call and nothing to substitute. It is now
+`MediaPlayerService.resume_after_announcement`, and the game hands it a
+`should_continue` callback — which means the guard is testable as behaviour on
+both sides of the seam: the game's callback with a fake speaker and no `hass`
+at all, and the loop itself as an ordinary method.
 """
 
 from __future__ import annotations
 
-from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from custom_components.beatify.game.state import GamePhase
-from tests.conftest import make_game_state
+from custom_components.beatify.services.media_player import MediaPlayerService
+from tests.conftest import make_game_state, make_songs
 
-SRC = (
-    Path(__file__).parents[2]
-    / "custom_components"
-    / "beatify"
-    / "game"
-    / "state_lifecycle.py"
-).read_text(encoding="utf-8")
+# ---------------------------------------------------------------------------
+# The game side: what it hands the port, with no Home Assistant in sight
+# ---------------------------------------------------------------------------
 
 
-class TestWatchdogGuard:
-    def test_the_guard_exists(self):
-        assert "song_stopped" in SRC, "watchdog does not consult song_stopped"
-        assert "self.phase != GamePhase.PLAYING" in SRC
+def _fake_speaker(handovers: list) -> MagicMock:
+    """A speaker that records the watchdog handover instead of making one."""
+    svc = MagicMock()
+    svc.is_available.return_value = True
+    svc.play_song = AsyncMock(return_value=True)
+    svc.verify_responsive = AsyncMock(return_value=(True, None))
+    svc.restore_volume = AsyncMock(return_value=True)
+    svc.restore_queue = AsyncMock(return_value=True)
+    svc.stop = AsyncMock(return_value=True)
 
-    def test_the_guard_runs_before_the_state_is_read(self):
-        """Order is the whole point: reading the player first and deciding
-        afterwards would still fire one kick on the tick where the host
-        stopped the song."""
-        guard = SRC.index("playback stopped on purpose")
-        # the first `states.get` inside the polling loop
-        loop = SRC.index("for tick in range(20):")
-        lookup = SRC.index("st = self._hass.states.get(self.media_player)", loop)
-        assert loop < guard < lookup
+    async def _watch() -> None:
+        return None
+
+    def _resume(*, lead_seconds: float, should_continue):
+        # Recorded synchronously, because that is when the game hands it over:
+        # `create_task` binds the arguments now and runs the body later.
+        handovers.append((lead_seconds, should_continue))
+        return _watch()
+
+    svc.resume_after_announcement = _resume
+    return svc
 
 
-class TestTheInputsTheGuardRelieson:
-    @pytest.mark.asyncio
-    async def test_pausing_leaves_the_playing_phase(self):
-        state = make_game_state()
-        state.phase = GamePhase.PLAYING
-        await state.pause_game("admin_disconnected")
-        assert state.phase is GamePhase.PAUSED
+async def _game_that_started_a_round(handovers: list):
+    """A real ``GameState`` mid-round, wired to fakes for speaker and voice."""
+    gs = make_game_state(
+        media_player=lambda *_a, **_kw: _fake_speaker(handovers),
+        tts=lambda **_kw: MagicMock(speak=AsyncMock()),
+    )
+    gs.create_game(
+        playlists=["t.json"],
+        songs=make_songs(3),
+        media_player="media_player.esszimmer",
+        base_url="http://h",
+    )
+    gs.platform = "music_assistant"
+    gs.add_player("Alice", MagicMock())
+    gs.add_player("Bob", MagicMock())
+    for p in gs.players.values():
+        p.connected = True
+    await gs.configure_tts("tts.google")
+    await gs.start_round()
+    return gs
 
-    def test_song_stopped_is_a_per_round_flag(self):
+
+@pytest.mark.asyncio
+class TestTheGameArmsTheWatchdogThroughThePort:
+    async def test_a_round_start_hands_the_watch_to_the_speaker(self):
+        """#2710: no `hass` stub anywhere — the fake from #2638 sees the call."""
+        handovers: list = []
+        gs = await _game_that_started_a_round(handovers)
+        try:
+            assert len(handovers) == 1
+            lead, should_continue = handovers[0]
+            assert lead >= 0.0
+            assert should_continue() is True
+        finally:
+            if gs._tts_resume_task:
+                gs._tts_resume_task.cancel()
+
+    async def test_stopping_the_song_ends_the_watch(self):
+        handovers: list = []
+        gs = await _game_that_started_a_round(handovers)
+        try:
+            _, should_continue = handovers[0]
+            gs.song_stopped = True
+            assert should_continue() is False
+        finally:
+            if gs._tts_resume_task:
+                gs._tts_resume_task.cancel()
+
+    async def test_pausing_the_game_ends_the_watch(self):
+        handovers: list = []
+        gs = await _game_that_started_a_round(handovers)
+        try:
+            _, should_continue = handovers[0]
+            await gs.pause_game("admin_disconnected")
+            assert gs.phase is GamePhase.PAUSED
+            assert should_continue() is False
+        finally:
+            if gs._tts_resume_task:
+                gs._tts_resume_task.cancel()
+
+    async def test_song_stopped_is_a_per_round_flag(self):
         """`song_stopped` belongs to the round — a stop in round 3 must not
         keep the watchdog disarmed in round 4."""
         state = make_game_state()
         state.song_stopped = True
         state._round_manager.reset()
         assert state.song_stopped is False
+
+
+# ---------------------------------------------------------------------------
+# The speaker side: the loop, now an ordinary method
+# ---------------------------------------------------------------------------
+
+
+def _state(kind: str = "playing", *, title: str = "Song", volume: float = 0.5):
+    st = MagicMock()
+    st.state = kind
+    st.attributes = {"media_title": title, "volume_level": volume}
+    return st
+
+
+def _hass(script: list) -> MagicMock:
+    """A `hass` whose `states.get` walks `script`, then repeats its last entry.
+
+    Entry 0 is the pre-announcement volume snapshot; with `lead_seconds=0`
+    every entry after it is one tick of the polling loop.
+    """
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    seq = list(script)
+    hass.states.get = MagicMock(
+        side_effect=lambda _e: seq.pop(0) if len(seq) > 1 else seq[0]
+    )
+    return hass
+
+
+def _service_calls(hass: MagicMock, service: str) -> list:
+    return [c for c in hass.services.async_call.call_args_list if c.args[1] == service]
+
+
+@pytest.mark.asyncio
+class TestTheLoopItself:
+    async def test_a_deliberate_stop_kicks_nothing(self):
+        """The guard runs BEFORE the player is read: reading first and deciding
+        afterwards would still fire one kick on the tick where the host
+        stopped the song."""
+        hass = _hass([_state("idle")])
+        svc = MediaPlayerService(hass, "media_player.esszimmer")
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await svc.resume_after_announcement(
+                lead_seconds=0.0, should_continue=lambda: False
+            )
+
+        assert _service_calls(hass, "media_play") == []
+        # one read for the volume snapshot, none from inside the loop
+        assert hass.states.get.call_count == 1
+
+    async def test_a_paused_player_is_kicked_three_times_then_left_alone(self):
+        hass = _hass([_state("paused")])
+        svc = MediaPlayerService(hass, "media_player.esszimmer")
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await svc.resume_after_announcement(
+                lead_seconds=0.0, should_continue=lambda: True
+            )
+
+        assert len(_service_calls(hass, "media_play")) == 3
+
+    async def test_idle_with_a_title_counts_as_stuck_after_two_ticks(self):
+        """MA voice satellites stick in 'idle' with a title loaded; HA never
+        reports 'paused' for them, so 'paused' alone would never fire."""
+        hass = _hass([_state("idle", title="Africa")])
+        svc = MediaPlayerService(hass, "media_player.esszimmer")
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await svc.resume_after_announcement(
+                lead_seconds=0.0, should_continue=lambda: True
+            )
+
+        assert len(_service_calls(hass, "media_play")) == 3
+
+    async def test_idle_without_a_title_is_not_stuck(self):
+        hass = _hass([_state("idle", title=None)])
+        svc = MediaPlayerService(hass, "media_player.esszimmer")
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await svc.resume_after_announcement(
+                lead_seconds=0.0, should_continue=lambda: True
+            )
+
+        assert _service_calls(hass, "media_play") == []
+
+    async def test_the_anticipatory_kick_fires_once_the_lead_is_over(self):
+        """v0.7.30: waiting for three idle ticks to confirm what we already
+        expect meant 3-4s of silence after "…3, 2, 1, go"."""
+        hass = _hass([_state("paused"), _state("paused"), _state("playing")])
+        svc = MediaPlayerService(hass, "media_player.esszimmer")
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await svc.resume_after_announcement(
+                lead_seconds=2.0, should_continue=lambda: True
+            )
+
+        assert len(_service_calls(hass, "media_play")) == 1
+
+    async def test_a_vanished_entity_ends_the_watch(self):
+        hass = _hass([_state("playing"), None])
+        svc = MediaPlayerService(hass, "media_player.esszimmer")
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await svc.resume_after_announcement(
+                lead_seconds=0.0, should_continue=lambda: True
+            )
+
+        assert hass.states.get.call_count == 2
+
+
+@pytest.mark.asyncio
+class TestTheVolumeRatchetGuard:
+    async def test_an_upward_drift_across_an_announcement_is_undone(self):
+        """MA's announce duck/restore wrote back a HIGHER level each round on
+        a ShieldTV feeding an AV receiver — painfully loud within a few
+        rounds."""
+        hass = _hass([_state(volume=0.30), _state(volume=0.60)])
+        svc = MediaPlayerService(hass, "media_player.esszimmer")
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await svc.resume_after_announcement(
+                lead_seconds=0.0, should_continue=lambda: True
+            )
+
+        calls = _service_calls(hass, "volume_set")
+        assert len(calls) == 1, "the guard must fire once per round, not per tick"
+        assert calls[0].args[2]["volume_level"] == 0.30
+
+    async def test_a_drift_after_the_window_is_the_host_turning_it_up(self):
+        """The host's own volume buttons must keep working for the rest of the
+        round, so the guard only looks inside the announcement window."""
+        # snapshot + ticks 0..10 quiet, the rise lands on tick 11
+        hass = _hass([_state(volume=0.30)] * 12 + [_state(volume=0.60)])
+        svc = MediaPlayerService(hass, "media_player.esszimmer")
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await svc.resume_after_announcement(
+                lead_seconds=0.0, should_continue=lambda: True
+            )
+
+        assert _service_calls(hass, "volume_set") == []
+
+    async def test_a_speaker_that_reports_no_level_is_left_alone(self):
+        hass = _hass([_state(volume=None), _state(volume=0.90)])
+        svc = MediaPlayerService(hass, "media_player.esszimmer")
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await svc.resume_after_announcement(
+                lead_seconds=0.0, should_continue=lambda: True
+            )
+
+        assert _service_calls(hass, "volume_set") == []


### PR DESCRIPTION
Two findings on the same seam: the game logic reaching past the media-player port, and the port not describing what the game reaches for.

## #2710 — the resume watchdog moves onto the port

About 215 lines inside `_start_round_locked` polled `hass.states.get(...)` and pushed `hass.services.async_call("media_player", "media_play" / "volume_set", ...)` on their own. Three consequences, all now gone: `game/state.py` claimed GameState does not know Home Assistant exists (false on every round with TTS); there were two ways to press play, only one of which recorded `_record_error`; and the whole path was invisible to the injected fake from #2638.

The loop is now `MediaPlayerService.resume_after_announcement`:

```python
async def resume_after_announcement(
    self,
    *,
    lead_seconds: float,
    should_continue: Callable[[], bool],
) -> None:
```

- `lead_seconds` — how long the announcements are still expected to hold the speaker. The TTS queue's own reservation (`announcement_busy_seconds()`, capped at 15s) is a game fact, so the caller computes it and the port only waits it out before the anticipatory kick.
- `should_continue` — asked once per tick, **before** the player is read. It answers the #2576 question that only the game can answer: a host tapping "stop song" and a `pause_game` both leave the speaker in states indistinguishable from a hang.

What stays in `RoundLifecycleMixin` is the announcement budget, that callback, and the task ownership. `self._hass` is gone from the whole block, including the arming condition — it meant "there is a state machine to poll", and nothing there polls one any more.

## #2711 — the Protocol now describes what the domain calls

`MediaPlayerProtocol` declared 13 members; the domain called `seek_forward` (`state_media.py`), `get_playback_state` (`state_auto_advance.py`) and read `last_failure_reason` / `last_attempted_uri` through `getattr(..., None)`. All four are declared now (plus `resume_after_announcement`), and the two `getattr` guards become plain attribute access — a guard on a name a conforming implementation is not required to have only ever hid the gap, by classifying every fake's failures as "error" so the #808/#1936 skip logic never fired.

## Why behaviour is unchanged

- The moved loop was compared line by line against the original after normalising the state read and the indentation. The only deltas are the intended ones: the `hass` service calls become `self.play(...)` / `self._set_volume_on(...)`, the phase/`song_stopped` check becomes `should_continue()`, and `lead` becomes a parameter. Tick counts, the `idle_streak >= 2` floor, the 3-kick cap, the `tick <= 10` volume window, the `+0.05` threshold and every exit are untouched.
- Both service calls kept `blocking=True` — `play()` and `_set_volume_on()` gained a `blocking` keyword (default `False`, so every existing caller is unaffected) rather than letting the watchdog quietly become fire-and-forget.
- A failed kick still ends the watch: `play()` catches `HomeAssistantError` / `ServiceNotFound` and returns `False`, which the loop treats exactly as the old bare `except Exception: return` did.
- The suite was green before the test rewrite except for five source-text assertions that no longer had a source to read. Nothing that executes changed its result.

Three deliberate, sub-behavioural differences, listed so they are not discovered later:

1. A failed kick now records a `MEDIA_PLAYER_ERROR` analytics event, because it goes through `play()`. That is the point of the issue.
2. The volume restore goes through `_set_volume_on`, which clamps to `[0.0, 1.0]`. The value being written back is a level the speaker itself reported, so the clamp cannot bite in practice.
3. The watchdog now targets the entity its service was built for rather than re-reading `self.media_player` each tick. Those agree — a speaker switch rebuilds the service — but the new form cannot drift onto a speaker the watch was not armed for.

## Which tests got simpler

`tests/unit/test_watchdog_respects_deliberate_stop_2576.py` opened with "The watchdog itself is a closure inside `_start_round_locked` and cannot be called directly, so this pins the guard in the source". It no longer has to. **4 tests → 13**, and the two `SRC.index(...)` assertions are gone:

- three tests drive a **real** `GameState` through a real `start_round` with the #2638 fake speaker and a fake voice — no `hass` anywhere — and assert the handover happens and that the callback flips to `False` on `song_stopped` and on `pause_game`;
- nine drive `resume_after_announcement` itself as an ordinary method: a deliberate stop kicks nothing and never even reads the player, a paused player is kicked three times and then left alone, `idle` with a title is stuck after two ticks but `idle` without one is not, the anticipatory kick fires once the lead is over, a vanished entity ends the watch, and the volume ratchet is undone exactly once and only inside the window.

`tests/unit/test_library_regressions.py`: **56 → 53**. Three structural greps (`"idle_streak >= 2" in src(...)`, `"_vol_before" in code`, `"not vol_restored" in code`) are deleted because the behaviour they stood in for is now tested for real; a pointer at the replacement stays behind. That file's header explains its greps as "the alternative to a source guard is no guard at all" — for these three it no longer is.

`tests/unit/test_service_injection_2638.py`: **12 → 19**. `MediaPlayerService` conformance is pinned with `isinstance(..., MediaPlayerProtocol)`, a half-implemented fake is rejected, and each of the five members is checked individually: a fake missing exactly one must fail the check rather than fail at 3 a.m. inside an `except Exception`.

Suite total: 2502 → 2517.

## Checks

- `pytest tests/unit tests/integration -q` — 2515 passed, 2 skipped
- `npm test` — 912 passed, 93 files
- `npm run build:check` — 16 artifacts and 76 .gz siblings match source
- `python3 -m ruff format --check .` — 236 files already formatted (`ruff check .` also clean)

## Left for its own issue

Nothing. No behaviour bug surfaced while moving the code.

Closes #2710
Closes #2711

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKsEKt68KHSqmi617XNCVi
