### PR TITLE
chore(playlists): youtube backfill — +9 youtube uris

### DIFF
--- a/custom_components/beatify/playlists/2000s-pop-anthems.json
+++ b/custom_components/beatify/playlists/2000s-pop-anthems.json
@@ -1,6 +1,6 @@
 {
   "name": "2000s Pop Anthems",
-  "version": "1.28",
+  "version": "1.29",
   "tags": [
     "2000s",
     "pop",
@@ -8266,7 +8266,8 @@
       "fun_fact_es": "La escribió Max Martin, y el sencillo dio el mayor salto semanal de la historia de las listas estadounidenses hasta entonces, del 97 al 1.",
       "fun_fact_fr": "Max Martin l'a écrite, et le single a réalisé le plus grand bond hebdomadaire de l'histoire des classements américains, de la 97e à la 1re place.",
       "fun_fact_nl": "Max Martin schreef het, en de single maakte de grootste weeksprong in de Amerikaanse hitlijstgeschiedenis tot dan, van 97 naar 1.",
-      "fun_fact_it": "La scrisse Max Martin, e il singolo fece il più grande balzo settimanale della storia delle classifiche americane, dal 97 al primo posto."
+      "fun_fact_it": "La scrisse Max Martin, e il singolo fece il più grande balzo settimanale della storia delle classifiche americane, dal 97 al primo posto.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cRM70Jw7F4M"
     },
     {
       "year": 2009,

--- a/custom_components/beatify/playlists/70s-hits.json
+++ b/custom_components/beatify/playlists/70s-hits.json
@@ -1,6 +1,6 @@
 {
   "name": "70s Hits",
-  "version": "1.23",
+  "version": "1.24",
   "tags": [
     "1970s",
     "classic-rock",
@@ -4442,7 +4442,8 @@
       "fun_fact_es": "Noddy Holder escribió la letra de gira por Estados Unidos y, por una vez, Slade escribió bien el título: la marca del grupo eran las faltas deliberadas.",
       "fun_fact_fr": "Noddy Holder a écrit le texte en tournée américaine et, pour une fois, Slade a écrit le titre correctement — la marque du groupe était la faute d'orthographe volontaire.",
       "fun_fact_nl": "Noddy Holder schreef de tekst tijdens een Amerikaanse tournee, en voor één keer spelde Slade de titel correct — het handelsmerk van de band waren opzettelijke spelfouten.",
-      "fun_fact_it": "Noddy Holder scrisse il testo in tournée in America e, per una volta, gli Slade scrissero il titolo correttamente: il marchio della band erano gli errori voluti."
+      "fun_fact_it": "Noddy Holder scrisse il testo in tournée in America e, per una volta, gli Slade scrissero il titolo correttamente: il marchio della band erano gli errori voluti.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=iQ5itYUNu70"
     },
     {
       "year": 1974,

--- a/custom_components/beatify/playlists/community/disney-latino.json
+++ b/custom_components/beatify/playlists/community/disney-latino.json
@@ -1,6 +1,6 @@
 {
   "name": "Disney Latino",
-  "version": "0.4",
+  "version": "0.5",
   "tags": [
     "disney",
     "movies",
@@ -28,7 +28,8 @@
         "Mateo Ramírez Velasco",
         "Tata Vega"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Coco» della Disney (2017)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Coco» della Disney (2017).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=8WtkRSa6lvw"
     },
     {
       "year": 1994,
@@ -47,7 +48,8 @@
         "Ana Torroja",
         "Natalia Lafourcade"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (1994)."
+      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (1994).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nl6wIrZxnEU"
     },
     {
       "year": 2019,
@@ -83,7 +85,8 @@
         "Elenco de Soy Luna",
         "Héctor Ortiz"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Toy Story 3» della Disney (2010)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Toy Story 3» della Disney (2010).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=eVRghsitMV0"
     },
     {
       "year": 2026,
@@ -140,7 +143,8 @@
         "Natalia Lafourcade",
         "Norma Herrera"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Encanto» della Disney (2021)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Encanto» della Disney (2021).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7JXVgNvIXcI"
     },
     {
       "year": 2019,
@@ -233,7 +237,8 @@
         "Mateo Ramírez Velasco",
         "TINI"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Encanto» della Disney (2021)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Encanto» della Disney (2021).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=JWe_smmkgrw"
     },
     {
       "year": 2017,
@@ -339,7 +344,8 @@
         "Gipsy Kings",
         "Mateo Ramírez Velasco"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (1991)."
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (1991).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Ns6RlF1bgh8"
     },
     {
       "year": 2013,
@@ -375,7 +381,8 @@
         "Ana Torroja",
         "Luis Fonsi"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (1991)."
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (1991).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=K8X0Kdceb6w"
     },
     {
       "year": 1994,
@@ -411,7 +418,8 @@
         "Marco Antonio Solís",
         "Sofia Carson"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Moana» della Disney (2016)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Moana» della Disney (2016).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ftNOCfqoIjQ"
     },
     {
       "year": 2010,
@@ -555,7 +563,8 @@
         "Luis Ángel Gómez Jaramillo",
         "Sugey Torres"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «La Sirenita» della Disney (1989)."
+      "fun_fact_it": "Dalla versione in spagnolo di «La Sirenita» della Disney (1989).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=OXMmxlAqKNM"
     },
     {
       "year": 1994,
@@ -574,7 +583,8 @@
         "Kalimba Marichal",
         "Tata Vega"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (1994)."
+      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (1994).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gJX8_Htt6Vk"
     },
     {
       "year": 1991,
@@ -593,7 +603,8 @@
         "Gonzo",
         "Mendez"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (1991)."
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (1991).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=A7qXfg9c29c"
     },
     {
       "year": 2010,
@@ -612,7 +623,8 @@
         "Sugey Torres",
         "Tata Vega"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Enredados» della Disney (2010)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Enredados» della Disney (2010).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=fZSZMp32XaA"
     },
     {
       "year": 2016,
@@ -630,7 +642,8 @@
         "Olga Lucía Vives"
       ],
       "fun_fact_it": "Dalla versione in spagnolo di «Tini: El gran cambio de Violetta» della Disney (2016).",
-      "uri_deezer": "deezer://track/123791408"
+      "uri_deezer": "deezer://track/123791408",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=O6RimxEkDPM"
     },
     {
       "year": 2019,
@@ -647,7 +660,8 @@
         "Elenco de Soy Luna",
         "Sara Paula Gómez Arias"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (2019)."
+      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (2019).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=eFEF2bckT1g"
     },
     {
       "year": 2013,
@@ -666,7 +680,8 @@
         "Analy",
         "Meli G"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Frozen» della Disney (2013)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Frozen» della Disney (2013).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YG2vqB408bk"
     },
     {
       "year": 2013,
@@ -685,7 +700,8 @@
         "Esteman",
         "Kalimba Marichal"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Frozen» della Disney (2013)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Frozen» della Disney (2013).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rVjI9YRc4pE"
     },
     {
       "year": 2016,
@@ -704,7 +720,8 @@
         "Romina Marroquín Payró",
         "Sebastian Yatra"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Moana» della Disney (2016)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Moana» della Disney (2016).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HS2qe2nL2Co"
     },
     {
       "year": 1970,
@@ -723,7 +740,8 @@
         "Marco Antonio Solís",
         "ZAYN"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Los Aristogatos» della Disney (1970)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Los Aristogatos» della Disney (1970).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=sgYSvpuGbcc"
     },
     {
       "year": 2017,
@@ -740,7 +758,8 @@
         "David Bisbal",
         "ZAYN"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (2017)."
+      "fun_fact_it": "Dalla versione in spagnolo di «La Bella y la Bestia» della Disney (2017).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=K8IhHiR6yqU"
     },
     {
       "year": 2013,
@@ -759,7 +778,8 @@
         "Carlos Vives",
         "Eduardo Tejedo"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Frozen» della Disney (2013)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Frozen» della Disney (2013).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ajVhh8tz_C8"
     },
     {
       "year": 1994,
@@ -776,7 +796,8 @@
         "Christina Aguilera",
         "TINI"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (1994)."
+      "fun_fact_it": "Dalla versione in spagnolo di «El Rey León» della Disney (1994).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=OAP8VltOxwc"
     },
     {
       "year": 2017,
@@ -795,7 +816,8 @@
         "Armando Gama",
         "Esteman"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Coco» della Disney (2017)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Coco» della Disney (2017).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=9tIn78xQExM"
     },
     {
       "year": 2017,
@@ -814,7 +836,8 @@
         "Carlos Rivera",
         "Meli G"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Coco» della Disney (2017)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Coco» della Disney (2017).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Jh36KGOqHEs"
     },
     {
       "year": 1997,
@@ -833,7 +856,8 @@
         "Carlos Rivera",
         "Tata Vega"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Hércules» della Disney (1997)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Hércules» della Disney (1997).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XDmJTJHWZv0"
     },
     {
       "year": 1999,
@@ -852,7 +876,8 @@
         "Gipsy Kings",
         "Rubén Albarrán"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Toy Story 2» della Disney (1999)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Toy Story 2» della Disney (1999).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7npcmylOmP8"
     },
     {
       "year": 2017,
@@ -871,7 +896,8 @@
         "Eros Ramazzotti",
         "Romina Marroquín Payró"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Coco» della Disney (2017)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Coco» della Disney (2017).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1KJrkpAcIeE"
     },
     {
       "year": 2013,
@@ -890,7 +916,8 @@
         "Eduardo Tejedo",
         "Mendez"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Frozen» della Disney (2013)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Frozen» della Disney (2013).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=5StQQ0LL1n8"
     },
     {
       "year": 1994,
@@ -927,7 +954,8 @@
         "Bronco",
         "Luis Ángel Gómez Jaramillo"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Moana» della Disney (2016)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Moana» della Disney (2016).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=1-Hu7xBSW0o"
     },
     {
       "year": 2019,
@@ -946,7 +974,8 @@
         "Analy",
         "Sara Paula Gómez Arias"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Toy Story 4» della Disney (2019)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Toy Story 4» della Disney (2019).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qM_DsJPDxak"
     },
     {
       "year": 1999,
@@ -965,7 +994,8 @@
         "Jessi Corti",
         "Renato Lopez"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Tarzán» della Disney (1999)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Tarzán» della Disney (1999).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VccbUMdkDsU"
     },
     {
       "year": 2013,
@@ -984,7 +1014,8 @@
         "Luis Ángel Gómez Jaramillo",
         "Renato Lopez"
       ],
-      "fun_fact_it": "Dalla versione in spagnolo di «Frozen» della Disney (2013)."
+      "fun_fact_it": "Dalla versione in spagnolo di «Frozen» della Disney (2013).",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=V2J-zzifWzU"
     },
     {
       "year": 1994,

--- a/custom_components/beatify/playlists/community/musica-italiana.json
+++ b/custom_components/beatify/playlists/community/musica-italiana.json
@@ -1,7 +1,7 @@
 {
   "name": "Musica Italiana 🇮🇹",
   "description": "Italian classics from the 1960s to the 2000s — cantautori, Sanremo winners and the songs every Italian party sings along to. Merged from playlist requests #2228 and #2229.",
-  "version": "0.15",
+  "version": "0.16",
   "songs": [
     {
       "year": 1962,
@@ -304,7 +304,8 @@
       "fun_fact_it": "Massimo Ranieri - \"Vent'anni\" (1970), dal canone del pop italiano.",
       "isrc": "ITR007000051",
       "uri_apple_music": "applemusic://track/1542206913",
-      "uri_deezer": "deezer://track/783929"
+      "uri_deezer": "deezer://track/783929",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=pIf7et701IU"
     },
     {
       "year": 1970,
@@ -322,7 +323,8 @@
       "fun_fact_it": "Massimo Ranieri - \"Rose rosse\" (1970), dal canone del pop italiano.",
       "isrc": "ITR006900021",
       "uri_apple_music": "applemusic://track/1532950592",
-      "uri_deezer": "deezer://track/751985"
+      "uri_deezer": "deezer://track/751985",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=IwacsU0Ul8Q"
     },
     {
       "year": 1971,
@@ -359,7 +361,8 @@
       "fun_fact_it": "Lucio Dalla - \"4/3/1943\" (1971), dal canone del pop italiano.",
       "isrc": "ITB007001022",
       "uri_apple_music": "applemusic://track/254149169",
-      "uri_deezer": "deezer://track/972768"
+      "uri_deezer": "deezer://track/972768",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=3C5fVNlWXrk"
     },
     {
       "year": 1971,
@@ -377,7 +380,8 @@
       "fun_fact_it": "Mia Martini - \"Piccolo uomo\" (1971), dal canone del pop italiano. Ha vinto il Festivalbar.",
       "isrc": "ITDV92500170",
       "uri_apple_music": "applemusic://track/1807966498",
-      "uri_deezer": "deezer://track/3731934942"
+      "uri_deezer": "deezer://track/3731934942",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VC2EhZ5sFFU"
     },
     {
       "year": 1971,
@@ -395,7 +399,8 @@
       "fun_fact_it": "Ricchi E Poveri - \"Che Sarà\" (1971), dal canone del pop italiano. Scritta da Jimmy Fontana. Presentata al Festival di Sanremo.",
       "isrc": "ITD009000010",
       "uri_apple_music": "applemusic://track/998281784",
-      "uri_deezer": "deezer://track/3293696"
+      "uri_deezer": "deezer://track/3293696",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=uttf8JSOtKw"
     },
     {
       "year": 1972,
@@ -413,7 +418,8 @@
       "fun_fact_it": "Claudio Baglioni - \"Porta Portese\" (1972), dal canone del pop italiano.",
       "isrc": "ITB007200862",
       "uri_apple_music": "applemusic://track/254225856",
-      "uri_deezer": "deezer://track/424505992"
+      "uri_deezer": "deezer://track/424505992",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=RXxLIs49SOA"
     },
     {
       "year": 1972,
@@ -431,7 +437,8 @@
       "fun_fact_it": "Claudio Baglioni - \"Mia Libertà\" (1972), dal canone del pop italiano.",
       "isrc": "ITB007200133",
       "uri_apple_music": "applemusic://track/200571073",
-      "uri_deezer": "deezer://track/1021893"
+      "uri_deezer": "deezer://track/1021893",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vrhkNYHKi58"
     },
     {
       "year": 1972,
@@ -449,7 +456,8 @@
       "fun_fact_it": "Claudio Baglioni - \"Questo piccolo grande amore\" (1972), dal canone del pop italiano.",
       "isrc": "ITB007200861",
       "uri_apple_music": "applemusic://track/200570600",
-      "uri_deezer": "deezer://track/576276"
+      "uri_deezer": "deezer://track/576276",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=taCUXg0xdcE"
     },
     {
       "year": 1972,
@@ -467,7 +475,8 @@
       "fun_fact_it": "Lucio Battisti - \"Il mio canto libero\" (1972), dal canone del pop italiano.",
       "isrc": "ITB001701090",
       "uri_apple_music": "applemusic://track/1480766133",
-      "uri_deezer": "deezer://track/764304922"
+      "uri_deezer": "deezer://track/764304922",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=UtUHEsPfjjE"
     },
     {
       "year": 1973,
@@ -485,7 +494,8 @@
       "fun_fact_it": "Claudio Baglioni - \"Amore bello\" (1973), dal canone del pop italiano.",
       "isrc": "ITB007301064",
       "uri_apple_music": "applemusic://track/253992888",
-      "uri_deezer": "deezer://track/1020156"
+      "uri_deezer": "deezer://track/1020156",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nj9ZT84uf64"
     },
     {
       "year": 1973,
@@ -503,7 +513,8 @@
       "fun_fact_it": "Umberto Tozzi - \"Tu\" (1973), dal canone del pop italiano. Scritta da Umberto Tozzi and Giancarlo Bigazzi.",
       "isrc": "ITR007800321",
       "uri_apple_music": "applemusic://track/1564230420",
-      "uri_deezer": "deezer://track/1351336652"
+      "uri_deezer": "deezer://track/1351336652",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=x39KPRT1BH8"
     },
     {
       "year": 1974,
@@ -521,7 +532,8 @@
       "fun_fact_it": "Riccardo Cocciante - \"Bella senz'anima\" (1974), dal canone del pop italiano.",
       "isrc": "ITB007401175",
       "uri_apple_music": "applemusic://track/255453955",
-      "uri_deezer": "deezer://track/985852"
+      "uri_deezer": "deezer://track/985852",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Rpv32GUxvcg"
     },
     {
       "year": 1975,
@@ -539,7 +551,8 @@
       "fun_fact_it": "Francesco De Gregori - \"Rimmel\" (1975), dal canone del pop italiano.",
       "isrc": "ITB007401283",
       "uri_apple_music": "applemusic://track/259987956",
-      "uri_deezer": "deezer://track/546135"
+      "uri_deezer": "deezer://track/546135",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Ydo-yfPze30"
     },
     {
       "year": 1975,
@@ -557,7 +570,8 @@
       "fun_fact_it": "Rino Gaetano - \"Ma il cielo è sempre più blu\" (1975), dal canone del pop italiano.",
       "isrc": "ITB008400575",
       "uri_apple_music": "applemusic://track/1571903770",
-      "uri_deezer": "deezer://track/1020925"
+      "uri_deezer": "deezer://track/1020925",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=rfaihaFlcSg"
     },
     {
       "year": 1976,
@@ -575,7 +589,8 @@
       "fun_fact_it": "Loredana Bertè - \"Sei bellissima\" (1976), dal canone del pop italiano. Pubblicata da Sony Music.",
       "isrc": "ITR007500231",
       "uri_apple_music": "applemusic://track/1631382207",
-      "uri_deezer": "deezer://track/689319"
+      "uri_deezer": "deezer://track/689319",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=O96IzoPUiFg"
     },
     {
       "year": 1977,
@@ -593,7 +608,8 @@
       "fun_fact_it": "Alan Sorrenti - \"Figli Delle Stelle\" (1977), dal canone del pop italiano. Pubblicata da EMI italiana.",
       "isrc": "ITD000500050",
       "uri_apple_music": "applemusic://track/1442578568",
-      "uri_deezer": "deezer://track/3371535"
+      "uri_deezer": "deezer://track/3371535",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Kqbm4I8iOm8"
     },
     {
       "year": 1977,
@@ -611,7 +627,8 @@
       "fun_fact_it": "Donatella Rettore - \"Donatella\" (1977), dal canone del pop italiano.",
       "isrc": "ITDV92500071",
       "uri_apple_music": "applemusic://track/1614482579",
-      "uri_deezer": "deezer://track/3731929282"
+      "uri_deezer": "deezer://track/3731929282",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SSpMXTp9mQk"
     },
     {
       "year": 1977,
@@ -629,7 +646,8 @@
       "fun_fact_it": "Pooh - \"Dammi solo un minuto - 2014 Remaster\" (1977), dal canone del pop italiano.",
       "isrc": "ITR001400162",
       "uri_apple_music": "applemusic://track/1710443769",
-      "uri_deezer": "deezer://track/124637040"
+      "uri_deezer": "deezer://track/124637040",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=3GJC1MApaqk"
     },
     {
       "year": 1977,
@@ -647,7 +665,8 @@
       "fun_fact_it": "Roberto Vecchioni - \"Samarcanda\" (1977), dal canone del pop italiano.",
       "isrc": "IT7009506670",
       "uri_apple_music": "applemusic://track/821631862",
-      "uri_deezer": "deezer://track/2297038065"
+      "uri_deezer": "deezer://track/2297038065",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Pk07iKa5wvk"
     },
     {
       "year": 1977,
@@ -665,7 +684,8 @@
       "fun_fact_it": "Umberto Tozzi - \"Ti Amo\" (1977), dal canone del pop italiano. Usata in seguito nel film Asterix & Obelix: Mission Cleopatra.",
       "isrc": "ITR007700021",
       "uri_apple_music": "applemusic://track/1565179218",
-      "uri_deezer": "deezer://track/1357589612"
+      "uri_deezer": "deezer://track/1357589612",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=M0zhHvs8kwA"
     },
     {
       "year": 1978,
@@ -683,7 +703,8 @@
       "fun_fact_it": "Anna Oxa - \"Un'emozione da poco\" (1978), dal canone del pop italiano. Arrivata al primo posto della classifica italiana. Contenuta nell'album Oxanna.",
       "isrc": "ITB007800565",
       "uri_apple_music": "applemusic://track/818784238",
-      "uri_deezer": "deezer://track/69008435"
+      "uri_deezer": "deezer://track/69008435",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=odqCkzNRvH8"
     },
     {
       "year": 1978,
@@ -701,7 +722,8 @@
       "fun_fact_it": "Antonello Venditti - \"Sara\" (1978), dal canone del pop italiano.",
       "isrc": "ITUM71800855",
       "uri_apple_music": "applemusic://track/252352184",
-      "uri_deezer": "deezer://track/555658072"
+      "uri_deezer": "deezer://track/555658072",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=I7WZxdnnUkg"
     },
     {
       "year": 1978,
@@ -719,7 +741,8 @@
       "fun_fact_it": "Claudio Baglioni - \"E tu come stai?\" (1978), dal canone del pop italiano.",
       "isrc": "ITM000102558",
       "uri_apple_music": "applemusic://track/200324416",
-      "uri_deezer": "deezer://track/1073047"
+      "uri_deezer": "deezer://track/1073047",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7SnnJtreSCY"
     },
     {
       "year": 1978,
@@ -737,7 +760,8 @@
       "fun_fact_it": "Francesco De Gregori - \"Generale\" (1978), dal canone del pop italiano.",
       "isrc": "ITB007701007",
       "uri_apple_music": "applemusic://track/254263491",
-      "uri_deezer": "deezer://track/1082468"
+      "uri_deezer": "deezer://track/1082468",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=C-G0QmbQNO4"
     },
     {
       "year": 1978,
@@ -755,7 +779,8 @@
       "fun_fact_it": "Loredana Bertè - \"Dedicato - 2016 Remastered\" (1978), dal canone del pop italiano.",
       "isrc": "ITR007800251",
       "uri_apple_music": "applemusic://track/1679436762",
-      "uri_deezer": "deezer://track/3920585"
+      "uri_deezer": "deezer://track/3920585",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=vHotqTS7qKE"
     },
     {
       "year": 1978,
@@ -773,7 +798,8 @@
       "fun_fact_it": "Patty Pravo - \"Pensiero stupendo\" (1978), dal canone del pop italiano. Scritta da Ivano Fossati.",
       "isrc": "ITB007701035",
       "uri_apple_music": "applemusic://track/254264774",
-      "uri_deezer": "deezer://track/1020587"
+      "uri_deezer": "deezer://track/1020587",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=f9Q5ndX9rAY"
     },
     {
       "year": 1978,
@@ -791,7 +817,8 @@
       "fun_fact_it": "Renato Zero - \"Triangolo\" (1978), dal canone del pop italiano.",
       "isrc": "ITB007800748",
       "uri_apple_music": "applemusic://track/275439955",
-      "uri_deezer": "deezer://track/64975600"
+      "uri_deezer": "deezer://track/64975600",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Ej9__NTLgAc"
     },
     {
       "year": 1978,
@@ -809,7 +836,8 @@
       "fun_fact_it": "Rino Gaetano - \"A mano a mano\" (1978), dal canone del pop italiano.",
       "isrc": "ITB000900104",
       "uri_apple_music": "applemusic://track/1536464463",
-      "uri_deezer": "deezer://track/101902307"
+      "uri_deezer": "deezer://track/101902307",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=H6QIXhyLR3Y"
     },
     {
       "year": 1978,
@@ -827,7 +855,8 @@
       "fun_fact_it": "Rino Gaetano - \"Gianna\" (1978), dal canone del pop italiano.",
       "isrc": "ITB008400565",
       "uri_apple_music": "applemusic://track/1299685367",
-      "uri_deezer": "deezer://track/634108"
+      "uri_deezer": "deezer://track/634108",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=laIH5AQqeH0"
     },
     {
       "year": 1978,
@@ -845,7 +874,8 @@
       "fun_fact_it": "Vasco Rossi - \"E...\" (1978), dal canone del pop italiano.",
       "isrc": "ITD000400182",
       "uri_apple_music": "applemusic://track/1443213284",
-      "uri_deezer": "deezer://track/135876548"
+      "uri_deezer": "deezer://track/135876548",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wYMuL0z2uJk"
     },
     {
       "year": 1979,
@@ -1452,7 +1482,8 @@
       "fun_fact_it": "Riccardo Fogli - \"Storie di tutti i giorni\" (1982), dal canone del pop italiano.",
       "isrc": "ITR008200471",
       "uri_apple_music": "applemusic://track/1453582477",
-      "uri_deezer": "deezer://track/755986"
+      "uri_deezer": "deezer://track/755986",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=bgLeOgspkEA"
     },
     {
       "year": 1982,
@@ -1489,7 +1520,8 @@
       "fun_fact_it": "Vasco Rossi - \"Ogni volta\" (1982), dal canone del pop italiano.",
       "isrc": "ITB260401560",
       "uri_apple_music": "applemusic://track/1327847262",
-      "uri_deezer": "deezer://track/104725328"
+      "uri_deezer": "deezer://track/104725328",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=7YKuFIJtnyE"
     },
     {
       "year": 1983,
@@ -1507,7 +1539,8 @@
       "fun_fact_it": "Fiordaliso - \"Non voglio mica la luna\" (1983), dal canone del pop italiano. Pubblicata da Durium nel 1984.",
       "isrc": "ITB008670575",
       "uri_apple_music": "applemusic://track/255738823",
-      "uri_deezer": "deezer://track/1017423"
+      "uri_deezer": "deezer://track/1017423",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=so34owtJSXY"
     },
     {
       "year": 1983,
@@ -1525,7 +1558,8 @@
       "fun_fact_it": "Franco Battiato - \"La Stagione Dell'Amore - Remastered 2008\" (1983), dal canone del pop italiano.",
       "isrc": "ITD000800110",
       "uri_apple_music": "applemusic://track/1606898557",
-      "uri_deezer": "deezer://track/3464234"
+      "uri_deezer": "deezer://track/3464234",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=J1IT9WqI7zA"
     },
     {
       "year": 1983,
@@ -1543,7 +1577,8 @@
       "fun_fact_it": "Loredana Bertè - \"Il mare d'inverno\" (1983), dal canone del pop italiano.",
       "isrc": "ITM009901369",
       "uri_apple_music": "applemusic://track/671755909",
-      "uri_deezer": "deezer://track/62912666"
+      "uri_deezer": "deezer://track/62912666",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wFuubVEdJ9Q"
     },
     {
       "year": 1983,
@@ -1561,7 +1596,8 @@
       "fun_fact_it": "Lu Colombo - \"Maracaibo\" (1983), dal canone del pop italiano.",
       "isrc": "ITD008400017",
       "uri_apple_music": "applemusic://track/405021856",
-      "uri_deezer": "deezer://track/3541677"
+      "uri_deezer": "deezer://track/3541677",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ParxYj8HtgA"
     },
     {
       "year": 1983,
@@ -1579,7 +1615,8 @@
       "fun_fact_it": "Nada - \"Amore Disperato - 2004 Remaster\" (1983), dal canone del pop italiano.",
       "isrc": "ITD000400067",
       "uri_apple_music": "applemusic://track/1647071573",
-      "uri_deezer": "deezer://track/3327907"
+      "uri_deezer": "deezer://track/3327907",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=syYgio-zR0g"
     },
     {
       "year": 1983,
@@ -1597,7 +1634,8 @@
       "fun_fact_it": "Toto Cutugno - \"Solo noi\" (1983), dal canone del pop italiano. Presentata al Festival di Sanremo.",
       "isrc": "ITB268000030",
       "uri_apple_music": "applemusic://track/1329256168",
-      "uri_deezer": "deezer://track/104724380"
+      "uri_deezer": "deezer://track/104724380",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=TiCMc4CW0dc"
     },
     {
       "year": 1986,
@@ -1615,7 +1653,8 @@
       "fun_fact_it": "Eros Ramazzotti - \"Adesso tu\" (1984), dal canone del pop italiano. Presentata al Festival di Sanremo.",
       "isrc": "ITB008671030",
       "uri_apple_music": "applemusic://track/254548552",
-      "uri_deezer": "deezer://track/87677323"
+      "uri_deezer": "deezer://track/87677323",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Wx3R0vUDG68"
     },
     {
       "year": 1984,
@@ -1633,7 +1672,8 @@
       "fun_fact_it": "Gianni Togni - \"Giulia\" (1984), dal canone del pop italiano.",
       "isrc": "ITR008400501",
       "uri_apple_music": "applemusic://track/79354753",
-      "uri_deezer": "deezer://track/818877"
+      "uri_deezer": "deezer://track/818877",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=VzuyrF0G2FQ"
     },
     {
       "year": 1985,
@@ -1651,7 +1691,8 @@
       "fun_fact_it": "Gianni Morandi - \"Uno su mille\" (1985), dal canone del pop italiano. Pubblicata da RCA Italiana.",
       "isrc": "ITB008500294",
       "uri_apple_music": "applemusic://track/796510429",
-      "uri_deezer": "deezer://track/74189254"
+      "uri_deezer": "deezer://track/74189254",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=gKo9naVHg2Q"
     },
     {
       "year": 1985,
@@ -1669,7 +1710,8 @@
       "fun_fact_it": "Vasco Rossi - \"T'immagini\" (1985), dal canone del pop italiano. Contenuta nell'album del 1985 Cosa succede in città.",
       "isrc": "ITB260401670",
       "uri_apple_music": "applemusic://track/1327592526",
-      "uri_deezer": "deezer://track/104726588"
+      "uri_deezer": "deezer://track/104726588",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Yh-KTLQRQgA"
     },
     {
       "year": 1986,
@@ -1687,7 +1729,8 @@
       "fun_fact_it": "Lucio Dalla - \"Caruso\" (1986), dal canone del pop italiano.",
       "isrc": "ITB008600207",
       "uri_apple_music": "applemusic://track/200934554",
-      "uri_deezer": "deezer://track/972492"
+      "uri_deezer": "deezer://track/972492",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=I84FCXqA1Vk"
     },
     {
       "year": 1986,
@@ -1705,7 +1748,8 @@
       "fun_fact_it": "Toto Cutugno - \"Serenata\" (1986), dal canone del pop italiano.",
       "isrc": "ITB268405760",
       "uri_apple_music": "applemusic://track/1329247255",
-      "uri_deezer": "deezer://track/104724382"
+      "uri_deezer": "deezer://track/104724382",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mlUFaSP3Bew"
     },
     {
       "year": 1987,
@@ -1723,7 +1767,8 @@
       "fun_fact_it": "Gianna Nannini - \"I maschi\" (1987), dal canone del pop italiano.",
       "isrc": "ITB000900945",
       "uri_apple_music": "applemusic://track/6768669894",
-      "uri_deezer": "deezer://track/88193681"
+      "uri_deezer": "deezer://track/88193681",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=pOeSUjNagCU"
     },
     {
       "year": 1987,
@@ -1741,7 +1786,8 @@
       "fun_fact_it": "Mango - \"Bella d'estate\" (1987), dal canone del pop italiano.",
       "isrc": "ITD018700009",
       "uri_apple_music": "applemusic://track/486352644",
-      "uri_deezer": "deezer://track/69025912"
+      "uri_deezer": "deezer://track/69025912",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=XOK0eC6U-gg"
     },
     {
       "year": 1988,
@@ -1759,7 +1805,8 @@
       "fun_fact_it": "Anna Oxa - \"Quando nasce un amore\" (1988), dal canone del pop italiano. Presentata al Festival di Sanremo. Contenuta nell'album della cantante Pensami per te.",
       "isrc": "ITM009700600",
       "uri_apple_music": "applemusic://track/819376891",
-      "uri_deezer": "deezer://track/69008453"
+      "uri_deezer": "deezer://track/69008453",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=YSNLzVEQhjQ"
     },
     {
       "year": 1988,
@@ -1777,7 +1824,8 @@
       "fun_fact_it": "Antonello Venditti - \"Ricordati di me\" (1988), dal canone del pop italiano.",
       "isrc": "ITG028800001",
       "uri_apple_music": "applemusic://track/304341668",
-      "uri_deezer": "deezer://track/566798"
+      "uri_deezer": "deezer://track/566798",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=QsTh_dKwx5I"
     },
     {
       "year": 1988,
@@ -1795,7 +1843,8 @@
       "fun_fact_it": "Massimo Ranieri - \"Perdere l'amore\" (1988), dal canone del pop italiano. Presentata al Festival di Sanremo.",
       "isrc": "ITQ008800011",
       "uri_apple_music": "applemusic://track/79281601",
-      "uri_deezer": "deezer://track/661313"
+      "uri_deezer": "deezer://track/661313",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Iw0cD44AhsA"
     },
     {
       "year": 1989,
@@ -1812,7 +1861,8 @@
       "fun_fact_nl": "Anna Oxa, Fausto Leali - \"Ti lascerò\" (1989), uit de Italiaanse popcanon.",
       "fun_fact_it": "Anna Oxa, Fausto Leali - \"Ti lascerò\" (1989), dal canone del pop italiano.",
       "isrc": "ITM009700604",
-      "uri_apple_music": "applemusic://track/335971114"
+      "uri_apple_music": "applemusic://track/335971114",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=nYs4-gsPIkU"
     },
     {
       "year": 1989,
@@ -1830,7 +1880,8 @@
       "fun_fact_it": "Lorella Cuccarini - \"La notte vola\" (1989), dal canone del pop italiano.",
       "isrc": "ITZ038901253",
       "uri_apple_music": "applemusic://track/518297844",
-      "uri_deezer": "deezer://track/18226796"
+      "uri_deezer": "deezer://track/18226796",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Sykr0FZZW7s"
     },
     {
       "year": 1989,
@@ -1848,7 +1899,8 @@
       "fun_fact_it": "Mia Martini - \"Almeno tu nell'universo\" (1989), dal canone del pop italiano.",
       "isrc": "ITB551110730",
       "uri_apple_music": "applemusic://track/1616014496",
-      "uri_deezer": "deezer://track/1696872787"
+      "uri_deezer": "deezer://track/1696872787",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=pSi0dbNAN9M"
     },
     {
       "year": 1992,
@@ -1866,7 +1918,8 @@
       "fun_fact_it": "Mia Martini - \"Gli Uomini Non Cambiano\" (1992), dal canone del pop italiano.",
       "isrc": "ITB551110740",
       "uri_apple_music": "applemusic://track/1616019807",
-      "uri_deezer": "deezer://track/1696905227"
+      "uri_deezer": "deezer://track/1696905227",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=eUXdvJe3-3c"
     },
     {
       "year": 1993,
@@ -1884,7 +1937,8 @@
       "fun_fact_it": "883 - \"Come mai\" (1993), dal canone del pop italiano.",
       "isrc": "ITQ000000822",
       "uri_apple_music": "applemusic://track/63831617",
-      "uri_deezer": "deezer://track/766655"
+      "uri_deezer": "deezer://track/766655",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ThGCZN1HPbE"
     },
     {
       "year": 1994,
@@ -1902,7 +1956,8 @@
       "fun_fact_it": "Michele Zarrillo - \"Cinque giorni\" (1994), dal canone del pop italiano.",
       "isrc": "ITB219900158",
       "uri_apple_music": "applemusic://track/271725260",
-      "uri_deezer": "deezer://track/2455279"
+      "uri_deezer": "deezer://track/2455279",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=mok-Mk0jXk8"
     },
     {
       "year": 1996,
@@ -1920,7 +1975,8 @@
       "fun_fact_it": "Franco Battiato - \"La Cura\" (1996), dal canone del pop italiano. Pubblicata da Mercury Records. Contenuta nell'album L'Imboscata.",
       "isrc": "IT7009609320",
       "uri_apple_music": "applemusic://track/1443744077",
-      "uri_deezer": "deezer://track/2432922"
+      "uri_deezer": "deezer://track/2432922",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cLJp-YJeuzc"
     },
     {
       "year": 1996,
@@ -1938,7 +1994,8 @@
       "fun_fact_it": "Ornella Vanoni - \"L'appuntamento\" (1996), dal canone del pop italiano.",
       "isrc": "ITB007071645",
       "uri_apple_music": "applemusic://track/254168669",
-      "uri_deezer": "deezer://track/564219"
+      "uri_deezer": "deezer://track/564219",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=z4nhDtkzhRg"
     },
     {
       "year": 1996,
@@ -1956,7 +2013,8 @@
       "fun_fact_it": "Vasco Rossi - \"Sally\" (1996), dal canone del pop italiano. Scritta da Vasco Rossi. Contenuta nell'album Nessun pericolo.",
       "isrc": "ITUM71700273",
       "uri_apple_music": "applemusic://track/1443087171",
-      "uri_deezer": "deezer://track/358728991"
+      "uri_deezer": "deezer://track/358728991",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=iVAZezs0H9s"
     },
     {
       "year": 1998,
@@ -1974,7 +2032,8 @@
       "fun_fact_it": "MINACELENTANO - \"Acqua e sale\" (1998), dal canone del pop italiano.",
       "isrc": "CH1439800020",
       "uri_apple_music": "applemusic://track/1719308553",
-      "uri_deezer": "deezer://track/2095901487"
+      "uri_deezer": "deezer://track/2095901487",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Krk7F7e28R0"
     },
     {
       "year": 1998,
@@ -1992,7 +2051,8 @@
       "fun_fact_it": "Vasco Rossi - \"Rewind - Radio Edit\" (1998), dal canone del pop italiano.",
       "isrc": "ITD009900052",
       "uri_apple_music": "applemusic://track/1443191612",
-      "uri_deezer": "deezer://track/3211478"
+      "uri_deezer": "deezer://track/3211478",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=qG3fXjVXuS0"
     },
     {
       "year": 1999,
@@ -2010,7 +2070,8 @@
       "fun_fact_it": "Adriano Celentano - \"L'Emozione Non Ha voce (Io Non So Parlar D'Amore)\" (1999), dal canone del pop italiano. Scritta da Mogol.",
       "isrc": "ITR059900002",
       "uri_apple_music": "applemusic://track/1702255790",
-      "uri_deezer": "deezer://track/2407440395"
+      "uri_deezer": "deezer://track/2407440395",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HHGHdMCCR1E"
     },
     {
       "year": 2000,
@@ -2028,7 +2089,8 @@
       "fun_fact_it": "Loretta Goggi - \"L'aria del sabato sera\" (2000), dal canone del pop italiano.",
       "isrc": "ITQ007900231",
       "uri_apple_music": "applemusic://track/698668390",
-      "uri_deezer": "deezer://track/4090058"
+      "uri_deezer": "deezer://track/4090058",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=4z_dU2OMrmY"
     },
     {
       "year": 2001,
@@ -2046,7 +2108,8 @@
       "fun_fact_it": "Gigi D'Alessio - \"Mon amour\" (2001), dal canone del pop italiano.",
       "isrc": "ITB000100006",
       "uri_apple_music": "applemusic://track/265973220",
-      "uri_deezer": "deezer://track/418533452"
+      "uri_deezer": "deezer://track/418533452",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=DGg7aNplmts"
     },
     {
       "year": 2002,
@@ -2063,7 +2126,8 @@
       "fun_fact_nl": "Gigi D'Alessio, Anna Tatangelo - \"Un nuovo bacio\" (2002), uit de Italiaanse popcanon.",
       "fun_fact_it": "Gigi D'Alessio, Anna Tatangelo - \"Un nuovo bacio\" (2002), dal canone del pop italiano.",
       "isrc": "ITB000200156",
-      "uri_apple_music": "applemusic://track/1308882452"
+      "uri_apple_music": "applemusic://track/1308882452",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=FwuIOnGppmY"
     },
     {
       "year": 2004,
@@ -2081,7 +2145,8 @@
       "fun_fact_it": "Vasco Rossi - \"Un Senso\" (2004), dal canone del pop italiano.",
       "isrc": "ITD000400186",
       "uri_apple_music": "applemusic://track/1443213440",
-      "uri_deezer": "deezer://track/135876550"
+      "uri_deezer": "deezer://track/135876550",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=StRtFh01XUo"
     },
     {
       "year": 2007,
@@ -2098,7 +2163,8 @@
       "fun_fact_nl": "Gianni Nazzaro - \"Quando L'Amore Diventa Poesía\" (2007), uit de Italiaanse popcanon.",
       "fun_fact_it": "Gianni Nazzaro - \"Quando L'Amore Diventa Poesía\" (2007), dal canone del pop italiano.",
       "isrc": null,
-      "uri_apple_music": "applemusic://track/1780787742"
+      "uri_apple_music": "applemusic://track/1780787742",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=-HQ9NZ3IJ7w"
     },
     {
       "year": 1990,
@@ -2118,7 +2184,8 @@
       "fun_fact_es": "Ramazzotti la escribió para un concierto benéfico en Milán y la cantó ante cuarenta mil personas que le devolvían el estribillo.",
       "fun_fact_fr": "Ramazzotti l'a écrite pour un concert caritatif à Milan et l'a chantée devant quarante mille personnes qui lui renvoyaient le refrain.",
       "fun_fact_nl": "Ramazzotti schreef het voor een benefietconcert in Milaan en zong het voor veertigduizend mensen die het refrein terugzongen.",
-      "fun_fact_it": "Ramazzotti la scrisse per un concerto di beneficenza a Milano e la cantò davanti a quarantamila persone che gli rimandavano il ritornello."
+      "fun_fact_it": "Ramazzotti la scrisse per un concerto di beneficenza a Milano e la cantò davanti a quarantamila persone che gli rimandavano il ritornello.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=C6dpQWnRII0"
     }
   ],
   "tags": [

--- a/custom_components/beatify/playlists/hits-2010s-2020s.json
+++ b/custom_components/beatify/playlists/hits-2010s-2020s.json
@@ -1,6 +1,6 @@
 {
   "name": "2010s & 2020s Hits",
-  "version": "1.19",
+  "version": "1.20",
   "tags": [
     "pop",
     "charts",
@@ -2419,7 +2419,8 @@
       "fun_fact_es": "Elizabeth Grant la publicó ella misma con un vídeo montado por ella a partir de material de archivo, y en meses consiguió un contrato discográfico.",
       "fun_fact_fr": "Elizabeth Grant l'a autopubliée avec un clip qu'elle a monté elle-même à partir d'images d'archives, et a décroché un contrat en quelques mois.",
       "fun_fact_nl": "Elizabeth Grant bracht het zelf uit met een video die ze zelf uit archiefbeelden monteerde, en had binnen maanden een platencontract.",
-      "fun_fact_it": "Elizabeth Grant la pubblicò da sé con un video montato da lei con materiale d'archivio, e in pochi mesi ottenne un contratto discografico."
+      "fun_fact_it": "Elizabeth Grant la pubblicò da sé con un video montato da lei con materiale d'archivio, e in pochi mesi ottenne un contratto discografico.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=cE6wxDqdOV0"
     },
     {
       "year": 2011,

--- a/custom_components/beatify/playlists/movies-100-greatest-themes.json
+++ b/custom_components/beatify/playlists/movies-100-greatest-themes.json
@@ -1,6 +1,6 @@
 {
   "name": "Movie & TV Soundtracks 🎬",
-  "version": "1.36",
+  "version": "1.37",
   "tags": [
     "movies",
     "soundtrack",
@@ -8850,7 +8850,8 @@
       "fun_fact_es": "Escrita para una mujer muda que solo habla a través de su piano, e interpretada en pantalla por Holly Hunter, que aprendió la parte ella misma. La banda sonora vendió más de tres millones de copias, algo insólito para la música clásica contemporánea.",
       "fun_fact_fr": "Écrite pour une femme muette qui ne s'exprime qu'au piano, et jouée à l'écran par Holly Hunter, qui a appris la partition elle-même. La bande originale s'est vendue à plus de trois millions d'exemplaires, chose rare pour de la musique classique contemporaine.",
       "fun_fact_nl": "Geschreven voor een stomme vrouw die alleen via haar piano spreekt, en op het scherm gespeeld door Holly Hunter, die de partij zelf instudeerde. De soundtrack verkocht meer dan drie miljoen exemplaren — ongehoord voor hedendaags klassiek.",
-      "fun_fact_it": "Scritta per una donna muta che parla soltanto attraverso il pianoforte, ed eseguita sullo schermo da Holly Hunter, che imparò la parte da sé. La colonna sonora vendette oltre tre milioni di copie, cosa rarissima per la classica contemporanea."
+      "fun_fact_it": "Scritta per una donna muta che parla soltanto attraverso il pianoforte, ed eseguita sullo schermo da Holly Hunter, che imparò la parte da sé. La colonna sonora vendette oltre tre milioni di copie, cosa rarissima per la classica contemporanea.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=toOShA7omUk"
     },
     {
       "artist": "Georges Delerue",
@@ -8889,7 +8890,8 @@
       "fun_fact_es": "La figura de violonchelo se escribió para unos títulos en los que mapas de relojería se despliegan ciudad a ciudad, así que la música gira como un mecanismo. Djawadi se formó en el estudio de Hans Zimmer y luego compuso Westworld con el mismo método: un tema recurrente, reconstruido sin fin.",
       "fun_fact_fr": "La figure de violoncelle a été écrite pour un générique où des cartes d'horlogerie se déplient ville après ville : la musique tourne donc comme un mécanisme. Djawadi est passé par le studio de Hans Zimmer, puis a composé Westworld selon le même principe — un thème, sans cesse reconstruit.",
       "fun_fact_nl": "De cellofiguur werd geschreven bij een titelsequentie waarin uurwerkkaarten zich stad na stad ontvouwen, dus de muziek draait als een mechaniek. Djawadi kwam uit de studio van Hans Zimmer en componeerde Westworld later volgens hetzelfde principe: één thema, eindeloos herbouwd.",
-      "fun_fact_it": "La figura di violoncello fu scritta per una sigla in cui mappe a orologeria si aprono città dopo città, così la musica gira come un meccanismo. Djawadi veniva dallo studio di Hans Zimmer e compose poi Westworld allo stesso modo: un tema solo, ricostruito all'infinito."
+      "fun_fact_it": "La figura di violoncello fu scritta per una sigla in cui mappe a orologeria si aprono città dopo città, così la musica gira come un meccanismo. Djawadi veniva dallo studio di Hans Zimmer e compose poi Westworld allo stesso modo: un tema solo, ricostruito all'infinito.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SJZfCg51xlU"
     },
     {
       "artist": "John Williams",
@@ -8908,7 +8910,8 @@
       "fun_fact_es": "Grabada con la London Symphony Orchestra en los mismos años que Tiburón, Star Wars y Encuentros en la tercera fase: cuatro temas que juntos fijaron cómo debe sonar una superproducción. Se dice a menudo que la frase principal sigue el ritmo del nombre del héroe.",
       "fun_fact_fr": "Enregistré avec le London Symphony Orchestra dans les mêmes années que Les Dents de la mer, Star Wars et Rencontres du troisième type — quatre thèmes qui ont ensemble défini le son du blockbuster. On dit souvent que la phrase principale épouse le rythme du nom du héros.",
       "fun_fact_nl": "Opgenomen met het London Symphony Orchestra in dezelfde jaren als Jaws, Star Wars en Close Encounters — vier thema's die samen vastlegden hoe een blockbuster hoort te klinken. Vaak wordt gezegd dat de hoofdfrase het ritme van de heldennaam volgt.",
-      "fun_fact_it": "Registrato con la London Symphony Orchestra negli stessi anni di Lo squalo, Guerre stellari e Incontri ravvicinati: quattro temi che insieme stabilirono come debba suonare un blockbuster. Si dice spesso che la frase principale segua il ritmo del nome dell'eroe."
+      "fun_fact_it": "Registrato con la London Symphony Orchestra negli stessi anni di Lo squalo, Guerre stellari e Incontri ravvicinati: quattro temi che insieme stabilirono come debba suonare un blockbuster. Si dice spesso che la frase principale segua il ritmo del nome dell'eroe.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=78N2SP6JFaI"
     },
     {
       "artist": "Howard Shore",
@@ -8927,7 +8930,8 @@
       "fun_fact_es": "Un silbato de hojalata y un violín sostienen toda la idea de hogar en una trilogía que por lo demás avanza a base de metales y coros. Shore escribió casi diez horas de música para las tres películas y ganó con ellas tres Oscar.",
       "fun_fact_fr": "Un tin whistle et un violon portent à eux seuls l'idée du foyer, dans une trilogie qui carbure par ailleurs aux cuivres et aux chœurs. Shore a écrit près de dix heures de musique pour les trois films et y a gagné trois Oscars.",
       "fun_fact_nl": "Een tinnen fluitje en een fiedel dragen het hele idee van thuis, in een trilogie die verder op koper en koren draait. Shore schreef bijna tien uur muziek voor de drie films en won er drie Oscars mee.",
-      "fun_fact_it": "Un flauto di latta e un violino reggono da soli l'idea di casa, in una trilogia che per il resto va avanti a ottoni e cori. Shore scrisse quasi dieci ore di musica per i tre film e ne ottenne tre Oscar."
+      "fun_fact_it": "Un flauto di latta e un violino reggono da soli l'idea di casa, in una trilogia che per il resto va avanti a ottoni e cori. Shore scrisse quasi dieci ore di musica per i tre film e ne ottenne tre Oscar.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=LML6SoNE7xE"
     },
     {
       "artist": "Keala Settle",
@@ -8946,7 +8950,8 @@
       "fun_fact_es": "Settle estaba tan nerviosa en el primer ensayo que casi no llegó a cantarla, y la toma de aquella sala forma parte de lo que acabó en el disco. La canción ganó el Globo de Oro a la mejor canción original y fue nominada al Oscar.",
       "fun_fact_fr": "Settle était si nerveuse lors du premier atelier qu'elle a failli ne pas la chanter, et la prise faite dans cette pièce fait partie de ce qui s'est retrouvé sur le disque. La chanson a remporté le Golden Globe de la meilleure chanson originale et été nommée aux Oscars.",
       "fun_fact_nl": "Settle was bij de eerste workshop zo zenuwachtig dat ze het bijna niet zong, en de opname uit die ruimte zit in wat uiteindelijk op de plaat belandde. Het nummer won de Golden Globe voor beste originele song en kreeg een Oscarnominatie.",
-      "fun_fact_it": "Settle era così nervosa al primo workshop che quasi non la cantò, e la take di quella stanza è parte di ciò che finì sul disco. La canzone vinse il Golden Globe come miglior canzone originale e ottenne una nomination all'Oscar."
+      "fun_fact_it": "Settle era così nervosa al primo workshop che quasi non la cantò, e la take di quella stanza è parte di ciò che finì sul disco. La canzone vinse il Golden Globe come miglior canzone originale e ottenne una nomination all'Oscar.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=DL72R0U8zuU"
     },
     {
       "artist": "James Horner",
@@ -8965,7 +8970,8 @@
       "fun_fact_es": "Horner recorrió toda la partitura de Braveheart con gaitas uilleann, de modo que una orquesta de Hollywood adopta un acento celta que no le es propio. Grabada con la London Symphony Orchestra, la banda sonora le valió una nominación al Oscar.",
       "fun_fact_fr": "Horner a fait courir les uilleann pipes dans toute la partition de Braveheart, si bien qu'un orchestre hollywoodien prend un accent celte qui n'est pas le sien. Enregistrée avec le London Symphony Orchestra, la musique lui a valu une nomination aux Oscars.",
       "fun_fact_nl": "Horner liet uilleann pipes door de hele Braveheart-partituur lopen, zodat een Hollywood-orkest een Keltisch accent krijgt dat het van huis uit niet heeft. Opgenomen met het London Symphony Orchestra leverde de muziek hem een Oscarnominatie op.",
-      "fun_fact_it": "Horner fece attraversare l'intera partitura di Braveheart dalle uilleann pipes, così un'orchestra hollywoodiana assume un accento celtico che non le appartiene. Registrata con la London Symphony Orchestra, la musica gli valse una nomination all'Oscar."
+      "fun_fact_it": "Horner fece attraversare l'intera partitura di Braveheart dalle uilleann pipes, così un'orchestra hollywoodiana assume un accento celtico che non le appartiene. Registrata con la London Symphony Orchestra, la musica gli valse una nomination all'Oscar.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=HSW9UPQbeVQ"
     },
     {
       "year": 1973,
@@ -8985,7 +8991,8 @@
       "fun_fact_es": "Karel Svoboda compuso el tema de una película de cuento checo-alemana que la televisión alemana emite cada Navidad desde 1973.",
       "fun_fact_fr": "Karel Svoboda a composé le thème d'un conte tchéco-allemand que la télévision allemande diffuse chaque Noël depuis 1973.",
       "fun_fact_nl": "Karel Svoboda schreef de muziek voor een Tsjechisch-Duitse sprookjesfilm die de Duitse televisie sinds 1973 elke kerst uitzendt.",
-      "fun_fact_it": "Karel Svoboda scrisse il tema di una fiaba ceco-tedesca che la televisione tedesca trasmette ogni Natale dal 1973."
+      "fun_fact_it": "Karel Svoboda scrisse il tema di una fiaba ceco-tedesca che la televisione tedesca trasmette ogni Natale dal 1973.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=xzSHh4BT4Vc"
     },
     {
       "year": 1987,
@@ -9026,7 +9033,8 @@
       "fun_fact_es": "Escrita para Oficial y caballero, casi la cortan porque el estudio creia que un duo frenaria el final; acabo ganando el Oscar.",
       "fun_fact_fr": "Ecrite pour Officier et gentleman, elle faillit etre coupee car le studio jugeait qu'un duo ralentirait la fin ; elle a remporte l'Oscar.",
       "fun_fact_nl": "Geschreven voor An Officer and a Gentleman en bijna geschrapt omdat de studio dacht dat een duet het slot zou vertragen; het won de Oscar.",
-      "fun_fact_it": "Scritta per Ufficiale e gentiluomo, rischio il taglio perche lo studio temeva che un duetto rallentasse il finale; vinse l'Oscar."
+      "fun_fact_it": "Scritta per Ufficiale e gentiluomo, rischio il taglio perche lo studio temeva che un duetto rallentasse il finale; vinse l'Oscar.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=bjrOcrisGyI"
     },
     {
       "year": 1977,
@@ -9046,7 +9054,8 @@
       "fun_fact_es": "La pelicula iba a llamarse Saturday Night hasta que los Bee Gees entregaron esta cancion y de ahi salio el titulo.",
       "fun_fact_fr": "Le film devait s'appeler Saturday Night jusqu'a ce que les Bee Gees livrent ce morceau, dont les producteurs ont tire le titre.",
       "fun_fact_nl": "De film zou Saturday Night heten, tot de Bee Gees dit nummer inleverden en de producenten de titel eruit haalden.",
-      "fun_fact_it": "Il film doveva chiamarsi Saturday Night finche i Bee Gees consegnarono questo brano e il titolo nacque da li."
+      "fun_fact_it": "Il film doveva chiamarsi Saturday Night finche i Bee Gees consegnarono questo brano e il titolo nacque da li.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=SkypZuY6ZvA"
     },
     {
       "year": 1984,
@@ -9066,7 +9075,8 @@
       "fun_fact_es": "Loggins la escribio por telefono con el guionista y grabo la voz en una tarde; estuvo tres semanas en el numero uno.",
       "fun_fact_fr": "Loggins l'a ecrite au telephone avec le scenariste et a enregistre la voix en un apres-midi ; trois semaines numero un.",
       "fun_fact_nl": "Loggins schreef het telefonisch met de scenarist en zong het in een middag in; drie weken op nummer een.",
-      "fun_fact_it": "Loggins la scrisse al telefono con lo sceneggiatore e incise la voce in un pomeriggio; tre settimane al primo posto."
+      "fun_fact_it": "Loggins la scrisse al telefono con lo sceneggiatore e incise la voce in un pomeriggio; tre settimane al primo posto.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ltrMfT4Qz5Y"
     },
     {
       "year": 1971,
@@ -9086,7 +9096,8 @@
       "fun_fact_es": "El charles suena dieciseis compases antes de la primera nota de melodia; primer Oscar a cancion original para un compositor negro.",
       "fun_fact_fr": "Le charleston tourne pendant seize mesures avant la premiere note de melodie ; premier Oscar de la chanson pour un compositeur noir.",
       "fun_fact_nl": "De hi-hat loopt zestien maten voor de eerste melodienoot klinkt; eerste songoscar voor een zwarte componist.",
-      "fun_fact_it": "Il charleston suona per sedici battute prima della prima nota di melodia; primo Oscar per la canzone a un compositore nero."
+      "fun_fact_it": "Il charleston suona per sedici battute prima della prima nota di melodia; primo Oscar per la canzone a un compositore nero.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Q429AOpL_ds"
     },
     {
       "year": 2006,
@@ -9104,7 +9115,8 @@
       "fun_fact_es": "Kent musicalizo un desayuno — huevos, naranja sangre, cafe — para que los sonidos matinales sonaran a ritual de un asesino.",
       "fun_fact_fr": "Kent a mis en musique un petit-dejeuner — oeufs, orange sanguine, cafe — pour que ces bruits ordinaires evoquent le rituel d'un tueur.",
       "fun_fact_nl": "Kent zette een ontbijt op muziek — eieren, bloedsinaasappel, koffie — zodat gewone ochtendgeluiden klinken als het ritueel van een moordenaar.",
-      "fun_fact_it": "Kent musico una colazione — uova, arancia rossa, caffe — perche i suoni del mattino suonassero come il rituale di un assassino."
+      "fun_fact_it": "Kent musico una colazione — uova, arancia rossa, caffe — perche i suoni del mattino suonassero come il rituale di un assassino.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=KWnhuDZMkuc"
     },
     {
       "year": 2004,
@@ -9124,7 +9136,8 @@
       "fun_fact_es": "Butler nunca habia cantado profesionalmente y tomo cuatro meses de clases; Lloyd Webber queria una voz de rock, no de opera.",
       "fun_fact_fr": "Butler n'avait jamais chante professionnellement et a pris quatre mois de cours ; Lloyd Webber voulait une voix rock, pas lyrique.",
       "fun_fact_nl": "Butler had nooit professioneel gezongen en nam vier maanden les; Lloyd Webber wilde een rockstem, geen operastem.",
-      "fun_fact_it": "Butler non aveva mai cantato da professionista e prese quattro mesi di lezioni; Lloyd Webber voleva una voce rock, non lirica."
+      "fun_fact_it": "Butler non aveva mai cantato da professionista e prese quattro mesi di lezioni; Lloyd Webber voleva una voce rock, non lirica.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=pgz6PnHkmpY"
     },
     {
       "year": 1953,
@@ -9144,7 +9157,8 @@
       "fun_fact_es": "El vestido rosa fue un cambio tardio: aparecieron fotos desnudas de Monroe y el estudio la vistio lo mas discreta posible.",
       "fun_fact_fr": "La robe rose fut un remplacement tardif : des photos denudees de Monroe avaient fuite et le studio l'habilla aussi sobrement que possible.",
       "fun_fact_nl": "De roze jurk was een late vervanging: er waren naaktfoto's opgedoken en de studio kleedde haar zo ingetogen als het nummer toeliet.",
-      "fun_fact_it": "L'abito rosa fu una sostituzione tardiva: erano emerse foto di nudo e lo studio la vesti nel modo piu sobrio possibile."
+      "fun_fact_it": "L'abito rosa fu una sostituzione tardiva: erano emerse foto di nudo e lo studio la vesti nel modo piu sobrio possibile.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=H69qXOHVS04"
     },
     {
       "year": 2002,
@@ -9164,7 +9178,8 @@
       "fun_fact_es": "Escrita para el album 18 sin pensar en cine, cierra desde entonces cada pelicula de Bourne; Moby la regrabo para cada una.",
       "fun_fact_fr": "Ecrite pour l'album 18 sans penser au cinema, elle clot depuis chaque film Bourne — Moby l'a reenregistree a chaque fois.",
       "fun_fact_nl": "Geschreven voor het album 18 zonder film in gedachten; sindsdien sluit het elke Bourne-film af, telkens opnieuw opgenomen.",
-      "fun_fact_it": "Scritta per l'album 18 senza pensare al cinema, da allora chiude ogni film di Bourne; Moby la reincise ogni volta."
+      "fun_fact_it": "Scritta per l'album 18 senza pensare al cinema, da allora chiude ogni film di Bourne; Moby la reincise ogni volta.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=ICjyAe9S54c"
     },
     {
       "year": 1964,
@@ -9184,7 +9199,8 @@
       "fun_fact_es": "Dos compositores demandaron a Disney alegando haber inventado la palabra en 1949; el tribunal supo que los ninos la cantaban desde los anos treinta.",
       "fun_fact_fr": "Deux auteurs ont attaque Disney en affirmant avoir invente le mot en 1949 ; le tribunal apprit que des enfants le scandaient depuis les annees 1930.",
       "fun_fact_nl": "Twee songschrijvers klaagden Disney aan omdat zij het woord in 1949 zouden hebben bedacht; kinderen zongen het al sinds de jaren dertig.",
-      "fun_fact_it": "Due autori fecero causa a Disney sostenendo di aver coniato la parola nel 1949; in aula emerse che i bambini la cantavano dagli anni trenta."
+      "fun_fact_it": "Due autori fecero causa a Disney sostenendo di aver coniato la parola nel 1949; in aula emerse che i bambini la cantavano dagli anni trenta.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=2Yq9Ebipbb8"
     },
     {
       "year": 1997,
@@ -9204,7 +9220,8 @@
       "fun_fact_es": "La banda la escribio sobre una mujer encarcelada por matar a su marido maltratador; David Chase la oyo en un recopilatorio y abrio Los Soprano con ella.",
       "fun_fact_fr": "Le groupe l'a ecrite sur une femme emprisonnee pour avoir tue son mari violent ; David Chase l'a entendue sur une compilation et en a fait le generique des Soprano.",
       "fun_fact_nl": "De band schreef het over een vrouw die haar gewelddadige man doodde; David Chase hoorde het op een verzamelaar en maakte er de Sopranos-titelsong van.",
-      "fun_fact_it": "La band la scrisse su una donna incarcerata per aver ucciso il marito violento; David Chase la senti su una compilation e ne fece la sigla dei Soprano."
+      "fun_fact_it": "La band la scrisse su una donna incarcerata per aver ucciso il marito violento; David Chase la senti su una compilation e ne fece la sigla dei Soprano.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=4Gbw60Iw-tA"
     },
     {
       "year": 2023,

--- a/custom_components/beatify/playlists/movies-100-greatest-themes.json
+++ b/custom_components/beatify/playlists/movies-100-greatest-themes.json
@@ -1,6 +1,6 @@
 {
   "name": "Movie & TV Soundtracks 🎬",
-  "version": "1.35",
+  "version": "1.36",
   "tags": [
     "movies",
     "soundtrack",
@@ -8461,7 +8461,8 @@
       "fun_fact_es": "Goldsmith escribió esta fanfarria para la primera película de Star Trek, y más tarde se adoptó como tema de La nueva generación: una música que sobrevivió a la producción para la que se hizo.",
       "fun_fact_fr": "Goldsmith a écrit cette fanfare pour le premier film Star Trek ; elle a ensuite été reprise comme thème de La Nouvelle Génération — une musique qui a survécu à la production pour laquelle elle fut écrite.",
       "fun_fact_nl": "Goldsmith schreef deze fanfare voor de eerste Star Trek-film; later werd ze overgenomen als thema voor The Next Generation — muziek die haar productie overleefde.",
-      "fun_fact_it": "Goldsmith scrisse questa fanfara per il primo film di Star Trek; fu poi ripresa come tema di The Next Generation, una musica sopravvissuta alla produzione per cui era nata."
+      "fun_fact_it": "Goldsmith scrisse questa fanfara per il primo film di Star Trek; fu poi ripresa come tema di The Next Generation, una musica sopravvissuta alla produzione per cui era nata.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=zI9YYe-jgHI"
     },
     {
       "artist": "Stu Phillips",
@@ -8480,7 +8481,8 @@
       "fun_fact_es": "Un pulso de sintetizador para una serie cuya verdadera estrella era un coche que hablaba. Phillips escribió también el tema de Galáctica, el otro sonido que la televisión de los ochenta le tomó prestado.",
       "fun_fact_fr": "Une pulsation de synthétiseur pour une série dont la vraie vedette était une voiture qui parle. Phillips a aussi écrit le thème de Galactica, l'autre son que la télévision des années quatre-vingt lui a emprunté.",
       "fun_fact_nl": "Een synthesizerpuls voor een serie waarvan de echte ster een pratende auto was. Phillips schreef ook het thema van Battlestar Galactica, het andere geluid dat de jaren-tachtigtelevisie van hem leende.",
-      "fun_fact_it": "Un impulso di sintetizzatore per una serie la cui vera star era un'auto parlante. Phillips scrisse anche il tema di Galactica, l'altro suono che la televisione degli anni Ottanta gli prese in prestito."
+      "fun_fact_it": "Un impulso di sintetizzatore per una serie la cui vera star era un'auto parlante. Phillips scrisse anche il tema di Galactica, l'altro suono che la televisione degli anni Ottanta gli prese in prestito.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=lxhWxv_5bQ0"
     },
     {
       "artist": "Harold Faltermeyer",
@@ -8499,7 +8501,8 @@
       "fun_fact_es": "Steve Stevens, más conocido como guitarrista de Billy Idol, toca el solo. La pieza ganó un Grammy y volvió sin cambios en la secuela treinta y seis años después.",
       "fun_fact_fr": "Steve Stevens, plus connu comme guitariste de Billy Idol, joue le solo. Le morceau a remporté un Grammy et est revenu inchangé dans la suite trente-six ans plus tard.",
       "fun_fact_nl": "Steve Stevens, beter bekend als gitarist van Billy Idol, speelt de solo. Het stuk won een Grammy en keerde zesendertig jaar later ongewijzigd terug in het vervolg.",
-      "fun_fact_it": "Steve Stevens, più noto come chitarrista di Billy Idol, suona l'assolo. Il pezzo vinse un Grammy e tornò immutato nel seguito trentasei anni dopo."
+      "fun_fact_it": "Steve Stevens, più noto come chitarrista di Billy Idol, suona l'assolo. Il pezzo vinse un Grammy e tornò immutato nel seguito trentasei anni dopo.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=wpvAKF00VNI"
     },
     {
       "artist": "Inner Circle",
@@ -8538,7 +8541,8 @@
       "fun_fact_es": "La película fracasó y la canción llegó igualmente al número uno. Madonna canta parte en español, algo insólito en un número uno estadounidense de aquel año.",
       "fun_fact_fr": "Le film a échoué et la chanson est tout de même montée en tête. Madonna en chante une partie en espagnol, chose inhabituelle pour un numéro un américain cette année-là.",
       "fun_fact_nl": "De film flopte en het nummer werd toch nummer één. Madonna zingt een deel in het Spaans, ongebruikelijk voor een Amerikaanse nummer één van dat jaar.",
-      "fun_fact_it": "Il film fu un insuccesso e la canzone arrivò comunque al primo posto. Madonna ne canta una parte in spagnolo, cosa insolita per un numero uno americano di quell'anno."
+      "fun_fact_it": "Il film fu un insuccesso e la canzone arrivò comunque al primo posto. Madonna ne canta una parte in spagnolo, cosa insolita per un numero uno americano di quell'anno.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=r0qDBYiOBrc"
     },
     {
       "artist": "James Horner",
@@ -8557,7 +8561,8 @@
       "fun_fact_es": "Horner se apoyó abiertamente en la Renana de Schumann para el tema principal, algo que después dijo que habría resuelto de otro modo. La partitura sigue entre las más interpretadas de su obra temprana.",
       "fun_fact_fr": "Horner s'est ouvertement appuyé sur la Rhénane de Schumann pour le thème principal, ce qu'il aurait, dit-il plus tard, traité autrement. La partition reste parmi les plus jouées de ses débuts.",
       "fun_fact_nl": "Horner leunde voor het hoofdthema openlijk op Schumanns Rijnlandse, iets wat hij later naar eigen zeggen anders zou hebben aangepakt. De partituur behoort nog altijd tot de meest gespeelde uit zijn vroege werk.",
-      "fun_fact_it": "Horner si appoggiò apertamente alla Renana di Schumann per il tema principale, cosa che disse poi che avrebbe trattato diversamente. La partitura resta tra le più eseguite del suo primo periodo."
+      "fun_fact_it": "Horner si appoggiò apertamente alla Renana di Schumann per il tema principale, cosa che disse poi che avrebbe trattato diversamente. La partitura resta tra le più eseguite del suo primo periodo.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=jAa6-xHBj7s"
     },
     {
       "artist": "Annie Lennox",
@@ -8710,7 +8715,8 @@
       "fun_fact_es": "Seis mujeres explican sus asesinatos sobre un tango que nunca resuelve. Zeta-Jones ganó el Óscar por el papel, y el número está montado como una fantasía dentro de una cárcel.",
       "fun_fact_fr": "Six femmes expliquent leurs meurtres sur un tango qui ne se résout jamais. Zeta-Jones a remporté l'Oscar pour ce rôle, et le numéro est mis en scène comme un fantasme en prison.",
       "fun_fact_nl": "Zes vrouwen verklaren hun moorden over een tango die nooit oplost. Zeta-Jones won de Oscar voor de rol, en het nummer is geënsceneerd als een fantasie in een gevangenis.",
-      "fun_fact_it": "Sei donne spiegano i loro omicidi su un tango che non si risolve mai. La Zeta-Jones vinse l'Oscar per il ruolo, e il numero è messo in scena come una fantasia dentro un carcere."
+      "fun_fact_it": "Sei donne spiegano i loro omicidi su un tango che non si risolve mai. La Zeta-Jones vinse l'Oscar per il ruolo, e il numero è messo in scena come una fantasia dentro un carcere.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=00oBK-x1pVk"
     },
     {
       "artist": "Glen Hansard",
@@ -8786,7 +8792,8 @@
       "fun_fact_es": "En la película la cantan un hombre y un sistema operativo, que es toda la premisa de Her en un dueto. Karen O la escribió con un ukelele y mantuvo el arreglo así de pequeño.",
       "fun_fact_fr": "Dans le film, elle est chantée par un homme et un système d'exploitation, ce qui résume tout le principe de Her en un duo. Karen O l'a écrite au ukulélé et a gardé cet arrangement minuscule.",
       "fun_fact_nl": "In de film wordt het gezongen door een man en een besturingssysteem, wat de hele premisse van Her in één duet is. Karen O schreef het op een ukelele en hield het arrangement zo klein.",
-      "fun_fact_it": "Nel film la cantano un uomo e un sistema operativo, che è tutta la premessa di Lei in un duetto. Karen O la scrisse con un ukulele e mantenne l'arrangiamento così essenziale."
+      "fun_fact_it": "Nel film la cantano un uomo e un sistema operativo, che è tutta la premessa di Lei in un duetto. Karen O la scrisse con un ukulele e mantenne l'arrangiamento così essenziale.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=CxahbnUCZxY"
     },
     {
       "artist": "Rodrigo Amarante",
@@ -9297,7 +9304,8 @@
       "fun_fact_es": "Piaf se la dedico a la Legion Extranjera, que la adopto como cancion de marcha; Origen la puso en el centro de su trama cuarenta y nueve anos despues.",
       "fun_fact_fr": "Piaf l'a dediee a la Legion etrangere, qui en a fait un chant de marche ; Inception l'a placee au coeur de son intrigue quarante-neuf ans plus tard.",
       "fun_fact_nl": "Piaf droeg het op aan het Vreemdelingenlegioen, dat het als marslied overnam; Inception zette het negenveertig jaar later centraal in de plot.",
-      "fun_fact_it": "Piaf la dedico alla Legione straniera, che la adotto come canto di marcia; Inception la mise al centro della trama quarantanove anni dopo."
+      "fun_fact_it": "Piaf la dedico alla Legione straniera, che la adotto come canto di marcia; Inception la mise al centro della trama quarantanove anni dopo.",
+      "uri_youtube_music": "https://music.youtube.com/watch?v=Q3Kvu6Kgp88"
     },
     {
       "year": 1981,


### PR DESCRIPTION
A `provider-uri-backfill` run, driven automatically by `com.beatify.youtube-backfill`.

- `hits-2010s-2020s` YouTube 73 -> **74**/124
- `movies-100-greatest-themes` YouTube 184 -> **192**/257

**Draft on purpose** — merged only once the maintainer approves.