### PR TITLE
Delete GameState.start_game(), the third copy of the start gate (#2717)

### DIFF
--- a/custom_components/beatify/game/state.py
+++ b/custom_components/beatify/game/state.py
@@ -122,10 +122,10 @@ class GamePhase(Enum):
 # checked — a resume legitimately restores PAUSED→PLAYING / PAUSED→REVEAL.
 #
 # Edges (source → allowed targets):
-#   * LOBBY and END are valid targets from ANY phase — ``start_game`` /
+#   * LOBBY and END are valid targets from ANY phase — create_game /
 #     rematch / reset re-initialise to LOBBY from anywhere, and
 #     ``advance_to_end`` is a documented universal terminal.
-#   * LOBBY   → PLAYING            (start_game)
+#   * LOBBY   → PLAYING            (first round via ``_initialize_round``)
 #   * PLAYING → REVEAL, PAUSED     (reveal / pause)
 #   * REVEAL  → PLAYING, PAUSED    (next-round commit / pause)
 # Same-phase forward writes (LOBBY→LOBBY re-init, PLAYING→PLAYING next round)
@@ -215,8 +215,8 @@ class GameState(
     :class:`~custom_components.beatify.game.state_serialization.StateSerializationMixin`.
 
     The round-lifecycle / round-start subsystem (Issue #1271 next-increment
-    extraction, stacked on the state-serialization cut — the LOBBY→PLAYING
-    start gate (``start_game``) plus the full ``start_round`` orchestration
+    extraction, stacked on the state-serialization cut — the full
+    ``start_round`` orchestration
     (song selection, playback dispatch, metadata build, round-state commit) and
     its setup helpers (``_ensure_media_player_service``, ``_prepare_intro_round``,
     ``_build_round_metadata``, ``_initialize_round``); the round-*end* /

--- a/custom_components/beatify/game/state_lifecycle.py
+++ b/custom_components/beatify/game/state_lifecycle.py
@@ -6,15 +6,19 @@ the **round-start / round-setup orchestration** cluster is pulled out of the
 ``game/state.py`` God-Object into this ``RoundLifecycleMixin``.
 
 The cluster is the "kick off the game and set up each new round" half of the
-class: the LOBBY→PLAYING start gate plus the full ``start_round`` orchestration
-(song selection, playback dispatch, metadata build, round-state commit). It is
-**behavior-preserving**: it carries the exact same methods that previously
-lived on ``GameState``, so its public API and every caller / test are
-unchanged.
+class: the full ``start_round`` orchestration (song selection, playback
+dispatch, metadata build, round-state commit) and its setup helpers.
 
-* ``start_game`` — the LOBBY→PLAYING start gate: validates the phase and the
-  minimum player count, then flips to PLAYING (#390 precursor). Called by the
-  admin ``start_game`` WebSocket / view handlers.
+#2717: there used to be a ``start_game`` here as well — a synchronous
+LOBBY→PLAYING flip with its own phase + minimum-player gate. Nothing in
+production ever called it (both start paths go straight to ``start_round``),
+and it could not be adopted either: ``start_round`` keys the sabotage grant and
+the crate-digger pre-start hook on ``self.phase == GamePhase.LOBBY``, so
+flipping to PLAYING first would silently skip both. It is gone; the phase flip
+belongs to ``_initialize_round`` and the start gate to the two handlers a host
+actually reaches (``ws_handlers/admin.admin_start_game`` and
+``server/game_views.StartGameplayView``).
+
 * ``start_round`` — the round-start orchestrator (#390): pulls the next
   playable song from the :class:`PlaylistManager`, skips/retries songs with no
   provider URI (capped at ``MAX_SONG_RETRIES``), dispatches playback through
@@ -53,9 +57,9 @@ The mixin relies on attributes / methods the host class owns and that live on
 ``self`` at runtime:
 
 * ``self.phase`` / ``self._set_phase`` — phase read + the single transition
-  chokepoint used by ``start_game`` / ``start_round`` / ``_initialize_round``.
-* ``self.players`` — minimum-player-count gate (``start_game``) and the
-  per-player round reset list passed to ``RoundManager.initialize_round``.
+  chokepoint used by ``start_round`` / ``_initialize_round``.
+* ``self.players`` — the sabotage-grant recipients and the per-player round
+  reset list passed to ``RoundManager.initialize_round``.
 * ``self._playlist_manager`` — next-song selection, remaining-count
   (``last_round``) and ``mark_played`` for skipped songs.
 * ``self.provider`` / ``self.storefront`` / ``self.platform`` /
@@ -106,12 +110,7 @@ import asyncio
 import contextlib
 import logging
 
-from custom_components.beatify.const import (
-    ERR_GAME_ALREADY_STARTED,
-    ERR_GAME_NOT_STARTED,
-    MAX_CONSECUTIVE_PLAYBACK_FAILURES,
-    MIN_PLAYERS,
-)
+from custom_components.beatify.const import MAX_CONSECUTIVE_PLAYBACK_FAILURES
 
 from .playlist import get_playback_uri, get_song_uri
 
@@ -121,35 +120,10 @@ _LOGGER = logging.getLogger(__name__)
 class RoundLifecycleMixin:
     """Round-start / round-setup behavior for :class:`GameState`.
 
-    Carries the LOBBY→PLAYING start gate plus the full ``start_round``
-    orchestration and its round-setup helpers (#1271 extraction). See the
-    module docstring for the full attribute / method contract this mixin
-    expects on ``self`` at runtime.
+    Carries the full ``start_round`` orchestration and its round-setup
+    helpers (#1271 extraction). See the module docstring for the full
+    attribute / method contract this mixin expects on ``self`` at runtime.
     """
-
-    def start_game(self) -> tuple[bool, str | None]:
-        """
-        Start the game, transitioning from LOBBY to PLAYING.
-
-        Returns:
-            (success, error_code) - error_code is None on success
-
-        """
-        from .state import GamePhase
-
-        if self.phase != GamePhase.LOBBY:
-            return False, ERR_GAME_ALREADY_STARTED
-
-        if len(self.players) < MIN_PLAYERS:
-            return False, ERR_GAME_NOT_STARTED  # Need at least MIN_PLAYERS to play
-
-        self._set_phase(GamePhase.PLAYING)
-
-        self._grant_sabotage_tokens()
-
-        # Round and song selection will be implemented in Epic 4
-        _LOGGER.info("Game started: %d players", len(self.players))
-        return True, None
 
     def _grant_sabotage_tokens(self) -> None:
         """Hand every player their single sabotage token (#1665).
@@ -159,10 +133,11 @@ class RoundLifecycleMixin:
         short game. No-op when the setting is off, so default games are
         unchanged, and idempotent, so being called twice cannot hand out two.
 
-        #2497: this used to live inline in ``start_game()``, which no
-        production path calls — both real start paths go straight to
-        ``start_round()``. It is called from the LOBBY transition there as well
-        now, and lives in its own method so the two callers cannot drift.
+        #2497: this used to live inline in a ``start_game()`` that no
+        production path called — both real start paths go straight to
+        ``start_round()``. The grant moved to the LOBBY transition there;
+        #2717 then deleted ``start_game()`` itself, so this method now has a
+        single caller and the drift it was factored out to prevent is gone.
         """
         if not self.sabotage_enabled:
             return
@@ -252,11 +227,12 @@ class RoundLifecycleMixin:
         # the worst case is the room keeping its creation-time songs.
         # #2497: the sabotage grant belongs to the LOBBY -> first-round
         # transition, and this is the only place both start paths pass through.
-        # It used to sit in start_game(), which nothing in production calls: the
-        # websocket admin handler and the REST start view both call start_round()
-        # directly and the phase flip happens inside _initialize_round. Same
-        # reasoning as the pre-start hook below, which is here for exactly that
-        # reason.
+        # It used to sit in a start_game() that nothing in production called
+        # (#2717 deleted it): the websocket admin handler and the REST start
+        # view both call start_round() directly and the phase flip happens
+        # inside _initialize_round. Note that this guard and the pre-start hook
+        # below both read GamePhase.LOBBY — any caller that flipped the phase
+        # before start_round would skip the grant AND the crate-digger hook.
         if self.phase == GamePhase.LOBBY and _retry_count == 0:
             self._grant_sabotage_tokens()
 

--- a/custom_components/beatify/server/game_views.py
+++ b/custom_components/beatify/server/game_views.py
@@ -1273,11 +1273,13 @@ class StartGameplayView(BeatifyAdminView):
         if game_state.phase != GamePhase.LOBBY:
             return _json_error("Game already started", 409, code="INVALID_PHASE")
 
-        # #2497: the minimum-player floor. It used to live in
-        # GameState.start_game(), which no production path calls, so a game
+        # #2497: the minimum-player floor. It used to live in a
+        # GameState.start_game() that no production path called, so a game
         # could be started alone. Enforced at the two places a *user* starts a
         # game — here and in the websocket admin handler — rather than inside
         # start_round(), which runs for every round of every game.
+        # #2717 deleted start_game() and its third, unreachable copy of this
+        # gate, which returned error codes no client ever saw.
         if len(game_state.players) < MIN_PLAYERS:
             return _json_error(
                 f"Need at least {MIN_PLAYERS} players to start",

--- a/custom_components/beatify/server/ws_handlers/admin.py
+++ b/custom_components/beatify/server/ws_handlers/admin.py
@@ -134,11 +134,13 @@ async def admin_start_game(
         )
         return
 
-    # #2497: the minimum-player check used to live in GameState.start_game(),
-    # which no production path calls — so a game could be started with a single
+    # #2497: the minimum-player check used to live in a GameState.start_game()
+    # that no production path called — so a game could be started with a single
     # player. It belongs here rather than inside start_round(): start_round runs
     # for every round of every game, while this is a property of *starting* one,
     # and only here is there a socket to tell the host why nothing happened.
+    # #2717 deleted start_game(), so this and StartGameplayView are now the only
+    # two copies of the floor, one per surface a host can start a game from.
     if len(game_state.players) < MIN_PLAYERS:
         await ws.send_json(
             {

--- a/tests/integration/test_round_flow.py
+++ b/tests/integration/test_round_flow.py
@@ -4,7 +4,7 @@ Issue #1587: ``tests/integration/`` held only ``test_placeholder.py`` (skipped
 WebSocket stubs from #197). The most load-bearing untested path is the *round
 lifecycle* — the seam where the #1271 mixins cooperate: ``GameSetupMixin``
 (create), ``PlayerLifecycleMixin`` (join), ``RoundLifecycleMixin``
-(start_game), ``RoundScoringMixin`` + ``ScoringService`` (end_round scoring),
+(start_round), ``RoundScoringMixin`` + ``ScoringService`` (end_round scoring),
 and ``LeaderboardMixin`` (ranking). ``test_state.py`` exercises only the
 *resilience* of ``end_round`` (one player throwing); it never asserts the
 **happy-path scoring outcome** of a real round driven through the public API.
@@ -18,7 +18,7 @@ plus the pure ``ScoringService`` make the flow fully deterministic.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -47,14 +47,28 @@ def _begin_round(state, *, year: int) -> None:
     state.phase = GamePhase.PLAYING
 
 
-def _setup_started_game(*names: str):
-    """Create a game, join ``names``, and start it — returns the GameState."""
+async def _setup_started_game(*names: str):
+    """Create a game, join ``names``, and start it — returns the GameState.
+
+    #2717: this used to call ``GameState.start_game()``, so the "start" leg of
+    the flow this module claims to cover was a synchronous phase flip no host
+    ever reaches. It now drives ``start_round()``, the method both the
+    websocket admin handler and the REST start view call, with only the media
+    player stubbed out. ``_begin_round`` still pins the song afterwards so the
+    scoring assertions stay deterministic.
+    """
     state = make_game_state()
     _create_fresh_game(state)
+    media = MagicMock()
+    media.is_available.return_value = True
+    media.play_song = AsyncMock(return_value=True)
+    media.verify_responsive = AsyncMock(return_value=(True, None))
+    state._media_player_service = media
+    state.platform = "music_assistant"
     for name in names:
         state.add_player(name, MagicMock())
-    started, _ = state.start_game()
-    assert started is True
+    assert await state.start_round() is True
+    assert state.phase == GamePhase.PLAYING
     return state
 
 
@@ -69,7 +83,7 @@ class TestSingleRoundScoring:
         """A full round: exact guess > near guess > far miss, and the phase
         transitions to REVEAL with the broadcast callback fired exactly once.
         """
-        state = _setup_started_game("Alice", "Bob", "Carol")
+        state = await _setup_started_game("Alice", "Bob", "Carol")
         broadcast = MagicMock()
 
         async def _broadcast() -> None:
@@ -102,7 +116,7 @@ class TestSingleRoundScoring:
     async def test_non_submitter_scores_zero_and_is_marked_missed(self):
         """A player who never submits earns nothing and is recorded as a miss
         in the shareable round_results card (#120)."""
-        state = _setup_started_game("Alice", "Bob")
+        state = await _setup_started_game("Alice", "Bob")
         _begin_round(state, year=2000)
         state.get_player("Alice").submit_guess(2000, state._now())
         # Bob stays silent.
@@ -127,7 +141,7 @@ class TestMultiRoundLeaderboard:
         """Two rounds with a lead change: scores accumulate and the leaderboard
         reports the rank movement (previous_rank -> rank_change) from round 1.
         """
-        state = _setup_started_game("Alice", "Bob")
+        state = await _setup_started_game("Alice", "Bob")
 
         # Round 1: Bob nails it, Alice is far off -> Bob leads.
         _begin_round(state, year=1990)
@@ -168,7 +182,7 @@ class TestMultiRoundLeaderboard:
     async def test_final_leaderboard_reflects_played_game(self):
         """After a played round the final leaderboard carries the end-of-game
         stat block and ranks players by their accumulated score."""
-        state = _setup_started_game("Alice", "Bob")
+        state = await _setup_started_game("Alice", "Bob")
         _begin_round(state, year=1990)
         state.get_player("Alice").submit_guess(1990, state._now())
         state.get_player("Bob").submit_guess(1995, state._now())

--- a/tests/unit/test_collection_2324.py
+++ b/tests/unit/test_collection_2324.py
@@ -27,11 +27,14 @@ from tests.conftest import make_game_state, make_player, make_songs
 
 
 def _started_game(*names: str, difficulty: str = "normal"):
-    """Start a game with ``names`` plus a silent extra player.
+    """Build a game with ``names`` plus a silent extra player.
 
-    ``MIN_PLAYERS`` is 2, so a one-player test still needs a body in the room.
     "Nobody" never submits, so it never collects and never affects a threshold
-    assertion — it exists only to clear the start gate.
+    assertion. It was added because ``MIN_PLAYERS`` is 2 and the old
+    ``start_game()`` shortcut refused a one-player room; #2717 deleted that
+    method (nothing in production called it) and ``_begin_round`` below owns
+    the PLAYING flip anyway. The extra body stays so the fixture shape — and
+    every round_results / leaderboard assertion built on it — is unchanged.
     """
     state = make_game_state()
     state.create_game(
@@ -43,8 +46,6 @@ def _started_game(*names: str, difficulty: str = "normal"):
     state.difficulty = difficulty
     for name in (*names, "Nobody"):
         state.add_player(name, MagicMock())
-    started, _ = state.start_game()
-    assert started is True
     return state
 
 

--- a/tests/unit/test_join_reject_1696.py
+++ b/tests/unit/test_join_reject_1696.py
@@ -136,9 +136,9 @@ class TestRejectPreservesReconnectedPlayer:
 
         game_state.add_player("Alice", _make_ws())
         game_state.get_player("Alice").score = 900
-        # Need a second player so the game can start.
+        # Need a second player so the game looks like a real, running room.
         game_state.add_player("Bob", _make_ws())
-        game_state.start_game()
+        game_state.phase = GamePhase.PLAYING
         assert game_state.phase != GamePhase.LOBBY
 
         _disconnect(game_state, "Alice")

--- a/tests/unit/test_sabotage_1665.py
+++ b/tests/unit/test_sabotage_1665.py
@@ -21,7 +21,7 @@ Guarantees under test:
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from custom_components.beatify.const import (
     ERR_CANNOT_SABOTAGE_SELF,
@@ -71,6 +71,19 @@ def _make_game(names, **create_kwargs):
     return state
 
 
+def _startable_game(**create_kwargs):
+    """A LOBBY game whose media player is stubbed, so ``start_round`` runs."""
+    state = make_game_state()
+    _create_fresh_game(state, **create_kwargs)
+    media = MagicMock()
+    media.is_available.return_value = True
+    media.play_song = AsyncMock(return_value=True)
+    media.verify_responsive = AsyncMock(return_value=(True, None))
+    state._media_player_service = media
+    state.platform = "music_assistant"
+    return state
+
+
 def _roll(effect):
     """An ``effect_roll`` chooser that always returns ``effect`` (test injection)."""
     return lambda _effects: effect
@@ -82,22 +95,34 @@ def _roll(effect):
 
 
 class TestTokenHandout:
-    def test_token_handed_out_when_enabled(self):
-        state = make_game_state()
-        _create_fresh_game(state, sabotage_enabled=True)
+    """The handout on the path a host actually takes.
+
+    These two used to drive ``GameState.start_game()``. That method granted the
+    tokens itself, and nothing in production called it — which is exactly how
+    #2497 shipped a sabotage setting that handed out nothing while these tests
+    stayed green. #2717 deleted the method; the assertions now run against
+    ``start_round()``, the LOBBY transition both real start paths go through.
+    """
+
+    async def test_token_handed_out_when_enabled(self):
+        state = _startable_game(sabotage_enabled=True)
         state.add_player("Alice", MagicMock())
         state.add_player("Bob", MagicMock())
-        ok, err = state.start_game()
-        assert ok is True and err is None
+        assert state.get_player("Alice").sabotage_available is False
+
+        assert await state.start_round() is True
+
+        assert state.phase == GamePhase.PLAYING
         assert state.get_player("Alice").sabotage_available is True
         assert state.get_player("Bob").sabotage_available is True
 
-    def test_no_token_when_disabled(self):
-        state = make_game_state()
-        _create_fresh_game(state, sabotage_enabled=False)
+    async def test_no_token_when_disabled(self):
+        state = _startable_game(sabotage_enabled=False)
         state.add_player("Alice", MagicMock())
         state.add_player("Bob", MagicMock())
-        state.start_game()
+
+        assert await state.start_round() is True
+
         assert state.get_player("Alice").sabotage_available is False
         assert state.get_player("Bob").sabotage_available is False
 

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -11,10 +11,8 @@ import pytest
 from custom_components.beatify.const import (
     DOMAIN,
     ERR_CANNOT_STEAL_SELF,
-    ERR_GAME_ALREADY_STARTED,
     ERR_GAME_ENDED,
     ERR_GAME_FULL,
-    ERR_GAME_NOT_STARTED,
     ERR_INVALID_ACTION,
     ERR_NAME_INVALID,
     ERR_NAME_TAKEN,
@@ -22,6 +20,7 @@ from custom_components.beatify.const import (
     ERR_NOT_IN_GAME,
     ERR_TARGET_NOT_SUBMITTED,
     MAX_PLAYERS,
+    MIN_PLAYERS,
     SUDDEN_DEATH_MIN_PLAYERS,
 )
 from custom_components.beatify.game.state import (
@@ -632,44 +631,6 @@ class TestAddPlayer:
 
 
 # ---------------------------------------------------------------------------
-# GameState.start_game
-# ---------------------------------------------------------------------------
-
-
-class TestStartGame:
-    def setup_method(self):
-        self.state = make_game_state()
-        _create_fresh_game(self.state)
-
-    def test_start_with_players(self):
-        self.state.add_player("Alice", MagicMock())
-        self.state.add_player("Bob", MagicMock())
-        ok, err = self.state.start_game()
-        assert ok is True
-        assert err is None
-        assert self.state.phase == GamePhase.PLAYING
-
-    def test_start_with_one_player_rejected(self):
-        self.state.add_player("Alice", MagicMock())
-        ok, err = self.state.start_game()
-        assert ok is False
-        assert err == ERR_GAME_NOT_STARTED
-
-    def test_start_with_no_players(self):
-        ok, err = self.state.start_game()
-        assert ok is False
-        assert err == ERR_GAME_NOT_STARTED
-
-    def test_double_start_rejected(self):
-        self.state.add_player("Alice", MagicMock())
-        self.state.add_player("Bob", MagicMock())
-        self.state.start_game()
-        ok, err = self.state.start_game()
-        assert ok is False
-        assert err == ERR_GAME_ALREADY_STARTED
-
-
-# ---------------------------------------------------------------------------
 # GameState.all_submitted
 # ---------------------------------------------------------------------------
 
@@ -1261,7 +1222,6 @@ def _setup_playing_game(state: GameState) -> None:
     ws = MagicMock()
     state.add_player("Admin", ws)
     state.set_admin("Admin")
-    state.start_game()
     state.phase = GamePhase.PLAYING
     state.deadline = int(state._now() * 1000) + 30_000  # 30s remaining
 
@@ -1546,7 +1506,7 @@ class TestEndRoundResilience:
         _create_fresh_game(self.state)
         self.state.add_player("Alice", MagicMock())
         self.state.add_player("Bob", MagicMock())
-        self.state.start_game()
+        self.state.phase = GamePhase.PLAYING
         # Set up a current song so end_round has correct_year context.
         self.state.current_song = {
             "title": "Test Song",
@@ -1628,7 +1588,7 @@ class TestTimerExpiryNoSubmissions:
         _create_fresh_game(self.state)
         self.state.add_player("Alice", MagicMock())
         self.state.add_player("Bob", MagicMock())
-        self.state.start_game()
+        self.state.phase = GamePhase.PLAYING
         self.state.current_song = {
             "title": "Test Song",
             "artist": "Test Artist",
@@ -1939,7 +1899,6 @@ class TestStartRoundGhostRoundGuard:
         state.add_player("Admin", MagicMock())
         state.add_player("Bob", MagicMock())
         state.set_admin("Admin")
-        state.start_game()  # LOBBY -> PLAYING (needs MIN_PLAYERS)
         state.phase = GamePhase.PLAYING
         # music_assistant platform skips the verify_responsive branch so the
         # only await before _initialize_round is play_song.
@@ -2141,7 +2100,6 @@ class TestMetadataCoroNoLeak:
         _create_fresh_game(state)
         state.add_player("Admin", MagicMock())
         state.set_admin("Admin")
-        state.start_game()
 
         # Force the intro-splash deferral path and a present media player.
         state._media_player_service = AsyncMock()
@@ -2169,7 +2127,6 @@ class TestEndGameSerializesWithRoundEnd:
         _create_fresh_game(state)
         state.add_player("Admin", MagicMock())
         state.set_admin("Admin")
-        state.start_game()
         state.phase = GamePhase.PLAYING
 
         order = []
@@ -2651,6 +2608,100 @@ class TestSuddenDeathLiveToggle:
         assert state._apply_sudden_death_elimination() == []
         # ...but Alice, already eliminated, stays out.
         assert state.get_player("Alice").eliminated is True
+
+
+class TestStartGameplayFloor:
+    """The minimum-player gate on the REST start path (#2717).
+
+    These four cases used to live in a ``TestStartGame`` class that drove
+    ``GameState.start_game()`` — a method no production path called. The gate
+    they were asserting was a third copy, with error codes (``(False,
+    ERR_GAME_NOT_STARTED)``) no client ever received. The floor a host actually
+    meets is this view's 409 ``NOT_ENOUGH_PLAYERS`` and the websocket handler's
+    error frame (covered in ``test_sabotage_start_path_2497.py``), so the cases
+    were repointed here rather than deleted.
+
+    ``start_round`` is stubbed for the same reason ``TestSuddenDeathStartFloor``
+    below stubs it: only the gate is under test, not the first-round machinery.
+    """
+
+    def _hass(self, state: GameState) -> MagicMock:
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"game": state}}  # no ws_handler
+        return hass
+
+    @patch(
+        "custom_components.beatify.server.game_views.is_authorized_http",
+        return_value=True,
+    )
+    async def test_start_at_the_floor_is_allowed(self, _auth):
+        state = make_game_state()
+        _create_fresh_game(state)
+        for i in range(MIN_PLAYERS):
+            _add_live_player(state, f"P{i}")
+        state.start_round = AsyncMock(return_value=True)
+
+        resp = await StartGameplayView(self._hass(state)).post(MagicMock())
+
+        assert resp.status == 200
+        state.start_round.assert_awaited_once()
+
+    @patch(
+        "custom_components.beatify.server.game_views.is_authorized_http",
+        return_value=True,
+    )
+    async def test_one_short_of_the_floor_is_refused(self, _auth):
+        state = make_game_state()
+        _create_fresh_game(state)
+        for i in range(MIN_PLAYERS - 1):
+            _add_live_player(state, f"P{i}")
+        state.start_round = AsyncMock(return_value=True)
+
+        resp = await StartGameplayView(self._hass(state)).post(MagicMock())
+        body = json.loads(resp.body)
+
+        assert resp.status == 409
+        assert body["code"] == "NOT_ENOUGH_PLAYERS"
+        # The message names the floor, so raising MIN_PLAYERS cannot leave the
+        # host reading the old number (same guarantee as #2699's warning).
+        assert str(MIN_PLAYERS) in body["message"]
+        assert state.phase == GamePhase.LOBBY
+        state.start_round.assert_not_awaited()
+
+    @patch(
+        "custom_components.beatify.server.game_views.is_authorized_http",
+        return_value=True,
+    )
+    async def test_empty_lobby_is_refused(self, _auth):
+        state = make_game_state()
+        _create_fresh_game(state)
+        state.start_round = AsyncMock(return_value=True)
+
+        resp = await StartGameplayView(self._hass(state)).post(MagicMock())
+
+        assert resp.status == 409
+        assert json.loads(resp.body)["code"] == "NOT_ENOUGH_PLAYERS"
+        assert state.phase == GamePhase.LOBBY
+        state.start_round.assert_not_awaited()
+
+    @patch(
+        "custom_components.beatify.server.game_views.is_authorized_http",
+        return_value=True,
+    )
+    async def test_starting_an_already_started_game_is_refused(self, _auth):
+        """The double-start case: the phase gate fires before the floor."""
+        state = make_game_state()
+        _create_fresh_game(state)
+        for i in range(MIN_PLAYERS):
+            _add_live_player(state, f"P{i}")
+        state._set_phase(GamePhase.PLAYING)
+        state.start_round = AsyncMock(return_value=True)
+
+        resp = await StartGameplayView(self._hass(state)).post(MagicMock())
+
+        assert resp.status == 409
+        assert json.loads(resp.body)["code"] == "INVALID_PHASE"
+        state.start_round.assert_not_awaited()
 
 
 class TestSuddenDeathStartFloor:

--- a/tests/unit/test_websocket.py
+++ b/tests/unit/test_websocket.py
@@ -235,7 +235,6 @@ class TestJoin:
         game_state.add_player("Host", admin_ws)
         game_state.set_admin("Host")
         game_state.add_player("Player2", _make_ws())
-        game_state.start_game()
         # Simulate admin disconnect and game pause
         game_state.get_player("Host").connected = False
         game_state.phase = GamePhase.PAUSED


### PR DESCRIPTION
`GameState.start_game()` carried a third copy of the minimum-players gate, and nothing in production called it. #2739 gave `SUDDEN_DEATH_MIN_PLAYERS` a single home in `const.py`; this is the same defect one level up — not a copied *number* (`MIN_PLAYERS` was already shared) but a copied *gate*, on a method no host can reach.

## The method is gone, not adopted

The obvious alternative was to make the production path call it. It cannot: `start_round()` keys **two** things on `self.phase == GamePhase.LOBBY` — the #2497 sabotage grant and the crate-digger `pre_start_hook` (regenerate songs from current settings, re-apply persisted output settings). `start_game()` flips to PLAYING *before* the round. Inserting it ahead of `start_round()` would silently skip both. So it was not merely unadopted, it was unadoptable, and this PR deletes it rather than inventing a mechanism beside the two live gates.

The two gates that remain are one per surface a host can start from — `admin_start_game` (websocket) and `StartGameplayView` (REST). Merging them into a shared predicate was considered and rejected: they diverge on what surrounds the check, not on the check itself (a `game_starting` transient broadcast and a socket error frame on one side; the Sudden Death floor, callback wiring and a 409 body on the other), and both already read `MIN_PLAYERS` from `const.py`, so the number cannot drift. The gate count is down from three to two, which is the number of surfaces.

## How the two had drifted

`start_game()` was a synchronous phase flip. The real path is `await start_round()`, which flips inside `_initialize_round` *after* a song is chosen and playback has been dispatched. A game "started" through `start_game()` was PLAYING with `round` still 0, no `current_song`, no deadline and no timer — a state no real game passes through. Beyond that it skipped the pre-start hook, the #1697 round-start lock and the song skip/retry machinery; and on the REST side the Sudden Death floor, the round-end / game-end / metadata callbacks, and on the websocket side the `game_starting` loader signal.

The error surfaces had drifted too, which is the part that mattered for the gate:

| | `start_game()` | websocket | REST |
|---|---|---|---|
| already started | `(False, ERR_GAME_ALREADY_STARTED)` | `ERR_INVALID_ACTION` | 409 `INVALID_PHASE` |
| below the floor | `(False, ERR_GAME_NOT_STARTED)` | `ERR_GAME_NOT_STARTED` frame | 409 `NOT_ENOUGH_PLAYERS` |

Four tests asserted the left column. No client has ever seen it.

## Every test whose coverage changed

**Stronger — 3 sites**

- `test_state.py` `TestStartGame` → `TestStartGameplayFloor`. The four cases (at the floor / one short / empty lobby / double start) now drive `StartGameplayView`. The REST minimum-player gate had **no test at all** before this — `test_sabotage_start_path_2497.py` covers only the websocket side, and `TestSuddenDeathStartFloor` covers only the Sudden Death floor. The one-short case additionally asserts `MIN_PLAYERS` appears in the message, the guarantee #2739 gave the Sudden Death warning. Verified red: deleting the gate from `game_views.py` fails 2 of the 4.
- `test_sabotage_1665.py` `TestTokenHandout` (2 tests) now drive `await start_round()` with a stubbed media player. This is the class that stayed green through #2497 while production handed out nothing, precisely because `start_game()` granted the tokens itself. Verified red: disarming the LOBBY grant in `_start_round_locked` fails `test_token_handed_out_when_enabled`. It overlaps `test_sabotage_start_path_2497.py` by design — that file owns the regression, this one owns the feature.
- `tests/integration/test_round_flow.py` `_setup_started_game` is now async and drives the real `start_round()`. The module docstring claimed a "create → join → start → submit → end_round" flow "exactly as the WebSocket layer would"; the start leg was the dead method. It is now the real one, and asserts PLAYING. `_begin_round` still pins the song afterwards so scoring stays deterministic.

**Unchanged — 6 sites.** Four were already no-ops: `test_state.py:1264` (`_setup_playing_game`), `:2144`, `:2172` and `test_websocket.py:238` called `start_game()` with a single player, so it returned `False` and never flipped anything — the explicit `state.phase = GamePhase.PLAYING` on the following line (or, at `:2144`, `start_round()` running from LOBBY) was doing all the work. `test_state.py:1942` did flip, then re-asserted the same phase on the next line. Removing the calls is a no-op in all five. `test_state.py:1549`/`:1631` and `test_join_reject_1696.py:141` used it purely to leave LOBBY; they now write the phase directly, the idiom the rest of those files already use.

**Weaker — none.** The one judgement call is `test_collection_2324.py`: its `_started_game` adds a silent "Nobody" player whose stated purpose was clearing the start gate. With the gate gone the filler is no longer required, but removing it would change player counts under every `round_results` / leaderboard / emoji-grid assertion in the file. It stays, and the docstring now says why.

## Checks

- `pytest tests/unit tests/integration -q` → 2638 passed, 2 skipped
- `npm test` → 101 files, 1036 tests passed
- `npm run build:check` → all 16 artifacts and 79 `.gz` siblings match source
- `python3 -m ruff format --check .` → 243 files already formatted (`ruff check` clean)

No shipped behaviour changes: the deleted method had no production caller, and no `www/js` artifact was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKsEKt68KHSqmi617XNCVi
