### PR TITLE
chore(playlists): youtube backfill — +2 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
+++ b/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
@@ -1,6 +1,6 @@
 {
   "name": "Tomorrowland Top 1000",
-  "version": "0.69",
+  "version": "0.70",
   "tags": [
     "edm",
     "electronic",
@@ -18866,7 +18866,7 @@
       "year": 2025,
       "isrc": "QMBZ92552535",
       "uri": "spotify:track:31yljlcH1pEm4Dz85D1KGC",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=3hlAVCBz6uc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3413000091",
       "fun_fact": "“Body Language” is the title track of Samm’s release of the same name.",

--- a/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
+++ b/custom_components/beatify/playlists/community/tomorrowland-top-1000.json
@@ -1,6 +1,6 @@
 {
   "name": "Tomorrowland Top 1000",
-  "version": "0.70",
+  "version": "0.71",
   "tags": [
     "edm",
     "electronic",
@@ -2215,7 +2215,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1826812710"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ovznTayG7FQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3443845841",
       "fun_fact": "“Blessings - Cassian Remix” is the title track of Calvin Harris’s release of the same name.",
@@ -3456,7 +3456,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1444889719"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=GElIBZYnFdM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/101022014",
       "fun_fact": "“Generate - Radio Edit” is the title track of Eric Prydz’s release of the same name.",
@@ -3480,7 +3480,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1511947026"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=klIF0nhsxxM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/952358062",
       "fun_fact": "“Split (Only U)” is the title track of Tiësto’s release of the same name.",
@@ -3528,7 +3528,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1692399425"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=luJJBeCFeM0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/56718321",
       "fun_fact": "“Internet Friends” appears on Knife Party’s release “100% No Modern Talking”.",
@@ -3572,7 +3572,7 @@
       "year": 2022,
       "isrc": "DEP992200001",
       "uri": "spotify:track:6oE5yvroDXWNYWpIFz2JJB",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VeYmdHS-iYA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1678490857",
       "fun_fact": "“Toca's Miracle - Radio Edit” appears on Fragma’s release “Toca (20th Anniversary Edition)”.",
@@ -3596,7 +3596,7 @@
       "year": 2009,
       "isrc": "GBARL0900102",
       "uri": "spotify:track:07POri5O6Xu0aVZzlvOcpy",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=w3qzlGCZXsg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/13131862",
       "fun_fact": "“I'm Not Alone - Radio Edit” appears on Calvin Harris’s release “Ready For The Weekend”.",
@@ -3620,7 +3620,7 @@
       "year": 2024,
       "isrc": "DEEC33501383",
       "uri": "spotify:track:4x6jx7AeSyE7PlQTdCjIJs",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=To_sGyJJoTo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2684663852",
       "fun_fact": "“Thandaza” is the title track of &ME’s release of the same name.",
@@ -3648,7 +3648,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1350851321"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=k0rwzGdWb68",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/463377162",
       "fun_fact": "“Break Through The Silence - Radio Edit” appears on Martin Garrix’s release “Break Through The Silence EP”.",
@@ -3696,7 +3696,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1336612552"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VMnPX3GeyEM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/452697792",
       "fun_fact": "“Melody - Radio Edit” appears on Oliver Heldens’s release “Melody”.",
@@ -3716,7 +3716,7 @@
       "year": 2012,
       "isrc": "FR9W11114947",
       "uri": "spotify:track:1pUsdir2xhSxP0RyBe9lLH",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XHs99iVpnXU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/16638433",
       "fun_fact": "“Icarus” is the title track of Madeon’s release of the same name.",
@@ -3792,7 +3792,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1054208532"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=sIqwKughd1g",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/111101816",
       "fun_fact": "“Remember (feat. The Presets)” is the title track of Steve Angello’s release of the same name.",
@@ -3860,7 +3860,7 @@
       "year": 2010,
       "isrc": "AUVC02203910",
       "uri": "spotify:track:3Yv9CEIOJjpw8tgKJhbOcc",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=97ZH96XXr9I",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/4106993181",
       "fun_fact": "“My Feelings For You - Radio Edit” appears on Avicii’s release “My Feelings For You”.",
@@ -3881,7 +3881,7 @@
       "year": 2009,
       "isrc": "AUUM70902040",
       "uri": "spotify:track:7tOcPDj3vyopZ404pY6UuP",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=BAdLRRbzOv4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/4231436",
       "fun_fact": "“Shooting Stars” is the title track of Bag Raiders’s release of the same name.",
@@ -3905,7 +3905,7 @@
       "year": 2014,
       "isrc": "NLB8R1400020",
       "uri": "spotify:track:2HDhsfCmbVjLHYXK32jaCC",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rwkoXft0dXU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1084862592",
       "fun_fact": "“Waves [feat. Chris Brown & T.I.] - Robin Schulz Remix” is the title track of Mr. Probz’s release of the same name.",
@@ -3929,7 +3929,7 @@
       "year": 2010,
       "isrc": "GBKCF1000157",
       "uri": "spotify:track:317BSQk5pe7FyV3VVmS62w",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=iOd4tHG3K_E",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/73460660",
       "fun_fact": "“Nothing But Love - Radio Edit” appears on Axwell’s release “Nothing But Love”.",
@@ -3953,7 +3953,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1565941214"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Qgx_V0So0qk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/937659352",
       "fun_fact": "“Out Of The Blue” is the title track of System F’s release of the same name.",
@@ -3977,7 +3977,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1523741361"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YMzbfDNdMaU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/994819972",
       "fun_fact": "“I Need You To Know” is the title track of Armin van Buuren’s release of the same name.",
@@ -4001,7 +4001,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1444887542"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=tSJSVmfaMCs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/451666062",
       "fun_fact": "“BOOM” is the title track of Tiësto’s release of the same name.",
@@ -4021,7 +4021,7 @@
       "year": 2010,
       "isrc": "BEG581000001",
       "uri": "spotify:track:71DiO15JfaJuQRiNUc6i1J",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=b3qFDrqCH3k",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/85997699",
       "fun_fact": "“Tomorrow - The Tomorrowland Anthem - Give in to the Night” appears on Dimitri Vegas’s release “Tomorrow (Give In To The Night / The Tomorrowland Anthem)”.",
@@ -4045,7 +4045,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1475915894"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=l56xgEYWocY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/728155102",
       "fun_fact": "“Home (feat. Bonn)” is the title track of Martin Garrix’s release of the same name.",
@@ -4065,7 +4065,7 @@
       "year": 2024,
       "isrc": "CBEFB2400006",
       "uri": "spotify:track:3Q2RZh5dlBuqaeDIxPeieP",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mE3HJZ6Zh7c",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2817234002",
       "fun_fact": "“Pretty Green Eyes (Sunset Ibiza Mix)” is the title track of KETTAMA’s release of the same name.",
@@ -4089,7 +4089,7 @@
       "year": 2019,
       "isrc": "SE5R71900301",
       "uri": "spotify:track:2x0RZdkZcD8QRI53XT4GI5",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=u8tdT5pAE34",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/679227012",
       "fun_fact": "“SOS (feat. Aloe Blacc)” appears on Avicii’s release “SOS (Laidback Luke Tribute Remix)”.",
@@ -4137,7 +4137,7 @@
       "year": 2016,
       "isrc": "SE4OX1600112",
       "uri": "spotify:track:78W8wiUIlQ2SnWY9TVowKZ",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=OggDVRkivs8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/125970763",
       "fun_fact": "“Back Where I Belong (feat. Avicii)” is the title track of Otto Knows’s release of the same name.",
@@ -4161,7 +4161,7 @@
       "year": 2007,
       "isrc": "GBEFR0701070",
       "uri": "spotify:track:1uqnKeoy55KA6LqoOiW4Pm",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wsl3k2mHDhQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/14155727",
       "fun_fact": "“I Want Your Soul” is the title track of Armand Van Helden’s release of the same name.",
@@ -4189,7 +4189,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1487717291"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SahRw77yvx0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/812497162",
       "fun_fact": "“Make It to Heaven (with Raye)” is the title track of David Guetta’s release of the same name.",
@@ -4213,7 +4213,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1793821451"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=IAmsHbAA6c0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3212563541",
       "fun_fact": "“Flight 643 - Radio Edit” appears on Tiësto’s release “Magikal Journey -The Hits Collection 1998 - 2008”.",
@@ -4237,7 +4237,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1269598586"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=NoBAfjvhj7o",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/393116082",
       "fun_fact": "“17” is the title track of MK’s release of the same name.",
@@ -4282,7 +4282,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1803490125"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FNHfPqti1V8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3288051331",
       "fun_fact": "“light years (feat. Inéz)” appears on John Summit’s release “light years”.",
@@ -4306,7 +4306,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1833479161"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YPuGEJ5fiew",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3510119541",
       "fun_fact": "“Feel It” appears on Amelie Lens’s release “Radiance”.",
@@ -4330,7 +4330,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1501718057"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=76mkEfxxIl0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/917700862",
       "fun_fact": "“Slow Down (feat. Jorja Smith) - Vintage Culture & Slow Motion Remix” is the title track of Maverick Sabre’s release of the same name.",
@@ -4354,7 +4354,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1711788460"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=T-8c6IAneZI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/69183334",
       "fun_fact": "“Ladi Dadi (feat. Wynter Gordon) - Tommy Trash Remix” appears on Steve Aoki’s release “Ladi Dadi (feat. Wynter Gordon)”.",
@@ -4402,7 +4402,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1762724674"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=CPzF73sLdrw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2496486291",
       "fun_fact": "“Drinkee - Vintage Culture & John Summit Remix” is the title track of SOFI TUKKER’s release of the same name.",
@@ -4426,7 +4426,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1445046707"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=AewNd29wRUM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/100334220",
       "fun_fact": "“The Only Way Is Up” appears on Martin Garrix’s release “Club Life, Vol. 4 - New York City”.",
@@ -4446,7 +4446,7 @@
       "year": 2004,
       "isrc": "GBEWA0400020",
       "uri": "spotify:track:4v4Dt0633CJyKmOrVz8Qb0",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=RA1phM0XYhE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/109922601",
       "fun_fact": "“No One On Earth - Original Mix” appears on Above & Beyond’s release “No One On Earth”.",
@@ -4466,7 +4466,7 @@
       "year": 2011,
       "isrc": "ARG991012059",
       "uri": "spotify:track:2Hy89WQAxszEUQAvpja0nx",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=LnET4RKXx5k",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/13214666",
       "fun_fact": "“Hello” appears on Martin Solveig’s release “Hello (Karaoke)”.",
@@ -4494,7 +4494,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1035668453"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Q52J_PHWYBo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/106695910",
       "fun_fact": "“Sugar (feat. Francesco Yates) - Stadiumx Remix” appears on Robin Schulz’s release “Sugar (feat. Francesco Yates) (ALOK Remix)”.",
@@ -4518,7 +4518,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1811404734"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=g5K-op3XUXs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3345287311",
       "fun_fact": "“Appetite” is the title track of Chris Lorenzo’s release of the same name.",
@@ -4542,7 +4542,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1814233144"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VNwigGCOIxk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3380574911",
       "fun_fact": "“Voices In My Head” appears on Anyma’s release “The End Of Genesys”.",
@@ -4566,7 +4566,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1346880700"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=J701ucIsrrk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/459990712",
       "fun_fact": "“Power” is the title track of Hardwell’s release of the same name.",
@@ -4590,7 +4590,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1606352057"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VVI6wGZTnU8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1629864532",
       "fun_fact": "“The Parade” is the title track of Joel Corry’s release of the same name.",
@@ -4610,7 +4610,7 @@
       "year": 2018,
       "isrc": "GBJAJ1801883",
       "uri": "spotify:track:3SzPA7bBOiaF4mvcujTGvy",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vSgvklLFhE0",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/578921802",
       "fun_fact": "“Right Here, Right Now - CamelPhat Remix” appears on Fatboy Slim’s release “Best Of Toolroom 2018 (Mixed By Illyus & Barrientos)”.",
@@ -4634,7 +4634,7 @@
       "year": 2018,
       "isrc": "NLM5S1800322",
       "uri": "spotify:track:4CbUxjNBBkRnoo7MzjUFP9",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=W6kBMEbCehU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/539409732",
       "fun_fact": "“Saga” is the title track of Matisse & Sadko’s release of the same name.",
@@ -4662,7 +4662,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1791736475"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Us-4C6Bz5nQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3278141651",
       "fun_fact": "“Don't Wake Me Up” is the title track of James Hype’s release of the same name.",
@@ -7334,7 +7334,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1727362089"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=IZ36b3q1elI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2633773772",
       "fun_fact": "“World Hold On (Children of the Sky) - Radio Edit” is the title track of Bob Sinclar’s release of the same name.",
@@ -18198,7 +18198,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1653471645"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qJ1GBL1TPLg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1894584167",
       "fun_fact": "“Danielle (smile on my face)” is the title track of Fred again..’s release of the same name.",
@@ -18218,7 +18218,7 @@
       "year": 2018,
       "isrc": "DEE861800415",
       "uri": "spotify:track:2yAOaUhMCX7irO3N1ygHs4",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=92Q6cXbTwJA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/472782882",
       "fun_fact": "“Part Eight” appears on Paul Kalkbrenner’s release “Parts of Life”.",
@@ -18246,7 +18246,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1813214930"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=JcX83mdWToQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3358703801",
       "fun_fact": "“Savana” is the title track of Chris Lake’s release of the same name.",
@@ -18266,7 +18266,7 @@
       "year": 2013,
       "isrc": "GBUYR1200032",
       "uri": "spotify:track:54ZPmGE1uOG9IYoUBSRSp7",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=0Ndc_AqQs4o",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/68601046",
       "fun_fact": "“City Of Dreams - Radio Edit” appears on Dirty South’s release “City Of Dreams”.",
@@ -18286,7 +18286,7 @@
       "year": 2023,
       "isrc": "NLZ542301634",
       "uri": "spotify:track:6uNmhuEwkqtDcyDYbc2vBo",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rSbN3rREOM8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2494445261",
       "fun_fact": "“Hold On - Radio Edit” appears on MOGUAI’s release “Hold On (Mixes)”.",
@@ -18306,7 +18306,7 @@
       "year": 2019,
       "isrc": "CYA111900050",
       "uri": "spotify:track:4FpsZqiM5vdrCh8QpCKJQd",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=w74O60CUuhY",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/857196102",
       "fun_fact": "“Can't Get Enough” appears on Tiësto’s release “Together”.",
@@ -18334,7 +18334,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1696083506"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1JPNFp0f53I",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2357139175",
       "fun_fact": "“Desire (with Sam Smith)” appears on Calvin Harris’s release “Desire (Calvin Harris VIP Mix)”.",
@@ -18358,7 +18358,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/918184083"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=CVvJp3d8xGQ",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/77542036",
       "fun_fact": "“Faded” appears on ZHU’s release “THE NIGHTDAY”.",
@@ -18382,7 +18382,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1504640961"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-SIK3vlMoV8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1055848662",
       "fun_fact": "“Strings ID” appears on ARTY’s release “Our Song (Mix)”.",
@@ -18402,7 +18402,7 @@
       "year": 2015,
       "isrc": "GBCEN1500880",
       "uri": "spotify:track:6rph5HqB8Ba2wOE6MoFTmW",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=hK2c8tgiOrI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3910318211",
       "fun_fact": "“Chunky - Radio Edit” appears on Format:B’s release “Chunky”.",
@@ -18426,7 +18426,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1450992992"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=r1m4E2gkCVE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/537682812",
       "fun_fact": "“Coffee Shop” appears on Sunnery James & Ryan Marciano’s release “Affective EP”.",
@@ -18450,7 +18450,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1336552260"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=JLASUu1Ekqg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/452692932",
       "fun_fact": "“Electric Elephants” is the title track of Jay Hardway’s release of the same name.",
@@ -18470,7 +18470,7 @@
       "year": 2018,
       "isrc": "NLZ541800423",
       "uri": "spotify:track:7BF5rE2EVDmWNXc0uoP8Bz",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=NPFkbYho2Js",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/501725912",
       "fun_fact": "“I Could Be Wrong - Radio Edit” appears on Lucas & Steve’s release “I Could Be Wrong”.",
@@ -18494,7 +18494,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1755039408"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vRLQQJtKEbs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2871900192",
       "fun_fact": "“Black Friday (pretty like the sun)” is the title track of Lost Frequencies’s release of the same name.",
@@ -18514,7 +18514,7 @@
       "year": 2018,
       "isrc": "GBAYE1800657",
       "uri": "spotify:track:3t462saypfWgBlj9cESaQc",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=QFM-pAssbKU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/525035212",
       "fun_fact": "“Hang Up Your Hang Ups (The Only One) [feat. Kim English]” is the title track of Paul Woolford’s release of the same name.",
@@ -18542,7 +18542,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1698253579"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jWVNji4yYsw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2310206575",
       "fun_fact": "“TAKE IT OFF” is the title track of FISHER’s release of the same name.",
@@ -18562,7 +18562,7 @@
       "year": 2021,
       "isrc": "NLF712109048",
       "uri": "spotify:track:1q3qh7hEJrPmPH7uOteYSr",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=tA0Tce1V4vM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1543695242",
       "fun_fact": "“No Fun” is the title track of Armin van Buuren’s release of the same name.",
@@ -18586,7 +18586,7 @@
       "year": 2020,
       "isrc": "NLM5S2000785",
       "uri": "spotify:track:4RVtBlHFKj51Ipvpfv5ER4",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=iGS07iQaAcg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/858386482",
       "fun_fact": "“Drown (feat. Clinton Kane)” is the title track of Martin Garrix’s release of the same name.",
@@ -18614,7 +18614,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1677879718"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=tYjKDEnYTyI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2200270587",
       "fun_fact": "“Madame Hollywood” appears on Felix Da Housecat’s release “Kittenz and Thee Glitz”.",
@@ -18638,7 +18638,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1346174729"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=K0KV7F4shEk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/459572422",
       "fun_fact": "“Tunnel Vision - Don Diablo Edit” appears on Zonderling’s release “Cluster EP”.",
@@ -18658,7 +18658,7 @@
       "year": 2016,
       "isrc": "UK98Q1600200",
       "uri": "spotify:track:4QcDkuGQx9824a6X9BZF4e",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=NJlOmDWyoA8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/136806118",
       "fun_fact": "“Places” is the title track of Martin Solveig’s release of the same name.",
@@ -18682,7 +18682,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1783936709"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ikJCO_FrQQ8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/3155427641",
       "fun_fact": "“The Cure & The Cause - Dennis Ferrer Remix” appears on Fish Go Deep’s release “Soul Heaven Presents Digital Heaven”.",
@@ -18706,7 +18706,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1457559430"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fQ94EsNi5Qs",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/664224582",
       "fun_fact": "“Me & You” is the title track of MORTEN’s release of the same name.",
@@ -18726,7 +18726,7 @@
       "year": 2020,
       "isrc": "USUG12001572",
       "uri": "spotify:track:3mCWozLIaOzbYzyshABNwD",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jdHArhpAtKw",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/942217702",
       "fun_fact": "“ily (i love you baby) (ARTY Remix) [feat. Emilee]” appears on Surf Mesa’s release “ily (i love you baby) (ARTY Remix)”.",
@@ -18750,7 +18750,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1700695874"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ywQvbGcCIEk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2393575535",
       "fun_fact": "“Dive” is the title track of Lost Frequencies’s release of the same name.",
@@ -18770,7 +18770,7 @@
       "year": 2019,
       "isrc": "CYA111900215",
       "uri": "spotify:track:2Y3P9IFAeNGH9qTZDp9N6W",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mqdT7BZryIE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/740582572",
       "fun_fact": "“Day Or Night” is the title track of Mike Williams’s release of the same name.",
@@ -18794,7 +18794,7 @@
       "year": 2020,
       "isrc": "USZ4V2000486",
       "uri": "spotify:track:1J2OlTIPluzOmf3RX8eKhT",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XuCa4VsuZNI",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1145132072",
       "fun_fact": "“Turn Back Time” is the title track of Diplo’s release of the same name.",
@@ -18822,7 +18822,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/714934373"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=kwvxKgk9fxA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/71110252",
       "fun_fact": "“My My My” appears on Armand Van Helden’s release “The Best of Armand Van Helden”.",
@@ -18842,7 +18842,7 @@
       "year": 2023,
       "isrc": "NLZ542300863",
       "uri": "spotify:track:4EmH2iRucAgCOnhuJRotUi",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=imAklKjAQDc",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2317153225",
       "fun_fact": "“Drifting” is the title track of Tiësto’s release of the same name.",
@@ -18894,7 +18894,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1762727380"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=MF0O2MZUYwk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1800448457",
       "fun_fact": "“Summer In New York - Öwnboss & Fancy Inc Remix” is the title track of SOFI TUKKER’s release of the same name.",
@@ -18918,7 +18918,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1467747046"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8I8QO5LYaek",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/701706242",
       "fun_fact": "“We Got That Cool (feat. Afrojack & Icona Pop)” is the title track of Yves V’s release of the same name.",
@@ -18938,7 +18938,7 @@
       "year": 2018,
       "isrc": "GBARL1801466",
       "uri": "spotify:track:5N5k9nd479b1xpDZ4usjrg",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=kkLk2XWMBf8",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/542335432",
       "fun_fact": "“Promises (with Sam Smith)” appears on Calvin Harris’s release “Promises (Remixes)”.",
@@ -18958,7 +18958,7 @@
       "year": 2010,
       "isrc": "NLF541000331",
       "uri": "spotify:track:4QWBcrylXagFizmFkt6X2t",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Lv-lpBfshHU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/10648388",
       "fun_fact": "“Mundocaso” appears on Gregor Salto’s release “Horizonte ep”.",
@@ -18986,7 +18986,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1649265022"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=pbyIzhfWgeg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1234385992",
       "fun_fact": "“Shadow (Maceo Plex Remix)” appears on Maceo Plex’s release “Shadow (Remixes)”.",
@@ -19006,7 +19006,7 @@
       "year": 2022,
       "isrc": "BEHP42200024",
       "uri": "spotify:track:4PdSICTVRI1xrXZM1sOSCe",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=eXBNFf7CF9U",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2023253397",
       "fun_fact": "“Back To You” is the title track of Lost Frequencies’s release of the same name.",
@@ -19034,7 +19034,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1451341736"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ROaCvn5_rYA",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/635276472",
       "fun_fact": "“I Do (feat. Andreas Moss)” is the title track of Zonderling’s release of the same name.",
@@ -19054,7 +19054,7 @@
       "year": 2006,
       "isrc": "GBCPZ0501380",
       "uri": "spotify:track:61RlktJeYy38pu1vY70pgU",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=5Ft8yL7VLR4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/90383245",
       "fun_fact": "“Discopolis” appears on Lifelike’s release “Deeper Sessions”.",
@@ -19082,7 +19082,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1732966798"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TMIxbMgRLG4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2675407682",
       "fun_fact": "“Empty” is the title track of Martin Garrix’s release of the same name.",
@@ -19106,7 +19106,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1848407764"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=AOwwihJpAVg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/66275128",
       "fun_fact": "“Running - Disclosure Remix” appears on Jessie Ware’s release “Devotion - The Gold Edition”.",
@@ -19130,7 +19130,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1135950694"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XFcajXnJOso",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/137751079",
       "fun_fact": "“Yebisah” appears on Mark Knight’s release “It's Julian Jordan”.",
@@ -19150,7 +19150,7 @@
       "year": 2012,
       "isrc": "GBKCF1200202",
       "uri": "spotify:track:0aeEe0nk4J2n2GiqSFtvHq",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=4HyXluv9Qeg",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/113475910",
       "fun_fact": "“Sing2Me” is the title track of Thomas Gold’s release of the same name.",
@@ -19178,7 +19178,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1522734996"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=IM3n-xKSgvU",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1015901462",
       "fun_fact": "“Parachute” is the title track of Paul Kalkbrenner’s release of the same name.",
@@ -19202,7 +19202,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1481875702"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=EBvxPnIyLBM",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/764557362",
       "fun_fact": "“The Beginning” appears on Pryda’s release “PRYDA 15 VOL III”.",
@@ -19226,7 +19226,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1440850841"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nUCoYcxNMBE",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/118585318",
       "fun_fact": "“Generate” appears on Eric Prydz’s release “Opus”.",
@@ -19246,7 +19246,7 @@
       "year": 2011,
       "isrc": "USUS11000974",
       "uri": "spotify:track:4IazOWzgfLB8MR5VIY368A",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SUgmtvP42Ms",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/69295405",
       "fun_fact": "“Cinema (feat. Gary Go) - Radio Edit” appears on Benny Benassi’s release “Electroman”.",
@@ -19270,7 +19270,7 @@
       "year": 2006,
       "isrc": "GBKCF2000929",
       "uri": "spotify:track:0zxUWZsgb9HX4WGYvUGkYF",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=h4Ix1bMet3U",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/997537372",
       "fun_fact": "“Tell Me Why - Original Mix” appears on Supermode’s release “Tell Me Why”.",
@@ -19290,7 +19290,7 @@
       "year": 2008,
       "isrc": "USUM70957532",
       "uri": "spotify:track:34sGnIHB3ZthMvHpNX1i7e",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=6JMgLuKrMpo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/4232307",
       "fun_fact": "“Day 'N' Nite - Crookers Remix” appears on Kid Cudi’s release “Man On The Moon: The End Of Day (Int'l Version)”.",
@@ -19310,7 +19310,7 @@
       "year": 2014,
       "isrc": "GB01A1400003",
       "uri": "spotify:track:7w9W20r1IpCDQQMRcLEsQZ",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TFXlWfzW9Uo",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/2986368051",
       "fun_fact": "“Sunlight (feat. Years and Years)” is the title track of The Magician’s release of the same name.",
@@ -19330,7 +19330,7 @@
       "year": 2012,
       "isrc": "GBTDG1200438",
       "uri": "spotify:track:5YaqbhEmoxSpIbdBTPG6KQ",
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xvtNS6hbVy4",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/60437441",
       "fun_fact": "“The Veldt” appears on deadmau5’s release “> album title goes here <”.",
@@ -19354,7 +19354,7 @@
       "uri_apple_music_by_region": {
         "us": "applemusic://track/1557873785"
       },
-      "uri_youtube_music": null,
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ASac36m_sWk",
       "uri_tidal": null,
       "uri_deezer": "deezer://track/1272005622",
       "fun_fact": "“Hide U - Tinlicker Remix” is the title track of Kosheen’s release of the same name.",

--- a/custom_components/beatify/playlists/hits-2010s-2020s.json
+++ b/custom_components/beatify/playlists/hits-2010s-2020s.json
@@ -1,6 +1,6 @@
 {
   "name": "2010s & 2020s Hits",
-  "version": "1.18",
+  "version": "1.19",
   "tags": [
     "pop",
     "charts",
@@ -2157,7 +2157,8 @@
       "fun_fact_es": "Ronson enfrentó un violín country a un ritmo de baile, y Miley Cyrus grabó la voz días después de que se quemara su casa en Malibú.",
       "fun_fact_fr": "Ronson a opposé un violon country à un beat dance, et Miley Cyrus a enregistré le chant quelques jours après l'incendie de sa maison de Malibu.",
       "fun_fact_nl": "Ronson zette een countryviool tegen een dancebeat, en Miley Cyrus nam de zang op enkele dagen nadat haar huis in Malibu was afgebrand.",
-      "fun_fact_it": "Ronson mise un violino country contro un ritmo dance, e Miley Cyrus incise la voce pochi giorni dopo l'incendio della sua casa a Malibu."
+      "fun_fact_it": "Ronson mise un violino country contro un ritmo dance, e Miley Cyrus incise la voce pochi giorni dopo l'incendio della sua casa a Malibu.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=A9hcJgtnm6Q"
     },
     {
       "year": 2019,

--- a/custom_components/beatify/playlists/movies-100-greatest-themes.json
+++ b/custom_components/beatify/playlists/movies-100-greatest-themes.json
@@ -1,6 +1,6 @@
 {
   "name": "Movie & TV Soundtracks 🎬",
-  "version": "1.34",
+  "version": "1.35",
   "tags": [
     "movies",
     "soundtrack",
@@ -8421,7 +8421,8 @@
       "fun_fact_es": "Streisand grabó dos versiones y los productores no supieron elegir, así que se quedaron ambas: una abre la película y la otra la cierra.",
       "fun_fact_fr": "Streisand a enregistré deux versions et les producteurs n'ont pas su choisir : les deux ont été gardées, l'une ouvre le film, l'autre le referme.",
       "fun_fact_nl": "Streisand nam twee versies op en de producenten konden niet kiezen, dus bleven ze allebei — de ene opent de film, de andere sluit hem af.",
-      "fun_fact_it": "La Streisand incise due versioni e i produttori non seppero scegliere: rimasero entrambe, una apre il film e l'altra lo chiude."
+      "fun_fact_it": "La Streisand incise due versioni e i produttori non seppero scegliere: rimasero entrambe, una apre il film e l'altra lo chiude.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ifWOSnoCS0M"
     },
     {
       "artist": "David Rose",
@@ -8440,7 +8441,8 @@
       "fun_fact_es": "Rose ya había escrito la música de Bonanza cuando aceptó esta serie. El tema suena bajo una cabecera de niñas rodando por una colina, y desde entonces es sinónimo de esa imagen.",
       "fun_fact_fr": "Rose avait déjà écrit la musique de Bonanza quand il a pris cette série. Le thème accompagne un générique d'enfants dévalant une colline, et il en est resté le raccourci.",
       "fun_fact_nl": "Rose had de muziek voor Bonanza al geschreven toen hij deze serie aannam. Het thema klinkt onder een titelsequentie van kinderen die van een heuvel rollen, en staat sindsdien voor dat beeld.",
-      "fun_fact_it": "Rose aveva già scritto la musica di Bonanza quando prese questa serie. Il tema accompagna una sigla di bambine che rotolano giù da una collina, e da allora ne è il simbolo."
+      "fun_fact_it": "Rose aveva già scritto la musica di Bonanza quando prese questa serie. Il tema accompagna una sigla di bambine che rotolano giù da una collina, e da allora ne è il simbolo.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=roy_fqf-Dk4"
     },
     {
       "artist": "Jerry Goldsmith",


### PR DESCRIPTION
A `provider-uri-backfill` run, driven automatically by `com.beatify.youtube-backfill`.

- `tomorrowland-top-1000` YouTube 730 -> **731**/825
- `hits-2010s-2020s` YouTube 72 -> **73**/124

**Draft on purpose** — merged only once the maintainer approves.