### PR TITLE
fix: set the playback budget from Music Assistant's retry curve, and name a throttled start in our own log (#2682)

### DIFF
--- a/custom_components/beatify/const.py
+++ b/custom_components/beatify/const.py
@@ -19,10 +19,16 @@ ROUND_DURATION_MAX = 60  # seconds (Story 13.1)
 
 # #1936: how many playback timeouts IN A ROW count as a systemic failure that
 # pauses the game. Below this, a timeout skips the song and play continues —
-# a rate-limiting provider (Music Assistant's Apple Music backs off ~15.7s,
-# longer than our own deadline) is not a broken one, and pausing on the first
+# a rate-limiting provider is not a broken one, and pausing on the first
 # timeout ended whole games over it. A genuinely offline speaker still reaches
 # the recovery banner, just a few songs later.
+#
+# #2682 raised MA_PLAYBACK_TIMEOUT to 25s, which now covers Music Assistant's
+# backoff up to its fifth retry (~23s to first audio). A timeout that still
+# happens under that budget means MA is at its sixth attempt or later, where
+# the next retry alone is ~16s — so waiting is no longer the better answer and
+# this counter is what keeps the game moving instead. Three of them in a row
+# still pauses, and the log now says which of the two causes it was.
 MAX_CONSECUTIVE_PLAYBACK_FAILURES = 3
 
 # Server-side round backstop (#1865). A periodic tick ends a round whose

--- a/custom_components/beatify/game/state_lifecycle.py
+++ b/custom_components/beatify/game/state_lifecycle.py
@@ -432,11 +432,19 @@ class RoundLifecycleMixin:
 
                 # #1936: a timeout is not proof of a broken system. Music
                 # Assistant's Apple Music provider rate-limits and then retries
-                # after its OWN backoff — measured at 15.7s, i.e. longer than
-                # the deadline we just gave it. Pausing the whole game on that
-                # first timeout ended the evening for a provider that was
-                # working, and handed the host a re-authenticate banner for a
-                # problem they did not have.
+                # on its OWN exponential backoff, which can outlast whatever
+                # deadline we gave it. Pausing the whole game on that first
+                # timeout ended the evening for a provider that was working,
+                # and handed the host a re-authenticate banner for a problem
+                # they did not have.
+                #
+                # #2682 moved the deadline out to 25s so a start throttled to
+                # MA's fifth retry (~23s) now lands instead of timing out, and
+                # made the log say which cause it was — `last_failure_reason`
+                # is "rate_limited" when a recent start was measurably slow,
+                # "error" when none was. Both count here, deliberately: past
+                # the fifth retry the next one is ~16s away, and skipping the
+                # song beats holding the room in silence for it.
                 #
                 # So the first failures skip the song, exactly like a
                 # storefront gap; only MAX_CONSECUTIVE_PLAYBACK_FAILURES in a

--- a/custom_components/beatify/services/playback/base.py
+++ b/custom_components/beatify/services/playback/base.py
@@ -80,9 +80,12 @@ class PlaybackStrategy(ABC):
     @property
     def last_failure_reason(self) -> str | None:
         """Why the most recent attempt failed — ``"unavailable"``, ``"error"``,
-        ``"wrong_track"`` — or None when it succeeded. Read by
-        ``game/state_lifecycle.py`` to decide whether a failure counts against
-        ``MAX_SONG_RETRIES``."""
+        ``"wrong_track"``, ``"rate_limited"`` — or None when it succeeded. Read
+        by ``game/state_lifecycle.py`` to decide whether a failure counts
+        against ``MAX_SONG_RETRIES``: only ``"unavailable"`` skips without
+        counting, so ``"rate_limited"`` (#2682) behaves exactly as ``"error"``
+        does and exists to carry the *reason* across the boundary rather than
+        to change what the game does with it."""
         return self.context.last_failure_reason
 
     @last_failure_reason.setter

--- a/custom_components/beatify/services/playback/music_assistant.py
+++ b/custom_components/beatify/services/playback/music_assistant.py
@@ -33,20 +33,86 @@ _LOGGER = logging.getLogger(__name__)
 # Denon AirPlay, some MA-wrapped Sonos setups) can take 10-12s to acknowledge
 # a new track on the first round. #777 showed 8s was too aggressive — rounds
 # advanced before the track had actually swapped on the speaker.
-MA_PLAYBACK_TIMEOUT = 15.0
+#
+# #2682 raised it from 15.0s, and the number comes from Music Assistant's own
+# retry schedule rather than from rounding up. 23 starts were timed on the real
+# installation during the v4.4.3-rc1 live test: median 4s to first audio, and
+# one at 14.6s — 0.4s inside the old deadline. The Music Assistant add-on log
+# named the cause: its Apple Music rate limiter had failed and slept 1.0s, then
+# 2.0s, then 4.3s, on an exponential schedule that runs to 8 attempts.
+#
+# That schedule is the whole arithmetic. Sleeping before attempt N costs
+# 2^(N-1) - 1 seconds, and the 4.3s observed for a nominal 4.0s puts the real
+# figure about 7% above nominal:
+#
+#     attempt 2 at   1.1s      attempt 5 at  16.1s
+#     attempt 3 at   3.2s      attempt 6 at  33.3s
+#     attempt 4 at   7.5s      attempt 7 at  67.7s
+#
+# On top of that sits the cost of the failed API calls (~0.8s each, so ~3s by
+# attempt 5) and the speaker's own start, which the same run measured at a 4s
+# median warm. So a start that only succeeds on Music Assistant's FIFTH attempt
+# is audible at about 16.1 + 3 + 4 = 23s, and one that needs the SIXTH at about
+# 33.3 + 3 + 4 = 40s.
+#
+# The budget is therefore set past attempt 5 and deliberately short of attempt
+# 6. 40 seconds of silence in front of guests is worse for the room than
+# skipping the song and drawing another one — and with
+# MAX_CONSECUTIVE_PLAYBACK_FAILURES the game would spend two minutes on it
+# before saying anything. 25.0 clears attempt 5 with ~2s to spare, and turns
+# the measured 14.6s start from 0.4s of headroom into 10.4s.
+#
+# The cost is paid by a genuinely dead URI, which now waits 25s instead of 15
+# before the cascade moves on. That is the trade #2682 asked for explicitly: a
+# longer deadline costs nothing when playback is fast, and the failure it slows
+# down is the one the log now names (see MA_SLOW_START_SECONDS below).
+MA_PLAYBACK_TIMEOUT = 25.0
 
-# #1936: the FIRST play of a game gets a third more time (15.0s → 20.0s). A
+# #1936: the FIRST play of a game gets a third more time (25.0s → 33.3s). A
 # speaker idle for a while was measured at 10.1s to first audio (Sonos via MA,
 # Apple Music) — close enough to the deadline that a cold start regularly lost
 # the race and the game paused before a single note had played. Later rounds
 # keep the shorter deadline: by then the speaker is warm and a longer wait is
 # just silence in front of the players.
 #
+# The factor still holds after #2682 raised the base, and for the same reason
+# the base was raised: a cold speaker (10.1s) that is ALSO throttled to Music
+# Assistant's fifth attempt (16.1s of backoff plus ~3s of failed calls) is
+# audible at ~29s, which 25.0 alone would not cover and 33.3 does.
+#
 # Expressed as a FACTOR, not a second absolute constant, so the one existing
 # patch point still governs both budgets — eight tests patch
 # MA_PLAYBACK_TIMEOUT down to keep the suite fast, and a separate absolute
-# constant would have silently made each of them wait the full 20s.
+# constant would have silently made each of them wait the full budget.
 MA_FIRST_PLAY_TIMEOUT_FACTOR = 4 / 3
+
+# #2682: how slow a CONFIRMED start has to be before it is worth a WARNING.
+#
+# This is the second half of the ticket, and the more useful half. A start that
+# is being throttled and a start whose URI is dead end at the same deadline
+# with the same message, and until now the only place the difference was
+# visible was the Music Assistant add-on log — a separate file most people
+# never open. But the two are not actually symmetric: throttling produces
+# something a dead URI never produces, namely a start that SUCCEEDS and takes
+# far too long. That is exactly what #2682 was written from.
+#
+# So the slow success is logged, loudly, at the moment it happens. Twice the
+# measured 4s median is a threshold no healthy warm start reaches and every
+# throttled one does (the run that produced the ticket sat at 14.6s).
+MA_SLOW_START_SECONDS = 8.0
+
+# #2682: how long a slow start stays evidence that the provider is throttling.
+#
+# Throttling is a property of the minute, not of the track — Apple was leaning
+# on that household for a window, and every start inside it paid. A dead URI is
+# the opposite: a property of one song, with the songs on either side of it
+# starting in four seconds. So "was a recent start slow?" is what separates the
+# two once a timeout has actually happened, and this is how far back to look.
+#
+# Long enough to span the gap between two consecutive starts, or it would
+# forget between rounds and never fire: a round is up to 60s of music and the
+# reveal dwell can be a full 90s auto-advance, so 150s is the gap to cover.
+MA_THROTTLE_MEMORY_SECONDS = 180.0
 
 # #1381: Fast-path Path 2 (title-advanced-without-exact-match) must not
 # instant-accept an *arbitrary* title change. If a requested URI fails to
@@ -243,6 +309,73 @@ class MusicAssistantStrategy(PlaybackStrategy):
         # must NOT misread that self-induced idle as a systemic 'error' (which
         # pauses the game). Reset before each song.
         self._stopped_for_cascade: bool = False
+        # #2682: when a start last took longer than MA_SLOW_START_SECONDS, and
+        # how long it took. A slow SUCCESS is the only in-band evidence that
+        # Music Assistant's provider is backing off — a dead URI never produces
+        # one — so it is remembered and used to explain the next timeout.
+        # NOT reset per song: throttling spans songs, which is the point.
+        self._last_slow_start: tuple[float, float] | None = None
+
+    # -- #2682: telling a throttled start apart from a dead URI --------------
+
+    def _note_start_duration(
+        self, elapsed: float, uri: str, timeout: float, *, first_play: bool
+    ) -> None:
+        """Log a confirmed start, loudly when it was slow (#2682).
+
+        The fast case stays at DEBUG, where it has always been. A start past
+        MA_SLOW_START_SECONDS is the throttling fingerprint and is raised to
+        WARNING, because the person who needs it is reading Beatify's log after
+        a party and would otherwise have to open the Music Assistant add-on log
+        to learn that anything was wrong at all.
+
+        The first play of a game is exempted from the *memory*, not from the
+        warning: a cold speaker was measured at 10.1s in #1936 with nothing
+        throttling it, so treating it as evidence would arm the throttle
+        explanation at the start of every game.
+        """
+        if elapsed < MA_SLOW_START_SECONDS:
+            return
+        if first_play:
+            _LOGGER.info(
+                "MA playback confirmed after %.1fs for %s — slow, but this is "
+                "the first start of the game and a cold speaker was measured "
+                "at ~10s on its own (#1936). Not counting it as evidence that "
+                "the provider is throttling.",
+                elapsed,
+                uri,
+            )
+            return
+        self._last_slow_start = (asyncio.get_event_loop().time(), elapsed)
+        _LOGGER.warning(
+            "MA playback confirmed after %.1fs for %s — past the %.0fs "
+            "slow-start mark, on a %.0fs budget (a healthy warm start is about "
+            "4s). Nothing failed, but Music Assistant's provider is very "
+            "likely backing off: its Apple Music rate limiter retries on an "
+            "exponential schedule (1s, 2s, 4s, 8s, ...) and that wait lands on "
+            "top of every start. The next one may not fit in the budget. "
+            "Confirm it in the Music Assistant add-on log — look for 'Rate "
+            "Limiter'. (#2682)",
+            elapsed,
+            uri,
+            MA_SLOW_START_SECONDS,
+            timeout,
+        )
+
+    def _recent_slow_start(self) -> tuple[float, float] | None:
+        """``(seconds ago, how long it took)`` of a recent slow start (#2682).
+
+        None when there was none inside MA_THROTTLE_MEMORY_SECONDS — which is
+        the reading that says "the provider was answering promptly for the
+        other songs", i.e. this failure is about THIS track or the speaker.
+        """
+        if self._last_slow_start is None:
+            return None
+        when, elapsed = self._last_slow_start
+        ago = asyncio.get_event_loop().time() - when
+        if ago > MA_THROTTLE_MEMORY_SECONDS:
+            return None
+        return ago, elapsed
 
     def uri_candidates(self, song: dict[str, Any]) -> list[tuple[str | None, str]]:
         """
@@ -555,8 +688,9 @@ class MusicAssistantStrategy(PlaybackStrategy):
         # reported with the URI that was really tried.
         self.last_attempted_uri = uri
         # #1936: cold-start budget for the very first attempt of a game only.
+        first_play = self._first_play_pending
         timeout = MA_PLAYBACK_TIMEOUT * (
-            MA_FIRST_PLAY_TIMEOUT_FACTOR if self._first_play_pending else 1
+            MA_FIRST_PLAY_TIMEOUT_FACTOR if first_play else 1
         )
         self._first_play_pending = False
         _LOGGER.debug(
@@ -763,6 +897,7 @@ class MusicAssistantStrategy(PlaybackStrategy):
                     current.attributes.get("media_title", ""),
                     current.attributes.get("media_position", 0),
                 )
+                self._note_start_duration(elapsed, uri, timeout, first_play=first_play)
                 return True
 
             await asyncio.wait_for(confirmed.wait(), timeout=timeout)
@@ -774,6 +909,7 @@ class MusicAssistantStrategy(PlaybackStrategy):
                 final.attributes.get("media_title", "") if final else "?",
                 final.attributes.get("media_position", 0) if final else 0,
             )
+            self._note_start_duration(elapsed, uri, timeout, first_play=first_play)
             return True
         except asyncio.TimeoutError:
             pass
@@ -782,6 +918,12 @@ class MusicAssistantStrategy(PlaybackStrategy):
 
         current_state = await self.context.state_with_retry()
         speaker_state = current_state.state if current_state else "unknown"
+
+        # #2682: the one question this timeout cannot answer on its own —
+        # was the provider throttling us in this window? A slow but successful
+        # start inside MA_THROTTLE_MEMORY_SECONDS says yes, and nothing else
+        # available on this side of the boundary does. See _recent_slow_start.
+        slow = self._recent_slow_start()
 
         # Hard failure: speaker is idle/unavailable/off — song won't play
         if speaker_state in ("idle", "unavailable", "off", "unknown"):
@@ -804,17 +946,51 @@ class MusicAssistantStrategy(PlaybackStrategy):
                 )
                 self.last_failure_reason = "unavailable"
                 return False
+            if slow is not None:
+                # #2682: a rate-limited start used to be indistinguishable
+                # from a dead URI here — same deadline, same sentence, and the
+                # only place the difference showed was the Music Assistant
+                # add-on log. It is distinguishable now, because a recent
+                # start already ran long and finished: the provider was
+                # answering slowly in this window, so this timeout is very
+                # likely the same backoff one step further along its curve.
+                _LOGGER.error(
+                    "MA playback failed after %.1fs for %s (state: %s) — and a "
+                    "start %.0fs ago already took %.1fs, so Music Assistant's "
+                    "provider was backing off during this window. Read this as "
+                    "rate limiting, NOT as a missing track and NOT as a "
+                    "provider that needs re-authenticating: the schedule "
+                    "doubles (1s, 2s, 4s, 8s, ...) and a start that lands one "
+                    "step further along it outlasts any budget worth waiting "
+                    "in front of guests. Nothing to fix — confirm it in the "
+                    "Music Assistant add-on log by searching for 'Rate "
+                    "Limiter'. (#2682)",
+                    timeout,
+                    uri,
+                    speaker_state,
+                    slow[0],
+                    slow[1],
+                )
+                # Counts exactly as "error" does in state_lifecycle (only
+                # "unavailable" skips without counting), so the game behaves
+                # as it did: skip, and pause once
+                # MAX_CONSECUTIVE_PLAYBACK_FAILURES land in a row. The value
+                # is separate so the reason survives the boundary instead of
+                # being flattened into the same word as a dead speaker.
+                self.last_failure_reason = "rate_limited"
+                return False
             _LOGGER.error(
                 "MA playback failed after %.1fs for %s (state: %s). "
                 "Either the speaker is offline, MA's provider is unauthenticated, "
                 "or the track is not available in your provider's catalog. If this "
                 "happens for many tracks, re-authenticate your music provider in MA. "
-                "A rate-limiting provider looks the same from here — Music "
-                "Assistant then retries the track after its own backoff, which "
-                "can outlast this budget. (#1936)",
+                "No start in the last %.0fs ran long, so the provider was "
+                "answering promptly for the other songs — this is about this "
+                "track or this speaker, not about rate limiting. (#2682)",
                 timeout,
                 uri,
                 speaker_state,
+                MA_THROTTLE_MEMORY_SECONDS,
             )
             # Conservative: speaker-idle failures could be systemic (provider
             # broken across the board) so we keep counting them toward
@@ -869,19 +1045,51 @@ class MusicAssistantStrategy(PlaybackStrategy):
             # @Levtos hit this for `apple_music://track/302229811` (US-only
             # 'All Together Now' on a DE-storefront MA), and the iTunes
             # Lookup confirmed: track in US catalog, NOT in DE catalog.
-            _LOGGER.warning(
-                "MA playback failed after %.1fs for %s — speaker still on "
-                "prior track %r (position timestamp %s). Track is likely "
-                "not available in your provider's catalog/storefront, OR "
-                "your provider needs re-authentication in MA. Skipping "
-                "this song silently — game will try the next one. (#795)",
-                timeout,
-                uri,
-                title_before,
+            # #2682: this branch is where the two failures are easiest to
+            # confuse. "Speaker still on the prior track" is the storefront-gap
+            # signature #795 was filed for, but it is ALSO what a throttled
+            # start looks like from here: Music Assistant is still sleeping
+            # between retries, so it never swapped the track either. A recent
+            # slow-but-successful start is what separates them.
+            position_note = (
                 "advanced — prior track still playing"
                 if position_changed
-                else "also unchanged",
+                else "also unchanged"
             )
+            if slow is not None:
+                _LOGGER.warning(
+                    "MA playback failed after %.1fs for %s — speaker still on "
+                    "prior track %r (position timestamp %s). A start %.0fs ago "
+                    "already took %.1fs, so read this as Music Assistant's "
+                    "provider rate-limiting us rather than the track being "
+                    "missing from your catalog/storefront: MA is still sleeping "
+                    "between retries and has not swapped the track yet. Search "
+                    "the Music Assistant add-on log for 'Rate Limiter' to "
+                    "confirm. Skipping this song silently — the game will try "
+                    "the next one, and there is nothing to re-authenticate. "
+                    "(#795, #2682)",
+                    timeout,
+                    uri,
+                    title_before,
+                    position_note,
+                    slow[0],
+                    slow[1],
+                )
+            else:
+                _LOGGER.warning(
+                    "MA playback failed after %.1fs for %s — speaker still on "
+                    "prior track %r (position timestamp %s). No start in the "
+                    "last %.0fs ran long, so the provider was answering "
+                    "promptly: the track is likely not available in your "
+                    "provider's catalog/storefront, OR your provider needs "
+                    "re-authentication in MA. Skipping this song silently — "
+                    "game will try the next one. (#795, #2682)",
+                    timeout,
+                    uri,
+                    title_before,
+                    position_note,
+                    MA_THROTTLE_MEMORY_SECONDS,
+                )
             # #801: Hard-stop the speaker so the prior track doesn't keep
             # playing while the fallback cascade tries the next URI. Without
             # this, Levtos's setup heard 'Kill Bill' continuing for multiple

--- a/custom_components/beatify/services/playback/queue_restore.py
+++ b/custom_components/beatify/services/playback/queue_restore.py
@@ -90,10 +90,16 @@ MA_PAUSE_GUARD_WINDOW = 2 * MA_PAUSE_ATTEMPT_COST
 # `play_media` and proves only that nothing has started YET.
 #
 # The number has to outlive Music Assistant's Apple Music provider, which
-# throttles and retries on its own backoff: roughly 15.7s, documented in
-# `game/state_lifecycle.py`, and 14.6s measured on the live installation in
-# #2682. Counted from the end of MA_QUEUE_RESTORE_WAIT, this covers
-# 5 + 18 = 23s after the `play_media` went out.
+# throttles and retries on its own backoff — 14.6s measured on the live
+# installation in #2682. Counted from the end of MA_QUEUE_RESTORE_WAIT, this
+# covers 5 + 18 = 23s after the `play_media` went out.
+#
+# #2682 later derived the same 23s from MA's retry schedule rather than from a
+# single measurement (see MA_PLAYBACK_TIMEOUT: backoff to MA's fifth attempt
+# plus the speaker's own start is ~23s), so this window and the play budget now
+# cover the same point on the same curve. They are still separate numbers on
+# purpose: this one is bought with teardown latency the host is watching a
+# spinner for, so it is not raised in step when the play budget moves.
 #
 # It is bought with teardown latency — the admin's end-game round trip can sit
 # here for the whole 18s — and that is the deliberate trade: a spinner the host

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -2750,12 +2750,15 @@ class TestFirstPlayBudget:
     """#1936 — the first play of a game gets a third more time (cold speaker)."""
 
     def test_factor_is_derived_from_the_base_timeout(self):
+        """#2682 moved the base from 15s to 25s; the factor rides along."""
         from custom_components.beatify.services.playback.music_assistant import (  # noqa: PLC0415
             MA_FIRST_PLAY_TIMEOUT_FACTOR,
             MA_PLAYBACK_TIMEOUT,
         )
 
-        assert MA_PLAYBACK_TIMEOUT * MA_FIRST_PLAY_TIMEOUT_FACTOR == 20.0
+        assert MA_PLAYBACK_TIMEOUT * MA_FIRST_PLAY_TIMEOUT_FACTOR == pytest.approx(
+            33.33, abs=0.01
+        )
 
     def test_a_fresh_service_is_pending_its_first_play(self):
         svc = MediaPlayerService(

--- a/tests/unit/test_playback_budget_2682.py
+++ b/tests/unit/test_playback_budget_2682.py
@@ -1,0 +1,312 @@
+"""#2682 — the playback budget, and telling a throttled start from a dead URI.
+
+The live test of ``v4.4.3-rc1`` timed 23 playback starts on the real
+installation: median 4s to first audio, one at 14.6s against a 15.0s deadline.
+Nothing failed, which is the point — 0.4s of headroom is a measurement of how
+hard Apple happened to be throttling that minute, not a safety margin.
+
+Two things follow, and this file covers both:
+
+* the budget is now derived from Music Assistant's retry schedule instead of
+  from a round number, and
+* a start that was rate-limited no longer reads in Beatify's own log like a
+  track that does not exist.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.beatify.services.media_player import MediaPlayerService
+from custom_components.beatify.services.playback.music_assistant import (
+    MA_FIRST_PLAY_TIMEOUT_FACTOR,
+    MA_PLAYBACK_TIMEOUT,
+    MA_SLOW_START_SECONDS,
+    MA_THROTTLE_MEMORY_SECONDS,
+)
+
+# Music Assistant's Apple Music rate limiter sleeps 2^(N-1) - 1 seconds in
+# total before its Nth attempt. The live log showed 1.0s, 2.0s and 4.3s for a
+# nominal 1/2/4, so the real schedule runs about 7% above nominal.
+_JITTER = 4.3 / 4.0
+# What the failed API calls themselves cost by the time attempt 5 goes out
+# (~0.8s each, four of them).
+_FAILED_CALL_COST = 3.0
+# The speaker's own time to first audio, measured across the 23 starts.
+_WARM_SPEAKER = 4.0
+_COLD_SPEAKER = 10.1  # #1936, a speaker that had been idle a while
+
+
+def _ma_backoff_before_attempt(n: int) -> float:
+    """Seconds Music Assistant spends asleep before its ``n``-th attempt."""
+    return (2 ** (n - 1) - 1) * _JITTER
+
+
+def _make_state(
+    state: str = "idle",
+    media_title: str = "Old Song",
+    media_position: float = 0,
+    media_position_updated_at: str = "2020-01-01T00:00:00+00:00",
+) -> MagicMock:
+    mock = MagicMock()
+    mock.state = state
+    mock.attributes = {
+        "friendly_name": "Test Speaker",
+        "volume_level": 0.5,
+        "media_artist": "Test Artist",
+        "media_title": media_title,
+        "media_position": media_position,
+        "media_position_updated_at": media_position_updated_at,
+    }
+    return mock
+
+
+def _make_song(title: str = "New Song") -> dict:
+    return {
+        "title": title,
+        "artist": "Test Artist",
+        "uri": "spotify:track:abc123",
+        "_resolved_uri": "spotify:track:abc123",
+        "year": 1999,
+    }
+
+
+def _service(states) -> MediaPlayerService:
+    """A Music Assistant service whose speaker walks ``states``."""
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    poll = 0
+
+    def progression(*_args):
+        nonlocal poll
+        poll += 1
+        return states[0] if poll <= 1 else states[1]
+
+    hass.states.get = MagicMock(side_effect=progression)
+    return MediaPlayerService(hass, "media_player.test", platform="music_assistant")
+
+
+async def _play_and_time_out(svc: MediaPlayerService) -> bool:
+    """Run one play_song that is guaranteed to exhaust its budget."""
+    with (
+        patch(
+            "custom_components.beatify.services.media_player.asyncio.sleep",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "custom_components.beatify.services.playback.music_assistant."
+            "MA_PLAYBACK_TIMEOUT",
+            0.01,
+        ),
+    ):
+        return await svc.play_song(_make_song())
+
+
+class TestBudgetArithmetic:
+    """The budget is a point on Music Assistant's retry curve, not a round number."""
+
+    def test_it_covers_a_start_throttled_to_mas_fifth_attempt(self):
+        """~16.1s of backoff + ~3s of failed calls + a 4s warm start = ~23s."""
+        fifth = _ma_backoff_before_attempt(5) + _FAILED_CALL_COST + _WARM_SPEAKER
+        assert fifth == pytest.approx(23.1, abs=0.3)
+        assert MA_PLAYBACK_TIMEOUT > fifth
+
+    def test_it_stops_deliberately_short_of_the_sixth(self):
+        """The sixth attempt lands near 40s.
+
+        Waiting for it is the wrong trade: 40 seconds of silence in front of
+        guests is worse than skipping the song, and three of those in a row is
+        the two minutes before the game says anything at all.
+        """
+        sixth = _ma_backoff_before_attempt(6) + _FAILED_CALL_COST + _WARM_SPEAKER
+        assert sixth == pytest.approx(40.3, abs=0.4)
+        assert MA_PLAYBACK_TIMEOUT < sixth
+
+    def test_the_measured_start_gains_ten_seconds_of_headroom(self):
+        """The 14.6s start that produced the ticket had 0.4s left under 15s."""
+        assert MA_PLAYBACK_TIMEOUT - 14.6 == pytest.approx(10.4)
+
+    def test_the_first_play_budget_covers_a_cold_speaker_that_is_also_throttled(self):
+        """#1936's factor still earns its keep after #2682 raised the base.
+
+        A cold speaker (10.1s) throttled to the same fifth attempt is audible
+        at ~29s — past the ordinary budget, inside the first-play one.
+        """
+        first_play = MA_PLAYBACK_TIMEOUT * MA_FIRST_PLAY_TIMEOUT_FACTOR
+        cold_and_throttled = (
+            _ma_backoff_before_attempt(5) + _FAILED_CALL_COST + _COLD_SPEAKER
+        )
+        assert cold_and_throttled == pytest.approx(29.2, abs=0.4)
+        assert MA_PLAYBACK_TIMEOUT < cold_and_throttled < first_play
+
+    def test_the_slow_start_mark_sits_above_every_healthy_start(self):
+        """Twice the measured median: no warm start reaches it, every
+        throttled one does."""
+        assert MA_SLOW_START_SECONDS == pytest.approx(2 * _WARM_SPEAKER)
+        assert MA_SLOW_START_SECONDS < 14.6
+
+    def test_the_throttle_memory_outlives_the_gap_between_two_starts(self):
+        """A round is up to 60s of music and the reveal dwell up to a 90s
+        auto-advance, so a shorter memory would forget between rounds."""
+        assert MA_THROTTLE_MEMORY_SECONDS >= 60 + 90
+
+
+class TestSlowStartEvidence:
+    """A slow but SUCCESSFUL start is the only in-band throttling signal."""
+
+    @pytest.mark.asyncio
+    async def test_a_slow_start_warns_and_is_remembered(self, caplog):
+        svc = _service([_make_state("idle"), _make_state("idle")])
+        with caplog.at_level(logging.WARNING):
+            svc._strategy._note_start_duration(
+                14.6, "apple_music://track/1", 25.0, first_play=False
+            )
+        assert svc._strategy._recent_slow_start() is not None
+        assert "Rate Limiter" in caplog.text
+        assert "14.6" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_a_fast_start_says_nothing_and_arms_nothing(self, caplog):
+        svc = _service([_make_state("idle"), _make_state("idle")])
+        with caplog.at_level(logging.DEBUG):
+            svc._strategy._note_start_duration(
+                4.0, "apple_music://track/1", 25.0, first_play=False
+            )
+        assert svc._strategy._recent_slow_start() is None
+        assert "Rate Limiter" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_a_slow_first_play_is_not_evidence(self):
+        """#1936 measured a cold speaker at 10.1s with nothing throttling it.
+
+        Counting that would arm the throttle explanation at the start of every
+        single game, which would make it worthless.
+        """
+        svc = _service([_make_state("idle"), _make_state("idle")])
+        svc._strategy._note_start_duration(
+            11.0, "apple_music://track/1", 33.3, first_play=True
+        )
+        assert svc._strategy._recent_slow_start() is None
+
+    @pytest.mark.asyncio
+    async def test_the_evidence_expires(self):
+        """Throttling is a property of the minute; an hour-old slow start says
+        nothing about now."""
+        svc = _service([_make_state("idle"), _make_state("idle")])
+        now = asyncio.get_event_loop().time()
+        svc._strategy._last_slow_start = (now - MA_THROTTLE_MEMORY_SECONDS - 1, 14.6)
+        assert svc._strategy._recent_slow_start() is None
+
+
+class TestIdleTimeoutIsClassified:
+    """The speaker went idle. Was that Apple throttling, or a dead track?"""
+
+    @pytest.mark.asyncio
+    async def test_with_recent_evidence_it_reads_as_rate_limiting(self, caplog):
+        svc = _service([_make_state("idle"), _make_state("idle")])
+        svc._strategy._last_slow_start = (asyncio.get_event_loop().time(), 14.6)
+
+        with caplog.at_level(logging.ERROR):
+            assert await _play_and_time_out(svc) is False
+
+        assert svc.last_failure_reason == "rate_limited"
+        assert "Rate Limiter" in caplog.text
+        assert "re-authenticating" in caplog.text  # ...as the thing NOT to do
+
+    @pytest.mark.asyncio
+    async def test_without_evidence_it_stays_the_old_systemic_error(self, caplog):
+        svc = _service([_make_state("idle"), _make_state("idle")])
+
+        with caplog.at_level(logging.ERROR):
+            assert await _play_and_time_out(svc) is False
+
+        assert svc.last_failure_reason == "error"
+        assert "Rate Limiter" not in caplog.text
+        assert "answering promptly" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_rate_limited_behaves_exactly_as_error_did(self):
+        """#2682 changed the wording, not the game's behaviour.
+
+        ``state_lifecycle`` gives only ``"unavailable"`` the free skip, so the
+        new reason has to walk the counted path: skip, skip, pause. If it ever
+        stopped counting, a genuinely dead provider on a household that had one
+        slow start would never reach the recovery banner.
+        """
+        from custom_components.beatify.const import (  # noqa: PLC0415
+            MAX_CONSECUTIVE_PLAYBACK_FAILURES,
+        )
+        from custom_components.beatify.game.state import GameState  # noqa: PLC0415
+        from tests.conftest import make_game_state, make_songs  # noqa: PLC0415
+
+        gs: GameState = make_game_state()
+        gs.create_game(
+            playlists=["test.json"],
+            songs=make_songs(10),
+            media_player="media_player.test",
+            base_url="http://localhost:8123",
+        )
+        mock_service = MagicMock()
+        mock_service.is_available.return_value = True
+        mock_service.last_failure_reason = "rate_limited"
+        mock_service.play_song = AsyncMock(return_value=False)
+        gs._media_player_service = mock_service
+        gs.media_player = "media_player.test"
+        gs.platform = "music_assistant"
+        gs.pause_game = AsyncMock()
+
+        with patch(
+            "custom_components.beatify.game.state.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            assert await gs.start_round() is False
+
+        assert mock_service.play_song.await_count == MAX_CONSECUTIVE_PLAYBACK_FAILURES
+        gs.pause_game.assert_awaited_once_with("media_player_error")
+
+
+class TestStaleTitleTimeoutIsClassified:
+    """The hardest pair to tell apart: both leave the prior track playing."""
+
+    @staticmethod
+    def _stuck_speaker():
+        before = _make_state(
+            "playing",
+            media_title="Old Song",
+            media_position=100,
+            media_position_updated_at="2020-01-01T00:00:00+00:00",
+        )
+        after = _make_state(
+            "playing",
+            media_title="Old Song",  # never swapped
+            media_position=101,
+            media_position_updated_at="2020-01-01T00:00:05+00:00",
+        )
+        return [before, after]
+
+    @pytest.mark.asyncio
+    async def test_with_recent_evidence_it_names_the_rate_limiter(self, caplog):
+        svc = _service(self._stuck_speaker())
+        svc._strategy._last_slow_start = (asyncio.get_event_loop().time(), 14.6)
+
+        with caplog.at_level(logging.WARNING):
+            assert await _play_and_time_out(svc) is False
+
+        assert "Rate Limiter" in caplog.text
+        # Behaviour is unchanged — a skipped song either way (#795/#808).
+        assert svc.last_failure_reason == "unavailable"
+
+    @pytest.mark.asyncio
+    async def test_without_evidence_it_stays_the_storefront_gap(self, caplog):
+        svc = _service(self._stuck_speaker())
+
+        with caplog.at_level(logging.WARNING):
+            assert await _play_and_time_out(svc) is False
+
+        assert "Rate Limiter" not in caplog.text
+        assert "catalog/storefront" in caplog.text
+        assert svc.last_failure_reason == "unavailable"


### PR DESCRIPTION
Closes #2682

## The measurement

23 playback starts were timed on the real installation during the `v4.4.3-rc1` live test. Median 4 s to first audio, one at **14.6 s** against `MA_PLAYBACK_TIMEOUT = 15.0`. Nothing failed. That is the reason for the ticket: 0.4 s of headroom measures how hard Apple was throttling that minute, not how safe the deadline is.

## Decision 1 — the budget, from MA's retry curve

Music Assistant's Apple Music rate limiter slept 1.0 s, 2.0 s, 4.3 s on the way to that start, on an exponential schedule that runs to 8 attempts. Total sleep before its *N*-th attempt is `2^(N-1) - 1` seconds, and the 4.3 s logged for a nominal 4.0 s puts the real schedule about 7 % above nominal:

| attempt | asleep by then | + failed calls (~0.8 s each) | + speaker start (4 s warm) |
|---|---|---|---|
| 4 | 7.5 s | ~9.9 s | **~13.9 s** ← the run that produced this ticket (measured 14.6 s) |
| 5 | 16.1 s | ~19.1 s | **~23.1 s** |
| 6 | 33.3 s | ~36.3 s | **~40.3 s** |
| 7 | 67.7 s | — | — |

So the budget is set **past attempt 5 and deliberately short of attempt 6**: `MA_PLAYBACK_TIMEOUT = 25.0`.

- 25.0 clears the attempt-5 arrival (~23.1 s) with about 2 s to spare.
- The measured 14.6 s start goes from **0.4 s of headroom to 10.4 s**.
- Attempt 6 is abandoned on purpose. 40 seconds of silence in front of guests is worse for the room than skipping the song and drawing another one, and with `MAX_CONSECUTIVE_PLAYBACK_FAILURES = 3` the game would spend two minutes on it before saying anything.

The #1936 first-play factor (`4/3`) stays, and the new base is what makes it earn its keep again: a **cold** speaker (10.1 s, measured in #1936) that is *also* throttled to attempt 5 is audible at ~29.2 s — past 25.0, inside 33.3.

**What it costs.** A genuinely dead URI now waits 25 s instead of 15 before the cascade moves to the next candidate. That is the trade the issue asked for explicitly ("a longer deadline costs nothing when playback is fast"), and the failure it slows down is exactly the one decision 2 now names in the log.

## Decision 2 — a throttled start no longer reads like a dead URI

The two are not symmetric, and that asymmetry is the whole mechanism: **throttling produces something a dead URI never produces — a start that succeeds and takes far too long.** That is precisely the observation this ticket was written from, and until now it was only visible at DEBUG.

- `MA_SLOW_START_SECONDS = 8.0` (twice the measured median). A **confirmed** start past it is logged at `WARNING`, names the elapsed time and the budget, and points at `Rate Limiter` in the Music Assistant add-on log. The first play of a game is exempt from counting as evidence — #1936 measured a cold speaker at 10.1 s with nothing throttling it — but still gets an INFO line saying so.
- `MA_THROTTLE_MEMORY_SECONDS = 180.0`. A slow start stays evidence for three minutes: a round is up to 60 s of music and the reveal dwell up to a 90 s auto-advance, so anything shorter would forget between two consecutive starts and never fire.

**What the two now look like in Beatify's own log.**

Throttled — the speaker went idle:
> `MA playback failed after 25.0s for apple_music://track/… (state: idle) — and a start 74s ago already took 14.6s, so Music Assistant's provider was backing off during this window. Read this as rate limiting, NOT as a missing track and NOT as a provider that needs re-authenticating: … confirm it in the Music Assistant add-on log by searching for 'Rate Limiter'. (#2682)`

Dead URI — same idle speaker, no recent slow start:
> `MA playback failed after 25.0s for apple_music://track/… (state: idle). Either the speaker is offline, MA's provider is unauthenticated, or the track is not available in your provider's catalog. … No start in the last 180s ran long, so the provider was answering promptly for the other songs — this is about this track or this speaker, not about rate limiting. (#2682)`

The same split is applied to the #795 branch (speaker still on the prior track), which is the harder of the two to tell apart: a throttled MA is still asleep between retries, so it has not swapped the track either — identical from here, and previously reported as a catalogue/storefront gap in both cases.

A throttled idle timeout now carries `last_failure_reason = "rate_limited"`. `state_lifecycle` gives only `"unavailable"` a free skip, so this counts exactly as `"error"` did: skip, skip, pause. **Wording changed, behaviour did not** — asserted by a test, because a dead provider on a household that once had a slow start must still reach the recovery banner.

## Neighbouring deadlines checked

| Deadline | Interaction | Verdict |
|---|---|---|
| Round timer / `deadline` | Stamped by `_initialize_round` **after** `play_song` returns; `defer_deadline` re-stamps it the moment the song is audible | No overlap — a longer start does not eat the round's music |
| `ROUND_SUPERVISOR_INTERVAL_SECONDS` / `ROUND_OVERDUE_GRACE_SECONDS` (2 s / 2 s) | Backstop that only fires on an overdue deadline while the phase is `PLAYING`; during `play_song` the phase has not flipped yet | Unaffected |
| Auto-advance stall guard (`hard_cap`, 360 s in song-end mode) | Runs in REVEAL and *calls* `start_round`; the extra 10 s is spent inside the call, not against the cap | Still comfortable |
| TTS resume watchdog (`resume_after_announcement`) | Armed after `play_song` has already succeeded | No overlap |
| Announcement pre-wait (capped 8 s, × 0.8) | Runs before `play_media` goes out, unchanged | Unaffected |
| `MA_QUEUE_RESTORE_WAIT` + `MA_LATE_START_WATCH` (5 + 18 = 23 s) | Teardown path. Its comment already cited #2682's 14.6 s; 23 s turns out to be the same point on the same curve (attempt 5) that the new play budget targets | Left at 18 s on purpose — bought with a spinner the host is watching; comment updated to say the two are deliberately separate numbers |
| `MAX_CONSECUTIVE_PLAYBACK_FAILURES = 3` | Worst case to the pause banner grows from ~90 s to ~150 s for a truly dead provider | Accepted; the reasoning is now in `const.py` |
| `PLAYBACK_TIMEOUT = 8.0` (Sonos/Alexa) | Separate constant, untouched | Unaffected |

Also corrected: `const.py` and `state_lifecycle.py` both claimed MA "backs off ~15.7 s, longer than our own deadline", which stopped being true with this change.

## Checks (all from the worktree)

- `pytest tests/unit tests/integration -q` — **2642 passed, 2 skipped**
- `npm test` — **1011 passed** (99 files)
- `npm run build:check` — **all 16 artifacts and 78 .gz siblings match source**
- `python3 -m ruff format --check .` — **243 files already formatted** (`ruff check` also clean)

New: `tests/unit/test_playback_budget_2682.py` (15 tests) — the arithmetic above as executable assertions, the slow-start evidence rules (armed, not armed on a first play, expiring), and both timeout branches classified with and without evidence.

## Not done here

- The pause-recovery banner still says the same thing for a rate-limited pause as for a dead provider. `"rate_limited"` now reaches `state_lifecycle`, so the banner *could* say "your provider is throttling, just resume" — that is a translated UI surface and a separate ticket.
- The retry schedule is reconstructed from the live log (1.0 / 2.0 / 4.3, 8 attempts), not read out of Music Assistant's source. If MA caps its backoff (e.g. at 10 s per sleep) the curve is gentler than assumed and 25 s covers *more* than attempt 5, not less — the budget errs in the safe direction either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKsEKt68KHSqmi617XNCVi
