### PR TITLE
Guard main's derived artifacts against merge bursts, and delete StartGameView's drifted fallback

### DIFF
--- a/.github/workflows/main-artifact-guard.yml
+++ b/.github/workflows/main-artifact-guard.yml
@@ -1,0 +1,163 @@
+# Main artifact guard (#2673)
+#
+# Every gate in `test.yml` runs against a pull request branch. A PR is green
+# against its own base; `main` is a combination no PR ever evaluated. For
+# hand-written code that is tolerable. For a *derived* artifact it is not: a
+# minified bundle or a `.gz` sibling silently encodes the state of the whole
+# tree it was generated from, so a PR that only regenerates artifacts is
+# instantly wrong the moment another PR lands a source change beside it.
+#
+# That is what happened on 2026-09-06. #2666 added 77 `.gz` siblings compressed
+# from its own branch snapshot; #2650 and #2663 landed frontend sources in
+# between. `main` then served five siblings that decompressed to the *previous*
+# version of their file for about twenty minutes. HA's static handler serves
+# `<file>.gz` verbatim to anything sending `Accept-Encoding: gzip` and derives
+# the ETag from the compressed file, so those stale bytes were served *and
+# cached* as current. A `curl` without the header saw the fresh file.
+#
+# `build:check` already ran on pushes to main and it did report the drift — but
+# only by luck. Seven PRs squashed onto main inside 30 seconds, and `test.yml`'s
+# `concurrency: cancel-in-progress: true` cancelled six of the seven runs. Only
+# the last commit of the burst was ever checked. Had one more merge followed it,
+# nothing would have reported anything.
+#
+# So this workflow is deliberately narrow: it does one thing, it cannot be
+# cancelled by the next merge, and it says out loud which files drifted.
+name: Main artifact guard
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# One group per commit — not per branch. `test.yml` groups by `github.ref`, so
+# every merge into main kills the run of the merge before it. Here each commit
+# gets its own group and `cancel-in-progress: false` on top, which means a burst
+# of merges produces a burst of guards instead of one survivor.
+concurrency:
+  group: main-artifact-guard-${{ github.sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  derived-artifacts:
+    name: Derived artifacts match main's sources
+    runs-on: ubuntu-latest
+    # A guard nobody waits for is a guard nobody reads. This job installs node
+    # deps and rebuilds ~13 bundles plus ~77 gzip siblings in memory; it has no
+    # matrix, no linter, no test suite. Under two minutes, warm or cold.
+    timeout-minutes: 10
+    steps:
+      - name: Checkout main at this commit
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      # There is no package-lock.json in the tree, so `npm ci` and setup-node's
+      # built-in npm cache are both out. Caching the download directory keyed on
+      # package.json still takes the install from ~30s to a few seconds.
+      - name: Cache npm downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('package.json') }}
+          restore-keys: ${{ runner.os }}-npm-
+
+      - name: Install build dependencies
+        run: npm install --no-audit --no-fund
+
+      # Rebuilds every minified bundle and every `.gz` sibling in memory and
+      # compares against what this commit of main actually ships. Deliberately
+      # not `npm run lint` or `npm test` — those belong on the PR, and bolting
+      # them on here would make the guard slow enough to be ignored.
+      - name: Rebuild every derived artifact and compare with main
+        id: check
+        shell: bash
+        run: |
+          set -o pipefail
+          node scripts/build.mjs --check 2>&1 | tee "$RUNNER_TEMP/build-check.log"
+
+      # Everything below only runs when the tree is wrong. A red X on a main
+      # commit is not an alarm in a repo that merges several times a day — on
+      # 2026-09-06 main was red for 23 minutes and the repair happened by
+      # accident, when an unrelated rebase conflict forced a full rebuild.
+      - name: Name the drifted files
+        if: failure() && steps.check.outcome == 'failure'
+        shell: bash
+        run: |
+          log="$RUNNER_TEMP/build-check.log"
+          [ -f "$log" ] || exit 0
+
+          # `build.mjs --check` prints one "   - <path> (reason)" line per
+          # offender. Turn each into a file annotation so the drift shows up on
+          # the commit and in the run's file view, not only in the raw log.
+          drifted=$(sed -n 's/^[[:space:]]*-[[:space:]]*//p' "$log")
+
+          {
+            echo "## Derived artifacts on \`main\` do not match their sources"
+            echo
+            echo "Commit \`${GITHUB_SHA:0:8}\` ships derived files that were generated"
+            echo "from a different state of the tree. Home Assistant serves \`<file>.gz\`"
+            echo "verbatim to every browser and builds the ETag from the compressed file,"
+            echo "so a stale sibling is served **and cached** as if it were current."
+            echo
+            echo "### Files"
+            echo
+            while IFS= read -r line; do
+              [ -n "$line" ] && echo "- \`$line\`"
+            done <<< "$drifted"
+            echo
+            echo "### Fix"
+            echo
+            echo '```'
+            echo "git checkout main && git pull"
+            echo "npm run build"
+            echo "git commit -am 'build: regenerate derived artifacts'"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          while IFS= read -r line; do
+            [ -n "$line" ] || continue
+            file="${line%% *}"
+            echo "::error file=${file},title=Stale derived artifact on main::${line}"
+          done <<< "$drifted"
+
+      - name: Open or update the drift issue
+        if: failure() && steps.check.outcome == 'failure' && github.repository == 'mholzi/beatify'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          title="main is serving stale derived artifacts"
+          log="$RUNNER_TEMP/build-check.log"
+          body="$RUNNER_TEMP/issue-body.md"
+
+          {
+            echo "\`main\` at \`${GITHUB_SHA}\` ships derived artifacts that do not match"
+            echo "their sources. Browsers receive the stale \`.gz\` siblings and cache them"
+            echo "under an ETag derived from the compressed file, so this is live for users"
+            echo "until \`npm run build\` is committed."
+            echo
+            echo '```'
+            cat "$log"
+            echo '```'
+            echo
+            echo "Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } > "$body"
+
+          # One open issue for the condition, commented on each recurrence —
+          # a fresh issue per red commit would train everyone to ignore them.
+          existing=$(gh issue list --state open --search "\"$title\" in:title" \
+            --json number,title --jq "[.[] | select(.title == \"$title\")][0].number")
+
+          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+            gh issue comment "$existing" --body-file "$body"
+          else
+            gh issue create --title "$title" --body-file "$body"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ DESIGN.md
 .github/workflows/*
 !.github/workflows/test.yml
 !.github/workflows/validate.yml
+!.github/workflows/main-artifact-guard.yml
 
 # Test infra needed by CI to run pytest cleanly. Without these, the test
 # workflow imports beatify and hits a homeassistant metaclass conflict

--- a/custom_components/beatify/server/game_views.py
+++ b/custom_components/beatify/server/game_views.py
@@ -20,6 +20,7 @@ from custom_components.beatify.const import (
     DIFFICULTY_HARD,
     DIFFICULTY_NORMAL,
     DOMAIN,
+    ERR_INTERNAL,
     ERR_MEDIA_PLAYER_UNAVAILABLE,
     ERR_NO_PLAYABLE_SONGS,
     ERR_NO_PLAYLISTS_SELECTED,
@@ -41,7 +42,7 @@ from custom_components.beatify.game.config import GameOptions
 from custom_components.beatify.game.playlist import (
     async_discover_playlists_detailed,
 )
-from custom_components.beatify.game.state import GamePhase, GameState
+from custom_components.beatify.game.state import GamePhase
 from custom_components.beatify.game.state_setup import NoPlayableSongsError
 from custom_components.beatify.server.ws_handlers._helpers import finalize_and_end
 from custom_components.beatify.server.base import (
@@ -55,7 +56,6 @@ from custom_components.beatify.server.serializers import (
     build_state_message,
 )
 from custom_components.beatify.server.setup_state import clear_setup
-from custom_components.beatify.services.factories import ha_service_factories
 from custom_components.beatify.services.media_player import (
     async_get_native_twin_remap,
     get_platform_capabilities,
@@ -160,8 +160,26 @@ class StartGameView(RateLimitMixin, HomeAssistantView):
         data = self.hass.data.get(DOMAIN, {})
         game_state = data.get("game")
 
+        # #2675: there is exactly one composition root, and it is
+        # ``async_setup_entry``. It builds the GameState, calls ``set_hass``,
+        # attaches the stats service and registers four callbacks that only the
+        # setup path holds references to. This view used to carry a second,
+        # partial copy of that wiring for the case where the domain key is
+        # missing — a branch ``async_setup_entry`` makes unreachable, and one
+        # that had already drifted: it never called ``set_hass``, so the game it
+        # built started fine and then failed at the first song. A second
+        # construction path is not defence, it is a copy that goes stale
+        # unnoticed. If the key is missing, the config entry is not set up; say
+        # so here rather than hand the host a game that cannot play music.
+        if game_state is None:
+            return _json_error(
+                "Beatify is not set up — reload the integration",
+                500,
+                code=ERR_INTERNAL,
+            )
+
         # Check for existing game
-        if game_state and game_state.game_id:
+        if game_state.game_id:
             if game_state.phase == GamePhase.END:
                 # Game is already finished -- auto-clean state so a new game can start
                 # without requiring the user to explicitly dismiss the end screen (#206)
@@ -400,18 +418,6 @@ class StartGameView(RateLimitMixin, HomeAssistantView):
 
         # Get base URL for join URL construction (from request URL)
         base_url = self._get_base_url(request)
-
-        # Initialize game state if needed
-        if not game_state:
-            # #2638: a composition point, so it wires the HA-backed service
-            # factories just like async_setup_entry does. (Defensive branch:
-            # async_setup_entry always seeds hass.data[DOMAIN]["game"].)
-            game_state = GameState(service_factories=ha_service_factories(self.hass))
-            self.hass.data[DOMAIN]["game"] = game_state
-            # Connect stats service if available (Story 14.4)
-            stats_service = self.hass.data.get(DOMAIN, {}).get("stats")
-            if stats_service:
-                game_state.set_stats_service(stats_service)
 
         # Detect platform and validate compatibility (resolves #38, #39)
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,3 +7,4 @@ aiohttp>=3.11
 num2words>=0.5.14  # spoken-number rendering for TTS announcements
 jsonschema>=4.0   # playlist JSON-schema gate (#1284)
 mypy==1.18.2      # static type checking gate (#1275)
+pyyaml>=6.0       # parse .github/workflows in the CI-plumbing tests (#2673)

--- a/tests/unit/test_main_artifact_guard.py
+++ b/tests/unit/test_main_artifact_guard.py
@@ -1,0 +1,166 @@
+"""The guard that watches ``main`` itself must stay uncancellable and fast (#2673).
+
+Every job in ``test.yml`` runs against a pull-request branch, and a PR is green
+against its own base. ``main`` is a combination no PR ever evaluated. That gap is
+invisible for hand-written code and unavoidable for *derived* artifacts, because
+a minified bundle or a ``.gz`` sibling encodes the state of the whole tree it was
+generated from.
+
+On 2026-09-06 it cost twenty minutes of wrong bytes: #2666 committed 77 ``.gz``
+siblings built from its own branch, #2650 and #2663 landed frontend sources in
+between, and ``main`` then served five siblings that decompressed to the previous
+version of their file. Home Assistant hands ``<file>.gz`` to every browser and
+derives the ETag from the compressed file, so those bytes were served *and*
+cached as current.
+
+``build:check`` did run on that push and did name all five files — but the report
+survived by luck. Seven merges landed inside 30 seconds and ``test.yml`` groups
+its concurrency by ``github.ref`` with ``cancel-in-progress: true``, so six of
+the seven runs were cancelled. Only the last commit of the burst was checked, and
+a cancelled run raises no alarm at all.
+
+``tests/unit/test_static_gzip_siblings.py`` owns the tree state. This module owns
+the plumbing: the properties whose absence let 2026-09-06 go unreported.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+yaml = pytest.importorskip("yaml", reason="PyYAML ships in requirements_test.txt")
+
+WORKFLOWS = Path(__file__).resolve().parents[2] / ".github" / "workflows"
+GUARD = WORKFLOWS / "main-artifact-guard.yml"
+
+# YAML 1.1 reads a bare ``on:`` key as the boolean True. GitHub means the
+# trigger block; both spellings are the same key to us.
+ON_KEYS = ("on", True)
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict[str, Any]) -> dict[str, Any]:
+    for key in ON_KEYS:
+        if key in workflow:
+            return workflow[key]
+    raise AssertionError(f"workflow has no trigger block: {sorted(workflow)}")
+
+
+def _steps(workflow: dict[str, Any]) -> list[dict[str, Any]]:
+    return [step for job in workflow["jobs"].values() for step in job.get("steps", [])]
+
+
+def _run_scripts(workflow: dict[str, Any]) -> str:
+    return "\n".join(step.get("run", "") for step in _steps(workflow))
+
+
+@pytest.fixture(name="guard")
+def guard_fixture() -> dict[str, Any]:
+    assert GUARD.is_file(), f"the main guard workflow is gone: {GUARD}"
+    return _load(GUARD)
+
+
+def test_guard_runs_on_every_push_to_main(guard: dict[str, Any]) -> None:
+    """The whole point: a gate that evaluates the combination, not a branch."""
+    push = _triggers(guard)["push"]
+
+    assert "main" in push["branches"]
+
+
+def test_guard_is_not_cancelled_by_the_next_merge(guard: dict[str, Any]) -> None:
+    """2026-09-06 in one assertion.
+
+    ``test.yml`` groups by ``github.ref``, so merge number two kills the run of
+    merge number one. Six of seven runs died that way and nobody noticed,
+    because a cancelled run is not a failed run. Keying the group to the commit
+    means a burst of merges produces a burst of guards, not one survivor.
+    """
+    concurrency = guard["concurrency"]
+
+    assert "github.sha" in concurrency["group"], (
+        "the guard must group per commit, not per branch — a branch-keyed group "
+        "lets each merge cancel the check of the merge before it"
+    )
+    assert concurrency["cancel-in-progress"] is False
+
+
+def test_guard_rebuilds_and_compares_the_derived_artifacts(
+    guard: dict[str, Any],
+) -> None:
+    """It has to run the check that named the five files, not a proxy for it."""
+    scripts = _run_scripts(guard)
+
+    assert "scripts/build.mjs --check" in scripts or "build:check" in scripts
+
+
+def test_guard_names_the_drifted_files(guard: dict[str, Any]) -> None:
+    """A red X that says only "failed" gets ignored; a list of paths does not."""
+    scripts = _run_scripts(guard)
+
+    assert "::error" in scripts, "drifted files must surface as run annotations"
+    assert "GITHUB_STEP_SUMMARY" in scripts, "the run needs a readable summary"
+
+
+def test_guard_announces_itself_beyond_a_red_commit(guard: dict[str, Any]) -> None:
+    """On 2026-09-06 main was red for 23 minutes and the fix was an accident.
+
+    In a repo merging several times a day, a red check on a main commit is not
+    an alarm. The guard opens (or comments on) an issue so the condition has an
+    owner and a timestamp.
+    """
+    scripts = _run_scripts(guard)
+
+    assert "gh issue create" in scripts
+    assert "gh issue comment" in scripts, (
+        "recurrences must not open a new issue each time"
+    )
+    assert guard["permissions"]["issues"] == "write"
+
+
+def test_guard_stays_fast_enough_to_be_read(guard: dict[str, Any]) -> None:
+    """No matrix, no linter, no test suite — install, rebuild, compare, done."""
+    jobs = guard["jobs"]
+
+    assert len(jobs) == 1, "a second job makes the guard a pipeline, not a guard"
+    job = next(iter(jobs.values()))
+    assert "strategy" not in job, "a matrix multiplies the wait for no extra signal"
+    assert job["timeout-minutes"] <= 10
+
+    scripts = _run_scripts(guard)
+    for slow in ("npm run lint", "npm test", "npm run test:coverage", "pytest"):
+        assert slow not in scripts, f"{slow!r} belongs on the pull request, not here"
+
+
+def test_the_guard_is_allowed_past_gitignore() -> None:
+    """A workflow GitHub never receives is the loudest possible no-op.
+
+    ``.gitignore`` ignores ``.github/workflows/*`` and re-admits files one by
+    one. That allowlist exists because untracking ``.github/`` in April 2026
+    silently switched CI off for two months (#784). A new workflow that is not
+    named there sits in the working tree looking correct and runs nowhere.
+    """
+    gitignore = (Path(__file__).resolve().parents[2] / ".gitignore").read_text(
+        encoding="utf-8"
+    )
+
+    assert f"!.github/workflows/{GUARD.name}" in gitignore
+
+
+def test_the_pull_request_gates_are_untouched() -> None:
+    """The guard adds coverage for main; it does not weaken the PR pipeline.
+
+    ``test.yml`` keeps ``cancel-in-progress: true`` on purpose — with several
+    merges a day, running every superseded PR push to completion costs far more
+    than it finds. The fix for #2673 is the uncancellable slice above, not
+    turning that saving off.
+    """
+    test_workflow = _load(WORKFLOWS / "test.yml")
+
+    triggers = _triggers(test_workflow)
+    assert "main" in triggers["pull_request"]["branches"]
+    assert "build:check" in _run_scripts(test_workflow)

--- a/tests/unit/test_start_game_view.py
+++ b/tests/unit/test_start_game_view.py
@@ -56,6 +56,54 @@ class TestStartGameExistingGameGuard:
         assert json.loads(resp.body)["error"] == "GAME_ALREADY_STARTED"
 
 
+class TestMissingGameStateIsRefused:
+    """One composition root, and start-game is not it (#2675).
+
+    ``async_setup_entry`` builds the GameState, calls ``set_hass``, attaches the
+    stats service and registers four callbacks. This view used to keep a second,
+    partial copy of that wiring for the case where ``hass.data[DOMAIN]["game"]``
+    is missing. The copy had drifted: it never called ``set_hass``, so it
+    produced a game that started cleanly and then failed on the first playback
+    attempt, with the error surfacing at song one rather than at Start.
+
+    The branch is unreachable in a set-up integration, so it was deleted. What
+    remains has to be an honest refusal — never a half-built game.
+    """
+
+    async def test_missing_domain_key_returns_internal_error(self):
+        hass = MagicMock()
+        hass.data = {DOMAIN: {}}
+
+        resp = await StartGameView(hass).post(_request())
+
+        assert resp.status == 500
+        assert json.loads(resp.body)["error"] == "INTERNAL_ERROR"
+
+    async def test_missing_domain_entirely_returns_internal_error(self):
+        """An unloaded entry leaves no DOMAIN key at all — not even a dict."""
+        hass = MagicMock()
+        hass.data = {}
+
+        resp = await StartGameView(hass).post(_request())
+
+        assert resp.status == 500
+        assert json.loads(resp.body)["error"] == "INTERNAL_ERROR"
+
+    async def test_no_game_state_is_constructed_behind_the_hosts_back(self):
+        """The refusal must not leave a stray GameState in hass.data.
+
+        That is the whole failure mode: a second construction path seeds the
+        domain key with something the setup path never wired, and every later
+        request finds it and believes the integration is healthy.
+        """
+        hass = MagicMock()
+        hass.data = {DOMAIN: {}}
+
+        await StartGameView(hass).post(_request())
+
+        assert "game" not in hass.data[DOMAIN]
+
+
 # ---------------------------------------------------------------------------
 # Happy-path start-game: body flags reach game_state (#1180)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_static_gzip_siblings.py
+++ b/tests/unit/test_static_gzip_siblings.py
@@ -89,3 +89,46 @@ def test_corrupt_sibling_is_reported(tmp_path: Path) -> None:
 
     assert len(problems) == 1
     assert "not a readable gzip stream" in problems[0]
+
+
+def test_the_2026_09_06_combination_is_reported(tmp_path: Path) -> None:
+    """Replay the shape that shipped: siblings from one snapshot, sources from another.
+
+    #2666 generated 77 siblings from its own branch. #2650 and #2663 landed four
+    frontend sources and one i18n file beside it, with no siblings to update —
+    their branches predated the feature. Neither PR was wrong on its own; the
+    combination on ``main`` was, and no job evaluated the combination.
+
+    Five files came out of that: ``i18n/de.json``, ``js/dashboard.js``,
+    ``js/dashboard.min.js``, ``js/player-game.js`` and
+    ``js/player.bundle.min.js``. Every one has to be named — reporting "the
+    build is stale" without the list is what makes people stop reading.
+    """
+    drifted = [
+        "i18n/de.json",
+        "js/dashboard.js",
+        "js/dashboard.min.js",
+        "js/player-game.js",
+        "js/player.bundle.min.js",
+    ]
+    untouched = ["js/admin.min.js", "css/styles.min.css"]
+
+    for rel in drifted + untouched:
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # The sibling is written first, from the state #2666 saw.
+        target.write_bytes(b"/* snapshot the .gz siblings were built from */\n")
+        (target.with_name(target.name + ".gz")).write_bytes(
+            gzip.compress(target.read_bytes())
+        )
+
+    # Then the two source PRs land on top, touching only their own files.
+    for rel in drifted:
+        (tmp_path / rel).write_bytes(b"/* landed after the siblings were built */\n")
+
+    problems = _gz_problems(tmp_path)
+
+    assert len(problems) == len(drifted)
+    assert all("stale" in problem for problem in problems)
+    for rel in drifted:
+        assert any(rel in problem for problem in problems), f"{rel} went unreported"


### PR DESCRIPTION
Two robustness fixes. They share no files; both are about a check or a path that exists without doing its job.

Closes #2673
Closes #2675

---

## #2673 — a guard on `main` that a merge burst cannot cancel

### What I found first

The issue's premise is half right. `build:check` **already runs on pushes to `main`** — `test.yml` has `push: branches: [main]`, and the `Frontend build check` job has no PR-only condition. It also **did** catch the 6 September state, one minute after the merge, naming exactly the five files ([run 34025603912](https://github.com/mholzi/beatify/actions/runs/34025603912)):

```
❌ static assets out of sync — run `npm run build` and commit:
   - custom_components/beatify/www/i18n/de.json.gz (stale — ...)
   - custom_components/beatify/www/js/dashboard.js.gz (stale — ...)
   - custom_components/beatify/www/js/dashboard.min.js.gz (stale — ...)
   - custom_components/beatify/www/js/player-game.js.gz (stale — ...)
   - custom_components/beatify/www/js/player.bundle.min.js.gz (stale — ...)
```

So the gap is not "no job ever checks the combination". It is that the job which does check it is **cancellable** and **mute**:

**Cancellable.** Seven PRs squashed onto `main` between 09:46:18 and 09:46:49 UTC. `test.yml` groups concurrency by `github.ref` with `cancel-in-progress: true`, so each merge killed the run of the merge before it:

| commit | Test run |
|---|---|
| `28d8df44` #2650 | cancelled |
| `d4a88395` #2663 | cancelled |
| `dbed617c` | cancelled |
| `73931d52` | cancelled |
| `299987b1` | cancelled |
| `90eb080c` #2666 — added the siblings | cancelled |
| `8a090d13` #2668 | **failure** |

The commit that introduced the drift was never evaluated. The report survived only because `8a090d13` happened to be last and nothing followed it for 23 minutes. One more merge and the twenty minutes of wrong bytes would have gone entirely unrecorded — which is very nearly what happened anyway.

**Mute.** A red check on a `main` commit in a repo merging several times a day is not an alarm. `main` was red for 23 minutes and the repair was an accident: #2667 hit a rebase conflict in `player.bundle.min.js`, and resolving it forced a full `npm run build`.

### What this PR adds

`.github/workflows/main-artifact-guard.yml` — deliberately narrow, and the properties that matter are the ones `test.yml` cannot give it:

- **Uncancellable.** `concurrency.group` is keyed to `github.sha`, not `github.ref`, plus `cancel-in-progress: false`. A burst of merges now produces a burst of guards instead of one survivor. Every commit on `main` is evaluated.
- **Fast enough to be read.** One job, no matrix, no ESLint, no vitest, no pytest: checkout, node, `npm install` against a cached `~/.npm`, `node scripts/build.mjs --check`. Under two minutes. The full `test.yml` matrix on every main commit would have bought the same signal at roughly fifteen times the runner cost and a wait nobody watches.
- **Loud, and it names the files.** Each drifted path becomes a `::error file=…` annotation, the run gets a `$GITHUB_STEP_SUMMARY` with the file list and the exact `npm run build` fix, and the guard opens a GitHub issue — commenting on the existing open one on a recurrence rather than filing a new one each time, so it stays an alarm instead of becoming noise.

`test.yml` is untouched. Its `cancel-in-progress: true` is the right trade for PR pushes; the fix is the uncancellable *slice*, not turning that saving off.

### A trap this hit on the way in

`.gitignore` ignores `.github/workflows/*` and re-admits files by name — that allowlist exists because untracking `.github/` in April 2026 switched CI off for two months (#784). A new workflow not named there sits in the tree looking correct and runs nowhere. `!.github/workflows/main-artifact-guard.yml` is added, and a test asserts it.

### Tests

`tests/unit/test_main_artifact_guard.py` (9 tests) parses the workflow and asserts the properties whose absence let 6 September go unreported: push-to-main trigger, per-commit concurrency, `cancel-in-progress: false`, that it runs `build.mjs --check`, that it emits annotations and a summary, that it can open *and* comment on an issue, that it stays a single job with no matrix and no slow step, that it is not gitignored, and that `test.yml`'s PR gates are unchanged.

`tests/unit/test_static_gzip_siblings.py` gains `test_the_2026_09_06_combination_is_reported`, which replays the shape literally: write siblings from one snapshot, land five source files on top, assert all five — and only those five — are named.

### Verification that it would have caught the real incident

I planted stale siblings for `www/js/dashboard.js.gz` and `www/i18n/de.json.gz` in a clean tree and ran the guard's own steps:

```
$ node scripts/build.mjs --check          # exit 1
❌ static assets out of sync — run `npm run build` and commit:
   - custom_components/beatify/www/i18n/de.json.gz (stale — ...)
   - custom_components/beatify/www/js/dashboard.js.gz (stale — ...)
```

and the reporting step, run against that log with `RUNNER_TEMP` / `GITHUB_STEP_SUMMARY` set, emitted:

```
::error file=custom_components/beatify/www/i18n/de.json.gz,title=Stale derived artifact on main::...
::error file=custom_components/beatify/www/js/dashboard.js.gz,title=Stale derived artifact on main::...
```

plus the file list in the summary. Every `run:` block also passes `bash -n`. The tree was restored afterwards; `build:check` is green on this branch.

### On `strict: true` — a deliberate decision, not an omission

**Not enabled here.** What it would buy and cost, so the call is made knowingly:

**Gains.** `strict` is the only option that *prevents* the condition rather than reporting it. `main` would never be briefly wrong, so no window in which a phone caches stale bytes under an ETag derived from the compressed file. It also closes the same hole for every other derived artifact — the minified bundles have exactly this property and have simply been lucky.

**Costs.** With the merge rate this repo actually runs at, the cost is not theoretical. On 6 September seven PRs merged inside 30 seconds; under `strict` each of those merges invalidates every other open PR, and each rebase re-runs 13 required checks. In a burst of seven, PR number seven rebases six times. Merging becomes serialised by hand, and the incentive is to batch merges — which is precisely the condition that produced this bug.

**Where I land.** `strict` solves a two-file-per-month problem by taxing every merge. The guard in this PR narrows the exposure window from "until someone happens to rebuild" to "one guard run, roughly 90 seconds, with an issue filed". If that turns out to be too slow — one real user report of stale bytes would be enough — the next step is a **merge queue** (option 3), not `strict`: it prevents the condition without making every open PR pay when `main` moves. Option 4 (stop committing derived artifacts) removes the class outright but is blocked on how HACS installs — it copies the repo directory onto the box and never runs a build step, so a `.gz` that only exists after `npm run build` would reach nobody.

---

## #2675 — delete the fallback

**Chosen: delete it (option 1).** `server/game_views.py:376` constructed a `GameState()` when `hass.data[DOMAIN]["game"]` was missing, and never called `set_hass()`.

**Why delete rather than complete.** The two options are not symmetric once you count what "complete" means. `async_setup_entry` is the composition root and does seven things:

```python
game_state = GameState(service_factories=ha_service_factories(hass))
game_state.set_hass(hass)
game_state.set_stats_service(stats_service)
game_state.set_round_end_callback(ws_handler.broadcast_state)
game_state.set_game_end_callback(functools.partial(finalize_and_end, ws_handler, game_state))
game_state.set_metadata_update_callback(ws_handler.broadcast_metadata_update)
game_state.register_reset_callback(ws_handler.clear_admin_socket)
```

The fallback did two of them. Completing it means the view reaching back through `hass.data` for the WebSocket handler and re-registering four callbacks that only the setup path holds references to — a second copy of `async_setup_entry` living inside an HTTP handler, for a branch no set-up integration can reach. And the drift is not hypothetical: it missed `set_hass()` for as long as it existed, which produced the worst possible failure shape — a game that starts cleanly and dies at the first song, because `MediaPlayerService(None, ...)` only fails on playback.

A construction path nothing exercises does not stay correct. It stays wrong quietly.

**What replaces it.** A missing domain key means the config entry is not set up. The view now says so at the top of `post()`:

```python
if game_state is None:
    return _json_error("Beatify is not set up — reload the integration", 500, code=ERR_INTERNAL)
```

Loud, at Start, before any playlist work — instead of a half-built game handed to the host. `game_state` is non-`None` from that point, so `if game_state and game_state.game_id` simplifies to `if game_state.game_id`, and the now-unused `GameState` / `ha_service_factories` imports are gone.

**Tests.** `TestMissingGameStateIsRefused` in `tests/unit/test_start_game_view.py`: a missing `"game"` key and a missing `DOMAIN` key both return 500 `INTERNAL_ERROR`, and — the point of the change — the refusal leaves no stray `GameState` behind in `hass.data`, so no later request can find something the setup path never wired and conclude the integration is healthy.

---

## Checks

Run from the worktree at `origin/main` + this branch:

| check | result |
|---|---|
| `pytest tests/unit tests/integration -q` | 2514 passed, 2 skipped |
| `npm test` | 95 files, 932 passed |
| `npm run build:check` | 16 artifacts + 76 `.gz` siblings match source |
| `python3 -m ruff format --check .` | 237 files already formatted |

Also green: `ruff check .`, `mypy` (15 files), `npm run lint` (0 errors; the 308 warnings are pre-existing).

## Unresolved / for review

- `requirements_test.txt` gains `pyyaml>=6.0` so the plumbing tests can parse the workflow YAML rather than regex it. It is one extra test-only dependency; a regex-based test would avoid it and be worse.
- The guard's issue-opening step needs `issues: write` and is fenced to `github.repository == 'mholzi/beatify'` so a fork's `main` cannot file issues here. If auto-filed issues turn out to be unwelcome, deleting that one step leaves the annotations and summary intact.
- `strict` and the merge queue stay open questions by design — see the section above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKsEKt68KHSqmi617XNCVi
