### PR TITLE
Wrap the YouTube resume cursor when it reaches the end (#2301)

### DIFF
--- a/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
+++ b/.claude/skills/provider-uri-backfill/scripts/backfill_provider_uris.py
@@ -594,6 +594,34 @@ def load_state(path: Path, today: str, budget: int) -> YouTubeBudget:
     )
 
 
+def wrap_cursor(cursor: int, total_songs: int) -> tuple[int, bool]:
+    """Bring a resume cursor back into range, returning ``(cursor, wrapped)``.
+
+    The YouTube resume cursor is a **positional** index into the flattened song
+    list of one run's playlist selection. Nothing ever reset it at the end of a
+    file, so once it reached the song count the run was finished for good: the
+    fast-forward near the top of the song loop skipped every song, and the
+    ``this_global_idx >= yt_state.cursor`` gate in front of ``search.list``
+    could not fire for any of them. Every slice then reported zero searches
+    with its full budget untouched.
+
+    Measured on 2026-09-08 across 13 consecutive agent runs (208 slices, 0
+    searches, +0 URIs): **18 of 35 playlists sat at exactly cursor == song
+    count**, tomorrowland-top-1000 at 825/825, salsa-y-merengue at 531/531.
+    Those are not a random 18 either — the queue picks the playlist with the
+    most gaps, and a playlist that was walked end to end without filling its
+    gaps is precisely one with many gaps left.
+
+    A positional cursor over a list that only grows at the end will always end
+    in this state, so the wrap belongs to the cursor rather than to any one
+    caller. ``total_songs <= 0`` leaves the cursor alone: an empty selection
+    says nothing about whether the cursor is stale.
+    """
+    if total_songs <= 0 or cursor < total_songs:
+        return cursor, False
+    return 0, True
+
+
 def save_state(path: Path, yt: YouTubeBudget) -> None:
     data = {}
     if path.exists():
@@ -1136,6 +1164,25 @@ def run(args: argparse.Namespace) -> int:
         if not playlist_paths:
             print(f"No playlist matched '{args.playlist}'", file=sys.stderr)
             return 2
+
+    # ---- Resume-Cursor in den Bereich zurueckholen (#2301) ------------------
+    # Der Cursor zeigt in die flache Songliste GENAU DIESER Auswahl. Stand er
+    # auf oder hinter deren Ende, sucht der Lauf keinen einzigen Song — siehe
+    # ``wrap_cursor``. Die Zaehlung kostet ein zusaetzliches Parsen je Datei;
+    # das ist der Preis dafuer, den Fehlstand zu erkennen, BEVOR die Scheibe
+    # verbraucht ist, statt ihn hinterher im Log zu beklagen.
+    total_songs = 0
+    for _p in playlist_paths:
+        try:
+            total_songs += len(json.loads(_p.read_text()).get("songs", []))
+        except (OSError, json.JSONDecodeError):
+            continue
+    yt_state.cursor, _wrapped = wrap_cursor(yt_state.cursor, total_songs)
+    if _wrapped:
+        print(
+            f"YouTube-Cursor stand auf oder hinter dem Ende der Auswahl "
+            f"({total_songs} Songs) und ist auf 0 zurueckgesetzt (#2301)"
+        )
 
     coverages: list[PlaylistCoverage] = []
     # Global flat index for the YouTube resume cursor.

--- a/tests/unit/test_backfill_youtube_first_2301.py
+++ b/tests/unit/test_backfill_youtube_first_2301.py
@@ -230,3 +230,84 @@ class TestSkipSongsWithoutAYouTubeGap:
     def test_the_condition_is_wired_into_the_song_loop(self):
         src = _SCRIPT.read_text()
         assert "if args.youtube_first and not yt_gap:" in src
+
+
+# ---------------------------------------------------------------------------
+# Der Cursor lief hinter das Ende und kam nie zurueck (#2301, 08.09.2026)
+#
+# Die Tests oben halten fest, WANN ein Song uebersprungen wird. Sie sagen
+# nichts darueber, was passiert, wenn der Cursor das Ende der Auswahl erreicht
+# hat — und genau dort stand der Job fuenf Tage lang: 13 Laeufe in Folge, 208
+# Scheiben, **null** ``search.list``-Aufrufe, Budget jedes Mal unberuehrt.
+#
+# 18 von 35 Playlists standen auf exakt ``cursor == Songzahl``. Fuer jeden Song
+# gilt dann ``idx < cursor``, die Schleife ueberspringt alles, und das Gate vor
+# der Suche (``idx >= cursor``) kann fuer keinen Song mehr feuern. Anders als
+# oben wird hier die **echte** Funktion geprueft, nicht ein nachgebildetes
+# Praedikat: sie ist rein, und ein Nachbau haette den Fehler mitgebaut.
+
+
+def _load_script_module():
+    """Laedt das Skript per Pfad. ``scripts/`` ist kein Package.
+
+    Der Eintrag in ``sys.modules`` VOR ``exec_module`` ist Pflicht und kein
+    Zierrat: ``PlaylistCoverage`` ist ein Dataclass mit ``from __future__
+    import annotations``, und ``dataclasses`` schlaegt beim Aufloesen der
+    String-Annotationen ueber ``sys.modules[cls.__module__]`` nach. Fehlt der
+    Eintrag, stirbt der Import mit ``AttributeError: 'NoneType' object has no
+    attribute '__dict__'`` — an einer Stelle, die mit diesem Test nichts zu tun
+    hat.
+    """
+    import importlib.util
+    import sys
+
+    spec = importlib.util.spec_from_file_location("_bpu_2301", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_bpu_2301"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestWrapCursor:
+    def test_a_cursor_at_the_end_wraps_to_zero(self):
+        # Der gemessene Fall: tomorrowland-top-1000, 825 von 825.
+        assert _load_script_module().wrap_cursor(825, 825) == (0, True)
+
+    def test_a_cursor_past_the_end_wraps_too(self):
+        # Eine Playlist kann zwischen zwei Laeufen schrumpfen (Dedup, Entfernen
+        # kaputter Eintraege). Dann steht der Cursor hinter dem Ende, ohne je
+        # genau darauf gestanden zu haben.
+        assert _load_script_module().wrap_cursor(900, 825) == (0, True)
+
+    def test_a_cursor_inside_the_selection_is_left_alone(self):
+        # Der Normalfall — hier darf nichts passieren, sonst faengt jeder Lauf
+        # wieder vorne an und die Wiederaufnahme ist ihren Namen nicht wert.
+        assert _load_script_module().wrap_cursor(46, 825) == (46, False)
+
+    def test_a_fresh_cursor_is_left_alone(self):
+        assert _load_script_module().wrap_cursor(0, 825) == (0, False)
+
+    def test_an_empty_selection_never_wraps(self):
+        # ``--playlist`` mit einem Namen, der nichts trifft, oder ein Lauf ohne
+        # Dateien: eine leere Auswahl ist kein Beleg dafuer, dass der Cursor
+        # veraltet ist. Ihn hier zu nullen wuerde einen intakten Stand
+        # wegwerfen, weil ein Aufrufer sich vertippt hat.
+        assert _load_script_module().wrap_cursor(5, 0) == (5, False)
+        assert _load_script_module().wrap_cursor(0, 0) == (0, False)
+
+
+class TestWrapIsWiredIntoTheRun:
+    def test_the_run_wraps_before_it_walks(self):
+        # Textprobe am echten Quelltext: der Aufruf muss VOR der Song-Schleife
+        # stehen. Stuende er dahinter, heilte sich der Lauf erst beim naechsten
+        # Mal — und genau eine verlorene Scheibe pro Fehlstand ist das, was
+        # dieser Fix verhindern soll.
+        source = _SCRIPT.read_text()
+        wrap_call = source.index("yt_state.cursor, _wrapped = wrap_cursor(")
+        song_loop = source.index("        for song in songs:")
+        assert wrap_call < song_loop
+
+    def test_the_wrap_is_reported_rather_than_silent(self):
+        # Ein stiller Reset waere schwer von „Playlist war einfach leer" zu
+        # unterscheiden. Der Lauf sagt, dass er den Cursor angefasst hat.
+        assert "auf 0 zurueckgesetzt (#2301)" in _SCRIPT.read_text()


### PR DESCRIPTION
The YouTube backfill has produced nothing since 2026-09-03. Thirteen consecutive agent runs made **208 slices, 0 `search.list` calls, +0 URIs**, each reporting `budget 12/12 left today`. It was never a quota problem and — despite what the log said — never the time cap.

## What actually blocked it

The resume cursor is a **positional** index into the flattened song list of a run's playlist selection, and nothing ever reset it at the end of a file. Once it reached the song count:

- the fast-forward near the top of the song loop skipped every song (`idx < cursor`),
- and the gate in front of `search.list` (`idx >= cursor`) could not fire for any of them.

On 2026-09-08, **18 of 35 playlists sat at exactly `cursor == song count`** — tomorrowland-top-1000 at 825/825, salsa-y-merengue at 531/531, koelner-karneval at 290/290. Those are not a random 18: the queue picks the playlist with the most gaps, and a playlist walked end to end without filling its gaps is precisely one with many gaps left. Every playlist the queue selected was an exhausted one.

## The fix

`wrap_cursor(cursor, total_songs)` — pure and unit-tested — brings the cursor back into range **before** the run walks, so a stale cursor costs nothing instead of a whole slice. Healing it after the walk would still have burned one slice per stale playlist, which is the thing this is meant to stop.

`total_songs <= 0` deliberately leaves the cursor alone: a `--playlist` name that matches nothing says nothing about whether the cursor is stale, and zeroing it there would throw away a good one because a caller mistyped.

## Why the two earlier attempts missed it

#2310's cursor skip and #2320's Odesli skip are both gated on `yt_gap`. A cursor past the end excludes every song from both **by construction**, so neither could ever see this.

## The log line that hid it for five days

The wrapper ended every run with "der Zeitdeckel fiel in der Odesli-Phase (#2301)" — while the 03:32 run took **five seconds for all sixteen slices**. A five-minute cap cannot have fired. Because the message named a cause, nobody looked for another one.

That wording now comes from the clock instead of from habit: each slice is timed, and a zero-search slice is only attributed to the time cap when it actually used ≥ 80 % of its allotted time; otherwise the log says explicitly that the cap was **not** it. It does not guess at a replacement cause — a second wrong one would cost as much as the first. That part lives in `beatifybot/scripts/youtube-backfill.sh` and ships outside this repo.

## Deliberately not in scope

Direction 3 of the issue — what the Odesli phase should do while `api.song.link` answers `401 PUBLIC_API_ACCESS_DEPRECATED`. It is called once per song to produce nothing, but it returns immediately and costs no measurable time, so it is noise rather than the blockage. Worth its own issue, not this PR.

## Tests

`tests/unit/test_backfill_youtube_first_2301.py` — 26 pass. Six cover `wrap_cursor` against the **real** function (a re-modelled predicate would have re-modelled the bug); two are text probes that the wrap is wired in *before* the song loop and that it reports itself rather than resetting silently.

Full suite: 2810 unit + 4 integration, green.

Closes #2301

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZgiCerwYUYJknd8EekVoD