### PR TITLE
perf: share the album-art fetch and put the beat loop on a command budget

### DIFF
--- a/custom_components/beatify/server/views.py
+++ b/custom_components/beatify/server/views.py
@@ -13,6 +13,7 @@ import logging
 import socket
 from ipaddress import ip_address
 from pathlib import Path
+from time import monotonic
 from typing import TYPE_CHECKING
 from urllib.parse import urlencode, urlsplit
 
@@ -759,6 +760,16 @@ class TtsEntitiesView(HomeAssistantView):
         return web.json_response({"entities": entities})
 
 
+# Error bodies for the album-art proxy, so the shared fetch can report a
+# status to every waiting client and each one renders the same page (#2709).
+_ALBUM_ART_ERRORS: dict[int, str] = {
+    403: "forbidden",
+    413: "image too large",
+    415: "not an image",
+    502: "upstream fetch failed",
+}
+
+
 class AlbumArtView(HomeAssistantView):
     """Same-origin proxy for media-player album art (#933).
 
@@ -777,9 +788,25 @@ class AlbumArtView(HomeAssistantView):
     # Cap the re-served image so a hostile/huge upstream can't exhaust memory.
     _MAX_BYTES = 5 * 1024 * 1024
 
+    # How long a fetched cover stays servable from memory (#2709). Everyone in
+    # the room asks for the same cover within one round, so this only has to
+    # outlive a round; the next round brings a different signed URL anyway.
+    _CACHE_TTL = 300.0
+
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the album-art proxy view."""
         self.hass = hass
+        # Single-entry cache (#2709): only the current round's cover is ever
+        # asked for, so a second entry would be dead weight and a second copy
+        # of up to 5 MB. A new cover evicts the old one.
+        self._cached_url: str | None = None
+        self._cached_body: bytes = b""
+        self._cached_type: str = ""
+        self._cached_at: float = 0.0
+        # In-flight fetches, keyed by signed URL. Twenty phones asking at the
+        # same instant join the one fetch already running instead of starting
+        # twenty of their own.
+        self._inflight: dict[str, asyncio.Task] = {}
 
     async def get(self, request: web.Request) -> web.Response:
         """Fetch the upstream image and re-serve it same-origin (#933, hardened #1356).
@@ -796,6 +823,13 @@ class AlbumArtView(HomeAssistantView):
           that is exactly where the Music Assistant LAN server lives (#933).
         * **No redirects**, a **read-size cap** and an **``image/*``
           content-type check** so the proxy can only ever return a bounded image.
+
+        Everyone in the room wants the same picture at the same moment, so the
+        fetch is shared (#2709): a server-side single-entry cache keyed by the
+        signed URL, plus in-flight coalescing so twenty phones asking at once
+        become one upstream request. ``Cache-Control`` alone helped only a
+        browser that had already seen the image — useless in round one of a
+        party where every phone is new.
         """
         raw_url = request.query.get("url", "")
         signature = request.query.get("sig", "")
@@ -805,10 +839,68 @@ class AlbumArtView(HomeAssistantView):
             _LOGGER.warning("Album-art proxy rejected an unsigned/forged URL")
             return web.Response(status=403, text="forbidden")
 
+        # Only past the signature gate — the cache must never be a way to read
+        # bytes without presenting a signature the integration itself issued.
+        cached = self._cache_get(raw_url)
+        if cached is not None:
+            return self._image_response(*cached)
+
+        task = self._inflight.get(raw_url)
+        if task is None:
+            task = asyncio.create_task(self._fetch(raw_url))
+            self._inflight[raw_url] = task
+            task.add_done_callback(lambda _t: self._inflight.pop(raw_url, None))
+
+        # shield(): a guest closing their browser cancels their handler, and
+        # that must not cancel the fetch the other twenty are waiting on.
+        try:
+            status, body, content_type = await asyncio.shield(task)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 — a failed share is still just a 502
+            _LOGGER.warning("Album-art proxy fetch failed")
+            return web.Response(status=502, text="upstream fetch failed")
+
+        if status != 200:
+            return web.Response(status=status, text=_ALBUM_ART_ERRORS[status])
+        return self._image_response(body, content_type)
+
+    def _cache_get(self, raw_url: str) -> tuple[bytes, str] | None:
+        """Return the cached image for ``raw_url`` while it is still fresh."""
+        if self._cached_url != raw_url or not self._cached_body:
+            return None
+        if monotonic() - self._cached_at > self._CACHE_TTL:
+            return None
+        return self._cached_body, self._cached_type
+
+    def _cache_put(self, raw_url: str, body: bytes, content_type: str) -> None:
+        """Store one image, evicting whatever the previous round left behind."""
+        self._cached_url = raw_url
+        self._cached_body = body
+        self._cached_type = content_type
+        self._cached_at = monotonic()
+
+    @staticmethod
+    def _image_response(body: bytes, content_type: str) -> web.Response:
+        """Re-serve an image same-origin."""
+        return web.Response(
+            body=body,
+            content_type=content_type,
+            headers={"Cache-Control": "public, max-age=86400"},
+        )
+
+    async def _fetch(self, raw_url: str) -> tuple[int, bytes, str]:
+        """Fetch one image upstream, for every client waiting on it (#2709).
+
+        Returns ``(status, body, content_type)``; on anything but 200 the body
+        is empty and the caller turns the status into the matching error page.
+        Only a successful fetch is cached — a transient 502 must not stick
+        around for the rest of the TTL.
+        """
         host = urlsplit(raw_url).hostname
         if not host or not await self._host_is_allowed(host):
             _LOGGER.warning("Album-art proxy refused a disallowed host")
-            return web.Response(status=403, text="forbidden")
+            return 403, b"", ""
 
         session = async_get_clientsession(self.hass)
         try:
@@ -818,28 +910,26 @@ class AlbumArtView(HomeAssistantView):
                 allow_redirects=False,
             ) as resp:
                 if resp.status != 200:
-                    return web.Response(status=502, text="upstream fetch failed")
+                    return 502, b"", ""
                 content_type = resp.headers.get("Content-Type", "")
                 if not content_type.startswith("image/"):
-                    return web.Response(status=415, text="not an image")
+                    return 415, b"", ""
                 declared = resp.headers.get("Content-Length")
                 if declared is not None and declared.isdigit():
                     if int(declared) > self._MAX_BYTES:
-                        return web.Response(status=413, text="image too large")
+                        return 413, b"", ""
                 body = bytearray()
                 async for chunk in resp.content.iter_chunked(65536):
                     body += chunk
                     if len(body) > self._MAX_BYTES:
-                        return web.Response(status=413, text="image too large")
+                        return 413, b"", ""
         except (ClientError, asyncio.TimeoutError):
             _LOGGER.warning("Album-art proxy fetch failed")
-            return web.Response(status=502, text="upstream fetch failed")
+            return 502, b"", ""
 
-        return web.Response(
-            body=bytes(body),
-            content_type=content_type,
-            headers={"Cache-Control": "public, max-age=86400"},
-        )
+        image = bytes(body)
+        self._cache_put(raw_url, image, content_type)
+        return 200, image, content_type
 
     async def _host_is_allowed(self, host: str) -> bool:
         """Reject hosts that resolve to loopback/link-local/reserved ranges (#1356)."""

--- a/custom_components/beatify/services/lights.py
+++ b/custom_components/beatify/services/lights.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from math import ceil
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.exceptions import HomeAssistantError, ServiceNotFound
@@ -62,6 +63,28 @@ BEAT_COLORS: list[list[int]] = [
     [0, 60, 200],
 ]
 
+# --- Beat-loop command budget (#2708) --------------------------------------
+# A Zigbee coordinator and a Hue bridge both start queueing commands somewhere
+# around ten per second. Past that point every later command — including the
+# REVEAL colour change, the one cue that is supposed to land on a beat — waits
+# behind the backlog and arrives seconds late.
+#
+# The beat loop therefore works to a fixed downstream budget instead of to the
+# music alone. Three limits together guarantee it:
+#
+# * ``BEAT_MAX_LIGHTS`` — only the first N configured lamps pulse. The rest
+#   hold the static PLAYING colour, so a twenty-lamp setup still looks lit
+#   without putting twenty commands per pulse on the radio.
+# * ``BEAT_MIN_BEATS_PER_PULSE`` — half time. One pulse every second beat, not
+#   one per beat.
+# * ``BEAT_COMMANDS_PER_SECOND`` — the pulse is stretched to a further whole
+#   number of beats if the lamp count would otherwise exceed this rate, so the
+#   budget holds at any BPM. It stays a whole number of beats so the pulse
+#   stays on the music.
+BEAT_MAX_LIGHTS: int = 6
+BEAT_MIN_BEATS_PER_PULSE: int = 2
+BEAT_COMMANDS_PER_SECOND: float = 6.0
+
 # Subtle mode: brightness offsets added to the saved (pre-game) brightness.
 # Values are fractions of 255 (0.2 = +51 out of 255).
 SUBTLE_BRIGHTNESS_OFFSETS: dict[str, float] = {
@@ -88,6 +111,8 @@ class PartyLightsService:
         self._light_mode: str = "dynamic"  # "static", "dynamic", "wled"
         self._wled_presets: dict[str, int] = dict(WLED_PRESET_DEFAULTS)
         self._wled_entities: set[str] = set()
+        # entity_id -> "rgb"/"ct"/"dim"/"onoff", resolved once (#2708)
+        self._capabilities: dict[str, str] = {}
 
     def snapshot_saved_states(self) -> dict[str, dict[str, Any]]:
         """Return a copy of the captured pre-party light states (#1402 B2).
@@ -133,6 +158,7 @@ class PartyLightsService:
         if wled_presets:
             self._wled_presets.update(wled_presets)
         self._saved_states = {}
+        self._capabilities = {}
 
         # Detect WLED entities via entity registry platform (reliable) or entity_id fallback
         self._wled_entities = set()
@@ -307,14 +333,30 @@ class PartyLightsService:
             self._beat_task.cancel()
             self._beat_task = None
 
+    def _beat_plan(self, bpm: int) -> tuple[list[str], float]:
+        """Pick the lamps that pulse and how long a pulse lasts (#2708).
+
+        Returns ``(entities, interval_seconds)``. The interval is always a
+        whole number of beats — at least ``BEAT_MIN_BEATS_PER_PULSE``, and more
+        when the lamp count would otherwise push the loop past
+        ``BEAT_COMMANDS_PER_SECOND`` downstream commands per second.
+        """
+        beat = 60.0 / max(bpm, 1)
+        # Only non-WLED entities pulse; WLED runs its own presets.
+        entities = [e for e in self._entity_ids if e not in self._wled_entities]
+        entities = entities[:BEAT_MAX_LIGHTS]
+        beats_per_pulse = BEAT_MIN_BEATS_PER_PULSE
+        if entities:
+            needed = len(entities) / (BEAT_COMMANDS_PER_SECOND * beat)
+            beats_per_pulse = max(BEAT_MIN_BEATS_PER_PULSE, ceil(needed))
+        return entities, beats_per_pulse * beat
+
     async def _beat_loop(self, bpm: int) -> None:
-        """Pulse between blue shades at the given BPM."""
-        interval = 60.0 / bpm
+        """Pulse between blue shades, within the beat-loop budget (#2708)."""
         i = 0
         try:
             while self._active:
-                # Only pulse non-WLED entities
-                entities = [e for e in self._entity_ids if e not in self._wled_entities]
+                entities, interval = self._beat_plan(bpm)
                 if entities:
                     await self._apply(
                         entities,
@@ -419,23 +461,37 @@ class PartyLightsService:
         self._current_phase = None
 
     def _get_capability(self, entity_id: str) -> str:
-        """Check entity attributes for supported_color_modes."""
+        """Check entity attributes for supported_color_modes.
+
+        The answer is a property of the hardware, so it is cached for the life
+        of the service (#2708) — the beat loop asked the state machine for it
+        once per lamp per pulse, several times a second, for the whole game.
+        Only a real state is cached; a missing entity may still appear later.
+        """
+        cached = self._capabilities.get(entity_id)
+        if cached is not None:
+            return cached
+
         state = self._hass.states.get(entity_id)
         if not state:
             return "onoff"
 
         color_modes = state.attributes.get("supported_color_modes", [])
         if not color_modes:
+            self._capabilities[entity_id] = "onoff"
             return "onoff"
 
         # Check from most capable to least
         if any(m in color_modes for m in ("rgb", "rgbw", "rgbww", "hs", "xy")):
-            return "rgb"
-        if any(m in color_modes for m in ("color_temp",)):
-            return "ct"
-        if any(m in color_modes for m in ("brightness",)):
-            return "dim"
-        return "onoff"
+            capability = "rgb"
+        elif any(m in color_modes for m in ("color_temp",)):
+            capability = "ct"
+        elif any(m in color_modes for m in ("brightness",)):
+            capability = "dim"
+        else:
+            capability = "onoff"
+        self._capabilities[entity_id] = capability
+        return capability
 
     async def _apply(
         self,
@@ -443,11 +499,21 @@ class PartyLightsService:
         service_data: dict[str, Any],
         transition: float = 1.0,
     ) -> None:
-        """Batch call hass.services for lights, adapting per capability."""
+        """Call ``light.turn_on`` once per distinct payload, not once per lamp.
+
+        Lamps of the same capability get byte-identical service data, so they
+        are collected into a single call carrying an ``entity_id`` list
+        (#2708). Six RGB lamps used to mean six service calls per pulse; they
+        now mean one. Grouping is by resolved payload rather than by capability
+        name so a future per-lamp adjustment cannot silently merge two lamps
+        that should have been told different things.
+        """
+        groups: dict[tuple[tuple[str, str], ...], list[str]] = {}
+        payloads: dict[tuple[tuple[str, str], ...], dict[str, Any]] = {}
+
         for entity_id in entity_ids:
             cap = self._get_capability(entity_id)
             call_data: dict[str, Any] = {
-                "entity_id": entity_id,
                 "transition": transition,
             }
 
@@ -477,12 +543,20 @@ class PartyLightsService:
                 # On/off only — just turn on
                 pass
 
+            key = tuple(sorted((k, repr(v)) for k, v in call_data.items()))
+            groups.setdefault(key, []).append(entity_id)
+            payloads.setdefault(key, call_data)
+
+        for key, group in groups.items():
             try:
                 await self._hass.services.async_call(
-                    "light", "turn_on", call_data, blocking=False
+                    "light",
+                    "turn_on",
+                    {**payloads[key], "entity_id": group},
+                    blocking=False,
                 )
             except (HomeAssistantError, ServiceNotFound):  # noqa: BLE001
-                _LOGGER.warning("Failed to control light: %s", entity_id)
+                _LOGGER.warning("Failed to control lights: %s", ", ".join(group))
 
     async def _apply_wled(self, entity_id: str, preset_id: int) -> None:
         """Activate a WLED preset by ID (#517).

--- a/tests/unit/test_album_art_view.py
+++ b/tests/unit/test_album_art_view.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from custom_components.beatify.server.views import AlbumArtView
@@ -191,3 +192,191 @@ class TestAlbumArtView:
         ):
             out = await view.get(_request(_signed_query(url)))
         assert out.status == 413
+
+
+class TestAlbumArtSharedFetch:
+    """One cover, one upstream fetch — however many guests are in the room (#2709)."""
+
+    URL = "http://192.168.1.9:8095/imageproxy?item=round1"
+
+    def _hass(self):
+        """A hass whose DNS resolution is countable as well as allowed."""
+        hass = MagicMock()
+        hass.dns_calls = 0
+
+        async def _resolve(_fn, *_a):
+            hass.dns_calls += 1
+            await asyncio.sleep(0)
+            return [(2, 1, 6, "", ("192.168.1.9", 0))]
+
+        hass.async_add_executor_job = AsyncMock(side_effect=_resolve)
+        return hass
+
+    def _counting_session(self, responses):
+        """A session that hands out ``responses`` in order and counts its GETs."""
+        session = MagicMock()
+        session.upstream = 0
+        queue = list(responses)
+
+        def _get(*_a, **_k):
+            session.upstream += 1
+            return queue.pop(0) if len(queue) > 1 else queue[0]
+
+        session.get = _get
+        return session
+
+    async def test_twenty_two_clients_are_one_upstream_fetch(self):
+        """Twenty guests, the TV and the host, all at the same instant."""
+        hass = self._hass()
+        view = AlbumArtView(hass)
+        session = self._counting_session(
+            [_FakeResponse(content_type="image/jpeg", chunks=(b"COVER",))]
+        )
+
+        with patch(
+            "custom_components.beatify.server.views.async_get_clientsession",
+            return_value=session,
+        ):
+            responses = await asyncio.gather(
+                *(view.get(_request(_signed_query(self.URL))) for _ in range(22))
+            )
+
+        assert session.upstream == 1
+        assert hass.dns_calls == 1
+        assert all(r.status == 200 for r in responses)
+        assert all(r.body == b"COVER" for r in responses)
+
+    async def test_a_later_request_is_served_from_cache(self):
+        """A phone that joins mid-round costs nothing upstream."""
+        hass = self._hass()
+        view = AlbumArtView(hass)
+        session = self._counting_session(
+            [_FakeResponse(content_type="image/png", chunks=(b"PNGDATA",))]
+        )
+
+        with patch(
+            "custom_components.beatify.server.views.async_get_clientsession",
+            return_value=session,
+        ):
+            first = await view.get(_request(_signed_query(self.URL)))
+            second = await view.get(_request(_signed_query(self.URL)))
+
+        assert session.upstream == 1
+        assert first.body == second.body == b"PNGDATA"
+
+    async def test_the_next_round_refetches(self):
+        """A new cover means a new signed URL, and the cache holds only one."""
+        hass = self._hass()
+        view = AlbumArtView(hass)
+        session = self._counting_session(
+            [
+                _FakeResponse(chunks=(b"ROUND1",)),
+                _FakeResponse(chunks=(b"ROUND2",)),
+            ]
+        )
+        next_url = "http://192.168.1.9:8095/imageproxy?item=round2"
+
+        with patch(
+            "custom_components.beatify.server.views.async_get_clientsession",
+            return_value=session,
+        ):
+            first = await view.get(_request(_signed_query(self.URL)))
+            second = await view.get(_request(_signed_query(next_url)))
+            again = await view.get(_request(_signed_query(next_url)))
+
+        assert session.upstream == 2
+        assert first.body == b"ROUND1"
+        assert second.body == again.body == b"ROUND2"
+        assert view._cached_url == next_url
+
+    async def test_a_stale_entry_is_not_served(self):
+        """Past the TTL the cover is fetched again rather than replayed."""
+        hass = self._hass()
+        view = AlbumArtView(hass)
+        session = self._counting_session(
+            [_FakeResponse(chunks=(b"OLD",)), _FakeResponse(chunks=(b"NEW",))]
+        )
+
+        with patch(
+            "custom_components.beatify.server.views.async_get_clientsession",
+            return_value=session,
+        ):
+            first = await view.get(_request(_signed_query(self.URL)))
+            view._cached_at -= view._CACHE_TTL + 1
+            second = await view.get(_request(_signed_query(self.URL)))
+
+        assert session.upstream == 2
+        assert first.body == b"OLD"
+        assert second.body == b"NEW"
+
+    async def test_a_failed_fetch_is_not_cached(self):
+        """A momentary upstream hiccup must not stick for the whole TTL."""
+        hass = self._hass()
+        view = AlbumArtView(hass)
+        session = self._counting_session(
+            [_FakeResponse(status=500), _FakeResponse(chunks=(b"COVER",))]
+        )
+
+        with patch(
+            "custom_components.beatify.server.views.async_get_clientsession",
+            return_value=session,
+        ):
+            first = await view.get(_request(_signed_query(self.URL)))
+            second = await view.get(_request(_signed_query(self.URL)))
+
+        assert first.status == 502
+        assert second.status == 200
+        assert second.body == b"COVER"
+
+    async def test_every_waiter_sees_the_shared_error(self):
+        """A shared failure reaches all of them, not just the one who asked first."""
+        hass = self._hass()
+        view = AlbumArtView(hass)
+        session = self._counting_session([_FakeResponse(content_type="text/html")])
+
+        with patch(
+            "custom_components.beatify.server.views.async_get_clientsession",
+            return_value=session,
+        ):
+            responses = await asyncio.gather(
+                *(view.get(_request(_signed_query(self.URL))) for _ in range(5))
+            )
+
+        assert session.upstream == 1
+        assert [r.status for r in responses] == [415] * 5
+
+    async def test_the_cache_is_behind_the_signature_gate(self):
+        """A cached cover is not a way to skip the HMAC check."""
+        hass = self._hass()
+        view = AlbumArtView(hass)
+        session = self._counting_session([_FakeResponse(chunks=(b"COVER",))])
+
+        with patch(
+            "custom_components.beatify.server.views.async_get_clientsession",
+            return_value=session,
+        ):
+            await view.get(_request(_signed_query(self.URL)))
+            forged = await view.get(_request({"url": self.URL, "sig": "deadbeef"}))
+
+        assert forged.status == 403
+
+    async def test_a_disconnecting_guest_does_not_cancel_the_shared_fetch(self):
+        """The first phone closing its browser must not strand the other twenty."""
+        hass = self._hass()
+        view = AlbumArtView(hass)
+        session = self._counting_session([_FakeResponse(chunks=(b"COVER",))])
+
+        with patch(
+            "custom_components.beatify.server.views.async_get_clientsession",
+            return_value=session,
+        ):
+            leaver = asyncio.ensure_future(view.get(_request(_signed_query(self.URL))))
+            await asyncio.sleep(0)  # let it start the shared fetch
+            stayer = asyncio.ensure_future(view.get(_request(_signed_query(self.URL))))
+            await asyncio.sleep(0)
+            leaver.cancel()
+            result = await stayer
+
+        assert session.upstream == 1
+        assert result.status == 200
+        assert result.body == b"COVER"

--- a/tests/unit/test_lights.py
+++ b/tests/unit/test_lights.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.beatify.services.lights import (
+    BEAT_COMMANDS_PER_SECOND,
+    BEAT_MAX_LIGHTS,
     RAINBOW_COLORS,
     PartyLightsService,
 )
@@ -844,9 +847,12 @@ class TestWledEndPreset:
         with patch("asyncio.sleep", new_callable=AsyncMock):
             await svc.celebrate()
 
-        # Every rainbow command targets only the non-WLED entity.
+        # Every rainbow command targets only the non-WLED entity. Lamps are
+        # grouped into one call carrying an entity_id list (#2708).
         targeted = {
-            call[0][2]["entity_id"] for call in hass.services.async_call.call_args_list
+            entity_id
+            for call in hass.services.async_call.call_args_list
+            for entity_id in call[0][2]["entity_id"]
         }
         assert targeted == {"light.living_room"}
 
@@ -1112,7 +1118,7 @@ class TestApplyCapability:
         call_args = hass.services.async_call.call_args[0][2]
         assert "rgb_color" not in call_args
         assert "brightness" not in call_args
-        assert call_args["entity_id"] == "light.sw"
+        assert call_args["entity_id"] == ["light.sw"]
 
     @pytest.mark.asyncio
     async def test_apply_handles_service_error(self):
@@ -1129,14 +1135,18 @@ class TestApplyCapability:
         )
 
     @pytest.mark.asyncio
-    async def test_apply_continues_after_one_light_fails(self):
-        """If one light errors, remaining lights should still be called."""
-        call_count = 0
+    async def test_apply_continues_after_one_call_fails(self):
+        """A failing call must not abandon the lights in the other groups.
 
-        async def fail_first_only(*args, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
+        Lamps that resolve to the same payload now travel in one call (#2708),
+        so the unit that can fail is the group, not the lamp. Two capabilities
+        means two groups: the first one erroring must not stop the second.
+        """
+        targeted: list[list[str]] = []
+
+        async def fail_first_only(_domain, _service, data, **kwargs):
+            targeted.append(data["entity_id"])
+            if len(targeted) == 1:
                 raise HomeAssistantError("HA error")
 
         hass = _make_hass(
@@ -1147,7 +1157,7 @@ class TestApplyCapability:
                 },
                 "light.b": {
                     "state": "on",
-                    "attributes": {"supported_color_modes": ["rgb"]},
+                    "attributes": {"supported_color_modes": ["brightness"]},
                 },
             }
         )
@@ -1160,8 +1170,7 @@ class TestApplyCapability:
             {"rgb_color": [255, 0, 0], "brightness": 255},
         )
 
-        # Both lights should have been attempted
-        assert call_count == 2
+        assert targeted == [["light.a"], ["light.b"]]
 
 
 # ---------------------------------------------------------------------------
@@ -1240,3 +1249,146 @@ class TestMultipleLights:
         dim_call = hass.services.async_call.call_args_list[1][0][2]
         assert "rgb_color" not in dim_call
         assert dim_call["brightness"] == 200
+
+
+# ---------------------------------------------------------------------------
+# #2708 — the beat loop's command budget
+# ---------------------------------------------------------------------------
+
+
+def _rgb_lamps(n: int) -> dict[str, dict]:
+    """``n`` identical RGB lamps, the setup the beat loop is worst at."""
+    return {
+        f"light.lamp{i}": {
+            "state": "on",
+            "attributes": {
+                "supported_color_modes": ["rgb"],
+                "brightness": 200,
+                "rgb_color": [255, 255, 255],
+            },
+        }
+        for i in range(n)
+    }
+
+
+async def _run_beat_loop(svc, bpm: int, seconds: float) -> None:
+    """Drive ``_beat_loop`` over ``seconds`` of virtual time.
+
+    Real sleeping would make this a minute-long test; the loop's own interval
+    is what advances the clock, so the measurement is of the real code.
+    """
+    clock = 0.0
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay, *args, **kwargs):
+        nonlocal clock
+        clock += delay
+        if clock > seconds:
+            raise asyncio.CancelledError
+        await real_sleep(0)
+
+    with patch("asyncio.sleep", fake_sleep):
+        await svc._beat_loop(bpm)
+
+
+class TestBeatLoopCommandBudget:
+    """The beat loop must stay under what a Zigbee radio can absorb (#2708)."""
+
+    @pytest.mark.asyncio
+    async def test_same_capability_lamps_travel_in_one_call(self):
+        """Six identical lamps are one service call, not six."""
+        hass = _make_hass(_rgb_lamps(6))
+        svc = PartyLightsService(hass)
+        await svc.start(list(_rgb_lamps(6)))
+        hass.services.async_call.reset_mock()
+
+        await svc._apply(list(_rgb_lamps(6)), {"rgb_color": [0, 100, 255]})
+
+        assert hass.services.async_call.call_count == 1
+        data = hass.services.async_call.call_args[0][2]
+        assert data["entity_id"] == [f"light.lamp{i}" for i in range(6)]
+        assert data["rgb_color"] == [0, 100, 255]
+
+    def test_pulse_is_half_time_by_default(self):
+        """Six lamps at 120 BPM pulse every second beat, not every beat."""
+        hass = _make_hass(_rgb_lamps(6))
+        svc = PartyLightsService(hass)
+        svc._entity_ids = list(_rgb_lamps(6))
+
+        entities, interval = svc._beat_plan(120)
+
+        assert len(entities) == 6
+        assert interval == pytest.approx(1.0)  # two beats of 0.5 s
+
+    def test_extra_lamps_hold_the_static_phase_colour(self):
+        """Only the first BEAT_MAX_LIGHTS lamps pulse; the rest are left alone."""
+        hass = _make_hass(_rgb_lamps(20))
+        svc = PartyLightsService(hass)
+        svc._entity_ids = list(_rgb_lamps(20))
+
+        entities, _interval = svc._beat_plan(120)
+
+        assert entities == [f"light.lamp{i}" for i in range(BEAT_MAX_LIGHTS)]
+
+    @pytest.mark.parametrize("bpm", [60, 120, 180, 240])
+    @pytest.mark.parametrize("lamps", [1, 2, 6, 20])
+    def test_budget_holds_at_any_bpm_and_lamp_count(self, bpm, lamps):
+        """The pulse rate never exceeds the downstream command budget."""
+        hass = _make_hass(_rgb_lamps(lamps))
+        svc = PartyLightsService(hass)
+        svc._entity_ids = list(_rgb_lamps(lamps))
+
+        entities, interval = svc._beat_plan(bpm)
+
+        assert len(entities) / interval <= BEAT_COMMANDS_PER_SECOND + 1e-9
+        # …and the pulse still lands on a beat.
+        beat = 60.0 / bpm
+        assert interval / beat == pytest.approx(round(interval / beat))
+
+    @pytest.mark.asyncio
+    async def test_twenty_lamps_over_a_thirty_second_round(self):
+        """The measurement the issue asked for, on the real loop."""
+        lamps = _rgb_lamps(20)
+        hass = _make_hass(lamps)
+        svc = PartyLightsService(hass)
+        await svc.start(list(lamps))
+        hass.services.async_call.reset_mock()
+
+        await _run_beat_loop(svc, 120, 30.0)
+
+        calls = hass.services.async_call.call_args_list
+        commands = sum(len(c[0][2]["entity_id"]) for c in calls)
+        # Before this change: 1,240 service calls and 1,240 lamp commands over
+        # the same thirty seconds — 41 commands a second at a coordinator that
+        # starts queueing at ten.
+        assert len(calls) == 31  # one pulse a second, plus the one at t=0
+        assert commands == 31 * BEAT_MAX_LIGHTS  # 186
+
+    @pytest.mark.asyncio
+    async def test_capability_is_resolved_once_per_lamp(self):
+        """The loop must not re-read the state machine on every pulse."""
+        lamps = _rgb_lamps(6)
+        hass = _make_hass(lamps)
+        svc = PartyLightsService(hass)
+        await svc.start(list(lamps))
+
+        probe = MagicMock(side_effect=hass.states.get)
+        hass.states.get = probe
+
+        await _run_beat_loop(svc, 120, 10.0)
+
+        # Eleven pulses, six lamps — one lookup each, not sixty-six.
+        assert probe.call_count == 6
+
+    @pytest.mark.asyncio
+    async def test_wled_entities_still_never_pulse(self):
+        """The WLED carve-out survives the cap."""
+        lamps = _rgb_lamps(3)
+        hass = _make_hass(lamps)
+        svc = PartyLightsService(hass)
+        await svc.start(list(lamps))
+        svc._wled_entities = {"light.lamp0"}
+
+        entities, _interval = svc._beat_plan(120)
+
+        assert entities == ["light.lamp1", "light.lamp2"]


### PR DESCRIPTION
Two places where the Raspberry Pi repeated the same work per client or per lamp while it was also trying to start the next song. Different files, one PR.

## #2708 — the beat loop's command budget

The beat loop pulsed every lamp on every beat, one `light.turn_on` per entity for the whole PLAYING phase. A Zigbee coordinator and a Hue bridge both start queueing around ten commands a second; past that, everything behind the backlog waits — including the REVEAL colour change, the one cue that is supposed to land on a beat.

Three of the four directions in the issue, wired together as one explicit budget:

- **One call with an entity list.** Lamps that resolve to the same payload now travel in a single `light.turn_on`. Grouping is by resolved payload rather than by capability name, so a future per-lamp adjustment cannot silently merge two lamps that should have been told different things.
- **Half time.** One pulse every second beat, not one per beat.
- **A lamp cap.** Only the first six configured lamps pulse; the rest hold the static PLAYING colour. The interval stretches to a further whole number of beats if the lamp count would still exceed six commands a second, so the budget holds at any BPM and the pulse stays on the music.

Capability lookups are also resolved once per lamp instead of once per lamp per pulse — `supported_color_modes` is a property of the hardware, and the loop was asking the state machine for it several times a second all game.

### Measured

Over a 30 s round at 120 BPM, driving the real `_beat_loop` with a virtual clock and counting `hass.services.async_call`. Thirty seconds per round is the issue's own working figure (it quotes ~7,200 calls over twenty rounds with six lamps).

| lamps | service calls / round | lamp commands / round | commands per second |
|---|---|---|---|
| 2  | 124 → **32**   | 124 → **64**   | 4.1 → **2.1** |
| 6  | 372 → **32**   | 372 → **192**  | 12.4 → **6.4** |
| 20 | 1,240 → **32** | 1,240 → **206** | 41.3 → **6.9** |

Over a twenty-round game with six lamps: 7,440 service calls → **640**, and 7,440 lamp commands → **3,840**. The per-second figures include the one-off phase apply at the start of the round; the loop itself holds at exactly 6.0 commands a second.

### This changes a default

`light_mode` defaults to `dynamic`, so **existing hosts will see a calmer pulse after updating**: half time rather than every beat, and lamps past the sixth holding the static PLAYING colour instead of pulsing. Worth a line in the release notes. No UI copy describes the old behaviour, so nothing else needed changing.

## #2709 — one cover, one fetch

`AlbumArtView` had no server-side cache, so every guest fetched the same cover through Home Assistant once a round — a `getaddrinfo` in the executor plus an aiohttp GET, with Music Assistant's `imageproxy` rescaling the image again each time. `Cache-Control` only ever helped a browser that had already seen the image, which is no help at all in round one of a party where every phone is new.

- **Single-entry cache keyed by the signed URL.** The current round's cover is the only one anyone asks for, and one entry bounds the retained memory at the existing 5 MB read cap. A five-minute TTL comfortably outlives a round; the next round brings a different signed URL anyway.
- **In-flight coalescing.** Two guests asking for the same image at the same instant: the first request creates one `asyncio.Task` for the fetch and registers it under the signed URL; the second finds it and awaits the same task. Waiters use `asyncio.shield`, so a guest closing their browser cancels their own handler without stranding the other twenty — there is a test for exactly that, and it fails if the shield is removed. The in-flight entry is cleared by a done-callback on the task, so a finished fetch never blocks a later one.

Two things kept deliberately in place:

- The cache is read **after** the HMAC signature check, so it is not a way to get bytes out of the proxy without a signature the integration itself issued.
- Only a 200 is cached. A momentary upstream 502 must not stick around for the rest of the TTL. Non-200 outcomes are still shared with everyone waiting on that one fetch, so all of them see the same status rather than only the client that happened to ask first.

### Measured

22 simultaneous clients (twenty guests, the TV, the host) on the same signed URL:

| | before | after |
|---|---|---|
| upstream GETs / round | 22 | **1** |
| `getaddrinfo` calls / round | 22 | **1** |
| upstream fetches over a twenty-round game | 440 | **20** |

## Checks

- `python -m pytest tests/unit tests/integration -q` — 2,596 passed, 2 skipped
- `npm test` — 999 passed, 98 files
- `npm run build:check` — all 16 artifacts and 76 .gz siblings match source
- `python3 -m ruff format --check .` — 238 files already formatted (`ruff check` also clean)

Three existing light tests asserted the old one-call-per-lamp shape and were updated to the grouped shape. One of them, `test_apply_continues_after_one_light_fails`, changed meaning rather than just form: the unit that can fail is now the group, not the lamp, so it was rewritten to use two capabilities — two groups — and assert that the first one erroring does not stop the second.

Closes #2708
Closes #2709

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKsEKt68KHSqmi617XNCVi
