### PR TITLE
fix: keep the reveal up after the host stops a song (#2690)

### DIFF
--- a/custom_components/beatify/game/state_auto_advance.py
+++ b/custom_components/beatify/game/state_auto_advance.py
@@ -16,7 +16,9 @@ on ``GameState``, so its public API and every caller / test are unchanged.
   which reference it via ``self``).
 * ``_song_finished`` — poll helper: ``True`` once the round's song is no longer
   playing (the media player drops out of "playing"/"buffering"), the song-end
-  signal both auto-advance tasks wait on.
+  signal both auto-advance tasks wait on. A non-playing speaker that stopped for
+  a reason other than the track ending — a TTS announcement, a network blip, the
+  host's "stop song" (#2690) — is not a song end and keeps the poll on False.
 * ``_auto_advance_broadcast`` — the single place the auto-advance pushes state
   to the clients (#2613). Every terminal branch of ``_reveal_auto_advance``
   (next round, pause, game end, finale playoff) ends here.
@@ -54,6 +56,10 @@ The mixin relies on attributes / methods the host class owns and that live on
   the scheduler), but the broadcast path depends on the host's player state.
 * ``self.reveal_auto_advance`` — the configured REVEAL dwell (seconds; 0 = off)
   passed into ``_reveal_auto_advance``.
+* ``self.song_stopped`` — the per-round "the host stopped playback on purpose"
+  flag (owned by ``RoundManager``, cleared on every ``commit_round``), read by
+  ``_song_finished`` so a deliberate stop is not mistaken for a song end
+  (#2690).
 * ``self.start_round`` — the next-round trigger the auto-advance fires.
 * ``self._on_round_end`` — the async WebSocket broadcast callback mirrored after
   the auto-advance ``start_round`` so the new PLAYING state reaches clients.
@@ -118,7 +124,28 @@ class RevealAutoAdvanceMixin:
         the idle-halt silence the speaker). Mirror the conservative
         exception branch below and stay on "still playing" for an unknown
         state — the hard cap still guarantees the game can never stall.
+
+        #2690: a deliberate stop is not a song end either. When the host taps
+        "stop song" the speaker goes ``idle`` mid-round and stays there, so by
+        the time REVEAL arms this poll the answer is already True — the very
+        first tick at 2s advanced to the next round and the reveal (answer,
+        scores, reaction buttons) was gone in two seconds. The speaker cannot
+        tell a deliberate stop from a track running out; only the game can, and
+        it already records it in the per-round ``song_stopped`` flag. The resume
+        watchdog asks the same question the same way (#2576,
+        ``state_lifecycle._watchdog_should_continue``) — this is the second
+        consumer of that signal, not a new mechanism. With the signal gone the
+        dwell falls through to whichever the host configured: the
+        ``reveal_auto_advance`` seconds, or the 360s stall-guard in "at song
+        end" mode, where a REVEAL that runs until the host taps Next is the
+        documented behaviour anyway (``reveal_auto_advance: 0 = manual only``).
         """
+        if getattr(self, "song_stopped", False):
+            _LOGGER.debug(
+                "song-finished poll: the host stopped the song — not a song "
+                "end, keeping the reveal up (#2690)"
+            )
+            return False
         if not self._media_player_service:
             return False
         try:

--- a/tests/unit/test_stop_song_keeps_the_reveal_2690.py
+++ b/tests/unit/test_stop_song_keeps_the_reveal_2690.py
@@ -1,0 +1,244 @@
+"""#2690: the host's "stop song" must not collapse the following reveal.
+
+`admin_stop_song` sends `media_stop` and sets `song_stopped`; the round keeps
+running to its deadline. When it ends, `_schedule_song_end_auto_advance` arms
+`_reveal_auto_advance`, whose wait loop breaks on `_song_finished()`. That poll
+read only the speaker — and the speaker has been `idle` since the host tapped
+Stop — so the very first tick at 2s said "the song is over" and pulled the next
+round. The answer, the scores and the reaction buttons were on screen for about
+two seconds.
+
+The poll's job is not "is the speaker quiet" but "did the round's song end", and
+it already refuses two other kinds of quiet: a transient `unavailable` blip
+(#1374) and a TTS announcement holding the device (#2576's sibling). A
+deliberate stop is a third. The game records it in the per-round `song_stopped`
+flag, which the resume watchdog already reads for exactly this reason (#2576) —
+so the fix is one more consumer of that signal, and the dwell falls through to
+whatever the host configured.
+
+Nothing covered stop_song together with auto-advance before this file;
+`test_pause_and_stop_hints_2552_2554.py` only checks the UI chips.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.beatify.game.state import GamePhase, GameState
+from tests.conftest import make_game_state, make_songs
+
+# `_reveal_auto_advance` / `_reveal_idle_halt` walk the wait in 2.0s ticks, and
+# fall back to a 360s stall-guard when no dwell is configured.
+POLL = 2.0
+HARD_CAP_TICKS = 180
+
+
+class _TickingSleep:
+    """Stand-in for ``asyncio.sleep`` that counts the auto-advance's polls.
+
+    The wait loop is a fixed 2s tick, so the number of sleeps IS the dwell:
+    one tick means the reveal lasted two seconds, 180 means it ran to the
+    stall-guard. Counting them is how these tests measure a duration without
+    spending it.
+    """
+
+    def __init__(self) -> None:
+        self.ticks = 0
+
+    async def __call__(self, _seconds: float) -> None:
+        self.ticks += 1
+        if self.ticks > HARD_CAP_TICKS + 10:
+            raise AssertionError("the auto-advance never left its wait loop")
+
+    @property
+    def reveal_seconds(self) -> float:
+        return self.ticks * POLL
+
+
+def _game_in_reveal(**game_kwargs) -> GameState:
+    """A game parked on REVEAL with a speaker that reports `idle`.
+
+    `idle` is what both a finished track and a stopped one look like — which is
+    the whole point: only `song_stopped` separates them.
+    """
+    state = make_game_state()
+    state.create_game(
+        playlists=["test.json"],
+        songs=make_songs(5),
+        media_player="media_player.test",
+        base_url="http://localhost:8123",
+        **game_kwargs,
+    )
+    speaker = MagicMock()
+    speaker.get_playback_state.return_value = "idle"
+    speaker.stop = AsyncMock()
+    state._media_player_service = speaker
+    state.phase = GamePhase.REVEAL
+    state.start_round = AsyncMock(return_value=True)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# The poll itself: a deliberate stop is not a song end
+# ---------------------------------------------------------------------------
+
+
+class TestSongFinishedIgnoresADeliberateStop:
+    def test_idle_after_a_host_stop_is_not_a_song_end(self):
+        state = _game_in_reveal()
+        state.song_stopped = True
+        assert state._song_finished() is False
+
+    def test_idle_is_still_a_song_end_when_nobody_stopped_it(self):
+        """The guard must not swallow the ordinary signal it exists to protect."""
+        state = _game_in_reveal()
+        assert state.song_stopped is False
+        assert state._song_finished() is True
+
+    def test_a_stop_never_reaches_the_speaker_at_all(self):
+        """Cheap short-circuit: no state read while the flag is up."""
+        state = _game_in_reveal()
+        state.song_stopped = True
+        state._song_finished()
+        state._media_player_service.get_playback_state.assert_not_called()
+
+    def test_the_flag_belongs_to_the_round_it_was_raised_in(self):
+        """A stop in round 3 must not keep round 4's song-end undetectable.
+
+        `RoundManager.initialize_round` clears the flag on every commit, so the
+        poll is back to reading the speaker the moment the next song starts.
+        """
+        state = _game_in_reveal()
+        state.song_stopped = True
+        assert state._song_finished() is False
+        state._round_manager.song_stopped = False  # what a new round commits
+        assert state._song_finished() is True
+
+
+# ---------------------------------------------------------------------------
+# The behaviour the party sees: how long the reveal actually stays up
+# ---------------------------------------------------------------------------
+
+
+class TestTheRevealSurvivesAStop:
+    async def test_stopped_song_no_longer_collapses_the_reveal(self):
+        """The #2690 regression, in the default "at song end" configuration.
+
+        Before the fix this advanced on the first tick — a two-second reveal.
+        """
+        state = _game_in_reveal(reveal_auto_advance=0)
+        state.song_stopped = True
+        sleep = _TickingSleep()
+
+        with patch("asyncio.sleep", new=sleep):
+            await state._reveal_auto_advance(0)
+
+        assert sleep.reveal_seconds > 2.0, (
+            "the reveal collapsed on the first poll — #2690 is back"
+        )
+        # With the song-end signal gone the 360s stall-guard governs; the host's
+        # "Next round" is still the ordinary way out, as "0 = manual only" says.
+        assert sleep.ticks == HARD_CAP_TICKS
+        state.start_round.assert_awaited_once()
+
+    async def test_an_unstopped_song_end_still_advances_immediately(self):
+        """The counterpart: a track that really ran out must not be delayed."""
+        state = _game_in_reveal(reveal_auto_advance=0)
+        sleep = _TickingSleep()
+
+        with patch("asyncio.sleep", new=sleep):
+            await state._reveal_auto_advance(0)
+
+        assert sleep.ticks == 1
+        state.start_round.assert_awaited_once()
+
+    @pytest.mark.parametrize("dwell", [10, 20, 45])
+    async def test_a_configured_dwell_still_governs_after_a_stop(self, dwell):
+        """With a dwell set, the reveal lasts exactly that — not two seconds,
+        and not the stall-guard either."""
+        state = _game_in_reveal(reveal_auto_advance=dwell)
+        state.song_stopped = True
+        sleep = _TickingSleep()
+
+        with patch("asyncio.sleep", new=sleep):
+            await state._reveal_auto_advance(dwell)
+
+        assert sleep.reveal_seconds == pytest.approx(dwell, abs=POLL)
+        state.start_round.assert_awaited_once()
+
+    async def test_the_zero_guess_halt_no_longer_fires_at_two_seconds(self):
+        """The idle-halt shares the poll, so it shared the bug: it "detected"
+        song-end two seconds into a reveal nobody had guessed in. It holds on
+        REVEAL either way, but it should not race there."""
+        state = _game_in_reveal(reveal_auto_advance=0)
+        state.song_stopped = True
+        sleep = _TickingSleep()
+
+        with patch("asyncio.sleep", new=sleep):
+            await state._reveal_idle_halt()
+
+        assert sleep.ticks == HARD_CAP_TICKS
+        state.start_round.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# TTS: the announcement grace hid this bug; it must not now stack with the fix
+# ---------------------------------------------------------------------------
+
+
+class TestTheAnnouncementGraceDoesNotStack:
+    """With announcements on, `_song_finished` was already returning False for
+    the whole announcement plus a 6s resume window — which is why the two-second
+    reveal only reproduced with TTS off. Both suppressions now apply at once, so
+    the thing to prove is that they do not add up: the dwell is one absolute
+    timer measured from REVEAL entry, not a sum of the reasons to keep waiting.
+    """
+
+    async def test_the_dwell_is_the_same_with_and_without_an_announcement(self):
+        dwell = 20
+
+        without = _game_in_reveal(reveal_auto_advance=dwell)
+        without.song_stopped = True
+        quiet = _TickingSleep()
+        with patch("asyncio.sleep", new=quiet):
+            await without._reveal_auto_advance(dwell)
+
+        speaking = _game_in_reveal(reveal_auto_advance=dwell)
+        speaking.song_stopped = True
+        # An announcement in flight, and the resume window still open behind it.
+        speaking._announce_busy_until = time.monotonic() + 30.0
+        talking = _TickingSleep()
+        with patch("asyncio.sleep", new=talking):
+            await speaking._reveal_auto_advance(dwell)
+
+        assert talking.ticks == quiet.ticks == dwell / POLL
+        speaking.start_round.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# The host action end to end: the Stop button raises the flag the poll reads
+# ---------------------------------------------------------------------------
+
+
+class TestTheStopButtonReachesThePoll:
+    async def test_admin_stop_song_leaves_the_reveal_poll_unconvinced(self):
+        """Drive the real WS handler rather than setting the flag by hand — the
+        seam between `admin_stop_song` and the auto-advance is the bug."""
+        from custom_components.beatify.server.ws_handlers.admin import admin_stop_song
+
+        state = _game_in_reveal()
+        state.phase = GamePhase.PLAYING  # the Stop button only exists mid-round
+        handler = MagicMock()
+        handler.broadcast = AsyncMock()
+        ws = AsyncMock()
+
+        await admin_stop_song(handler, ws, {"action": "stop_song"}, state)
+
+        state._media_player_service.stop.assert_awaited_once()
+        handler.broadcast.assert_awaited_once_with({"type": "song_stopped"})
+        # And now the round ends and REVEAL arms the poll:
+        state.phase = GamePhase.REVEAL
+        assert state._song_finished() is False


### PR DESCRIPTION
Closes #2690

## What happened

The host taps **stop song**. `admin_stop_song` sends `media_stop` and sets `song_stopped`; the round keeps running to its deadline. When it ends, `_schedule_song_end_auto_advance` arms `_reveal_auto_advance`, whose wait loop breaks on `self._song_finished() or elapsed >= hard_cap`.

`_song_finished` read only the media player's state — and the speaker had been `idle` since the Stop. So the very first poll at 2s returned `True` and the next round started. The answer, the scores and the reaction buttons were on screen for about two seconds, which is the part of the game people actually talk over.

Deterministic in the default `reveal_auto_advance = 0` ("at song end") and with a configured dwell alike, since the timer is whichever-comes-first. With TTS on, the announcement grace masked it.

## The fix

`_song_finished` returns `False` while `song_stopped` is set.

I took the issue's first direction. The reasoning:

* **The poll's job is already "did the round's song end", not "is the speaker quiet."** It refuses two other kinds of quiet: a transient `unavailable`/`None` read (#1374) and a TTS announcement holding the device. A deliberate stop is a third of the same shape, so it belongs in the same function rather than in a new mechanism around it.
* **The signal exists and has a precedent consumer.** `song_stopped` is per-round state on `RoundManager`, cleared on every `initialize_round`. `state_lifecycle._watchdog_should_continue` already reads it, with the same `getattr` idiom, to answer the same question — #2576 was this bug in the resume watchdog. This is the second consumer, not new state.
* **The alternative is less precise, not more.** Snapshotting "the speaker was already idle at REVEAL entry" would also swallow a genuine song-end that lands right on the round deadline — a short track under a 30s round — and it needs a new field, a new reset and a hook in `_transition_to_reveal`. Keying on the explicit host action has no such false positive.
* **It fixes both consumers of the poll.** `_reveal_idle_halt` shares `_song_finished` and shared the bug.

With the signal gone, the dwell falls through to whatever the host configured: the `reveal_auto_advance` seconds, or the 360s stall-guard in "at song end" mode — where a reveal that stands until the host taps Next is the documented behaviour anyway (`reveal_auto_advance: 0 = manual only`).

## TTS

The two suppressions do not stack. `timer_seconds` / `hard_cap` is one absolute timer measured from REVEAL entry, not a sum of the reasons to keep waiting, and the new check short-circuits before the announcement branch is reached. `test_the_dwell_is_the_same_with_and_without_an_announcement` asserts it directly: same tick count with an announcement in flight and the resume window open as with the speaker quiet.

## Tests

New `tests/unit/test_stop_song_keeps_the_reveal_2690.py` (12 tests). Nothing covered stop_song together with auto-advance before — `test_pause_and_stop_hints_2552_2554.py` only checks the UI chips, and no test in the repo called `admin_stop_song` at all.

It measures the reveal by counting the wait loop's fixed 2s ticks instead of spending them, and covers: the poll under a stop and without one, the short-circuit, the per-round lifetime of the flag, the default "at song end" case, a parametrised configured dwell, the zero-guess idle-halt, the TTS non-stacking, and the real `admin_stop_song` handler through to the poll.

**Verified by breaking it on purpose.** With the guard removed: **10 failed, 2 passed** — the two survivors are the deliberate counterparts (`test_idle_is_still_a_song_end_when_nobody_stopped_it`, `test_an_unstopped_song_end_still_advances_immediately`) that guard against the fix over-reaching. Guard restored: **12 passed**.

## Gates

| | |
|---|---|
| `pytest tests/unit tests/integration -q` | 2578 passed, 2 skipped |
| `npm test` | 999 passed, 98 files |
| `npm run build:check` | 16 artifacts + 76 .gz siblings match |
| `ruff format --check .` | 239 files already formatted |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKsEKt68KHSqmi617XNCVi
