### PR TITLE
Drain the pre-warm coroutine in the #2693 fixture

### DIFF
--- a/tests/unit/test_pre_start_speaker_platform_2693.py
+++ b/tests/unit/test_pre_start_speaker_platform_2693.py
@@ -61,9 +61,23 @@ def _registry() -> MagicMock:
     return reg
 
 
+def _closing_background_task(coro, *_args, **_kwargs):
+    """``async_create_background_task`` stub that closes the coro (no event loop).
+
+    Same stub as ``tests/unit/test_media_player_prewarm.py``, and it is here for
+    the same reason. ``create_game`` schedules the #1540 LOBBY pre-warm through
+    this method; a bare ``MagicMock`` would record the coroutine and never await
+    it, so the ``RuntimeWarning`` fires whenever the GC gets round to collecting
+    it — inside whichever test happens to be running by then.
+    """
+    coro.close()
+    return MagicMock()
+
+
 def _hass() -> MagicMock:
     hass = MagicMock()
     hass.states.get.return_value = MagicMock(state="playing")
+    hass.async_create_background_task = MagicMock(side_effect=_closing_background_task)
     return hass
 
 


### PR DESCRIPTION
`Burn-in (Flaky Detection)` fails intermittently on `tests/unit/test_state.py::TestMetadataCoroNoLeak::test_start_round_deferred_does_not_warn`, for a reason that has nothing to do with the PR under test. Most recently on #2739, **iteration 7 of 10** ([job](https://github.com/mholzi/beatify/actions/runs/34105898111/job/101690698997)). The burn-in loop runs the identical command ten times with no shuffling, so a failure on 7 alone is already non-determinism rather than an ordering effect.

## What was happening

`GameState.create_game` schedules the #1540 LOBBY pre-warm through `hass.async_create_background_task`:

```python
# game/state_lifecycle.py
creator = getattr(self._hass, "async_create_background_task", None)
if callable(creator):
    self._prewarm_task = creator(_runner(), name="beatify_media_player_prewarm")
```

`tests/unit/test_pre_start_speaker_platform_2693.py` builds its `hass` as a bare `MagicMock()`. `async_create_background_task` is therefore an auto-created child mock — it *records* the coroutine it is handed and never awaits it. When the GC gets round to collecting that coroutine, Python raises `RuntimeWarning: coroutine ... was never awaited`.

The leak test uses `recwarn`, which records **any** warning raised during its window, regardless of which test created the object being collected. So whenever a GC pass happens to land inside that test, it fails — and the collection point genuinely roams: the same warning is attributed to `test_queue_restore_stays_paused_2605.py` in CI and to `test_provider_uri_backfill.py` locally.

`tests/unit/test_media_player_prewarm.py` exercises the same path deliberately and already has the stub for it — `_closing_background_task`, which closes the coroutine and returns a mock. This uses that same stub rather than introducing a second pattern.

## Verified, not assumed

A green suite proves nothing here — the flake only surfaces about one run in ten. So the check is the leak itself, with a forced collection:

```
$ python - <<PY
import gc, warnings, pytest
with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter("always")
    pytest.main(["-q", "tests/unit/test_pre_start_speaker_platform_2693.py"])
    gc.collect()
    print("LEAKED:", len([x for x in w if "never awaited" in str(x.message)]))
PY
```

| | before | after |
|---|---|---|
| that file alone | `LEAKED: 2` | `LEAKED: 0` |
| whole suite, warnings summary | 3 warnings | 1 warning |

The two that disappear are the `schedule_media_player_prewarm._runner` pair. Confirmed against a clean `origin/main` worktree, so the "before" figure is the tree as it stands, not a local artefact.

## One warning deliberately left

`tests/unit/test_rearm_after_elapsed_vote_window_2575.py` still raises `coroutine 'AsyncMockMixin._execute_mock_call' was never awaited` at `state_pause.py:349`. It is left alone because it does **not** roam: it is attributed to that same test on every run, i.e. it is raised inside its own test rather than at an arbitrary GC point, so it cannot land in another test's `recwarn` window. Worth tidying eventually; not what is breaking the burn-in.

## Checks

- `pytest tests/unit tests/integration -q` → 2608 passed, 2 skipped
- `npm test` → 999 tests passed
- `npm run build:check` → all 16 artifacts and 76 `.gz` siblings match source
- `python3 -m ruff format --check .` → 239 files already formatted (`ruff check` clean)

Kept separate from #2739 on purpose: that PR is about two shared constants, and a fixture change buried in it would be unreadable months from now. On `main` this also covers the other open PRs, whose burn-ins run against a merge ref.

Closes #2744

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKsEKt68KHSqmi617XNCVi
