### PR TITLE
Release v4.6.0-rc4 — Second Wind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [4.6.0-rc4] - 2026-09-10
+
+Zwei Eintraege aus dem Rueckstand, beide klein, einer davon hoerbar.
+
+### Added
+- **Das Stechen sagt sich jetzt an** (#2734 via #2803). „Kopf an Kopf! {names} — ein
+  Song entscheidet." in allen sechs Sprachen. Der Satz kommt erst, wenn die
+  Stechrunde wirklich gestartet ist — eine Ansage fuer ein Stechen, das dann doch
+  nicht stattfindet, waere schlimmer als das Schweigen, das sie ersetzt.
+
+### Fixed
+- **Der zeitempfindliche Queue-Restore-Test laeuft auf simulierter Zeit** (#2747 via
+  #2804). Er mass Sekunden gegen die Wanduhr, waehrend der Code darunter echt schlief,
+  und fiel unter Last um: einmal in sechs Suite-Laeufen, immer im langsamsten. Jetzt
+  15 identische Laeufe in je 0,04 s statt 7,2 s. Kein Produktionscode angefasst.
+
 ## [4.6.0-rc3] - 2026-09-10
 
 Ein Kandidat ohne sichtbare Aenderung. Er existiert, weil `main` nach dem rc2-Tag noch einen

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -20,5 +20,5 @@
     "num2words==0.5.14"
   ],
   "single_config_entry": true,
-  "version": "4.6.0-rc3"
+  "version": "4.6.0-rc4"
 }

--- a/docs/release-notes-v4.6.0-rc4.md
+++ b/docs/release-notes-v4.6.0-rc4.md
@@ -1,0 +1,19 @@
+## 4.6.0-rc4 — Second Wind
+
+Nobody sits out any more, and no evening has to end just because the round counter ran out.
+
+### 👻 Knocked out, still playing
+
+Get eliminated and you keep guessing to the last song — in your own league, with your own score on the TV and your own trophy at the finish. The room stops splitting into players and spectators halfway through.
+
+### 🎉 The evening ends when you say so
+
+One round before the end the host is offered five more, and every point already scored stays. Someone has to leave? Take them out and the game carries on without waiting. Someone shows up late? The join link is still on screen while you play.
+
+Also: two songs that used to fail mid-round are gone, and 97 more tracks now play for anyone on YouTube Music.
+
+---
+
+**66 playlists · 6 music platforms · 6 languages**
+
+[Report a Bug](https://github.com/mholzi/beatify/issues) · [Discussions](https://github.com/mholzi/beatify/discussions) · [Full Changelog](https://github.com/mholzi/beatify/blob/main/CHANGELOG.md)


### PR DESCRIPTION
Manifest to `4.6.0-rc4`, CHANGELOG section, release notes.

**What is in it beyond rc3:** #2734 (the finale playoff now says so out loud, six languages) and #2747 (the queue-restore tests run on simulated time — no shipped file changes).

**Cut against a green `main`:** the Test run covering both merges finished before this branch was created.

No playlist file changed since rc3, so no version field needs lifting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDoMzWDFdkYWirPG13sNKr