### PR TITLE
Release v4.6.0-rc1 — Second Wind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [4.6.0-rc1] - 2026-09-08
+
+Die Woche 2026-W37b: sechs Eintraege aus der Redaktionskonferenz vom 08.09., alle gebaut und
+gemergt. Drei davon liefen durchs Design-Gate — #2503, #2746 und #2559, jeder mit vier
+gezeichneten Varianten und Markus' Auswahl.
+
+### Added
+- **Geister-Liga**: wer im Sudden Death ausscheidet, raet weiter — in einer eigenen Wertung, mit
+  eigenem Block auf dem Fernseher und einem Best-Ghost-Award am Ende (#2559, Variante B). Die
+  Wertung geht **pro gespielter Geisterrunde**, sonst gewaenne, wer am fruehesten rausfliegt.
+- **Encore**: auf dem Reveal vor der letzten Runde bietet das Spiel fuenf weitere Runden an, ohne
+  einen Punktestand zu ruehren. Nach dem Start der letzten Runde ist das Angebot weg, damit das
+  Finale ein Finale bleibt (#2503, Variante D).
+- **Einen Gast mitten im Spiel herausnehmen** — verbunden oder nicht. Die Runde wartet nicht mehr
+  auf ihn, Punkte und Rang bleiben stehen, und er kommt ueber sein eigenes Handy zur naechsten
+  Runde zurueck (#2746, Variante B).
+
+### Changed
+- Das Endbild sagt jetzt, dass **Rematch jeden Punktestand auf 0 setzt**. Vorher stand das nirgends.
+
+### Fixed
+- Der Einrichtungs-Assistent schreibt seine Aenderungen auf ein offenes Lobby-Spiel, statt es mit
+  den ersetzten Einstellungen weiterlaufen zu lassen (#2769).
+- Der YouTube-Backfill sucht wieder: sein Wiederaufnahme-Zeiger lief hinter das Ende der Playlist
+  und kam nie zurueck — 18 von 35 Playlists standen auf genau diesem Stand (#2301).
+
 ## [4.5.0] - 2026-09-08
 
 Die Woche 2026-W37: fuenfzig Eintraege aus der Redaktionskonferenz, alle gebaut und gemergt. Zwoelf

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -20,5 +20,5 @@
     "num2words==0.5.14"
   ],
   "single_config_entry": true,
-  "version": "4.5.0"
+  "version": "4.6.0-rc1"
 }

--- a/docs/release-notes-v4.6.0-rc1.md
+++ b/docs/release-notes-v4.6.0-rc1.md
@@ -1,0 +1,23 @@
+## 4.6.0-rc1 — Second Wind
+
+Two evenings ended too early, in different ways: the ones where somebody flew out in round two and watched the other eighteen, and the ones where the last song played while the room was clearly not finished.
+
+### 👻 Being out stops meaning being done
+
+An eliminated player keeps guessing. Their points go into a league of their own — the TV carries it as a second block under the survivors, marked "own points, no effect on the game", and the end screen hands out a Best Ghost card. It counts per ghost round played, so nobody wins it by going out early.
+
+### 🎉 Five more rounds, without resetting anything
+
+On the reveal before the last round the host is offered an encore. Scores stay exactly where they are. Once the last round starts the offer is gone, so the finale stays final — and the end screen finally admits that Rematch sets every score back to zero.
+
+### 🚪 A guest who has to leave
+
+The host can take anyone out mid-game now, connected or not. The round stops waiting, the points and the rank stay put, and the guest taps their own way back in at the next round.
+
+Also fixed: finishing the setup wizard no longer leaves a lobby game running the settings you just replaced, and the YouTube backfill searches again after five silent days.
+
+---
+
+**66 playlists · 6 music platforms · 6 languages**
+
+[Report a Bug](https://github.com/mholzi/beatify/issues) · [Discussions](https://github.com/mholzi/beatify/discussions) · [Full Changelog](https://github.com/mholzi/beatify/blob/main/CHANGELOG.md)


### PR DESCRIPTION
Der Kandidat der Woche **2026-W37b**. Sechs Blattplan-Eintraege, alle gemergt.

## Inhalt

| Eintrag | Was |
|---|---|
| #2559 | Geister-Liga (Variante B) — Ausgeschiedene raten weiter, in eigener Wertung |
| #2503 | Encore (Variante D) — fuenf Runden mehr, ohne einen Punktestand zu ruehren |
| #2746 | Gast mitten im Spiel herausnehmen (Variante B), Rueckkehr ueber sein eigenes Handy |
| #2769 | Wizard schreibt auf das offene Lobby-Spiel statt daneben |
| #2301 | YouTube-Backfill sucht wieder — der Wiederaufnahme-Zeiger lief hinter das Ende |
| #2504 | Beitritts-Code bleibt waehrend des Spiels sichtbar (bereits in v4.5.0-Nachlauf gemergt) |

Drei liefen durchs Design-Gate mit je vier gezeichneten Varianten und Markus' Auswahl.

**Minor, nicht Patch**: zwei ausgelieferte Spielweisen kommen dazu, es verschwinden nicht nur Fehler.

## Playlist-Versions-Pruefung

**Null geaenderte Playlist-Dateien** im Bereich `v4.5.0..main` — der Schritt entfaellt fuer diesen Cut. Er steht in der `rc-cut`-command.md, weil am 03.09.2026 vierunddreissig geaenderte Dateien ihre `version` nicht mitbekamen: `_copy_bundled_playlists` ueberschreibt nur bei strikt hoeherer Version, die Aenderung haette also keine bestehende Installation erreicht.

## Geprueft

2870 Python-Tests + Integration, 1439 JS-Tests, `ruff check` und `format` sauber, Bundles synchron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZgiCerwYUYJknd8EekVoD