### PR TITLE
Pin ruff where contributors install it, and guard both pins (#2580)

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,4 +7,5 @@ aiohttp>=3.14.3
 num2words>=0.5.14  # spoken-number rendering for TTS announcements
 jsonschema>=4.0   # playlist JSON-schema gate (#1284)
 mypy==1.18.2      # static type checking gate (#1275)
+ruff==0.15.7      # lint gate (#2580) — same pin as .github/workflows/test.yml
 pyyaml>=6.0.3       # parse .github/workflows in the CI-plumbing tests (#2673)

--- a/tests/unit/test_ci_tool_pins_2580.py
+++ b/tests/unit/test_ci_tool_pins_2580.py
@@ -1,0 +1,67 @@
+"""#2580: the lint and type-check tools are pinned in two files — keep them equal.
+
+`requirements_test.txt` is what a contributor installs locally; the workflow is
+what the gate actually runs. Until now ruff appeared only in the workflow, so
+`pip install -r requirements_test.txt` gave you no ruff at all and whichever
+version your machine happened to have. mypy appeared in both, with nothing
+keeping the two numbers in step.
+
+The drift is silent in the worst direction: a local run that passes against a
+newer ruff, and a CI run that fails against the pinned one — or the reverse,
+which is worse, because then the gate is not checking what the author checked.
+
+This test does not care *which* version is pinned. It cares that the two files
+say the same thing, so bumping a tool stays one edit with one obvious other
+place to change.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "test.yml"
+REQUIREMENTS = ROOT / "requirements_test.txt"
+
+#: Tools whose pin has to agree between the two files.
+PINNED_TOOLS = ("ruff", "mypy")
+
+
+def _requirement_pin(tool: str) -> str | None:
+    """The `==` pin for `tool` in requirements_test.txt, comments stripped."""
+    for line in REQUIREMENTS.read_text(encoding="utf-8").splitlines():
+        line = line.split("#", 1)[0].strip()
+        m = re.fullmatch(rf"{tool}==([\w.]+)", line)
+        if m:
+            return m.group(1)
+    return None
+
+
+def _workflow_pins(tool: str) -> list[str]:
+    """Every `pip install <tool>==x.y.z` version in the workflow."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    return re.findall(rf"pip install [^\n]*\b{tool}==([\w.]+)", text)
+
+
+class TestCiToolPins:
+    @pytest.mark.parametrize("tool", PINNED_TOOLS)
+    def test_tool_is_pinned_in_requirements(self, tool: str) -> None:
+        assert _requirement_pin(tool) is not None, (
+            f"{tool} has no == pin in requirements_test.txt — a local install "
+            f"then differs from the gate"
+        )
+
+    @pytest.mark.parametrize("tool", PINNED_TOOLS)
+    def test_workflow_matches_requirements(self, tool: str) -> None:
+        wanted = _requirement_pin(tool)
+        found = _workflow_pins(tool)
+        assert found, f"no `pip install {tool}==…` step found in test.yml"
+        for got in found:
+            assert got == wanted, (
+                f"{tool} is pinned to {got} in test.yml but {wanted} in "
+                f"requirements_test.txt — the gate runs a different version "
+                f"than a contributor installs"
+            )


### PR DESCRIPTION
## What was already done

The four numbered steps in #2580 shipped with **v4.6.0-rc2**, verified against the tree just now:

1. `package-lock.json` is tracked, `.gitignore` no longer excludes it, and CI installs with `npm ci --no-audit --no-fund`
2. `npm audit` reports **0** across info/low/moderate/high/critical — the critical vitest advisory included
3. esbuild is pinned exactly at `0.28.2` with its bundle rebuilt in the same PR, so `build:check` stays honest
4. `.github/dependabot.yml` watches npm, github-actions and pip; the actions are on v6/v7 majors

## What was left

The paragraph under the numbered list. **ruff was pinned in exactly one place — the workflow.** A contributor running `pip install -r requirements_test.txt` got no ruff at all and linted with whatever their machine had, against a gate running 0.15.7. **mypy** was named in both files with nothing keeping the two numbers in step.

## This change

- `ruff==0.15.7` joins `requirements_test.txt`, at the version the gate uses
- `tests/unit/test_ci_tool_pins_2580.py` asserts that ruff and mypy carry the **same** pin in `requirements_test.txt` and `.github/workflows/test.yml`

The test is deliberately indifferent to *which* version is pinned — it refuses only to let the two places drift. Checked against the real failure mode: raising the workflow's ruff to 0.16.6 on its own turns it red (1 failed, 3 passed).

**Versions are unchanged.** Moving ruff to 0.16.6 rewrites what the lint gate accepts and belongs in its own change.

## Note on timing

Merging this puts `main` ahead of `v4.6.0-rc2` and turns gate condition 8 red before Friday's cut. It is plumbing, not a release blocker — holding it until after the release costs nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDoMzWDFdkYWirPG13sNKr