### PR TITLE
release: v4.5.0-rc1 (Your Call)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [4.5.0-rc1] - 2026-09-08
+
+Die Woche 2026-W37: fuenfzig Eintraege aus der Redaktionskonferenz, alle gebaut und gemergt. Zwoelf
+davon liefen durchs Design-Gate, jeder mit Entwurf und Markus' Auswahl. Der Kandidat traegt sie
+vollstaendig.
+
+### Added
+- **Der Host bekommt echte Knoepfe aufs Handy**, gebuendelt in einer Schublade: Pause mit Grund fuer
+  den Raum (#2645), Sudden Death scharfstellen (#2723), Partylicht zurueckholen (#2649),
+  Spielstand-Ansicht fuer den Gast (#2718 Folgearbeit, #2757).
+- **Eine Runde verwerfen, statt einen kaputten Song zu werten** — mit Folgenvorschau vor der
+  Rueckfrage und optionalem Grund (#2646).
+- **Rematch mit anderer Playlist, ohne dass zwanzig Leute neu scannen** — der Endbildschirm wird der
+  Startbildschirm (#2648).
+- **Reaktionen waehrend der Runde** fuer alle, die schon abgegeben haben (#2562).
+- **Sechs fertige Spielmodi bekommen einen Weg hinein**, gefuehrt ueber eine Spielart (#2692).
+- **Die Lobby sagt, welches Spiel gleich laeuft** — ein generierter Satz statt einer Liste (#2647).
+- **Jedes Gast-Handy spricht die Sprache des Gasts** (#2585).
+
+### Fixed
+- **Abwesende Gaeste verlassen das Lobby-Raster** und stehen in einer Liste mit Abwesenheitsdauer
+  (#2718). Offen geblieben und in den Montagstopf gelegt: Rauswerfen geht weiter nur in der Lobby
+  und nur bei getrennter Verbindung (#2746).
+- **Der Comeback-Token wird angekuendigt** statt still vergeben (#2721).
+- **Der Fernseher sagt, warum sich eine Zahl geaendert hat** (#2703, #2719, #2720, #2722).
+- **Die Luecke zwischen zwei Runden** traegt einen drehenden Ring und eine gestaffelte Aufloesung
+  statt einer stehenden Null (#2702).
+- **Die Aufloesung bleibt stehen**, wenn der Host einen Song stoppt (#2690).
+- **Das Wiedergabe-Budget folgt der Retry-Kurve von Music Assistant**, ein gedrosselter Start steht
+  im eigenen Log (#2682).
+- **`End` beendet das Spiel**, ein Rematch vom Handy behaelt seinen eigenen Socket (#2726); das
+  Podium ueberlebt den REST-Weg (#2724).
+- **14 kaputte Apple-Music-Regions-URIs** in `pure-pop-punk` (#2766), tote YT-Music- und
+  Tidal-URIs in `koelner-karneval` (#2686).
+
+### Changed
+- **Eine Provider-Registry statt fuenfzehn handgepflegter Kopien** — ein vergessener Ort scheiterte
+  vorher lautlos (#2713).
+- **Der TTS-Resume-Watchdog liegt hinter dem Media-Player-Port** statt in der Spiellogik (#2710).
+- **Das Albumcover wird einmal geholt und geteilt** statt zweiundzwanzigmal pro Runde (#2709).
+- **Die `window`-Globals um `admin.js` sind auf beiden Seiten festgenagelt** (#2712).
+- **Konfetti und die Dashboard-Stylesheets kommen von dieser Box**, nicht aus dem Internet (#2742).
+- **`MediaPlayerProtocol` deckt ab, was das Spiel wirklich aufruft** (#2711).
+
+### Removed
+- **Fuenf veraltete Sourcemaps und drei ungelesene `hass.data`-Schluessel** (#2715, #2716).
+- **`GameState.start_game()`**, die dritte Kopie des Start-Gates (#2717).
+- **Vier Player-Handler ohne Element und drei Elemente ohne Schreiber** (#2714).
+
+
 ## [4.4.3] - 2026-09-06
 
 Die Woche 2026-W38: zweiunddreissig Eintraege aus der Redaktionskonferenz, alle gebaut und gemergt —

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -20,5 +20,5 @@
     "num2words==0.5.14"
   ],
   "single_config_entry": true,
-  "version": "4.4.3"
+  "version": "4.5.0"
 }

--- a/docs/release-notes-v4.5.0-rc1.md
+++ b/docs/release-notes-v4.5.0-rc1.md
@@ -1,0 +1,17 @@
+## 4.5.0-rc1 — Your Call
+
+The host stops being someone who has to walk over to a laptop.
+
+### 🎛️ The room, from your hand
+
+Pause a round when the doorbell goes, and the room is told why the music stopped. Drop a song that turned out to be a bad recording without it counting against anybody. Arm Sudden Death, take the party lights back mid-game, and start a rematch on a different playlist without twenty people scanning the code again. A guest who scanned, typed a name and wandered off moves out of the lobby grid into a list that says how long they have been gone. All of it sits in one drawer on the host's phone.
+
+### 📣 Nothing happens without a word
+
+The Comeback Token used to appear in silence and looked like a bug; it gets announced now. The lobby says what game is about to be played, the TV says why a number changed, and the gap between two rounds fills with a turning ring and a reveal that builds instead of a frozen zero. Each guest's phone picks the guest's own language.
+
+---
+
+**66 playlists · 8,432 songs · 6 music platforms · 6 languages**
+
+[Report a Bug](https://github.com/mholzi/beatify/issues) · [Discussions](https://github.com/mholzi/beatify/discussions) · [Full Changelog](https://github.com/mholzi/beatify/blob/main/CHANGELOG.md)


### PR DESCRIPTION
Bumps the manifest to 4.5.0, adds the CHANGELOG section for the week 2026-W37 and the release notes for the candidate.

All fifty entries of the W37 editorial plan are merged; twelve went through the design gate with a draft and a picked variant.

**Playlist version check** over `v4.4.3..main`: two playlist files changed, and both moved their `version` field in the same commit as the data, so the changes reach existing installations (`_copy_bundled_playlists` only overwrites on a strictly higher version).

| File | version |
|---|---|
| `community/koelner-karneval.json` | 1.15 → 1.16 |
| `community/pure-pop-punk.json` | 1.14 → 1.15 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HuVrowXzVVF2timndSMeMb