### PR TITLE
release: v4.5.0 (Your Call)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
-## [4.5.0-rc1] - 2026-09-08
+## [4.5.0] - 2026-09-08
 
 Die Woche 2026-W37: fuenfzig Eintraege aus der Redaktionskonferenz, alle gebaut und gemergt. Zwoelf
 davon liefen durchs Design-Gate, jeder mit Entwurf und Markus' Auswahl. Der Kandidat traegt sie

--- a/docs/release-notes-v4.5.0.md
+++ b/docs/release-notes-v4.5.0.md
@@ -1,0 +1,21 @@
+## 4.5.0 — Your Call
+
+The host stops being someone who has to walk over to a laptop, and six finished game modes that no host could reach finally have a way in.
+
+### 🎛️ The room, from your hand
+
+Pause a round when the doorbell goes, and the room is told why the music stopped. Drop a song that turned out to be a bad recording without it counting against anybody. Arm Sudden Death, take the party lights back mid-game, and start a rematch on a different playlist without twenty people scanning the code again. All of it sits in one drawer on the host's phone.
+
+### 🎲 One decision instead of eleven switches
+
+Ramp-up ordering, Finale ×2, the finale tiebreaker, the Comeback Token, bet scaling and Sabotage were all built and all unreachable. Setup now offers three play styles — Classic, Dramatic, Chaos — and picking one sets every mode behind it. The individual switches are still one tap below, for a different combination.
+
+### 📣 Nothing happens without a word
+
+The Comeback Token used to appear in silence and looked like a bug; it gets announced now. The lobby says what game is about to be played, the TV says why a number changed, and the gap between two rounds fills with a turning ring instead of a frozen zero. Each guest's phone speaks the guest's own language, and players already done with a round can react while the others think.
+
+---
+
+**66 playlists · 8,432 songs · 6 music platforms · 6 languages**
+
+[Report a Bug](https://github.com/mholzi/beatify/issues) · [Discussions](https://github.com/mholzi/beatify/discussions) · [Full Changelog](https://github.com/mholzi/beatify/blob/main/CHANGELOG.md)


### PR DESCRIPTION
Promotes `v4.5.0-rc1` to stable.

- CHANGELOG section renamed from the candidate to `[4.5.0]`
- Stable release notes added as `docs/release-notes-v4.5.0.md`

The manifest already carries `4.5.0`, and `main` is identical to the tested candidate (`compare v4.5.0-rc1...main` is 0 ahead), so no code changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyYy4DcqkxbumasVCip3Bg