### PR TITLE
test: assert on behaviour instead of source text (#2701)

### DIFF
--- a/custom_components/beatify/www/js/__tests__/collection-row-2324.test.js
+++ b/custom_components/beatify/www/js/__tests__/collection-row-2324.test.js
@@ -1,84 +1,198 @@
 /**
- * The collected row (#2324, shape E) — wiring, ordering and locale coverage.
+ * The collected row (#2324, shape E) — what it renders, when, and in what order.
  *
- * `player-reveal.js` pulls in the whole player-utils graph, and this suite runs
- * in vitest's `node` environment with no DOM, so the renderer is asserted at
- * the source level the same way the Streak-Shield badge is (#1666). The one
- * piece with real logic — the sort that makes the row a timeline rather than a
- * list — is re-run here against the same comparator, because getting it wrong
- * produces a row that still looks plausible and is simply in the wrong order.
+ * #2701: this suite used to assert on the TEXT of `player-reveal.js` — that it
+ * contained `renderCollection(currentPlayer);`, `escapeHtml(entry.title`, the
+ * string `collection-card--new`, and a regex over the empty-row branch — while
+ * re-running a hand-copied comparator to cover the ordering. Every one of those
+ * would go red on a rename and stay green on a row rendered in the wrong order,
+ * escaped nowhere, or marked on the wrong card.
+ *
+ * `renderCollection` is imported and run instead, the way
+ * `player-reveal-view.test.js` drives `updateRevealView`: vitest's env is `node`
+ * with no jsdom, so the elements are hand-rolled and the module's cross-file
+ * imports are mocked.
  */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { WWW_DIR } from './helpers/js-source.js';
+import { doc, el } from './helpers/mini-dom.js';
 
-import { describe, it, expect } from 'vitest';
-import fs from 'node:fs';
-import path from 'node:path';
+const HTML = readFileSync(join(WWW_DIR, 'player.html'), 'utf8');
 
-const ROOT = path.resolve(__dirname, '../../..');
-const REVEAL = fs.readFileSync(path.join(ROOT, 'www/js/player-reveal.js'), 'utf8');
-const HTML = fs.readFileSync(path.join(ROOT, 'www/player.html'), 'utf8');
+const mockState = { playerName: null, lastRevealContext: null, lastDifficulty: '' };
+vi.mock('../player-utils.js', () => ({
+    state: mockState,
+    // A real (minimal) escaper wrapped in markers: the markers make "did this
+    // field go through the escaper?" an observable property of the rendered
+    // row, and the escaping keeps the row parseable when a title carries tags.
+    escapeHtml: (s) => `«${String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')}»`,
+    prefersReducedMotion: () => true,
+    animateValue: () => {},
+    previousState: {},
+    isPreviousStateInitialized: () => false,
+    AnimationUtils: {},
+    triggerConfetti: () => {},
+    stopConfetti: () => {},
+    isTitleArtistMode: (data) => !!(data && data.title_artist_mode),
+}));
+vi.mock('../player-game.js', () => ({
+    updateLeaderboard: () => {},
+    renderArtistReveal: () => {},
+    renderMovieReveal: () => {},
+}));
 
-describe('#2324 collected row — wiring', () => {
-    it('is rendered on every reveal, not only on a scoring round', () => {
-        // The row has to redraw on re-broadcasts too (reactions, votes), or a
-        // reveal that fires twice would show a stale row on the second frame.
-        expect(REVEAL).toContain('renderCollection(currentPlayer);');
-    });
+global.window = {
+    BeatifyUtils: {
+        t: (key, params) => (params && params.count != null ? `${key}:${params.count}` : key),
+        getLocalizedSongField: (song, field) => (song ? song[field] : undefined),
+    },
+    matchMedia: () => ({ matches: true, addEventListener: () => {} }),
+};
+global.WebSocket = { OPEN: 1 };
 
-    it('has a section to render into', () => {
-        expect(HTML).toContain('id="collection-section"');
-        expect(HTML).toContain('id="collection-row"');
-        expect(HTML).toContain('id="collection-count"');
-    });
+let els;
+let document_;
+global.document = {
+    getElementById: (id) => document_.getElementById(id),
+    querySelector: (sel) => document_.querySelector(sel),
+    querySelectorAll: () => [],
+};
 
-    it('hides the section while the row is empty', () => {
-        // An empty shelf is worse than no shelf: before the first keeper there
-        // is nothing to say, and a permanent empty box reads as a broken card.
-        expect(REVEAL).toMatch(/if \(!items\.length\) \{[\s\S]*?section\.classList\.add\('hidden'\)/);
-    });
+const { renderCollection, updateRevealView, stopRevealCountdown } =
+    await import('../player-reveal.js');
 
-    it('escapes song text', () => {
-        // Titles and artists come from the catalogue, which is user-editable
-        // through the library views — they are not safe to interpolate raw.
-        expect(REVEAL).toContain('escapeHtml(entry.title');
-        expect(REVEAL).toContain('escapeHtml(entry.artist');
-    });
+function reset() {
+    els = {
+        'collection-section': el('collection-section'),
+        'collection-row': el('collection-row'),
+        'collection-count': el('collection-count'),
+    };
+    document_ = doc(els);
+}
 
-    it('marks the card won this round', () => {
-        expect(REVEAL).toContain('collection-card--new');
-    });
+beforeEach(reset);
+
+/** The cards the row ended up holding, in DOM order. */
+function cards() {
+    return [...els['collection-row'].innerHTML.matchAll(/<div class="(collection-card[^"]*)"[^>]*>([\s\S]*?)<\/div>/g)]
+        .map((m) => ({
+            classes: m[1],
+            year: /collection-card-year">([^<]*)</.exec(m[2])?.[1],
+            title: /collection-card-title">([^<]*)</.exec(m[2])?.[1],
+            artist: /collection-card-artist">([^<]*)</.exec(m[2])?.[1],
+        }));
+}
+
+const kept = (year, round, extra = {}) => ({
+    year, round, title: `T${round}`, artist: `A${round}`, ...extra,
 });
 
-describe('#2324 collected row — ordering', () => {
-    /** The comparator as it stands in renderCollection. */
-    const byYearThenRound = (a, b) => (a.year - b.year) || (a.round - b.round);
-
+describe('#2324 collected row — what it draws', () => {
     it('reads left to right in years, not in the order won', () => {
-        const items = [
-            { year: 2004, round: 1 },
-            { year: 1968, round: 2 },
-            { year: 1991, round: 3 },
-        ];
-        expect(items.slice().sort(byYearThenRound).map((e) => e.year))
-            .toEqual([1968, 1991, 2004]);
+        renderCollection({ collection: [kept(2004, 1), kept(1968, 2), kept(1991, 3)] });
+        expect(cards().map((c) => c.year)).toEqual(['«1968»', '«1991»', '«2004»']);
     });
 
     it('is stable for two songs from the same year', () => {
-        // REVEAL re-broadcasts on every reaction; a comparator returning 0 for
+        // The reveal re-renders on every reaction; a comparator returning 0 for
         // a tie would let the two cards swap places under the player's thumb.
-        const items = [
-            { year: 1985, round: 7 },
-            { year: 1985, round: 2 },
-        ];
-        expect(items.slice().sort(byYearThenRound).map((e) => e.round))
-            .toEqual([2, 7]);
+        renderCollection({ collection: [kept(1985, 7), kept(1985, 2)] });
+        expect(cards().map((c) => c.title)).toEqual(['«T2»', '«T7»']);
+    });
+
+    it('marks the card won this round, and only that one', () => {
+        renderCollection({ collection: [kept(2004, 1), kept(1968, 3), kept(1991, 2)] });
+        const marked = cards().filter((c) => c.classes.includes('collection-card--new'));
+        expect(marked).toHaveLength(1);
+        expect(marked[0].title).toBe('«T3»');  // round 3 is the newest
+    });
+
+    it('scrolls the freshly kept card into view', () => {
+        // A long row runs off the right edge of a phone, and the one card the
+        // player wants to see is the one that just appeared.
+        const newCard = el(null);
+        els['collection-row'].children['.collection-card--new'] = newCard;
+        renderCollection({ collection: [kept(2004, 1), kept(1968, 3)] });
+        expect(newCard.scrolledIntoView).toMatchObject({ inline: 'center' });
+    });
+
+    it('escapes every field that comes from the catalogue', () => {
+        // Titles and artists are user-editable through the library views —
+        // they are not safe to interpolate raw.
+        renderCollection({
+            collection: [{ year: 1999, round: 1, title: '<img src=x>', artist: '"><script>' }],
+        });
+        const card = cards()[0];
+        expect(card.title).toBe('«&lt;img src=x&gt;»');
+        expect(card.artist).toBe('«&quot;&gt;&lt;script&gt;»');
+        expect(card.year).toBe('«1999»');
+        expect(els['collection-row'].innerHTML).not.toContain('<img');
+        expect(els['collection-row'].innerHTML).not.toContain('<script');
+    });
+
+    it('counts what it drew, through i18n', () => {
+        renderCollection({ collection: [kept(2004, 1), kept(1968, 2)] });
+        expect(els['collection-count'].textContent).toBe('reveal.collection.count:2');
+    });
+});
+
+describe('#2324 collected row — when it is there at all', () => {
+    it('hides the section while the row is empty', () => {
+        // An empty shelf is worse than no shelf: before the first keeper there
+        // is nothing to say, and a permanent empty box reads as a broken card.
+        renderCollection({ collection: [] });
+        expect(els['collection-section'].classList.contains('hidden')).toBe(true);
+        expect(els['collection-row'].textContent).toBe('');
+    });
+
+    it('hides it for a player payload that has no collection at all', () => {
+        renderCollection({});
+        renderCollection(null);
+        expect(els['collection-section'].classList.contains('hidden')).toBe(true);
+    });
+
+    it('shows the section again once the first card is kept', () => {
+        renderCollection({ collection: [] });
+        renderCollection({ collection: [kept(1977, 1)] });
+        expect(els['collection-section'].classList.contains('hidden')).toBe(false);
+    });
+
+    it('redraws on a reveal that scored nothing', () => {
+        // The row has to redraw on re-broadcasts too (reactions, votes), so it
+        // hangs off every reveal rather than off the scoring branch — a reveal
+        // that fires twice would otherwise show a stale row on the second frame.
+        mockState.playerName = 'Alice';
+        updateRevealView({
+            round: 4,
+            total_rounds: 12,
+            song: { title: 'Africa', artist: 'Toto', year: 1982 },
+            players: [{ name: 'Alice', score: 0, points_earned: 0, collection: [kept(1982, 4)] }],
+        });
+        stopRevealCountdown();
+        expect(cards().map((c) => c.title)).toEqual(['«T4»']);
+    });
+
+    it('asks player.html for elements player.html actually has', () => {
+        // Derived, not typed out: whatever ids the renderer looks up must exist
+        // in the markup it renders into. A renamed id in either file fails here.
+        renderCollection({ collection: [kept(1977, 1)] });
+        expect(document_.lookedUp.length).toBeGreaterThan(0);
+        for (const id of new Set(document_.lookedUp)) {
+            expect(HTML, `player.html has no #${id}`).toContain(`id="${id}"`);
+        }
     });
 });
 
 describe('#2324 collected row — locales', () => {
     it('has both strings in every shipped locale', () => {
         for (const lang of ['en', 'de', 'es', 'fr', 'nl', 'it']) {
-            const dict = JSON.parse(fs.readFileSync(
-                path.join(ROOT, `www/i18n/${lang}.json`), 'utf8'));
+            const dict = JSON.parse(readFileSync(join(WWW_DIR, 'i18n', `${lang}.json`), 'utf8'));
             expect(dict.reveal?.collection?.title, `${lang} missing title`).toBeTruthy();
             expect(dict.reveal?.collection?.count, `${lang} missing count`).toBeTruthy();
             // A missing placeholder does not throw — it renders "kept" with no

--- a/custom_components/beatify/www/js/__tests__/dashboard-2130-end-stage.test.js
+++ b/custom_components/beatify/www/js/__tests__/dashboard-2130-end-stage.test.js
@@ -12,107 +12,142 @@
  *   2. the award row wrote its values outside the card border,
  *   3. a two-player game showed a third, empty stand with "---" and 0 PTS.
  *
- * dashboard.js is a DOM-coupled IIFE with no exported helpers and the vitest
- * env is `node` with no jsdom, so — as in dashboard-b8.test.js and
- * dashboard-sd-ending.test.js — the load-bearing LOGIC is asserted against a
- * verbatim copy. Unlike those files the copy is not kept in sync by hand: the
- * source guards below read dashboard.js and dashboard.css from disk and fail if
- * the shipped code stops carrying the fix.
+ * #2701: point 3 used to be covered by a hand-written copy of the podium loop
+ * plus three greps over `dashboard.js` that existed to catch the copy drifting.
+ * `renderEndView` is compiled out of the shipped file and run here instead —
+ * the copy is gone, and with it the greps that guarded it.
+ *
+ * Points 1 and 2 are still asserted against the stylesheet text, deliberately:
+ * see the second block.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
+import { declaration, evaluate, readSource, WWW_DIR } from './helpers/js-source.js';
+import { doc, el } from './helpers/mini-dom.js';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const JS = readFileSync(join(__dirname, '..', 'dashboard.js'), 'utf8');
-const CSS = readFileSync(join(__dirname, '..', '..', 'css', 'dashboard.css'), 'utf8');
+const DASHBOARD = readSource('dashboard.js');
+const CSS = readFileSync(join(WWW_DIR, 'css', 'dashboard.css'), 'utf8');
 
-/**
- * Minimal stand-in for one podium slot. `closest` walks to the place element
- * exactly as the browser would; `classList.toggle(name, force)` keeps the
- * two-argument form the fix relies on.
- */
-function makePodium(place) {
-    const classes = new Set(['podium-place', `podium-${place}`]);
-    const placeEl = {
-        classList: {
-            toggle: (name, force) => (force ? classes.add(name) : classes.delete(name)),
-            contains: (name) => classes.has(name),
-        },
-    };
-    const child = () => ({ textContent: '', style: {}, closest: (sel) => (sel === '.podium-place' ? placeEl : null) });
-    return { placeEl, nameEl: child(), scoreEl: child(), avatarEl: child() };
-}
-
-/** Verbatim copy of the per-place body of renderEndView(). */
-function renderPlace(slot, player) {
-    const { nameEl, scoreEl, avatarEl } = slot;
-    if (nameEl) nameEl.textContent = player ? player.name : '---';
-    if (scoreEl) scoreEl.textContent = player ? player.score : '0';
-
-    let placeEl = (nameEl || scoreEl || avatarEl);
-    placeEl = placeEl && placeEl.closest ? placeEl.closest('.podium-place') : null;
-    if (placeEl) placeEl.classList.toggle('podium-place--empty', !player);
-}
-
-/** Runs all three slots against a leaderboard, returns which ones are hidden. */
-function render(leaderboard) {
-    const hidden = [];
+/** The three podium slots plus the elements around them, as one document. */
+function endScreen() {
+    const places = {};
+    const elements = {};
     [1, 2, 3].forEach((place) => {
-        const slot = makePodium(place);
-        const player = leaderboard.find((p) => p.rank === place);
-        renderPlace(slot, player);
-        if (slot.placeEl.classList.contains('podium-place--empty')) hidden.push(place);
+        const placeEl = el(`podium-place-${place}`);
+        places[place] = placeEl;
+        const under = { selector: '.podium-place', node: placeEl };
+        for (const part of ['name', 'score', 'avatar']) {
+            elements[`end-podium-${place}-${part}`] = el(
+                `end-podium-${place}-${part}`,
+                { closest: under },
+            );
+        }
     });
-    return hidden;
+    elements['end-meta-rounds'] = el('end-meta-rounds');
+    elements['end-meta-players'] = el('end-meta-players');
+    elements['end-leaderboard'] = el('end-leaderboard');
+    return { places, elements, document: doc(elements) };
+}
+
+/** Run the shipped `renderEndView` and report what the podium ended up as. */
+function renderEnd(leaderboard, { screen = endScreen(), ...extra } = {}) {
+    const noop = () => {};
+    evaluate(declaration(DASHBOARD, 'renderEndView', 'dashboard.js'), 'renderEndView', {
+        document: screen.document,
+        utils: { escapeHtml: (s) => String(s) },
+        renderSuddenDeathLastStanding: noop,
+        renderStatsComparison: noop,
+        renderSuperlatives: noop,
+        renderHighlights: noop,
+        triggerConfetti: noop,
+        endAvatarGradient: () => 'linear-gradient(#000,#fff)',
+    })({ leaderboard, ...extra });
+
+    const hidden = [1, 2, 3].filter((p) =>
+        screen.places[p].classList.contains('podium-place--empty'));
+    return { ...screen, hidden };
 }
 
 describe('#2130 — no podium stand without a player on it', () => {
     it('hides the third stand in a two-player game', () => {
         // Exactly the game in the reporter's screenshot: Sandra 162, Aaron 128.
-        const hidden = render([
+        expect(renderEnd([
             { rank: 1, name: 'Sandra', score: 162 },
             { rank: 2, name: 'Aaron', score: 128 },
-        ]);
-        expect(hidden).toEqual([3]);
+        ]).hidden).toEqual([3]);
     });
 
     it('hides the second and third stand in a single-player game', () => {
-        expect(render([{ rank: 1, name: 'Sandra', score: 162 }])).toEqual([2, 3]);
+        expect(renderEnd([{ rank: 1, name: 'Sandra', score: 162 }]).hidden).toEqual([2, 3]);
     });
 
     it('hides nothing once three players are ranked', () => {
-        expect(render([
+        expect(renderEnd([
             { rank: 1, name: 'Sandra', score: 162 },
             { rank: 2, name: 'Aaron', score: 128 },
             { rank: 3, name: 'Kim', score: 90 },
-        ])).toEqual([]);
+        ]).hidden).toEqual([]);
+    });
+
+    it('hides the stand with a class, not with `hidden`', () => {
+        // `.podium-place` is display:flex, which beats the UA rule for
+        // [hidden] — a stand hidden that way stays on the screen.
+        const out = renderEnd([{ rank: 1, name: 'Sandra', score: 162 }]);
+        expect(out.places[3].hidden).toBe(false);
+        expect(out.places[3].classList.contains('podium-place--empty')).toBe(true);
     });
 
     it('still fills the placeholders it always filled', () => {
         // The '---' / '0' assignment predates this fix and stays: hiding the
         // stand is a display decision, not a reason to change what it holds.
-        const slot = makePodium(3);
-        renderPlace(slot, undefined);
-        expect(slot.nameEl.textContent).toBe('---');
-        expect(slot.scoreEl.textContent).toBe('0');
+        const out = renderEnd([{ rank: 1, name: 'Sandra', score: 162 }]);
+        expect(out.elements['end-podium-3-name'].textContent).toBe('---');
+        expect(out.elements['end-podium-3-score'].textContent).toBe('0');
+        expect(out.elements['end-podium-1-name'].textContent).toBe('Sandra');
+    });
+
+    it('re-shows a stand that was empty on the previous game', () => {
+        // The toggle has to run in both directions: the dashboard is a
+        // long-lived page and renders one game after another into the same
+        // elements. A one-way `add` would leave the third stand hidden for the
+        // rest of the evening.
+        const screen = endScreen();
+        renderEnd([
+            { rank: 1, name: 'Sandra', score: 162 },
+            { rank: 2, name: 'Aaron', score: 128 },
+        ], { screen });
+        expect(screen.places[3].classList.contains('podium-place--empty')).toBe(true);
+
+        const out = renderEnd([
+            { rank: 1, name: 'Sandra', score: 162 },
+            { rank: 2, name: 'Aaron', score: 128 },
+            { rank: 3, name: 'Kim', score: 90 },
+        ], { screen });
+        expect(out.hidden).toEqual([]);
     });
 });
 
-describe('#2130 — the shipped code still carries the fix', () => {
-    it('toggles a class on the place element, not `hidden`', () => {
-        expect(JS).toContain("closest('.podium-place')");
-        expect(JS).toContain("classList.toggle('podium-place--empty', !player)");
-        // `.podium-place` is display:flex, which beats the UA rule for [hidden].
-        expect(JS).not.toMatch(/placeEl\.hidden\s*=/);
-    });
-
-    it('defines the empty-stand rule the toggle depends on', () => {
+describe('#2130 — the stylesheet rules the fix depends on', () => {
+    /**
+     * These four stay assertions on the stylesheet TEXT, and that is the
+     * intended shape rather than a leftover.
+     *
+     * The defect here is a layout one — a name breaking mid-word, an award
+     * value drawn outside its card — and reproducing it needs a layout engine.
+     * The repo runs vitest in the `node` environment with no jsdom and no CSSOM,
+     * so nothing in this process can compute a box. What CAN be checked is that
+     * the declarations the fix consists of are still in the stylesheet the
+     * browser loads, and that is what these do.
+     *
+     * The first of them is also the other half of the block above: the JS
+     * toggles `.podium-place--empty`, and a class nothing styles hides nothing.
+     */
+    it('defines the empty-stand rule the toggle depends on (stylesheet guard)', () => {
         expect(CSS).toMatch(/\.end-stage-layout \.podium-place--empty \{\s*display: none;\s*\}/);
     });
 
-    it('keeps the podium from shrinking below its stand', () => {
+    it('keeps the podium from shrinking below its stand (stylesheet guard)', () => {
         // The name broke mid-word because the place could shrink under the
         // stand's fixed 200px, not because the font was too large.
         const place = CSS.match(/\.end-stage-layout \.podium-place \{[^}]*\}/)[0];
@@ -123,7 +158,7 @@ describe('#2130 — the shipped code still carries the fix', () => {
         expect(name).toContain('white-space: nowrap');
     });
 
-    it('keeps the award cards inside their grid track', () => {
+    it('keeps the award cards inside their grid track (stylesheet guard)', () => {
         const card = CSS.match(/\.end-stage-layout \.superlative-card \{[^}]*\}/)[0];
         expect(card).toContain('min-width: 0');
         expect(card).toContain('grid-template-columns: auto minmax(0, 1fr) auto');

--- a/custom_components/beatify/www/js/__tests__/dashboard-nosleep-reset.test.js
+++ b/custom_components/beatify/www/js/__tests__/dashboard-nosleep-reset.test.js
@@ -6,11 +6,15 @@
  * dashboard.js is a self-running IIFE (no exports, touches the DOM + registers
  * a service worker on load), so it can't be imported cleanly under vitest.
  * Instead we extract the `requestWakeLock` source straight from the served
- * file and evaluate it in a controlled scope with stubbed globals. This both
- * proves the fix and pins the exact source line so the bug can't silently
- * regress (the build then re-minifies it 1:1 into dashboard.min.js).
+ * file and evaluate it in a controlled scope with stubbed globals: the bytes
+ * under test are the bytes that ship.
+ *
+ * #2701 dropped a fourth test that read the catch handler's text and matched
+ * `/_noSleepActive\s*=\s*false/` against it. The two tests below already drive
+ * that handler — they reject the enable() promise and then read the flag — so
+ * the regex added no coverage and would have gone red on a rename of a local.
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
@@ -103,15 +107,6 @@ function makeRequestWakeLock({ enableImpl, hasNativeWakeLock }) {
 describe('#1400 dashboard requestWakeLock NoSleep flag reset', () => {
     beforeEach(() => {
         delete globalThis.__nsa;
-    });
-
-    it('still references _noSleepActive in the rejection handler (source pin)', () => {
-        const body = extractRequestWakeLockBody();
-        // The catch handler must reset the flag, not just log.
-        const catchIdx = body.indexOf('Layer 2 enable promise rejected');
-        expect(catchIdx).toBeGreaterThan(-1);
-        const handler = body.slice(catchIdx - 200, catchIdx);
-        expect(handler).toMatch(/_noSleepActive\s*=\s*false/);
     });
 
     it('resets _noSleepActive to false when enable() rejects async', async () => {

--- a/custom_components/beatify/www/js/__tests__/dashboard-paused-view-2617.test.js
+++ b/custom_components/beatify/www/js/__tests__/dashboard-paused-view-2617.test.js
@@ -11,52 +11,91 @@
  * #2551, #2552) was invisible in the room because of it, and the message from
  * #2569 was never displayed.
  *
- * dashboard.js is a DOM-coupled IIFE with no exports and the vitest env is
- * `node` without jsdom, so — as in dashboard-2130-end-stage.test.js — the
- * guard reads the shipped source from disk.
- *
- * The second assertion is the one that matters going forward: it does not
- * hard-code `data`, it requires every phase branch to hand the SAME
- * identifier to its renderer. A future rename of the parameter keeps passing;
- * a single branch drifting off it fails, whatever the name.
+ * #2701: this used to be two regexes over `dashboard.js` plus one over
+ * `dashboard.min.js`. The dispatcher is run for real now — compiled out of the
+ * shipped file in strict mode, exactly as the browser compiles it — so the
+ * ReferenceError reproduces instead of being described. That also removes the
+ * minified assertion: `npm run build:check` already rebuilds every bundle and
+ * fails on any drift from its source, so a test grepping terser's output only
+ * duplicated that guarantee while breaking whenever terser changes its mind.
  */
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { declaration, evaluate, readSource } from './helpers/js-source.js';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const JS = readFileSync(join(__dirname, '..', 'dashboard.js'), 'utf8');
-const MIN = readFileSync(join(__dirname, '..', 'dashboard.min.js'), 'utf8');
+const DASHBOARD = readSource('dashboard.js');
 
-/** The `switch (phase)` block that dispatches the phase renderers. */
-function phaseSwitch() {
-    const start = JS.indexOf("case 'LOBBY':");
-    expect(start, "the phase switch should still start at case 'LOBBY'").toBeGreaterThan(-1);
-    const end = JS.indexOf("Unknown phase", start);
-    expect(end, 'the phase switch should still end at the default branch').toBeGreaterThan(start);
-    return JS.slice(start, end);
+/** Every phase the dispatcher must handle, with the renderer it belongs to. */
+const PHASES = [
+    ['LOBBY', 'renderLobbyView', 'dashboard-lobby'],
+    ['PLAYING', 'renderPlayingView', 'dashboard-playing'],
+    ['REVEAL', 'renderRevealView', 'dashboard-reveal'],
+    ['END', 'renderEndView', 'dashboard-end'],
+    ['PAUSED', 'renderPausedView', 'dashboard-paused'],
+];
+
+/**
+ * Run the shipped phase dispatcher for one payload.
+ *
+ * Every renderer, `showView` and the countdown are stubs that record what they
+ * were handed. Nothing else is provided on purpose: an identifier the
+ * dispatcher reads and this scope does not name throws a ReferenceError, which
+ * is #2617 itself.
+ */
+function dispatch(data) {
+    const calls = [];
+    const scope = {
+        utils: { hydrateLeaderboard: (lb) => lb },
+        showView: (view) => calls.push({ fn: 'showView', arg: view }),
+        stopCountdown: () => calls.push({ fn: 'stopCountdown' }),
+        debug: () => calls.push({ fn: 'debug' }),
+    };
+    for (const [, renderer] of PHASES) {
+        scope[renderer] = (arg) => calls.push({ fn: renderer, arg });
+    }
+    evaluate(
+        declaration(DASHBOARD, '_applyStateRender', 'dashboard.js'),
+        '_applyStateRender',
+        scope,
+    )(data);
+    return calls;
 }
 
 describe('#2617 dashboard phase dispatch', () => {
-    it('hands the PAUSED branch the same object as every other branch', () => {
-        expect(phaseSwitch()).toMatch(/renderPausedView\(data\)/);
+    it('shows the Paused screen and renders it', () => {
+        // The bug in one line: before the fix this call threw a ReferenceError
+        // on `state` and neither entry below was ever reached.
+        const calls = dispatch({ phase: 'PAUSED', game_id: 'g1', pause_reason: 'speaker' });
+        expect(calls.map((c) => c.fn)).toContain('renderPausedView');
+        expect(calls).toContainEqual({ fn: 'showView', arg: 'dashboard-paused' });
     });
 
-    it('passes one and the same identifier to every phase renderer', () => {
-        const args = [...phaseSwitch().matchAll(/render(\w+)View\((\w+)\)/g)].map((m) => ({
-            view: m[1],
-            arg: m[2],
-        }));
-        // Lobby, Playing, Reveal, End, Paused — a shrinking list would mean a
-        // branch lost its renderer, which this guard should also catch.
-        expect(args.length).toBeGreaterThanOrEqual(5);
-        const distinct = [...new Set(args.map((a) => a.arg))];
-        expect(distinct, `phase renderers disagree on their argument: ${JSON.stringify(args)}`).toHaveLength(1);
+    it('hands the paused renderer the payload, with the pause reason intact', () => {
+        const data = { phase: 'PAUSED', game_id: 'g1', pause_reason: 'media_player_error' };
+        const call = dispatch(data).find((c) => c.fn === 'renderPausedView');
+        // #2552 reads `pause_reason` off this object; an empty stand-in would
+        // put "the host disconnected" on a speaker failure.
+        expect(call.arg.pause_reason).toBe('media_player_error');
     });
 
-    it('ships the fix in the bundle, not only in the source', () => {
-        // The bundle is what the TV loads. #2617 was present in both.
-        expect(MIN).not.toMatch(/case"PAUSED":[^;]*\(state\)/);
+    it.each(PHASES)('routes %s to %s and shows %s', (phase, renderer, view) => {
+        const calls = dispatch({ phase, game_id: 'g1' });
+        expect(calls.map((c) => c.fn)).toContain(renderer);
+        expect(calls).toContainEqual({ fn: 'showView', arg: view });
+    });
+
+    it('gives every phase renderer the same payload', () => {
+        // Rename-proof by construction: it does not care what the parameter is
+        // called, only that no branch drifts off it onto something else.
+        for (const [phase, renderer] of PHASES) {
+            const data = { phase, game_id: 'g1', marker: phase };
+            const call = dispatch(data).find((c) => c.fn === renderer);
+            expect(call, `${phase} rendered nothing`).toBeTruthy();
+            expect(call.arg.marker, `${phase} was handed a different object`).toBe(phase);
+        }
+    });
+
+    it('leaves an unknown phase to the default branch without throwing', () => {
+        const calls = dispatch({ phase: 'TELEPORTING', game_id: 'g1' });
+        expect(calls.map((c) => c.fn)).toEqual(['debug']);
     });
 });

--- a/custom_components/beatify/www/js/__tests__/dashboard-stats-i18n-2619.test.js
+++ b/custom_components/beatify/www/js/__tests__/dashboard-stats-i18n-2619.test.js
@@ -16,100 +16,72 @@
  *    the English string stays as the fallback for an unknown type.
  *
  * dashboard.js is a DOM-coupled IIFE with no exports and the vitest env is
- * `node`, so the two renderers are cut out of the shipped source and run
- * against stubs. That makes this a behaviour test, not a grep: it asserts the
- * text that lands in the DOM.
+ * `node`, so the renderers are cut out of the shipped source and run against
+ * stubs. That makes these behaviour tests, not greps: they assert the text that
+ * lands in the DOM.
+ *
+ * #2701 removed the three assertions against `dashboard.min.js`. They tested
+ * the minifier, not the fix: `npm run build:check` rebuilds every bundle in
+ * memory and fails on any drift from its source, so the bundle is already
+ * guaranteed to carry whatever the source carries — while a `toContain` over
+ * terser's output breaks whenever terser changes how it emits a string.
  */
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
+import {
+    declaration,
+    evaluate,
+    locale,
+    readSource,
+    REPO_DIR,
+} from './helpers/js-source.js';
+import { doc, el, translator } from './helpers/mini-dom.js';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const JS_DIR = join(__dirname, '..');
-const WWW = join(__dirname, '..', '..');
-const REPO = join(__dirname, '..', '..', '..', '..', '..');
-const SRC = readFileSync(join(JS_DIR, 'dashboard.js'), 'utf8');
-const MIN = readFileSync(join(JS_DIR, 'dashboard.min.js'), 'utf8');
+const SRC = readSource('dashboard.js');
 const STATS_PY = readFileSync(
-    join(REPO, 'custom_components', 'beatify', 'services', 'stats.py'),
+    join(REPO_DIR, 'custom_components', 'beatify', 'services', 'stats.py'),
     'utf8',
 );
 const LOCALES = ['en', 'de', 'es', 'fr', 'it', 'nl'];
-
-const i18n = {};
-beforeAll(() => {
-    for (const l of LOCALES) {
-        i18n[l] = JSON.parse(readFileSync(join(WWW, 'i18n', `${l}.json`), 'utf8'));
-    }
-});
+const i18n = Object.fromEntries(LOCALES.map((l) => [l, locale(l)]));
 
 function lookup(obj, key) {
     return key.split('.').reduce((n, p) => (n && typeof n === 'object' ? n[p] : undefined), obj);
 }
 
-/** Cut a top-level declaration out of the IIFE by matching its braces. */
-function declaration(name) {
-    for (const head of [`    function ${name}(`, `    var ${name} = {`]) {
-        const start = SRC.indexOf(head);
-        if (start === -1) continue;
-        let i = SRC.indexOf('{', start);
-        let depth = 0;
-        for (; i < SRC.length; i++) {
-            if (SRC[i] === '{') depth++;
-            else if (SRC[i] === '}' && --depth === 0) return SRC.slice(start, i + 1);
-        }
-    }
-    throw new Error(`dashboard.js no longer declares ${name}`);
+const decl = (name) => declaration(SRC, name, 'dashboard.js');
+
+/** Run the shipped end-screen renderer and read back what it painted. */
+function renderStats(performance, lang) {
+    const icon = el(null);
+    const text = el(null);
+    const container = el('end-stats-comparison', {
+        children: { '.stats-comparison-icon': icon, '.stats-comparison-text': text },
+    });
+    evaluate(decl('renderStatsComparison'), 'renderStatsComparison', {
+        document: doc({ 'end-stats-comparison': container }),
+        utils: translator(i18n[lang]),
+    })(performance);
+    return { icon: icon.textContent, text: text.textContent, css: container.className };
 }
 
-/** BeatifyI18n.t / utils.t for one locale, same lookup + interpolation. */
-function utilsFor(locale) {
-    return {
-        t(key, params) {
-            const value = lookup(i18n[locale], key);
-            if (typeof value !== 'string') return key;
-            if (!params) return value;
-            return Object.keys(params).reduce(
-                (s, p) => s.replace(new RegExp(`\\{${p}\\}`, 'g'), params[p]),
-                value,
-            );
+/** Run the shipped reveal-chip renderer and read back what it painted. */
+function renderChip(performance, lang) {
+    const icon = el(null);
+    const text = el(null);
+    const container = el('reveal-motivational', {
+        children: { '.motivational-icon': icon, '.motivational-text': text },
+    });
+    evaluate(
+        [decl('MOTIVATIONAL_KEYS'), decl('motivationalText'), decl('renderMotivationalMessage')],
+        'renderMotivationalMessage',
+        {
+            document: doc({ 'reveal-motivational': container }),
+            utils: translator(i18n[lang]),
         },
-    };
-}
-
-/** Minimal stand-in for the end-screen container and its two child spans. */
-function stubDom() {
-    const child = () => ({ textContent: '' });
-    const els = { '.stats-comparison-icon': child(), '.stats-comparison-text': child() };
-    const container = {
-        className: 'stats-comparison',
-        classList: { add() {}, remove() {} },
-        querySelector: (sel) => els[sel],
-    };
-    return { document: { getElementById: () => container }, container, els };
-}
-
-function renderStats(performance, locale) {
-    const dom = stubDom();
-    const run = new Function(
-        'document',
-        'utils',
-        `${declaration('renderStatsComparison')}\nreturn renderStatsComparison;`,
-    )(dom.document, utilsFor(locale));
-    run(performance);
-    return {
-        icon: dom.els['.stats-comparison-icon'].textContent,
-        text: dom.els['.stats-comparison-text'].textContent,
-    };
-}
-
-function motivational(message, difference, locale) {
-    const run = new Function(
-        'utils',
-        `${declaration('MOTIVATIONAL_KEYS')};\n${declaration('motivationalText')}\nreturn motivationalText;`,
-    )(utilsFor(locale));
-    return run(message, difference);
+    )(performance);
+    return { icon: icon.textContent, text: text.textContent, css: container.className };
 }
 
 const FIRST = { is_first_game: true, current_avg: 12.34, all_time_avg: 0, difference: 0 };
@@ -162,21 +134,29 @@ describe('#2619 end-screen stats line', () => {
         }
     });
 
-    it('keeps the icons and the css modifier per branch', () => {
-        expect(renderStats(FIRST, 'de').icon).toBe('🌟');
-        expect(renderStats(RECORD, 'de').icon).toBe('🏆');
-        expect(renderStats(ABOVE, 'de').icon).toBe('📈');
-        expect(renderStats(BELOW, 'de').icon).toBe('📊');
+    it('never leaves a raw key on the screen', () => {
+        // `t()` returns the key on a miss (#1402-B8), so a key that lost its
+        // translation shows up as "stats.newRecordEnd" on the TV rather than
+        // as an empty line — visible, but only to whoever is looking.
+        for (const l of LOCALES) {
+            for (const p of [FIRST, RECORD, ABOVE, BELOW]) {
+                expect(renderStats(p, l).text, l).not.toMatch(/^stats\./);
+                expect(renderStats(p, l).text, l).not.toMatch(/\{[a-z_]+\}/i);
+            }
+        }
     });
 
-    it('no longer carries the literals, in the source or in the bundle', () => {
-        for (const bundle of [SRC, MIN]) {
-            expect(bundle).not.toContain('First game recorded! Avg: ');
-            expect(bundle).not.toContain('NEW RECORD! ');
-            expect(bundle).not.toContain(' vs all-time avg)');
+    it('keeps the icons and the css modifier per branch', () => {
+        for (const [perf, icon, modifier] of [
+            [FIRST, '🌟', 'stats-comparison--first'],
+            [RECORD, '🏆', 'stats-comparison--record'],
+            [ABOVE, '📈', 'stats-comparison--above'],
+            [BELOW, '📊', 'stats-comparison--below'],
+        ]) {
+            const out = renderStats(perf, 'de');
+            expect(out.icon).toBe(icon);
+            expect(out.css).toContain(modifier);
         }
-        expect(MIN).toContain('stats.firstGameRecorded');
-        expect(MIN).toContain('stats.newRecordEnd');
     });
 });
 
@@ -189,46 +169,73 @@ describe('#2619 reveal motivation chip', () => {
         close: { type: 'close', message: 'Close to average! Just 2.5 pts below' },
     };
 
-    it('translates every type the server can emit', () => {
-        expect(motivational(SERVER.first, 0, 'de')).toBe('Erstes Spiel! Maßstab gesetzt');
-        expect(motivational(SERVER.record, 0, 'de')).toBe(
-            'Neuer Rekord! Höchste Punktzahl aller Zeiten!',
-        );
-        expect(motivational(SERVER.strong, 7.5, 'de')).toBe(
-            'Ausgezeichnet! 7.5 Pkt über Durchschnitt',
-        );
-        expect(motivational(SERVER.above, 2.5, 'de')).toBe(
-            'Starkes Spiel! 2.5 Pkt über Durchschnitt',
-        );
-        expect(motivational(SERVER.close, -2.5, 'de')).toBe(
-            'Knapp am Durchschnitt! Nur 2.5 Pkt darunter',
-        );
+    it('paints the translated wording into the chip, not the server string', () => {
+        // The regression this replaces a grep for: the chip used to render
+        // `message.message` verbatim, so a German TV read the English sentence
+        // the server had composed.
+        expect(renderChip({ message: SERVER.first, difference: 0 }, 'de').text)
+            .toBe('Erstes Spiel! Maßstab gesetzt');
+        expect(renderChip({ message: SERVER.record, difference: 0 }, 'de').text)
+            .toBe('Neuer Rekord! Höchste Punktzahl aller Zeiten!');
+        expect(renderChip({ message: SERVER.strong, difference: 7.5 }, 'de').text)
+            .toBe('Ausgezeichnet! 7.5 Pkt über Durchschnitt');
+        expect(renderChip({ message: SERVER.above, difference: 2.5 }, 'de').text)
+            .toBe('Starkes Spiel! 2.5 Pkt über Durchschnitt');
+        expect(renderChip({ message: SERVER.close, difference: -2.5 }, 'de').text)
+            .toBe('Knapp am Durchschnitt! Nur 2.5 Pkt darunter');
+    });
+
+    it('keeps the per-type icon and css modifier', () => {
+        const out = renderChip({ message: SERVER.record, difference: 0 }, 'de');
+        expect(out.icon).toBe('🏆');
+        expect(out.css).toContain('motivational-message--record');
     });
 
     it('drops the sign for the "below average" wording', () => {
         // The template says "below" in words, so a "-2.5 pts below" would read
         // as a double negative.
-        expect(motivational(SERVER.close, -2.5, 'en')).toBe('Close to average! Just 2.5 pts below');
+        expect(renderChip({ message: SERVER.close, difference: -2.5 }, 'en').text)
+            .toBe('Close to average! Just 2.5 pts below');
     });
 
     it('falls back to the server text for a type the map does not know', () => {
-        expect(motivational({ type: 'legendary', message: 'Legendary!' }, 0, 'de')).toBe(
-            'Legendary!',
-        );
+        const unknown = { type: 'legendary', message: 'Legendary!' };
+        expect(renderChip({ message: unknown, difference: 0 }, 'de').text).toBe('Legendary!');
     });
 
-    it('covers every message type services/stats.py emits', () => {
+    it('translates every message type services/stats.py can emit', () => {
+        // Not a grep over the key map: each type the server can send is
+        // actually rendered, and a type the client cannot translate falls back
+        // to the server's English — which is exactly what would show on the TV.
         const types = [...STATS_PY.matchAll(/"type":\s*"(\w+)"/g)].map((m) => m[1]);
         expect(types.length, 'the scan found no types — has stats.py been restructured?')
             .toBeGreaterThanOrEqual(5);
-        const map = declaration('MOTIVATIONAL_KEYS');
-        for (const t of new Set(types)) {
-            expect(map, `dashboard.js has no translation for type "${t}"`).toContain(`'${t}':`);
+        for (const type of new Set(types)) {
+            const english = `SERVER TEXT for ${type}`;
+            const painted = renderChip(
+                { message: { type, message: english }, difference: 2.5 },
+                'de',
+            ).text;
+            expect(painted, `dashboard.js has no translation for type "${type}"`)
+                .not.toBe(english);
         }
     });
 
-    it('no longer prints the server string straight into the chip', () => {
-        expect(SRC).not.toContain("textEl.textContent = message.message || ''");
+    it('hides the chip when the round carries no message', () => {
+        const icon = el(null);
+        const text = el(null);
+        const container = el('reveal-motivational', {
+            children: { '.motivational-icon': icon, '.motivational-text': text },
+        });
+        evaluate(
+            [decl('MOTIVATIONAL_KEYS'), decl('motivationalText'), decl('renderMotivationalMessage')],
+            'renderMotivationalMessage',
+            {
+                document: doc({ 'reveal-motivational': container }),
+                utils: translator(i18n.de),
+            },
+        )(null);
+        expect(container.classList.contains('hidden')).toBe(true);
     });
 });
 

--- a/custom_components/beatify/www/js/__tests__/game-settings-merge-2573.test.js
+++ b/custom_components/beatify/www/js/__tests__/game-settings-merge-2573.test.js
@@ -11,44 +11,74 @@
  *
  * The fix merges into the stored blob instead of replacing it, which also
  * covers any future setting that takes the same route.
+ *
+ * #2701: this file used to exercise a hand-written copy of the save named
+ * `speichern`, with one test grepping `game-settings.js` for the literal
+ * `Object.assign({}, bestehend, settings)` to keep the copy honest. That grep
+ * went red on a rename of a German local and stayed green on a merge that
+ * dropped a key. The real `saveGameSettings` is imported and run instead; the
+ * copy and the grep are both gone.
  */
-import { describe, it, expect, beforeEach } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const SRC = readFileSync(
-    join(__dirname, '..', 'admin', 'sections', 'game-settings.js'),
-    'utf8',
-);
+// The sections this one imports are irrelevant to the storage round-trip, and
+// two of them (party-lights, tts-settings) reach for the DOM at call time.
+vi.mock('../admin/sections/playlists.js', () => ({ renderPlaylists: () => {} }));
+vi.mock('../admin/sections/library.js', () => ({
+    setupLibrarySettings: () => {},
+    syncLibraryControls: () => {},
+    updateLibraryPanelVisibility: () => {},
+}));
+vi.mock('../tts-settings.js', () => ({ ttsConfig: () => ({ enabled: false }) }));
+vi.mock('../party-lights.js', () => ({ partyLightsConfig: () => ({ enabled: false }) }));
+
 const KEY = 'beatify_game_settings';
-
-/** The exact write the fixed `saveGameSettings` performs. */
-function speichern(store, settings) {
-    let bestehend = {};
-    try {
-        bestehend = JSON.parse(store.getItem(KEY) || '{}') || {};
-    } catch (e) {
-        bestehend = {};
-    }
-    store.setItem(KEY, JSON.stringify(Object.assign({}, bestehend, settings)));
-}
 
 function makeStore() {
     const data = {};
     return {
         getItem: (k) => (k in data ? data[k] : null),
-        setItem: (k, v) => {
-            data[k] = String(v);
-        },
+        setItem: (k, v) => { data[k] = String(v); },
+        removeItem: (k) => { delete data[k]; },
     };
 }
 
+let store;
+globalThis.localStorage = {
+    getItem: (k) => store.getItem(k),
+    setItem: (k, v) => store.setItem(k, v),
+    removeItem: (k) => store.removeItem(k),
+};
+// saveGameSettings also fires a lobby-update request; it is wrapped in its own
+// try/catch and has nothing to do with what lands in storage.
+globalThis.window = globalThis.window || {};
+globalThis.document = globalThis.document || {
+    getElementById: () => null,
+    querySelectorAll: () => [],
+    querySelector: () => null,
+};
+
+const { STORAGE_GAME_SETTINGS } = await import('../admin/constants.js');
+const { adminState } = await import('../admin/state.js');
+const { saveGameSettings } = await import('../admin/sections/game-settings.js');
+
+/** What the host has picked in the admin, as adminState holds it. */
+function pickInAdmin(settings) {
+    Object.assign(adminState, settings);
+    saveGameSettings();
+}
+
+const stored = () => JSON.parse(store.getItem(KEY));
+
 describe('#2573 game settings merge instead of replace', () => {
-    let store;
     beforeEach(() => {
         store = makeStore();
+    });
+
+    it('writes to the key admin.js reads at game start', () => {
+        // The whole bug is about one blob being shared by two writers, so the
+        // key itself is load-bearing.
+        expect(STORAGE_GAME_SETTINGS).toBe(KEY);
     });
 
     it('keeps wizard-only settings when the admin saves', () => {
@@ -57,34 +87,52 @@ describe('#2573 game settings merge instead of replace', () => {
             JSON.stringify({ suddenDeathMode: true, maxRounds: 20, language: 'de' }),
         );
 
-        speichern(store, { language: 'en', difficulty: 'hard' });
+        pickInAdmin({ selectedLanguage: 'en', selectedDifficulty: 'hard' });
 
-        const nachher = JSON.parse(store.getItem(KEY));
-        expect(nachher.suddenDeathMode).toBe(true);
-        expect(nachher.maxRounds).toBe(20);
+        // The two the wizard owns and adminState knows nothing about.
+        expect(stored().suddenDeathMode).toBe(true);
+        expect(stored().maxRounds).toBe(20);
         // What the admin does own still wins.
-        expect(nachher.language).toBe('en');
-        expect(nachher.difficulty).toBe('hard');
+        expect(stored().language).toBe('en');
+        expect(stored().difficulty).toBe('hard');
     });
 
     it('survives repeated saves — the wizard settings do not erode', () => {
         store.setItem(KEY, JSON.stringify({ suddenDeathMode: true, maxRounds: 20 }));
-        for (let i = 0; i < 5; i++) speichern(store, { difficulty: `d${i}` });
-        const nachher = JSON.parse(store.getItem(KEY));
-        expect(nachher.suddenDeathMode).toBe(true);
-        expect(nachher.maxRounds).toBe(20);
-        expect(nachher.difficulty).toBe('d4');
+        ['easy', 'normal', 'hard', 'easy', 'hard'].forEach((d) => {
+            pickInAdmin({ selectedDifficulty: d });
+        });
+        expect(stored().suddenDeathMode).toBe(true);
+        expect(stored().maxRounds).toBe(20);
+        expect(stored().difficulty).toBe('hard');
+    });
+
+    it('keeps a setting nobody has written yet — the next one, whatever it is', () => {
+        // The point of merging rather than listing exceptions: a future wizard
+        // setting takes the same route and is already covered.
+        store.setItem(KEY, JSON.stringify({ someFutureWizardSetting: 'kept' }));
+        pickInAdmin({ selectedLanguage: 'de' });
+        expect(stored().someFutureWizardSetting).toBe('kept');
     });
 
     it('a corrupt blob does not take the save down with it', () => {
         store.setItem(KEY, '{not json');
-        speichern(store, { language: 'de' });
-        expect(JSON.parse(store.getItem(KEY)).language).toBe('de');
+        pickInAdmin({ selectedLanguage: 'de' });
+        expect(stored().language).toBe('de');
     });
 
-    it('the source really merges — a plain setItem would regress this', () => {
-        expect(SRC).toContain('Object.assign({}, bestehend, settings)');
-        // The old unconditional overwrite must be gone.
-        expect(SRC).not.toContain('setItem(STORAGE_GAME_SETTINGS, JSON.stringify(settings))');
+    it('writes the admin-owned settings on an empty store', () => {
+        pickInAdmin({
+            selectedLanguage: 'es',
+            selectedDuration: 45,
+            selectedDifficulty: 'easy',
+            sabotageEnabled: true,
+        });
+        expect(stored()).toMatchObject({
+            language: 'es',
+            duration: 45,
+            difficulty: 'easy',
+            sabotage: true,
+        });
     });
 });

--- a/custom_components/beatify/www/js/__tests__/helpers/js-source.js
+++ b/custom_components/beatify/www/js/__tests__/helpers/js-source.js
@@ -1,0 +1,114 @@
+/**
+ * Run a piece of the SHIPPED frontend source, instead of asserting on its text.
+ *
+ * Why this exists (#2701): a handful of suites had grown into `expect(src)
+ * .toContain('...')` greps. Such a test fails on a harmless rename and passes
+ * while the behaviour it is named after is broken — the two costs #2701
+ * describes. But the code they cover is genuinely hard to import: `dashboard.js`
+ * is a DOM-coupled IIFE with no exports, and several admin/player helpers are
+ * module-private. vitest runs in the `node` environment here with no jsdom, and
+ * the repo's convention is to hand-roll the little DOM a test needs rather than
+ * take on a dependency.
+ *
+ * So: cut the declaration out of the file on disk, compile it with `new
+ * Function`, and hand it stubs for everything it closes over. The bytes under
+ * test are the bytes that ship — a rename inside the function is invisible to
+ * the test, and a behavioural regression fails it.
+ *
+ * Everything is compiled in strict mode, which is what the browser does too:
+ * `dashboard.js` opens with `'use strict'` and the ES modules are strict by
+ * definition. That matters for more than tidiness — reading an undeclared
+ * identifier throws a ReferenceError under strict mode, which is exactly the
+ * defect #2617 shipped.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+/** `custom_components/beatify/www/js` */
+export const JS_DIR = join(HERE, '..', '..');
+/** `custom_components/beatify/www` */
+export const WWW_DIR = join(JS_DIR, '..');
+/** repository root */
+export const REPO_DIR = join(WWW_DIR, '..', '..', '..');
+
+/** Read a frontend source file, path relative to `www/js`. */
+export function readSource(relPath) {
+    return readFileSync(join(JS_DIR, relPath), 'utf8');
+}
+
+/** Read a JSON locale file, e.g. `locale('de')`. */
+export function locale(lang) {
+    return JSON.parse(readFileSync(join(WWW_DIR, 'i18n', `${lang}.json`), 'utf8'));
+}
+
+/**
+ * Slice out the balanced `{ … }` that starts at or after `from`.
+ * Returns the source from `from` up to and including the closing brace.
+ */
+function balanced(src, from) {
+    let i = src.indexOf('{', from);
+    if (i === -1) throw new Error('no opening brace after offset ' + from);
+    let depth = 0;
+    for (; i < src.length; i++) {
+        const c = src[i];
+        if (c === '{') depth++;
+        else if (c === '}' && --depth === 0) return src.slice(from, i + 1);
+    }
+    throw new Error('unbalanced braces from offset ' + from);
+}
+
+/**
+ * Cut one top-level declaration out of a source file, verbatim.
+ *
+ * Accepts the shapes the frontend actually uses: a bare `function f()`, an
+ * `export function f()`, either of those indented four spaces inside the
+ * dashboard IIFE, and `var NAME = {` / `const NAME = {` for the lookup tables.
+ *
+ * Throws — loudly, naming the file — when the declaration is gone. That is the
+ * one thing a source guard did well and this keeps: a test whose subject has
+ * been deleted must fail rather than silently cover nothing.
+ */
+export function declaration(src, name, label = 'the source') {
+    for (const head of [
+        `\nfunction ${name}(`,
+        `\nexport function ${name}(`,
+        `\n    function ${name}(`,
+        `\nvar ${name} = {`,
+        `\n    var ${name} = {`,
+        `\nexport var ${name} = {`,
+        `\nconst ${name} = {`,
+        `\n    const ${name} = {`,
+    ]) {
+        const at = src.indexOf(head);
+        if (at === -1) continue;
+        // +1 skips the newline the head is anchored on.
+        return balanced(src, at + 1).replace(/^export\s+/, '');
+    }
+    throw new Error(`${label} no longer declares ${name}`);
+}
+
+/**
+ * Cut out a statement that begins with `header` (an `if (…) {` line, say),
+ * balanced braces included. Used where the interesting code is one branch of a
+ * long dispatcher that would need thirty stubs to reach.
+ */
+export function block(src, header, label = 'the source') {
+    const at = src.indexOf(header);
+    if (at === -1) throw new Error(`${label} no longer contains \`${header}\``);
+    return balanced(src, at);
+}
+
+/**
+ * Compile extracted snippets and evaluate `returnExpr` against `scope`.
+ *
+ * `scope` becomes the free variables of the snippet — the closure the browser
+ * would have provided. Anything the snippet touches and `scope` does not name
+ * throws a ReferenceError, which is a feature, not a limitation.
+ */
+export function evaluate(snippets, returnExpr, scope = {}) {
+    const names = Object.keys(scope);
+    const body = `'use strict';\n${[].concat(snippets).join('\n')}\nreturn (${returnExpr});`;
+    return new Function(...names, body)(...names.map((n) => scope[n]));
+}

--- a/custom_components/beatify/www/js/__tests__/helpers/mini-dom.js
+++ b/custom_components/beatify/www/js/__tests__/helpers/mini-dom.js
@@ -1,0 +1,108 @@
+/**
+ * The smallest DOM the frontend tests need (#2701).
+ *
+ * vitest runs in the `node` environment here and the repo deliberately carries
+ * no jsdom, so every suite that needs elements hand-rolls a few — see
+ * `player-reveal-view.test.js` and `dashboard-2130-end-stage.test.js`. This is
+ * that same hand-rolled DOM, in one place, so a test can assert on what lands
+ * on the screen instead of on the source text that puts it there.
+ *
+ * It is deliberately not a DOM implementation. `innerHTML` is a string, not a
+ * parser; `querySelector` is a lookup table you fill in. That is enough for the
+ * renderers under test, which build strings and set properties.
+ */
+
+/** One element. `children` maps a selector to the element `querySelector` returns. */
+export function el(id, { children = {}, closest = null } = {}) {
+    const classes = new Set();
+    const node = {
+        id,
+        tagName: 'DIV',
+        textContent: '',
+        innerHTML: '',
+        className: '',
+        style: {},
+        hidden: false,
+        children,
+        appended: [],
+        scrolledIntoView: null,
+        attrs: {},
+        classList: {
+            add: (...c) => c.forEach((x) => classes.add(x)),
+            remove: (...c) => c.forEach((x) => classes.delete(x)),
+            contains: (c) => classes.has(c),
+            toggle: (c, force) => {
+                const want = force === undefined ? !classes.has(c) : !!force;
+                if (want) classes.add(c);
+                else classes.delete(c);
+                return want;
+            },
+        },
+        classes,
+        setAttribute: (k, v) => { node.attrs[k] = String(v); },
+        getAttribute: (k) => (k in node.attrs ? node.attrs[k] : null),
+        removeAttribute: (k) => { delete node.attrs[k]; },
+        querySelector: (sel) => children[sel] || null,
+        appendChild: (child) => { node.appended.push(child); return child; },
+        closest: (sel) => (closest && closest.selector === sel ? closest.node : null),
+        scrollIntoView: (opts) => { node.scrolledIntoView = opts; },
+    };
+    return node;
+}
+
+/**
+ * A document over a fixed `{ id: element }` map.
+ *
+ * `lookedUp` records every id the code under test asked for — which turns
+ * "does the markup carry the hooks the renderer wants?" from a grep over the
+ * HTML into a question the renderer itself answers.
+ */
+export function doc(elements = {}, { createElement } = {}) {
+    const lookedUp = [];
+    return {
+        lookedUp,
+        elements,
+        getElementById: (id) => {
+            lookedUp.push(id);
+            return elements[id] || null;
+        },
+        querySelector: (sel) => elements[sel] || null,
+        querySelectorAll: (sel) => (elements[sel] ? [elements[sel]] : []),
+        createElement: (tag) => {
+            const node = el(null);
+            node.tagName = String(tag).toUpperCase();
+            node.created = String(tag);
+            if (createElement) createElement(node);
+            return node;
+        },
+    };
+}
+
+/**
+ * A `utils`-shaped translator over a real locale file, with the same lookup and
+ * `{placeholder}` interpolation `BeatifyI18n.t` performs — so a test that reads
+ * German out of the DOM is reading the shipped German, not a fixture.
+ */
+export function translator(dict, { escapeHtml = (s) => String(s) } = {}) {
+    function lookup(key) {
+        return String(key)
+            .split('.')
+            .reduce((n, p) => (n && typeof n === 'object' ? n[p] : undefined), dict);
+    }
+    return {
+        escapeHtml,
+        t(key, params) {
+            const value = lookup(key);
+            if (typeof value !== 'string') {
+                // `t(key, fallback)` is the two-argument shape several call
+                // sites use; `t(key, {…})` is the interpolating one.
+                return typeof params === 'string' ? params : key;
+            }
+            if (!params || typeof params === 'string') return value;
+            return Object.keys(params).reduce(
+                (s, p) => s.replace(new RegExp(`\\{${p}\\}`, 'g'), params[p]),
+                value,
+            );
+        },
+    };
+}

--- a/custom_components/beatify/www/js/__tests__/localization-gaps-2582.test.js
+++ b/custom_components/beatify/www/js/__tests__/localization-gaps-2582.test.js
@@ -15,16 +15,20 @@
  * 4. `library-fix.js` reimplemented the i18n fallback helper with the
  *    #1402-B8 bug: `t()` returns the key on a miss, and a key is truthy, so
  *    the fallback could never win.
+ *
+ * #2701: points 2, 3 and 4 were `expect(src).toContain(...)` pairs. Each of the
+ * three is a small pure function or a single branch, so each is now compiled
+ * out of the shipped file and run — see `helpers/js-source.js`. Point 2's TV
+ * half stays an assertion on the markup, for the reason given at that test.
  */
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
+import { block, declaration, evaluate, locale, readSource, WWW_DIR } from './helpers/js-source.js';
+import { translator } from './helpers/mini-dom.js';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const JS = join(__dirname, '..');            // .../www/js
-const WWW = join(__dirname, '..', '..');    // .../www
 const LOCALES = ['en', 'de', 'es', 'fr', 'it', 'nl'];
+const i18n = Object.fromEntries(LOCALES.map((l) => [l, locale(l)]));
 
 const NEUE_KEYS = [
     'wizard.step2.explainer.amazonTitle',
@@ -45,18 +49,11 @@ const NEUE_KEYS = [
     'playlistGenerator.submit.invalidIssueUrl',
 ];
 
-const i18n = {};
-beforeAll(() => {
-    for (const l of LOCALES) {
-        i18n[l] = JSON.parse(readFileSync(join(WWW, 'i18n', `${l}.json`), 'utf8'));
-    }
-});
-
 function lookup(obj, key) {
     return key.split('.').reduce((n, p) => (n && typeof n === 'object' ? n[p] : undefined), obj);
 }
 
-describe('#2582 localisation gaps', () => {
+describe('#2582 the sixteen missing keys', () => {
     it('all 16 keys exist in all six locales', () => {
         for (const l of LOCALES) {
             for (const k of NEUE_KEYS) {
@@ -91,37 +88,144 @@ describe('#2582 localisation gaps', () => {
             }
         }
     });
+});
 
-    it('the TV podium no longer hard-codes PTS', () => {
-        const html = readFileSync(join(WWW, 'dashboard.html'), 'utf8');
-        const roh = html.match(/<span class="podium-pts">PTS<\/span>/g) || [];
-        expect(roh.length).toBe(0);
-        const uebersetzt = html.match(/podium-pts" data-i18n="reveal\.pointsShort"/g) || [];
-        expect(uebersetzt.length).toBe(3);
+describe('#2582 the points unit on the two end screens', () => {
+    const PLAYER_END = readSource('player-end.js');
+
+    /** Run the shipped label helper against one locale. */
+    const label = (lang) => evaluate(
+        declaration(PLAYER_END, '_ptsLabel', 'player-end.js'),
+        '_ptsLabel',
+        { utils: lang === null ? {} : translator(i18n[lang]) },
+    )();
+
+    it('paints the translated unit on the shareable vinyl', () => {
+        expect(label('de')).toBe(i18n.de.reveal.pointsShort.toUpperCase());
+        expect(label('en')).toBe(i18n.en.reveal.pointsShort.toUpperCase());
     });
 
-    it('the shared vinyl graphic asks i18n for the unit', () => {
-        const src = readFileSync(join(JS, 'player-end.js'), 'utf8');
-        expect(src).toContain("utils.t('reveal.pointsShort')");
-        expect(src).not.toContain("ctx.fillText('PTS'");
+    it('never paints a raw key onto the graphic', () => {
+        // The graphic is what guests post; "reveal.pointsShort" on it would
+        // outlive the party. `t()` returns the key on a miss (#1402-B8), so the
+        // miss has to be checked for explicitly.
+        for (const l of LOCALES) {
+            expect(label(l), l).not.toMatch(/^reveal\./i);
+        }
+        // i18n not loaded yet: an English unit beats a broken one.
+        expect(label(null)).toBe('PTS');
+        expect(evaluate(
+            declaration(PLAYER_END, '_ptsLabel', 'player-end.js'),
+            '_ptsLabel',
+            { utils: { t: (key) => key } },
+        )()).toBe('PTS');
     });
 
-    it('ADMIN_CANNOT_LEAVE looks up the code before the server text', () => {
-        const src = readFileSync(join(JS, 'player-core.js'), 'utf8');
-        expect(src).toContain("utils.t('errors.ADMIN_CANNOT_LEAVE')");
-        expect(src).not.toContain(
-            "showToast(data.message || 'Host cannot leave. End the game instead.')",
+    it('the TV podium asks i18n for the unit (markup guard)', () => {
+        // This one stays an assertion on the markup on purpose: the three
+        // podium labels are static HTML translated by the `data-i18n` sweep at
+        // load, so there is no function to run — the defect is literally
+        // "does the element carry the attribute". The count is part of it: the
+        // podium has three stands and #2582 was one of them being missed.
+        const html = readFileSync(join(WWW_DIR, 'dashboard.html'), 'utf8');
+        expect(html.match(/<span class="podium-pts">PTS<\/span>/g) || []).toHaveLength(0);
+        expect(html.match(/podium-pts" data-i18n="reveal\.pointsShort"/g) || []).toHaveLength(3);
+    });
+
+    it('the unit exists in all six locales', () => {
+        for (const l of LOCALES) {
+            expect(lookup(i18n[l], 'reveal.pointsShort'), l).toBeTruthy();
+        }
+    });
+});
+
+describe('#2582 ADMIN_CANNOT_LEAVE looks up the code before the server text', () => {
+    const PLAYER_CORE = readSource('player-core.js');
+
+    /** The shipped branch, wrapped so it can be called. */
+    function handle(data, { lang } = {}) {
+        const toasts = [];
+        const state = { intentionalLeave: true };
+        const branch = block(
+            PLAYER_CORE,
+            "if (data.code === 'ADMIN_CANNOT_LEAVE') {",
+            'player-core.js',
         );
+        evaluate(
+            [`function run(data) {\n${branch}\n}`],
+            'run',
+            { state, utils: lang ? translator(i18n[lang]) : {}, showToast: (m) => toasts.push(m) },
+        )(data);
+        return { toasts, state };
+    }
+
+    const SERVER_TEXT = 'Host cannot leave. End the game instead.';
+
+    it('shows the German sentence to a German host', () => {
+        const { toasts } = handle({ code: 'ADMIN_CANNOT_LEAVE', message: SERVER_TEXT }, { lang: 'de' });
+        expect(toasts).toEqual([i18n.de.errors.ADMIN_CANNOT_LEAVE]);
+        expect(toasts[0]).not.toBe(SERVER_TEXT);
+    });
+
+    it('prefers the translation in every locale that has one', () => {
+        for (const l of LOCALES.filter((x) => x !== 'en')) {
+            const { toasts } = handle(
+                { code: 'ADMIN_CANNOT_LEAVE', message: SERVER_TEXT }, { lang: l },
+            );
+            expect(toasts[0], l).toBe(i18n[l].errors.ADMIN_CANNOT_LEAVE);
+        }
+    });
+
+    it('falls back to the server text while i18n has nothing', () => {
+        expect(handle({ code: 'ADMIN_CANNOT_LEAVE', message: SERVER_TEXT }).toasts)
+            .toEqual([SERVER_TEXT]);
+    });
+
+    it('keeps the host in the game', () => {
+        // The toast is only half of it: a rejected leave must not leave
+        // `intentionalLeave` set, or the next socket close is treated as
+        // deliberate and the host is dropped for real.
+        expect(handle({ code: 'ADMIN_CANNOT_LEAVE', message: SERVER_TEXT }).state.intentionalLeave)
+            .toBe(false);
+    });
+
+    it('the key exists in all six locales', () => {
         for (const l of LOCALES) {
             expect(lookup(i18n[l], 'errors.ADMIN_CANNOT_LEAVE'), l).toBeTruthy();
         }
     });
+});
 
-    it('the library-fix fallback can actually fall back (#1402-B8 again)', () => {
-        const src = readFileSync(join(JS, 'admin', 'sections', 'library-fix.js'), 'utf8');
+describe('#2582 the library-fix fallback can actually fall back (#1402-B8 again)', () => {
+    const LIBRARY_FIX = readSource('admin/sections/library-fix.js');
+
+    /** The shipped `_t`, with `BeatifyI18n` swapped for a controlled one. */
+    function t(key, fallback, i18nStub) {
+        return evaluate(
+            declaration(LIBRARY_FIX, '_t', 'library-fix.js'),
+            '_t',
+            { window: { BeatifyI18n: i18nStub } },
+        )(key, fallback);
+    }
+
+    const REAL = { t: (key) => lookup(i18n.de, key) ?? key };
+
+    it('returns the translation when there is one', () => {
+        expect(t('errors.ADMIN_CANNOT_LEAVE', 'fallback', REAL))
+            .toBe(i18n.de.errors.ADMIN_CANNOT_LEAVE);
+    });
+
+    it('returns the fallback when the key is missing', () => {
         // The broken shape returned the key, which is truthy, so `|| fallback`
-        // never ran.
-        expect(src).not.toContain('window.BeatifyI18n.t(key)) || fallback');
-        expect(src).toContain('s === key');
+        // never ran and the admin showed "library.fix.noSuchKey" on screen.
+        expect(t('library.fix.noSuchKey', 'Fix it', REAL)).toBe('Fix it');
+    });
+
+    it('returns the fallback when the translation is empty', () => {
+        expect(t('whatever', 'Fix it', { t: () => '' })).toBe('Fix it');
+    });
+
+    it('returns the fallback before i18n has loaded at all', () => {
+        expect(t('whatever', 'Fix it', undefined)).toBe('Fix it');
     });
 });

--- a/custom_components/beatify/www/js/__tests__/mix-error-detail-2294.test.js
+++ b/custom_components/beatify/www/js/__tests__/mix-error-detail-2294.test.js
@@ -9,14 +9,33 @@
  * These cover the decision (via the shared helper) and the rendering rule that
  * is specific to this surface: #mix-error is a <p>, so the detail must be a
  * <span> — a block child would close the paragraph.
+ *
+ * #2701: the rendering rule used to be checked by slicing `showMixError` out of
+ * `mix.js` and grepping the slice for `createElement('span')`. The function is
+ * compiled and run here instead, against a document that records what it was
+ * asked to create — so the assertion is about the element that reaches the
+ * page, and a rewrite that produces the same element keeps passing.
  */
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { describe, it, expect } from 'vitest';
 import { errorHeadlineAndDetail } from '../admin/util.js';
+import { declaration, evaluate, readSource } from './helpers/js-source.js';
+import { doc, el } from './helpers/mini-dom.js';
+
+const MIX = readSource('admin/sections/mix.js');
+// The element itself is written by the Mix tab's own template.
+const HUB = readSource('playlist-hub.js');
 
 const DE = { 'errors.INVALID_REQUEST': 'Diese Anfrage war ungültig. Prüfe deine Einrichtung.' };
 const t = (key) => (Object.prototype.hasOwnProperty.call(DE, key) ? DE[key] : key);
+
+/** Run the shipped `showMixError` and report what it put on the page. */
+function showError(msg, detail) {
+    const box = el('mix-error');
+    box.classList.add('hidden');
+    const document = doc({ 'mix-error': box });
+    evaluate(declaration(MIX, 'showMixError', 'mix.js'), 'showMixError', { document })(msg, detail);
+    return { box, detail: box.appended[0] || null };
+}
 
 describe('#2294 mix errors keep the server reason', () => {
     it('separates two mix rejections that share INVALID_REQUEST', () => {
@@ -34,26 +53,36 @@ describe('#2294 mix errors keep the server reason', () => {
         expect(out.message).toBe('Failed to assemble mix.');
         expect(out.detail).toBe('');
     });
+});
 
-    it('uses a span for the detail, because #mix-error is a <p>', () => {
+describe('#2294 how the mix error is drawn', () => {
+    it('shows the headline and reveals the box', () => {
+        const { box } = showError('Failed to assemble mix.', '');
+        expect(box.textContent).toBe('Failed to assemble mix.');
+        expect(box.classList.contains('hidden')).toBe(false);
+    });
+
+    it('adds the server reason as a second line', () => {
+        const { detail } = showError(
+            DE['errors.INVALID_REQUEST'], 'No songs match the selected tags');
+        expect(detail.textContent).toBe('No songs match the selected tags');
+        expect(detail.className).toBe('mix-error-detail');
+    });
+
+    it('makes that second line an inline element, because #mix-error is a <p>', () => {
         // A <div> inside a <p> is closed by the parser, which would drop the
         // detail out of the error element entirely.
-        const src = readMixSource();
-        const fn = src.slice(src.indexOf('function showMixError'));
-        const body = fn.slice(0, fn.indexOf('\n}'));
-        expect(body).toContain("createElement('span')");
-        expect(body).not.toContain("createElement('div')");
+        expect(HUB).toMatch(/<p[^>]*\bid="mix-error"/);
+        const { detail } = showError('Headline', 'The reason from the server');
+        expect(detail.tagName).toBe('SPAN');
     });
 
     it('renders no detail when it would only repeat the headline', () => {
-        const src = readMixSource();
-        const fn = src.slice(src.indexOf('function showMixError'));
-        const body = fn.slice(0, fn.indexOf('\n}'));
-        expect(body).toContain('detail !== msg');
+        expect(showError('Same text', 'Same text').detail).toBeNull();
+    });
+
+    it('renders no detail when there is none', () => {
+        expect(showError('Headline', '').detail).toBeNull();
+        expect(showError('Headline', undefined).detail).toBeNull();
     });
 });
-
-function readMixSource() {
-    const here = fileURLToPath(import.meta.url);
-    return readFileSync(here.replace(/__tests__.*/, 'admin/sections/mix.js'), 'utf8');
-}

--- a/custom_components/beatify/www/js/__tests__/playoff-badge-2578.test.js
+++ b/custom_components/beatify/www/js/__tests__/playoff-badge-2578.test.js
@@ -4,19 +4,48 @@
  * Design variant B. The server no longer marks non-leaders `eliminated`, so
  * the skulls disappear on their own; what is added is the positive statement —
  * two players are in the playoff.
+ *
+ * #2701: the badge used to be checked by grepping `dashboard.js` for
+ * `'playoffLaeuft && !entry.playoff_spectator'`. That fails on a rename of a
+ * German local and passes if the badge is attached to the wrong row. The
+ * renderer is run for real here instead: `renderLeaderboard` is cut out of the
+ * shipped file and given a `_reconcileRows` stub that captures the rows it
+ * builds, so the assertions are about which player carries the badge.
  */
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { declaration, evaluate, locale, readSource } from './helpers/js-source.js';
+import { doc, el, translator } from './helpers/mini-dom.js';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const JS = join(__dirname, '..');
-const WWW = join(__dirname, '..', '..');
+const DASHBOARD = readSource('dashboard.js');
 
 global.window = global.window || {};
 await import('../utils.js');
 const U = global.window.BeatifyUtils;
+
+/**
+ * Run the shipped `renderLeaderboard` and return the HTML it produced per row.
+ * `_reconcileRows` is where the rows meet the DOM, so stubbing it captures the
+ * complete output without needing a diffing DOM.
+ */
+function renderRows(leaderboard, { lang = 'en', players = null } = {}) {
+    const container = el('leaderboard');
+    let captured = null;
+    evaluate(
+        declaration(DASHBOARD, 'renderLeaderboard', 'dashboard.js'),
+        'renderLeaderboard',
+        {
+            document: doc({ leaderboard: container }),
+            utils: translator(locale(lang), { escapeHtml: U.escapeHtml }),
+            _reconcileRows: (target, rows) => {
+                expect(target).toBe(container);
+                captured = rows;
+            },
+        },
+    )(leaderboard, players, 'leaderboard', false, false);
+    return captured;
+}
+
+const rowFor = (rows, name) => rows.find((r) => r.key === name).html;
 
 describe('#2578 playoff spectators on the TV', () => {
     it('hydrateLeaderboard carries playoff_spectator', () => {
@@ -34,22 +63,53 @@ describe('#2578 playoff spectators on the TV', () => {
         expect(out[1].playoff_spectator).toBe(true);
     });
 
-    it('the badge marks the finalists, not the spectators', () => {
-        const src = readFileSync(join(JS, 'dashboard.js'), 'utf8');
-        expect(src).toContain('playoffLaeuft && !entry.playoff_spectator');
-        expect(src).toContain('finalist-badge');
+    it('badges the finalists and leaves the spectators plain', () => {
+        const rows = renderRows([
+            { rank: 1, name: 'Anna', score: 84, playoff_spectator: false },
+            { rank: 1, name: 'Bea', score: 84, playoff_spectator: false },
+            { rank: 3, name: 'Clara', score: 66, playoff_spectator: true },
+            { rank: 4, name: 'Dana', score: 51, playoff_spectator: true },
+        ]);
+        expect(rowFor(rows, 'Anna')).toContain('finalist-badge');
+        expect(rowFor(rows, 'Bea')).toContain('finalist-badge');
+        expect(rowFor(rows, 'Clara')).not.toContain('finalist-badge');
+        expect(rowFor(rows, 'Dana')).not.toContain('finalist-badge');
+    });
+
+    it('nobody gets a skull for standing outside the playoff', () => {
+        // The regression that started #2578: six of eight rows rendered 💀
+        // although nobody had been eliminated.
+        const rows = renderRows([
+            { rank: 1, name: 'Anna', score: 84, playoff_spectator: false },
+            { rank: 3, name: 'Clara', score: 66, playoff_spectator: true },
+        ]);
+        expect(rows.map((r) => r.html).join('')).not.toContain('💀');
     });
 
     it('the badge only appears while a playoff is running', () => {
-        const src = readFileSync(join(JS, 'dashboard.js'), 'utf8');
-        // Derived from the data, not from a separate flag that could go stale.
-        expect(src).toContain('leaderboard.some(function (x) { return x.playoff_spectator; })');
+        // Derived from the data, not from a separate flag that could go stale:
+        // with no spectator in the board there is no playoff, so no badge.
+        const rows = renderRows([
+            { rank: 1, name: 'Anna', score: 84, playoff_spectator: false },
+            { rank: 2, name: 'Clara', score: 66, playoff_spectator: false },
+        ]);
+        expect(rows.map((r) => r.html).join('')).not.toContain('finalist-badge');
+    });
+
+    it('the badge carries the translated label, not a literal', () => {
+        const rows = renderRows(
+            [
+                { rank: 1, name: 'Anna', score: 84, playoff_spectator: false },
+                { rank: 3, name: 'Clara', score: 66, playoff_spectator: true },
+            ],
+            { lang: 'de' },
+        );
+        expect(rowFor(rows, 'Anna')).toContain(locale('de').reveal.finalePlayoff);
     });
 
     it('the label exists in all six locales', () => {
         for (const l of ['en', 'de', 'es', 'fr', 'it', 'nl']) {
-            const j = JSON.parse(readFileSync(join(WWW, 'i18n', `${l}.json`), 'utf8'));
-            expect(j.reveal?.finalePlayoff, l).toBeTruthy();
+            expect(locale(l).reveal?.finalePlayoff, l).toBeTruthy();
         }
     });
 });

--- a/tests/unit/test_error_codes_2294.py
+++ b/tests/unit/test_error_codes_2294.py
@@ -6,15 +6,29 @@ one generic sentence ("this request was invalid, check your setup"). On
 every speaker was unavailable, and the screen never said so.
 
 Three of the twelve are things a host can actually fix. They now have codes.
+
+#2701: the three call sites used to be checked by reading ``game_views.py`` and
+asserting ``"code=ERR_NO_PLAYLISTS_SELECTED" in src``. That is green for a call
+site that passes the code positionally and red for one that spreads a kwargs
+dict — neither of which a host would notice either way. ``StartGameView.post``
+is driven for real below, once per rejection, and the code is read off the
+response body the client actually receives.
 """
 
 from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from custom_components.beatify.const import (
     ERR_MEDIA_PLAYER_UNAVAILABLE,
     ERR_NO_PLAYABLE_SONGS,
     ERR_NO_PLAYLISTS_SELECTED,
 )
+
+from .conftest import make_start_game_request
 
 
 class TestDistinctErrorCodes:
@@ -43,21 +57,86 @@ class TestDistinctErrorCodes:
         # growing a second, parallel code for the same situation.
         assert ERR_MEDIA_PLAYER_UNAVAILABLE == "MEDIA_PLAYER_UNAVAILABLE"
 
-    def test_create_game_emits_the_new_codes(self):
-        # Structural guard: the three call sites in the create path must use the
-        # constants. A literal "INVALID_REQUEST" creeping back would be invisible
-        # to a behavioural test that only checks the constants themselves.
-        from pathlib import Path
 
-        src = Path("custom_components/beatify/server/game_views.py").read_text()
-        assert "code=ERR_NO_PLAYLISTS_SELECTED" in src
-        assert "code=ERR_MEDIA_PLAYER_UNAVAILABLE" in src
-        assert "code=ERR_NO_PLAYABLE_SONGS" in src
+class TestCreateGameEmitsTheNewCodes:
+    """Each rejection is provoked and the response is read back.
+
+    Status and code are asserted together, for the reason spelled out in
+    ``test_no_playable_songs_500_2530.py``: a test that only checks "not 200"
+    passes on a 500, which is the response with no code at all.
+    """
+
+    @staticmethod
+    def _rejection(resp) -> tuple[int, str]:
+        body = json.loads(resp.body)
+        # Both keys are populated by ``_json_error``; ``code`` is what the
+        # client reads for its ``errors.<CODE>`` lookup.
+        assert body["code"] == body["error"]
+        return resp.status, body["code"]
+
+    async def test_no_playlists_selected(self, start_game_env):
+        view, hass, body = start_game_env
+        body["playlists"] = []
+
+        resp = await view.post(make_start_game_request(hass, body))
+        assert self._rejection(resp) == (400, ERR_NO_PLAYLISTS_SELECTED)
+
+    async def test_media_player_unavailable(self, start_game_env):
+        # The 2026-08-21 evening exactly: Music Assistant down, every speaker
+        # entity reporting `unavailable`.
+        view, hass, body = start_game_env
+        hass.states.get.return_value = MagicMock(state="unavailable")
+
+        resp = await view.post(make_start_game_request(hass, body))
+        status, code = self._rejection(resp)
+        assert (status, code) == (400, ERR_MEDIA_PLAYER_UNAVAILABLE)
+        # #2269: the speaker banner needs to know WHICH entity to offer.
+        assert json.loads(resp.body)["entity_id"] == "media_player.test"
+
+    async def test_no_playable_songs(self, start_game_env):
+        # The fixture's playlist carries Spotify URIs only; asking for Apple
+        # Music loads songs of which none is playable on the chosen provider.
+        view, hass, body = start_game_env
+        body["provider"] = "apple_music"
+
+        with patch(
+            "custom_components.beatify.server.game_views.get_platform_capabilities",
+            return_value={"supported": True, "apple_music": True},
+        ):
+            resp = await view.post(make_start_game_request(hass, body))
+        assert self._rejection(resp) == (400, ERR_NO_PLAYABLE_SONGS)
+
+    async def test_the_three_rejections_stay_told_apart(self, start_game_env):
+        """The regression this issue is about, in one assertion.
+
+        Before #2294 all three answered ``INVALID_REQUEST`` and the host saw the
+        same sentence for a missing playlist, a dead speaker and an unplayable
+        provider. Collapsing any two of them back together fails here.
+        """
+        view, hass, body = start_game_env
+
+        async def code_for(payload) -> str:
+            resp = await view.post(make_start_game_request(hass, payload))
+            return json.loads(resp.body)["code"]
+
+        seen = [await code_for(dict(body, playlists=[]))]
+
+        hass.states.get.return_value = MagicMock(state="unavailable")
+        seen.append(await code_for(body))
+
+        hass.states.get.return_value = MagicMock(state="playing")
+        with patch(
+            "custom_components.beatify.server.game_views.get_platform_capabilities",
+            return_value={"supported": True, "apple_music": True},
+        ):
+            seen.append(await code_for(dict(body, provider="apple_music")))
+
+        assert len(set(seen)) == 3, f"two rejections share a code: {seen}"
+        assert "INVALID_REQUEST" not in seen
 
 
 class TestTranslations:
     def test_every_locale_has_a_string_for_each_new_code(self):
-        import json
         from pathlib import Path
 
         for path in sorted(Path("custom_components/beatify/www/i18n").glob("*.json")):
@@ -70,7 +149,6 @@ class TestTranslations:
         # getErrorMessage rejects a translation still holding {placeholder} and
         # falls back to the English backend message — which would silently undo
         # the translation work.
-        import json
         import re
         from pathlib import Path
 
@@ -78,3 +156,14 @@ class TestTranslations:
             errors = json.loads(path.read_text())["errors"]
             for code in (ERR_NO_PLAYLISTS_SELECTED, ERR_NO_PLAYABLE_SONGS):
                 assert not re.search(r"\{[a-z_]+\}", errors[code], re.I)
+
+
+@pytest.mark.parametrize(
+    "code",
+    [ERR_MEDIA_PLAYER_UNAVAILABLE, ERR_NO_PLAYLISTS_SELECTED, ERR_NO_PLAYABLE_SONGS],
+)
+def test_every_code_is_a_stable_screaming_snake_identifier(code):
+    # The codes are the client's contract; a lowercase or spaced one would miss
+    # the `errors.<CODE>` lookup and fall back to the English server message.
+    assert code == code.upper()
+    assert " " not in code

--- a/tests/unit/test_year_guess_range_2623.py
+++ b/tests/unit/test_year_guess_range_2623.py
@@ -15,16 +15,38 @@ The fix is not a wider constant. Both sides now ask the same function, so the
 two answers cannot drift apart again — which is the actual defect. A wider
 constant would have fixed today's 27 songs and left the next widening to
 rediscover the bug.
+
+#2701: the handler used to be covered by reading ``guessing.py`` and asserting
+``"year_range(game_state)" in src`` with ``"YEAR_MIN" not in src``. That was
+red on renaming a local to ``gs`` and green on a validator that returned a
+hardcoded 1950. ``handle_submit`` is driven for real below — a pre-1950 guess
+goes in and has to come back as ``submit_ack``.
 """
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
 
-from custom_components.beatify.const import YEAR_MAX, YEAR_MIN
+import pytest
+
+from custom_components.beatify.const import (
+    DOMAIN,
+    ERR_INVALID_ACTION,
+    YEAR_MAX,
+    YEAR_MIN,
+)
 from custom_components.beatify.game.serializers import (
     GameStateSerializer,
     year_range,
+)
+from custom_components.beatify.game.state import GamePhase
+from custom_components.beatify.server.ws_handlers.guessing import handle_submit
+from tests.conftest import make_game_state
+
+from custom_components.beatify.server.websocket import (  # isort: skip
+    BeatifyWebSocketHandler,
 )
 
 
@@ -64,20 +86,136 @@ class TestOneSourceForBothSides:
         assert rng["max"] >= YEAR_MAX
 
 
-class TestValidatorUsesIt:
-    def test_handler_no_longer_reads_the_constants(self):
-        """A source guard: the drift came from two literals, so neither may
-        return to the submit path.
+# ---------------------------------------------------------------------------
+# The validator itself, driven through the websocket handler.
+# ---------------------------------------------------------------------------
 
-        Asserting on behaviour would need the full websocket handler with a
-        game, a player and a live round; the defect, however, is entirely in
-        *which bounds the check reads*. That is what this pins.
+
+def _songs(*years: int) -> list[dict]:
+    return [
+        {
+            "year": year,
+            "title": f"Song {year}",
+            "artist": f"Artist {year}",
+            "uri": f"spotify:track:{i:022d}",
+            "_resolved_uri": f"spotify:track:{i:022d}",
+        }
+        for i, year in enumerate(years)
+    ]
+
+
+def _stub_media_service() -> MagicMock:
+    svc = MagicMock()
+    svc.is_available.return_value = True
+    svc.play_song = AsyncMock(return_value=True)
+    svc.verify_responsive = AsyncMock(return_value=(True, None))
+    return svc
+
+
+def _ws() -> AsyncMock:
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+    ws.closed = False
+    ws.close = AsyncMock()
+    return ws
+
+
+async def _playing_game(*years: int):
+    """A game in PLAYING phase, its playlist spanning ``years``."""
+    hass = MagicMock()
+    gs = make_game_state()
+    gs.create_game(
+        playlists=["t.json"],
+        songs=_songs(*years),
+        media_player="media_player.x",
+        base_url="http://h",
+    )
+    gs._media_player_service = _stub_media_service()
+    gs.platform = "music_assistant"
+    hass.data = {DOMAIN: {"game": gs}}
+
+    handler = BeatifyWebSocketHandler(hass)
+    handler.broadcast_state = AsyncMock()
+    handler.broadcast = AsyncMock()
+    handler.debounced_broadcast_state = AsyncMock()
+
+    ws = _ws()
+    gs.add_player("Alice", ws)
+    gs.get_player("Alice").connected = True
+    await gs.start_round()
+    assert gs.phase == GamePhase.PLAYING
+    return handler, gs, ws
+
+
+def _replies(ws: AsyncMock) -> list[dict]:
+    return [c.args[0] for c in ws.send_json.call_args_list if c.args]
+
+
+async def _submit(year, *, span_years):
+    """Submit ``year`` into a game whose playlist spans ``span_years``."""
+    handler, gs, ws = await _playing_game(*span_years)
+    await handle_submit(handler, ws, {"year": year}, gs)
+    return gs, ws, _replies(ws)
+
+
+class TestValidatorAcceptsWhatTheSliderOffers:
+    """The handler and the slider answer to the same bounds."""
+
+    async def test_the_slider_and_the_handler_agree_on_this_playlist(self):
+        # The premise: the slider really does reach below YEAR_MIN here.
+        _, gs, _ = await _playing_game(1937, 2001)
+        assert year_range(gs)["min"] == 1937 < YEAR_MIN
+
+    @pytest.mark.parametrize("year", [1937, 1945, 1949])
+    async def test_a_pre_1950_guess_is_banked_not_rejected(self, year):
+        # #2623 in one call: 27 catalogue songs sit in this window, and every
+        # correct answer for them used to come back as "Invalid year".
+        gs, ws, replies = await _submit(year, span_years=(1937, 2001))
+        assert [r["type"] for r in replies] == ["submit_ack"]
+        assert replies[0]["year"] == year
+        assert gs.get_player("Alice").current_guess == year
+
+    async def test_the_current_year_is_accepted_whatever_the_constant_says(self):
+        # The January failure mode: the slider maximum follows the clock, so a
+        # literal ceiling starts rejecting the current year at some new year.
+        gs, ws, replies = await _submit(_this_year(), span_years=(1990, 2001))
+        assert [r["type"] for r in replies] == ["submit_ack"]
+        assert gs.get_player("Alice").current_guess == _this_year()
+
+    @pytest.mark.parametrize("year", [1900, 1936])
+    async def test_a_year_below_the_slider_is_still_rejected(self, year):
+        # Widening is not the same as accepting anything: the range still has a
+        # floor, it is just the playlist's floor rather than a constant.
+        gs, ws, replies = await _submit(year, span_years=(1937, 2001))
+        assert replies[0]["code"] == ERR_INVALID_ACTION
+        assert gs.get_player("Alice").current_guess is None
+
+    async def test_a_year_beyond_the_clock_is_still_rejected(self):
+        gs, ws, replies = await _submit(_this_year() + 1, span_years=(1990, 2001))
+        assert replies[0]["code"] == ERR_INVALID_ACTION
+        assert gs.get_player("Alice").current_guess is None
+
+    @pytest.mark.parametrize("year", ["1970", None, 1970.5])
+    async def test_a_non_integer_year_is_rejected(self, year):
+        gs, ws, replies = await _submit(year, span_years=(1937, 2001))
+        assert replies[0]["code"] == ERR_INVALID_ACTION
+        assert gs.get_player("Alice").current_guess is None
+
+    async def test_the_bounds_the_player_was_shown_are_the_bounds_applied(self):
+        """The two sides are checked against each other, not against literals.
+
+        This is the shape of the defect rather than one instance of it: whatever
+        the slider offers, the extremes of that offer must be accepted. A
+        validator that hardcoded any bound fails here on some playlist.
         """
-        from pathlib import Path
+        handler, gs, ws = await _playing_game(1937, 2001)
+        offered = json.loads(json.dumps(year_range(gs)))  # the payload's copy
 
-        src = Path(
-            "custom_components/beatify/server/ws_handlers/guessing.py"
-        ).read_text(encoding="utf-8")
-        assert "year_range(game_state)" in src
-        assert "YEAR_MIN" not in src
-        assert "YEAR_MAX" not in src
+        for year in (offered["min"], offered["max"]):
+            player_ws = _ws()
+            gs.add_player(f"P{year}", player_ws)
+            gs.get_player(f"P{year}").connected = True
+            await handle_submit(handler, player_ws, {"year": year}, gs)
+            assert [r["type"] for r in _replies(player_ws)] == ["submit_ack"], (
+                f"the slider offered {year} and the handler refused it"
+            )


### PR DESCRIPTION
Closes #2701

Eleven tests asserted on the text of the file they covered. That costs twice: red on a harmless rename, which trains people to edit the test rather than read it, and green while the behaviour the test is named after is broken. Two of them read `dashboard.min.js`, so terser's output was part of their contract.

Only files under `tests/` and `www/js/__tests__/` are touched. No production source changed.

## What happened to each

| Test | Was | Is now |
|---|---|---|
| `game-settings-merge-2573.test.js:86-88` | grep for `Object.assign({}, bestehend, settings)`, around a hand-written copy of the save named `speichern` | imports and runs the real `saveGameSettings`; the copy and the grep are gone |
| `playoff-badge-2578.test.js:39-46` | grep for `playoffLaeuft && !entry.playoff_spectator` and `finalist-badge` | runs `renderLeaderboard` with a `_reconcileRows` stub and asserts **which row** carries the badge |
| `collection-row-2324.test.js:24-47` | five greps over `player-reveal.js` + a hand-copied sort comparator | imports `renderCollection` and asserts the rendered cards: order, the `--new` marker, escaping, the count, the empty state |
| `localization-gaps-2582.test.js:105-125` | greps over `player-end.js`, `player-core.js`, `library-fix.js` | each of the three is compiled out of the file and run: `_ptsLabel` per locale, the `ADMIN_CANNOT_LEAVE` branch, `_t`'s fallback |
| `dashboard-2130-end-stage.test.js:105-129` (JS half) | a verbatim copy of the podium loop plus three greps guarding the copy | runs the real `renderEndView` against a stub podium |
| `mix-error-detail-2294.test.js:44-52` | grep for `createElement('span')` and `detail !== msg` inside a sliced function body | runs `showMixError` against a document that records what it created |
| `dashboard-nosleep-reset.test.js:114` | a source pin on the catch handler | removed — the two tests beside it already reject the `enable()` promise and read the flag back |
| `dashboard-paused-view-2617.test.js:60` | two regexes over the source + one over the **minified bundle** | runs `_applyStateRender` in strict mode, so the ReferenceError reproduces instead of being described |
| `dashboard-stats-i18n-2619.test.js:178` | three assertions on the **minified bundle** + two source greps | bundle assertions removed (see below); the reveal chip is now rendered into a stub DOM |
| `test_year_guess_range_2623.py:78-83` | `"year_range(game_state)" in src`, `"YEAR_MIN" not in src` | drives `handle_submit` — a 1937 guess has to come back as `submit_ack` |
| `test_error_codes_2294.py:46-55` | `"code=ERR_NO_PLAYLISTS_SELECTED" in src` ×3 | drives `StartGameView.post` once per rejection and reads the code off the response body |

## Kept as source guards, on purpose

Four assertions still read text, and their names now say which and why.

- **`dashboard-2130-end-stage.test.js`** — three assertions on `dashboard.css` (`podium-place--empty { display:none }`, `flex: 0 1 200px` + `min-width: 0`, `grid-template-columns: auto minmax(0, 1fr) auto`). The defect is a layout one — a name breaking mid-word, an award value drawn outside its card — and reproducing it needs a layout engine. There is no jsdom and no CSSOM in this process, so nothing here can compute a box. The block is titled *"the stylesheet rules the fix depends on"* and each test ends in `(stylesheet guard)`.
- **`localization-gaps-2582.test.js`** — the TV podium's `data-i18n="reveal.pointsShort"`, three times. Those three labels are static HTML translated by the `data-i18n` sweep at load; there is no function to run, and the defect is literally "does the element carry the attribute". Named `(markup guard)`.

Two smaller ones are markup checks that back a behaviour assertion rather than replace it: `mix-error-detail` asserts `#mix-error` really is a `<p>` (which is what makes the `<span>` requirement real, and it lives in `playlist-hub.js`, not `admin.html`), and `collection-row` derives the ids to check from what the renderer actually looked up, so neither file can drift alone.

## Why the minified assertions went, rather than moved

`npm run build:check` rebuilds every bundle in memory and fails on any drift from its source — it is in CI (`test.yml:124`) and in the required set for this PR. So `expect(MIN).toContain('stats.firstGameRecorded')` guaranteed nothing that build:check does not already guarantee, while breaking whenever terser changes how it emits a string.

## Proof that the rewrites are stronger

Each mutation was applied to production source, both the old and the new test were run, then the source was reverted. Full harness output below.

**Eight defects the old greps could not see:**

| # | Mutation | old | new |
|---|---|---|---|
| M1 | badge computed, never concatenated into the row | GREEN | **RED** |
| M4 | podium `closest()` lookup returns nothing, so no stand is hidden | GREEN | **RED** |
| M5 | the merge reads `beatify_game_settings_v2` — wizard settings dropped again | GREEN | **RED** |
| M7 | the collected row sorts by round instead of year | GREEN | **RED** |
| M9 | the mix detail span repeats the headline instead of the server reason | GREEN | **RED** |
| M10 | the vinyl graphic paints the raw key `REVEAL.POINTSSHORT` | GREEN | **RED** |
| M11 | `ADMIN_CANNOT_LEAVE` prefers the server's English again | GREEN | **RED** |
| M12 | the validator re-floors the range at 1950 — pre-1950 guesses vanish | GREEN | **RED** |
| M17 | the reveal chip prints `performance.message.message` (same bug, different spelling) | GREEN | **RED** |
| M18 | the no-playlists rejection becomes unreachable, call site intact | GREEN | **RED** |

M7 is the sharpest: the old test re-ran its own copy of the comparator, so breaking the shipped one changed nothing.

**Three harmless refactors that used to break the suite:**

| # | Mutation | old | new |
|---|---|---|---|
| M2 | rename the local `playoffLaeuft` → `playoffRunning` | **RED** | GREEN |
| M6 | rename the local `bestehend` → `existing` | **RED** | GREEN |
| M16 | rename the dispatcher's `data` parameter → `payload` | **RED** | GREEN |

**Parity, no regression:** M3 (the shipped #2617 bug), M8 (unescaped artist), M13 (two rejections swap codes), M14 (chip prints the server string verbatim), M15 (the NoSleep flag stops resetting) — red before and red after.

## Shared helpers

Two new files under `www/js/__tests__/helpers/`, both outside vitest's `*.test.js` include pattern:

- `js-source.js` — `declaration()` / `block()` cut a verbatim slice out of a source file; `evaluate()` compiles it in strict mode against an explicit scope. Anything the slice reads that the scope does not name throws a ReferenceError, which is what makes #2617 reproducible. A missing declaration throws by name, so a test whose subject was deleted fails rather than silently covering nothing.
- `mini-dom.js` — the hand-rolled elements the repo already writes per file (`player-reveal-view.test.js`, the old `dashboard-2130-end-stage.test.js`), in one place. No new dependency; jsdom stays out.

## Nothing skipped

Every test in the issue was addressed without touching production source, so none had to be left.

## Checks

- `pytest tests/unit tests/integration -q` — 2519 passed, 2 skipped
- `npm test` — 93 files, 939 tests passed
- `npm run build:check` — 16 artifacts and 76 .gz siblings match source
- `python3 -m ruff format --check .` — 236 files already formatted
- `npm run lint` — 0 errors, 305 warnings (307 on main; two pre-existing ones removed along the way)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKsEKt68KHSqmi617XNCVi
