### PR TITLE
Release v4.6.0-rc2 — Second Wind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [4.6.0-rc2] - 2026-09-09
+
+Ein Nachschlag zum rc1, ohne eine Zeile Spiellogik. Alles hier ist Katalogpflege und
+Werkzeugkette — was auf dem Fernseher passiert, ist unveraendert.
+
+### Fixed
+- **Vier kaputte Provider-URIs** in `polish-all-time-hits` (#2785 via #2786). Zwei davon
+  wurden **entfernt statt ersetzt**: eine fehlende URI laesst Beatify den Anbieter
+  ueberspringen, eine tote laesst die Wiedergabe vor Gaesten scheitern. Beim Varius-Manx-
+  Eintrag kam das Schwerere dazu — der Link zeigte auf eine Live-Aufnahme von 2016, waehrend
+  die richtige Antwort 1995 lautet.
+- **Der Playlist-Pruefer stellte die falschen Fragen** (#2785 via #2787). Fuenf von neun
+  Befunden eines Laufs waren Fehlalarme: Deezer wurde am Anzeigenamen gemessen statt an der
+  ISRC, und Apple wurde bei einer polnischen Playlist gegen US/DE/GB aufgeloest. Beides
+  behoben, gegen alle sechs bekannten Faelle geprueft — die zwei echten Fehler fallen
+  weiterhin auf.
+
+### Changed
+- **+97 YouTube-URIs** aus den Backfill-Laeufen (#2783, #2784).
+- **Die Werkzeugkette ist reproduzierbar** (#2580 via #2788, #2789, #2790): `package-lock.json`
+  wird eingecheckt, die CI installiert mit `npm ci`, und Dependabot ist eingerichtet. Dazu
+  `npm audit` von acht Meldungen auf **null** — vitest 2.1.9 auf 5.0.0, esbuild auf 0.28.2.
+  Der Neubau mit dem neuen esbuild liess jedes Artefakt bytegleich; ausgeliefert aendert sich
+  dadurch nichts.
+
 ## [4.6.0-rc1] - 2026-09-08
 
 Die Woche 2026-W37b: sechs Eintraege aus der Redaktionskonferenz vom 08.09., alle gebaut und

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -20,5 +20,5 @@
     "num2words==0.5.14"
   ],
   "single_config_entry": true,
-  "version": "4.6.0-rc1"
+  "version": "4.6.0-rc2"
 }

--- a/docs/release-notes-v4.6.0-rc2.md
+++ b/docs/release-notes-v4.6.0-rc2.md
@@ -1,0 +1,19 @@
+## 4.6.0-rc2 — Second Wind
+
+Everything from rc1 is unchanged: the ghost league, the encore, taking a guest out mid-game. This candidate adds no gameplay at all. It exists because a catalogue check went looking for broken links and found something about itself.
+
+### 🎵 Four broken links, and two of them deleted rather than replaced
+
+`polish-all-time-hits` had four provider URIs that no longer play. Two are simply gone instead of swapped: a missing URI makes Beatify skip that provider, a dead one makes playback fail in front of your guests. One was worse than dead — it pointed at a 2016 live recording while the answer on screen said 1995.
+
+### 🔍 The checker was asking the wrong questions
+
+Five of that run's nine findings were false alarms. Deezer was judged on its display name, which carries an album prefix on compilations; Apple was looked up in US/DE/GB for a Polish playlist. Now the ISRC decides for Deezer, and Apple is asked in the storefronts the entry itself claims. Both real defects still fail the check.
+
+Also in: 97 more YouTube links, and a build toolchain that resolves the same way twice — with its security advisories down from eight to zero.
+
+---
+
+**66 playlists · 6 music platforms · 6 languages**
+
+[Report a Bug](https://github.com/mholzi/beatify/issues) · [Discussions](https://github.com/mholzi/beatify/discussions) · [Full Changelog](https://github.com/mholzi/beatify/blob/main/CHANGELOG.md)


### PR DESCRIPTION
Second candidate for 4.6.0. **No gameplay change against rc1** — the ghost league, the encore and taking a guest out mid-game are all unchanged.

Everything in here is catalogue upkeep and toolchain. It exists because a health check went looking for broken links and found something about itself.

| Area | What moved |
|---|---|
| Catalogue | four dead URIs in `polish-all-time-hits`, two **removed** rather than replaced (#2786) |
| Checker | ISRC for Deezer, claimed storefronts for Apple — five false alarms out of nine gone, both real defects still caught (#2787) |
| Providers | +97 YouTube URIs (#2783, #2784) |
| Toolchain | lockfile committed, CI on `npm ci`, dependabot live, `npm audit` **8 → 0** (#2788, #2789, #2790) |

**Playlist version check**, the step that exists because 34 files once missed it: all five touched playlist files carry a bumped `version` across `v4.6.0-rc1..main`. Without it the change never reaches an existing installation — `_copy_bundled_playlists` only overwrites on a strictly higher version.

The esbuild bump left every built artifact byte-identical, so nothing that ships changed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcFTBQHh6oB2HTBmiPRSsC
