### PR TITLE
data: fix 14 broken Apple Music region map URIs in pure-pop-punk (#2766)

### DIFF
--- a/custom_components/beatify/playlists/community/pure-pop-punk.json
+++ b/custom_components/beatify/playlists/community/pure-pop-punk.json
@@ -1,6 +1,6 @@
 {
   "name": "Pure Pop Punk 🎸",
-  "version": "1.14",
+  "version": "1.15",
   "tags": [
     "2000s",
     "pop-punk",
@@ -659,13 +659,13 @@
       "awards_nl": [],
       "isrc": "USDW10110256",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/1706919742",
-        "de": "applemusic://track/1706919742",
-        "gb": "applemusic://track/1706919742",
-        "fr": "applemusic://track/1706919742",
-        "es": "applemusic://track/1706919742",
-        "nl": "applemusic://track/1706919742",
-        "it": "applemusic://track/1706919742"
+        "us": "applemusic://track/1450030115",
+        "de": "applemusic://track/1450030115",
+        "gb": "applemusic://track/1450030115",
+        "fr": "applemusic://track/1450030115",
+        "es": "applemusic://track/1450030115",
+        "nl": "applemusic://track/1450030115",
+        "it": "applemusic://track/1450030115"
       }
     },
     {
@@ -3462,13 +3462,13 @@
       "awards_nl": [],
       "isrc": "USAT21002551",
       "uri_apple_music_by_region": {
-        "us": "applemusic://track/1764037543",
-        "de": "applemusic://track/1835077739",
-        "gb": "applemusic://track/1764037543",
-        "fr": "applemusic://track/1764037543",
-        "es": "applemusic://track/1764037543",
-        "nl": "applemusic://track/1764037543",
-        "it": "applemusic://track/1764037543"
+        "us": "applemusic://track/1132426469",
+        "de": "applemusic://track/1132426469",
+        "gb": "applemusic://track/1132426469",
+        "fr": "applemusic://track/1132426469",
+        "es": "applemusic://track/1132426469",
+        "nl": "applemusic://track/1132426469",
+        "it": "applemusic://track/1132426469"
       }
     },
     {


### PR DESCRIPTION
Closes #2766. Replaced 14 stale/wrong Apple Music region map URIs across 2 tracks, bumped playlist version to 1.15.

## Changes

**Jimmy Eat World — The Middle**
- All 7 storefronts (us/de/gb/fr/es/nl/it) had dead ID `1706919742` (404)
- Updated to `1450030115` (the healthy base URI, confirmed valid)

**Neck Deep — December (again)**
- All storefronts had wrong IDs (`1764037543` / `1835077739` for DE) resolving to *The Ballad of Mona Lisa* by Panic! At The Disco
- Updated to `1132426469` (correct Mark Hoppus feat. version, confirmed via Apple Music GB)

All 498 base URIs remain healthy — no other changes.

---
*Generated by playlist-health-check — 2026-09-07*