### PR TITLE
Separate the game's promises from the speaker's own state (#2678)

### DIFF
--- a/custom_components/beatify/services/media_player.py
+++ b/custom_components/beatify/services/media_player.py
@@ -40,6 +40,7 @@ from .playback import (
     uri_match_tokens,
 )
 from .playback.base import PLAYBACK_TIMEOUT
+from .speaker_promises import SpeakerPromises
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -258,6 +259,13 @@ class MediaPlayerService:
         self._hass = hass
         self._entity_id = entity_id
         self._analytics: AnalyticsStorage | None = None
+
+        # #179: this speaker answered a ping, so later rounds can skip the
+        # blocking pre-flight. THIS SPEAKER'S lifetime, and therefore the
+        # service's: the service is thrown away and rebuilt when the entity or
+        # platform changes, and the new speaker has to prove itself again.
+        # Everything with the GAME's lifetime lives in `_promises` below
+        # instead of alongside this flag (#2678).
         self._preflight_verified: bool = False
 
         # #2636: everything platform-specific now lives behind one interface.
@@ -280,42 +288,13 @@ class MediaPlayerService:
         self._strategy = build_strategy(self._context)
         self._restorer = MaQueueRestorer(hass)
 
-        # #1516: the speaker's volume as it was BEFORE Beatify first changed it
-        # this game. Captured once (via save_volume) on the first in-game volume
-        # change so the host's original listening level can be handed back at
-        # game end. None = nothing to restore (Beatify never touched the volume).
-        self._saved_volume: float | None = None
-
-        # #2143: what the speaker was playing before Beatify claimed the queue.
-        # The MA strategy sends `enqueue: "replace"`, which wipes whatever the
-        # host had queued — in EVERY round, for every Music Assistant user,
-        # whether or not they use Crate Digger. Captured once per game (like
-        # `_saved_volume`) and handed back at game end.
-        #
-        # Three shapes, deliberately distinct:
-        #   None — not captured yet (or already restored)
-        #   {}   — captured, but the speaker was idle: nothing to hand back
-        #   {…}  — the track, its position, shuffle and repeat mode
-        #
-        # What CANNOT be captured: the queue behind the current track. MA's
-        # `get_queue` reports `items` as a COUNT, not a list, and exposes only
-        # `current_item` / `next_item` — measured against a live queue on
-        # 2026-08-13. Restoring "the first entry with replace, the rest with
-        # add" (the original plan in #2143) is therefore not implementable.
-        self._saved_queue: dict[str, Any] | None = None
-
-        # Speakers this game already touched and then switched away from —
-        # {entity_id: {"volume": …, "queue": …}}. Our OWN entity's snapshot is
-        # adopted into the fields above instead of living here, so a switch
-        # back to a speaker does not re-capture an already-Beatify-altered
-        # level as if it were the host's original.
-        self._inherited_states: dict[str, dict[str, Any]] = {
-            eid: dict(snap) for eid, snap in (inherited_states or {}).items()
-        }
-        own_snapshot = self._inherited_states.pop(entity_id, None)
-        if own_snapshot:
-            self._saved_volume = own_snapshot.get("volume")
-            self._saved_queue = own_snapshot.get("queue")
+        # #2678: the host's pre-game volume (#1516) and pre-game queue (#2143)
+        # belong to the GAME, not to this service. They outlive every speaker
+        # switch and every service rebuild, so they live in their own object —
+        # the one thing that is handed over when this service is replaced. See
+        # `speaker_promises.SpeakerPromises` for what each field means and why
+        # its hand-over has to be lossless.
+        self._promises = SpeakerPromises(entity_id, inherited_states)
 
     @property
     def _platform(self) -> str:
@@ -377,16 +356,11 @@ class MediaPlayerService:
         Mirrors ``PartyLightsService.snapshot_saved_states``: a mid-game
         speaker switch discards this service, and the caller hands the result
         of this method to the replacement so the promise survives the switch.
+
+        The promises themselves know how to serialise (#2678) — including the
+        empty queue capture, which a truthiness test used to drop.
         """
-        states = {eid: dict(snap) for eid, snap in self._inherited_states.items()}
-        own: dict[str, Any] = {}
-        if self._saved_volume is not None:
-            own["volume"] = self._saved_volume
-        if self._saved_queue:
-            own["queue"] = dict(self._saved_queue)
-        if own:
-            states[self._entity_id] = own
-        return states
+        return self._promises.snapshot()
 
     def save_volume(self) -> None:
         """Remember the speaker's current volume for later restore (#1516).
@@ -397,8 +371,8 @@ class MediaPlayerService:
         one. ``restore_volume`` clears the capture, so the next game re-captures
         fresh.
         """
-        if self._saved_volume is None:
-            self._saved_volume = self.get_volume()
+        if self._promises.volume is None:
+            self._promises.volume = self.get_volume()
 
     async def restore_volume(self) -> bool:
         """Restore the volume captured by :meth:`save_volume` (#1516).
@@ -412,19 +386,16 @@ class MediaPlayerService:
             nothing to restore (Beatify never changed any volume this game).
         """
         applied = False
-        for entity_id, snapshot in list(self._inherited_states.items()):
-            level = snapshot.pop("volume", None)
-            if level is None:
-                continue
+        # Every promise is cleared as it is taken, BEFORE the first await, so a
+        # re-entrant call can't double-restore and the next game starts from a
+        # clean (uncaptured) slate.
+        for entity_id, level in self._promises.take_owed_volumes():
             if await self._set_volume_on(entity_id, level):
                 applied = True
-        if self._saved_volume is None:
+        own_level = self._promises.take_volume()
+        if own_level is None:
             return applied
-        level = self._saved_volume
-        # Clear BEFORE the await so a re-entrant call can't double-restore, and
-        # so the next game starts from a clean (uncaptured) slate.
-        self._saved_volume = None
-        return await self._set_volume_on(self._entity_id, level) or applied
+        return await self._set_volume_on(self._entity_id, own_level) or applied
 
     async def save_queue(self) -> None:
         """Remember what the speaker was playing before Beatify took it (#2143).
@@ -438,14 +409,14 @@ class MediaPlayerService:
         :meth:`~.playback.base.PlaybackStrategy.capture_queue`. WHEN it is
         remembered is this shell's, which is why the guard below stayed here
         (#2636). A strategy that reports None (every platform but MA, and a
-        platform Beatify cannot play on at all) leaves ``_saved_queue`` unset,
+        platform Beatify cannot play on at all) leaves the promise unset,
         so ``restore_queue`` hands nothing back — exactly as before.
         """
-        if self._saved_queue is not None or self._strategy is None:
+        if self._promises.queue is not None or self._strategy is None:
             return
         snapshot = await self._strategy.capture_queue()
         if snapshot is not None:
-            self._saved_queue = snapshot
+            self._promises.queue = snapshot
 
     async def restore_queue(self) -> bool:
         """Hand the speaker back what it was playing before the game (#2143).
@@ -455,21 +426,20 @@ class MediaPlayerService:
         game, so starting their music unasked would be its own surprise.
 
         Only the track that was playing returns. What sat behind it in the
-        queue is gone — MA's ``get_queue`` never exposed it (see the
-        ``_saved_queue`` comment in ``__init__``).
+        queue is gone — MA's ``get_queue`` never exposed it (see
+        :class:`~.speaker_promises.SpeakerPromises`).
 
         Returns:
             True if at least one speaker got something back.
         """
         restored = False
-        for entity_id, snapshot in list(self._inherited_states.items()):
-            queue = snapshot.pop("queue", None)
+        # Cleared as taken, BEFORE the awaits, so a re-entrant call can't
+        # double-restore.
+        for entity_id, queue in self._promises.take_owed_queues():
             if await self._restorer.restore_on(entity_id, queue):
                 restored = True
-        queue = self._saved_queue
-        # Clear BEFORE the awaits so a re-entrant call can't double-restore.
-        self._saved_queue = None
-        return await self._restorer.restore_on(self._entity_id, queue) or restored
+        own_queue = self._promises.take_queue()
+        return await self._restorer.restore_on(self._entity_id, own_queue) or restored
 
     def set_analytics(self, analytics: AnalyticsStorage) -> None:
         """

--- a/custom_components/beatify/services/speaker_promises.py
+++ b/custom_components/beatify/services/speaker_promises.py
@@ -1,0 +1,136 @@
+"""What a game still owes the speakers it has touched (#1516/#2143).
+
+Split out of :class:`~.media_player.MediaPlayerService` for #2678, because two
+different lifetimes shared that one object and nothing said so:
+
+* **The speaker's** — ``_preflight_verified``. A service is built for one
+  entity on one platform and thrown away the moment either changes, so "this
+  speaker answered a ping" (#179) is exactly as long-lived as the service. It
+  stays there.
+* **The game's** — the host's pre-game volume (#1516) and pre-game queue
+  (#2143). These outlive any single service: a mid-game speaker switch
+  (#1516/#2143) discards the service, and ``UpdateLobbyView`` rebuilds it on a
+  lobby update, but the promise to hand a speaker back what it had is owed
+  until the game ends.
+
+The mismatch was bridged by copying a plain ``dict`` from the outgoing service
+into the incoming one (``snapshot_saved_states`` / ``inherited_states``), and
+that copy silently lost one of the queue's three states — see
+:meth:`SpeakerPromises.snapshot`. Everything with the game's lifetime now lives
+in this one object, and this object is what travels.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class SpeakerPromises:
+    """Every promise this game has made to a speaker, for one service.
+
+    Deliberately a plain state holder. WHEN a promise is made or paid out is
+    game lifecycle and stays with :class:`~.media_player.MediaPlayerService`
+    (the same split #2636 drew for ``save_queue``); WHAT is owed, and how it
+    survives a service rebuild, is here.
+
+    ``volume`` — the speaker's level as it was BEFORE Beatify first changed it
+    this game (#1516). ``None`` means nothing to restore.
+
+    ``queue`` — what the speaker was playing before Beatify claimed it (#2143).
+    Three shapes, deliberately distinct:
+
+      ``None`` — not captured yet (or already restored)
+      ``{}``   — captured, but the speaker was idle: nothing to hand back
+      ``{…}``  — the track, its position, shuffle and repeat mode
+
+    What CANNOT be captured is the queue BEHIND the current track: MA's
+    ``get_queue`` reports ``items`` as a COUNT and exposes only
+    ``current_item`` / ``next_item`` — measured against a live queue on
+    2026-08-13. Restoring "the first entry with replace, the rest with add"
+    (the original plan in #2143) is therefore not implementable.
+
+    ``others`` — speakers this game already switched away from,
+    ``{entity_id: {"volume": …, "queue": …}}``. Our OWN entity's entry is
+    adopted into the two fields above instead of staying here, so a switch back
+    to a speaker does not re-capture an already-Beatify-altered level as if it
+    were the host's original.
+    """
+
+    def __init__(
+        self,
+        entity_id: str,
+        inherited: dict[str, dict[str, Any]] | None = None,
+    ) -> None:
+        self._entity_id = entity_id
+        self.volume: float | None = None
+        self.queue: dict[str, Any] | None = None
+        self.others: dict[str, dict[str, Any]] = {
+            eid: dict(snap) for eid, snap in (inherited or {}).items()
+        }
+        own = self.others.pop(entity_id, None)
+        if own is not None:
+            self.volume = own.get("volume")
+            self.queue = own.get("queue")
+
+    def snapshot(self) -> dict[str, dict[str, Any]]:
+        """The hand-over to whichever service replaces this one.
+
+        ``queue`` is written whenever it has been CAPTURED — the empty capture
+        included. ``{}`` means "asked the speaker, it was idle, nothing to hand
+        back", and it is what stops the next round from capturing Beatify's own
+        track and calling it the host's music (#2143).
+
+        Writing it only ``if self.queue`` (#2678) dropped that flag at every
+        service rebuild, because ``{}`` is falsy. An idle-at-start speaker then
+        looked uncaptured to the new service, the next round captured Beatify's
+        quiz track, and the game ended by parking that track on the host's
+        speaker — the exact outcome the capture-once rule exists to prevent.
+        """
+        # A speaker whose promises have all been paid out leaves an empty
+        # entry behind. Dropping it here keeps "is anything still owed?" — the
+        # question ``end_game`` asks of ``_pending_speaker_states`` — an honest
+        # truthiness test on the bag as a whole.
+        states = {eid: dict(snap) for eid, snap in self.others.items() if snap}
+        own: dict[str, Any] = {}
+        if self.volume is not None:
+            own["volume"] = self.volume
+        if self.queue is not None:
+            own["queue"] = dict(self.queue)
+        if own:
+            states[self._entity_id] = own
+        return states
+
+    def take_volume(self) -> float | None:
+        """This speaker's volume promise, cleared as it is handed out.
+
+        Cleared BEFORE the caller awaits anything, so a re-entrant restore
+        cannot pay the same promise twice and the next game starts from a clean
+        (uncaptured) slate.
+        """
+        level, self.volume = self.volume, None
+        return level
+
+    def take_owed_volumes(self) -> list[tuple[str, float]]:
+        """Every OTHER speaker's volume promise, each cleared as it is taken.
+
+        Each speaker is owed ITS own level, never this one's — restoring the
+        old speaker's volume onto the new one would be a different bug.
+        """
+        owed: list[tuple[str, float]] = []
+        for entity_id, snapshot in list(self.others.items()):
+            level = snapshot.pop("volume", None)
+            if level is not None:
+                owed.append((entity_id, level))
+        return owed
+
+    def take_queue(self) -> dict[str, Any] | None:
+        """This speaker's queue promise, cleared as it is handed out."""
+        queue, self.queue = self.queue, None
+        return queue
+
+    def take_owed_queues(self) -> list[tuple[str, dict[str, Any] | None]]:
+        """Every OTHER speaker's queue promise, each cleared as it is taken."""
+        return [
+            (entity_id, snapshot.pop("queue", None))
+            for entity_id, snapshot in list(self.others.items())
+        ]

--- a/tests/unit/test_ma_queue_restore_2143.py
+++ b/tests/unit/test_ma_queue_restore_2143.py
@@ -106,7 +106,7 @@ class TestQueueSnapshot:
 
         await svc.save_queue()
 
-        assert svc._saved_queue == {
+        assert svc._promises.queue == {
             "uri": "apple_music://track/1686851478",
             "name": "Stuck In The Middle With You",
             "elapsed_time": 9.0,
@@ -135,7 +135,7 @@ class TestQueueSnapshot:
         }
         await svc.save_queue()
 
-        assert svc._saved_queue["uri"] == "apple_music://track/1686851478"
+        assert svc._promises.queue["uri"] == "apple_music://track/1686851478"
         assert len(_calls_to(hass, "music_assistant", "get_queue")) == 1
 
     @pytest.mark.asyncio
@@ -147,7 +147,7 @@ class TestQueueSnapshot:
         await svc.save_queue()
         await svc.save_queue()
 
-        assert svc._saved_queue == {}
+        assert svc._promises.queue == {}
         assert len(_calls_to(hass, "music_assistant", "get_queue")) == 1
         assert await svc.restore_queue() is False
 
@@ -159,7 +159,7 @@ class TestQueueSnapshot:
 
         await svc.save_queue()
 
-        assert svc._saved_queue is None
+        assert svc._promises.queue is None
         assert hass.services.async_call.await_count == 0
 
     @pytest.mark.asyncio
@@ -174,7 +174,7 @@ class TestQueueSnapshot:
 
         await svc.save_queue()
 
-        assert svc._saved_queue == {}
+        assert svc._promises.queue == {}
 
 
 class TestQueueRestore:
@@ -306,8 +306,8 @@ class TestSnapshotSurvivesASpeakerSwitch:
 
         svc.save_volume()  # would capture the current 0.5 if the adopt failed
 
-        assert svc._saved_volume == 0.2
-        assert svc._inherited_states == {}
+        assert svc._promises.volume == 0.2
+        assert svc._promises.others == {}
 
     @pytest.mark.asyncio
     async def test_the_old_speaker_gets_its_queue_back_too(self):

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -2349,7 +2349,7 @@ class TestVolumeSaveRestore:
 
         svc.save_volume()
 
-        assert svc._saved_volume == 0.4
+        assert svc._promises.volume == 0.4
 
     @pytest.mark.asyncio
     async def test_save_volume_is_idempotent(self):
@@ -2365,7 +2365,7 @@ class TestVolumeSaveRestore:
         state.attributes["volume_level"] = 0.1
         svc.save_volume()
 
-        assert svc._saved_volume == 0.4
+        assert svc._promises.volume == 0.4
 
     @pytest.mark.asyncio
     async def test_restore_volume_applies_and_clears(self):
@@ -2387,7 +2387,7 @@ class TestVolumeSaveRestore:
         assert len(vol_calls) == 1
         assert vol_calls[0].args[2]["volume_level"] == 0.4
         # Cleared so the next game re-captures fresh and a re-call is a no-op.
-        assert svc._saved_volume is None
+        assert svc._promises.volume is None
         assert await svc.restore_volume() is False
 
     @pytest.mark.asyncio

--- a/tests/unit/test_media_player_lifetimes_2678.py
+++ b/tests/unit/test_media_player_lifetimes_2678.py
@@ -1,0 +1,257 @@
+"""#2678: two lifetimes used to share one object, and the shorter one won.
+
+``MediaPlayerService`` holds state with two different lifetimes:
+
+* ``_preflight_verified`` (#179) belongs to THE SPEAKER. The service is rebuilt
+  whenever the entity or platform changes, so the flag dying with it is right —
+  a new speaker has to answer its own ping.
+* the pre-game volume (#1516) and pre-game queue (#2143) belong to THE GAME.
+  They have to survive every rebuild, because the promise to hand a speaker
+  back what it had is owed until the game ends.
+
+The bridge between the two is ``snapshot_saved_states`` → ``inherited_states``,
+and it used to write the queue only ``if self._saved_queue``. ``{}`` — "asked
+the speaker, it was idle, nothing to hand back", the flag that stops the next
+round capturing Beatify's own track — is falsy, so every rebuild forgot it.
+
+These tests drive the sequence that made that visible, and pin the boundary
+that now separates the two lifetimes.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.beatify.services.media_player import MediaPlayerService
+from custom_components.beatify.services.playback import queue_restore
+from custom_components.beatify.services.speaker_promises import SpeakerPromises
+
+ESSZIMMER = "media_player.esszimmer"
+KUECHE = "media_player.kueche"
+
+#: The host's speaker was idle when the game started: MA answers get_queue,
+#: but there is no current item.
+IDLE_QUEUE = {ESSZIMMER: {"current_item": None}}
+
+#: Round seven. The only thing on the speaker now is Beatify's own quiz track.
+BEATIFY_QUEUE = {
+    ESSZIMMER: {
+        "elapsed_time": 30,
+        "current_item": {
+            "media_item": {"uri": "spotify:track:beatify_round_7", "name": "Round 7"}
+        },
+    }
+}
+
+HOSTS_OWN_QUEUE = {
+    ESSZIMMER: {
+        "elapsed_time": 9,
+        "shuffle_enabled": True,
+        "repeat_mode": "all",
+        "current_item": {
+            "media_item": {
+                "uri": "apple_music://track/1686851478",
+                "name": "Stuck In The Middle With You",
+            }
+        },
+    }
+}
+
+
+@pytest.fixture(autouse=True)
+def _fast_pause_guard(monkeypatch):
+    """The #2605 pause guard on a compressed clock — durations only."""
+    monkeypatch.setattr(queue_restore, "MA_PAUSE_CONFIRM_WAIT", 0.05)
+    monkeypatch.setattr(queue_restore, "MA_PAUSE_SETTLE_HOLD", 0.05)
+    monkeypatch.setattr(queue_restore, "MA_PAUSE_GUARD_WINDOW", 0.30)
+    monkeypatch.setattr(queue_restore, "MA_LATE_START_WATCH", 0.30)
+    monkeypatch.setattr(queue_restore, "MA_PAUSE_POLL", 0.01)
+
+
+def _hass(queue_response) -> MagicMock:
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock(return_value=queue_response)
+    state = MagicMock()
+    state.state = "playing"
+    state.attributes = {"volume_level": 0.5}
+    hass.states.get = MagicMock(return_value=state)
+    return hass
+
+
+def _service(hass, entity_id=ESSZIMMER, **kwargs) -> MediaPlayerService:
+    return MediaPlayerService(hass, entity_id, platform="music_assistant", **kwargs)
+
+
+def _calls_to(hass, domain, service):
+    return [
+        c
+        for c in hass.services.async_call.await_args_list
+        if c.args[:2] == (domain, service)
+    ]
+
+
+class TestTheGamesPromisesSurviveTheServiceRebuild:
+    """The game-lifetime half must cross every hand-over intact."""
+
+    def test_an_empty_capture_is_still_a_capture_on_the_other_side(self):
+        """`{}` is the flag, not the absence of one — it has to travel.
+
+        This is the whole defect in one assertion: the snapshot wrote the queue
+        only when it was truthy, so the idle capture never reached the service
+        that replaced this one.
+        """
+        first = _service(_hass(IDLE_QUEUE))
+        first._promises.queue = {}
+
+        second = _service(
+            _hass(IDLE_QUEUE), inherited_states=first.snapshot_saved_states()
+        )
+
+        assert second._promises.queue == {}
+
+    @pytest.mark.asyncio
+    async def test_a_rebuild_does_not_let_round_two_capture_beatifys_own_track(self):
+        """The sequence, end to end, on one speaker.
+
+        1. The game starts on an MA speaker that is idle. Round one asks
+           get_queue and records the empty capture.
+        2. Anything that rebuilds the service happens — a speaker switch, or
+           the lobby update the admin UI fires on every settings save.
+        3. Round N asks get_queue again, because the new service believes
+           nothing has been captured. The speaker is now on Beatify's own quiz
+           track, so THAT is recorded as "the host's music".
+        4. The game ends and parks Beatify's round-seven track on the host's
+           speaker — the exact outcome the capture-once rule exists to prevent.
+        """
+        first_hass = _hass(IDLE_QUEUE)
+        first = _service(first_hass)
+        await first.save_queue()
+        assert first._promises.queue == {}
+
+        second_hass = _hass(BEATIFY_QUEUE)
+        second = _service(second_hass, inherited_states=first.snapshot_saved_states())
+        await second.save_queue()
+
+        assert second._promises.queue == {}
+        assert _calls_to(second_hass, "music_assistant", "get_queue") == []
+        assert await second.restore_queue() is False
+        assert _calls_to(second_hass, "music_assistant", "play_media") == []
+
+    @pytest.mark.asyncio
+    async def test_the_same_holds_when_the_game_switches_away_and_back(self):
+        """A → B → A. The empty capture rides along in the inherited bag."""
+        on_a = _service(_hass(IDLE_QUEUE))
+        await on_a.save_queue()
+
+        on_b = _service(
+            _hass(IDLE_QUEUE),
+            entity_id=KUECHE,
+            inherited_states=on_a.snapshot_saved_states(),
+        )
+        assert on_b._promises.others == {ESSZIMMER: {"queue": {}}}
+
+        back_hass = _hass(BEATIFY_QUEUE)
+        back_on_a = _service(back_hass, inherited_states=on_b.snapshot_saved_states())
+
+        assert back_on_a._promises.queue == {}
+        await back_on_a.save_queue()
+        assert back_on_a._promises.queue == {}
+        assert await back_on_a.restore_queue() is False
+
+    @pytest.mark.asyncio
+    async def test_a_real_track_still_travels_and_still_comes_back(self):
+        """The fix must not turn every capture into "nothing owed"."""
+        first = _service(_hass(HOSTS_OWN_QUEUE))
+        first.save_volume()
+        await first.save_queue()
+
+        second_hass = _hass(HOSTS_OWN_QUEUE)
+        second = _service(second_hass, inherited_states=first.snapshot_saved_states())
+
+        assert second._promises.volume == 0.5
+        assert second._promises.queue["uri"] == "apple_music://track/1686851478"
+        assert await second.restore_queue() is True
+        play = _calls_to(second_hass, "music_assistant", "play_media")
+        assert len(play) == 1
+        assert play[0].args[2]["media_id"] == "apple_music://track/1686851478"
+
+
+class TestTheSpeakersOwnStateDoesNotTravel:
+    """The other half of the split: what belongs to the speaker stays put."""
+
+    def test_the_new_service_re_verifies_the_speaker(self):
+        """#179's cache is the SERVICE's, and a rebuild means a new speaker
+        may be behind the same game. It must not ride in on the promises."""
+        first = _service(_hass(HOSTS_OWN_QUEUE))
+        first._preflight_verified = True
+        first.save_volume()
+
+        second = _service(
+            _hass(HOSTS_OWN_QUEUE),
+            entity_id=KUECHE,
+            inherited_states=first.snapshot_saved_states(),
+        )
+
+        assert second._preflight_verified is False
+        # ...while the game's promise to the old speaker did cross.
+        assert second._promises.others == {ESSZIMMER: {"volume": 0.5}}
+
+    def test_the_hand_over_carries_nothing_but_the_promises(self):
+        """A snapshot is game state only — no speaker, platform or ping flag."""
+        svc = _service(_hass(HOSTS_OWN_QUEUE))
+        svc._preflight_verified = True
+        svc.save_volume()
+
+        snapshot = svc.snapshot_saved_states()
+
+        assert snapshot == {ESSZIMMER: {"volume": 0.5}}
+
+
+class TestSpeakerPromises:
+    """The boundary itself, without a speaker in the way."""
+
+    def test_an_uncaptured_queue_is_absent_a_captured_empty_one_is_present(self):
+        uncaptured = SpeakerPromises(ESSZIMMER)
+        assert uncaptured.snapshot() == {}
+
+        captured = SpeakerPromises(ESSZIMMER)
+        captured.queue = {}
+        assert captured.snapshot() == {ESSZIMMER: {"queue": {}}}
+
+    def test_it_adopts_its_own_entitys_entry_and_leaves_the_rest(self):
+        promises = SpeakerPromises(
+            ESSZIMMER,
+            {ESSZIMMER: {"volume": 0.2, "queue": {}}, KUECHE: {"volume": 0.4}},
+        )
+
+        assert promises.volume == 0.2
+        assert promises.queue == {}
+        assert promises.others == {KUECHE: {"volume": 0.4}}
+
+    def test_taking_a_promise_clears_it(self):
+        promises = SpeakerPromises(ESSZIMMER, {KUECHE: {"volume": 0.4, "queue": {}}})
+        promises.volume = 0.2
+        promises.queue = {"uri": "spotify:track:x"}
+
+        assert promises.take_owed_volumes() == [(KUECHE, 0.4)]
+        assert promises.take_volume() == 0.2
+        assert promises.take_owed_queues() == [(KUECHE, {})]
+        assert promises.take_queue() == {"uri": "spotify:track:x"}
+
+        assert promises.snapshot() == {}
+        assert promises.take_owed_volumes() == []
+        assert promises.take_volume() is None
+
+    def test_a_snapshot_is_a_copy_not_a_view(self):
+        """The outgoing service is discarded, but nothing may share its dicts."""
+        promises = SpeakerPromises(ESSZIMMER, {KUECHE: {"volume": 0.4}})
+        promises.queue = {"uri": "spotify:track:x"}
+
+        snapshot = promises.snapshot()
+        snapshot[ESSZIMMER]["queue"]["uri"] = "spotify:track:tampered"
+        snapshot[KUECHE]["volume"] = 0.9
+
+        assert promises.queue == {"uri": "spotify:track:x"}
+        assert promises.others == {KUECHE: {"volume": 0.4}}


### PR DESCRIPTION
Item 2 of #2678, the last open half — item 1 went with the provider registry in #2740.

The issue called this one "probably the intent, but nobody says so", and asked for a comment or a test. It is a live bug.

## The sequence that produces a wrong result

`capture_queue` has three answers, and the middle one is the interesting one:

```
None — not captured yet
{}   — captured, but the speaker was idle: nothing to hand back
{…}  — the track, its position, shuffle and repeat mode
```

`{}` is not "nothing". It is the flag that stops round two from capturing Beatify's own track and calling it the host's music — the whole point of `save_queue` being idempotent. `snapshot_saved_states` wrote it out as

```python
if self._saved_queue:
    own["queue"] = dict(self._saved_queue)
```

and `{}` is falsy. So the flag never crossed a service rebuild:

1. The game starts on a Music Assistant speaker that was **idle** — no music playing before the party. Round one asks `get_queue`, gets no `current_item`, records `{}`.
2. Anything rebuilds the service. A mid-game speaker switch A→B→A (`UpdateLobbyView` permits switching during PLAYING and REVEAL), or simply a lobby update: `game-settings.js::saveGameSettings` posts `/game/update-lobby` with the currently selected `media_player` on **every** settings save, and the handler releases and rebuilds unconditionally. The new service inherits a volume promise but no queue promise, so `_saved_queue` is `None` again.
3. Round seven. `save_queue` runs, believes nothing has been captured, and asks the speaker — which is now playing **Beatify's own quiz track**. That gets recorded as the host's music.
4. `end_game` calls `restore_queue`, which plays Beatify's round-seven track back on the host's speaker, seeks to its old position and pauses it there.

A host whose speaker was silent before the game ends the game with a Beatify quiz track parked on it. Exactly the outcome the capture-once rule exists to prevent, reintroduced at the boundary between the two lifetimes.

The volume half is unaffected: `_saved_volume` is `None` or a float, never a falsy-but-meaningful value, so it always crossed.

## Where the two lifetimes live now

**The speaker's** — `_preflight_verified` (#179). Stays on `MediaPlayerService`. The service is built for one entity on one platform and thrown away when either changes, so "this speaker answered a ping" is exactly as long-lived as the service, and a new speaker proving itself again is correct.

**The game's** — the pre-game volume (#1516), the pre-game queue (#2143), and what is still owed to speakers the game switched away from. These move to `services/speaker_promises.py::SpeakerPromises`, one object that is the thing handed over when a service is replaced. Its `snapshot()` writes the queue whenever it has been captured, empty capture included, so all three states survive the crossing.

The split is a state move, not a behaviour change beyond the fix. `SpeakerPromises` is a plain holder: WHEN a promise is made or paid out stays with the service, the same line #2636 drew for `save_queue`; WHAT is owed and how it survives a rebuild is in the new object. `take_*` methods clear each promise as they hand it out, keeping the "clear before the await so a re-entrant restore cannot pay twice" rule that was previously spelled out inline at both call sites.

One small consequence, deliberate: a speaker whose promises have all been paid out no longer leaves an empty entry behind in the bag. `end_game` asks `if self._pending_speaker_states` before building a service to pay out, and that truthiness test should mean "something is still owed".

## Red, then green

The three tests that pin the defect were run against pristine `origin/main` first, translated into main's attribute names:

```
FAILED test_an_empty_capture_is_still_a_capture_on_the_other_side
FAILED test_a_rebuild_does_not_let_round_two_capture_beatifys_own_track
FAILED test_the_same_holds_when_the_game_switches_away_and_back
3 failed, 3 passed
```

The middle one fails with the round-seven track where `{}` was expected — step 3 above, caught in the act:

```
assert second._saved_queue == {}
E  Left contains 5 more items:
E  {'uri': 'spotify:track:beatify_round_7', 'name': 'Round 7', 'elapsed_time': 30.0, ...}
```

The three that passed on main are the guards against over-fixing: a real captured track must still travel and still come back, `_preflight_verified` must **not** ride in on the promises, and a snapshot must carry nothing but promises. They pass on both sides.

On this branch: 10 passed.

## What I did not change

`UpdateLobbyView` rebuilds the media-player service even when the posted `media_player` is the one the game already has, which is what makes step 2 reachable without any speaker switch at all. The sibling pre-start hook a few hundred lines up does guard on `gs.media_player != mp`. Adding the same guard there would save a discarded pre-flight verification per settings save, but it sits in the persistence path of that view and belongs in its own change — after this one the rebuild is lossless, so it costs latency, not correctness.

## Checks

- `pytest tests/unit tests/integration -q` — 2680 passed, 2 skipped
- `npm test` — 105 files, 1102 passed
- `npm run build:check` — 16 artifacts and 79 .gz siblings match source
- `python3 -m ruff format --check .` — 247 files already formatted

Closes #2678

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKsEKt68KHSqmi617XNCVi
