### PR TITLE
Make "pull the docs along" a check instead of a sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,6 +825,15 @@ The neon dark theme is built-in and looks stunning. Custom theming is on the roa
 
 ## What's New
 
+### v4.6.0 — Second Wind 👻
+- **Ghost league** — get knocked out in Sudden Death and you keep guessing to the last song, in a league of your own: your score sits under the survivors on the TV, and there is a Best Ghost award at the finish. Counted per ghost round played, so going out early wins nothing (#2559)
+- **Encore** — on the reveal before the last round the host is offered five more rounds, with every score left exactly where it is. Once the last round starts the offer is gone (#2503)
+- **Take a guest out mid-game** — connected or not. The round stops waiting for them, their points and rank stay put, and they tap their own way back in at the next round (#2746)
+- **The finale playoff says so out loud** — when two players finish level, the room hears it in all six languages before the deciding song (#2734)
+- **The way in stays visible** while the game runs, so a latecomer still finds the join link (#2504)
+
+> Versions between v4.2.0 and v4.6.0 are not repeated here — v4.3.0, the v4.4.x line and v4.5.0 each shipped their own set. The [CHANGELOG](CHANGELOG.md) carries all of them, and every release has its own notes on the [Releases page](https://github.com/mholzi/beatify/releases).
+
 ### v4.2.0 — Mix & Match 🎛️
 - **Mix tab in the playlist picker** — assemble a de-duplicated set on the fly from any combination of decade, style, region and special tags, at 30, 50 or 100 songs, and save it as a community playlist in one tap (#1538)
 - **Suggestion of the season** in the setup screen, one tap to add the matching playlist (#1539)

--- a/docs/provider-coverage.md
+++ b/docs/provider-coverage.md
@@ -1,78 +1,84 @@
 # Beatify Provider-URI Coverage
-> Generated: 2026-08-09
+> Generated: 2026-09-10
 > Mode: OFFLINE COUNT (existing URIs counted from the playlist JSON; no network, no writes)
-> Catalogue state: v4.2.0
+> Catalogue state: v4.6.0
 
 ## Summary
 
 | Provider | Have | Total | Coverage |
 |---|---:|---:|---:|
-| Apple | 5117 | 5980 | 85.6% |
-| Tidal | 5190 | 5980 | 86.8% |
-| Deezer | 5483 | 5980 | 91.7% |
-| YouTube | 5433 | 5980 | 90.9% |
+| Apple | 8123 | 8432 | 96.3% |
+| Tidal | 5959 | 8432 | 70.7% |
+| Deezer | 8340 | 8432 | 98.9% |
+| YouTube | 7523 | 8432 | 89.2% |
 
 ## Per-playlist coverage
 
 | Playlist | Songs | Apple | Tidal | Deezer | YouTube |
 |---|---:|---:|---:|---:|---:|
-| 2000s-pop-anthems.json | 182 | 175 | 182 | 179 | 182 |
-| 40s-50s-classics.json | 152 | 115 | 151 | 149 | 152 |
-| 70s-hits.json | 163 | 84 | 162 | 163 | 163 |
-| 80er-hits.json | 238 | 229 | 237 | 238 | 234 |
-| 90er-hits.json | 115 | 99 | 114 | 113 | 115 |
-| community/100-greatest-rock-songs.json | 122 | 120 | 122 | 122 | 122 |
+| 2000s-pop-anthems.json | 224 | 221 | 181 | 224 | 181 |
+| 40s-50s-classics.json | 154 | 154 | 151 | 154 | 152 |
+| 70s-hits.json | 211 | 207 | 169 | 211 | 170 |
+| 80er-hits.json | 267 | 266 | 232 | 266 | 233 |
+| 90er-hits.json | 158 | 154 | 108 | 158 | 108 |
+| community/100-greatest-rock-songs.json | 151 | 150 | 122 | 151 | 122 |
 | community/90s-2000s-hiphop-bangers.json | 40 | 40 | 40 | 40 | 40 |
-| community/anime-openings.json | 140 | 140 | 87 | 102 | 139 |
-| community/ballermann-party-hits.json | 189 | 177 | 189 | 175 | 189 |
-| community/best-canadian-hits.json | 100 | 97 | 99 | 98 | 92 |
-| community/best-of-giraffenaffen.json | 26 | 26 | 26 | 25 | 25 |
-| community/british-invasion-britpop.json | 100 | 86 | 99 | 100 | 98 |
-| community/deutschpop-klassiker.json | 107 | 106 | 107 | 107 | 107 |
-| community/deutschrock-best-of.json | 100 | 0 | 99 | 100 | 0 |
-| community/disney-hits-deutschland.json | 97 | 63 | 91 | 93 | 97 |
-| community/divorced-dad-rock.json | 107 | 56 | 107 | 107 | 107 |
-| community/edm-anthems.json | 190 | 135 | 190 | 175 | 125 |
-| community/essential-alternative.json | 100 | 100 | 100 | 98 | 100 |
-| community/eurodance-90s.json | 100 | 86 | 97 | 91 | 97 |
-| community/fiesta-latina-90s.json | 50 | 48 | 50 | 50 | 50 |
-| community/finnish-iskelma-classics.json | 293 | 252 | 293 | 289 | 195 |
-| community/funk-carioca.json | 20 | 9 | 20 | 20 | 20 |
+| community/anime-openings.json | 140 | 140 | 101 | 139 | 140 |
+| community/ballermann-party-hits.json | 189 | 188 | 189 | 188 | 189 |
+| community/best-canadian-hits.json | 100 | 98 | 99 | 99 | 100 |
+| community/best-of-giraffenaffen.json | 26 | 26 | 26 | 26 | 26 |
+| community/british-invasion-britpop.json | 100 | 96 | 100 | 100 | 100 |
+| community/clasicos-disney-castellano.json | 64 | 47 | 0 | 37 | 16 |
+| community/clasicos-rock-en-espanol.json | 39 | 33 | 0 | 39 | 0 |
+| community/deutschpop-klassiker.json | 118 | 118 | 107 | 118 | 107 |
+| community/deutschrap-klassiker.json | 26 | 17 | 0 | 26 | 0 |
+| community/deutschrock-best-of.json | 100 | 85 | 100 | 100 | 98 |
+| community/disney-hits-deutschland.json | 97 | 82 | 95 | 96 | 97 |
+| community/disney-latino.json | 54 | 54 | 0 | 38 | 1 |
+| community/divorced-dad-rock.json | 107 | 104 | 107 | 107 | 107 |
+| community/edm-anthems.json | 246 | 230 | 190 | 246 | 233 |
+| community/essential-alternative.json | 100 | 100 | 100 | 100 | 100 |
+| community/eurodance-90s.json | 100 | 97 | 98 | 98 | 100 |
+| community/fiesta-latina-90s.json | 50 | 50 | 50 | 50 | 50 |
+| community/finnish-iskelma-classics.json | 293 | 287 | 293 | 293 | 293 |
+| community/funk-carioca.json | 20 | 19 | 20 | 20 | 20 |
 | community/gen-z-anthems.json | 30 | 30 | 30 | 30 | 30 |
-| community/greatest-metal-songs.json | 61 | 61 | 61 | 0 | 61 |
-| community/harder-styles.json | 190 | 181 | 181 | 181 | 190 |
-| community/hitster-100-en-espanol.json | 127 | 127 | 127 | 0 | 127 |
+| community/greatest-metal-songs.json | 61 | 61 | 61 | 61 | 61 |
+| community/harder-styles.json | 190 | 182 | 181 | 190 | 190 |
+| community/hitster-100-en-espanol.json | 127 | 127 | 127 | 127 | 127 |
 | community/hitster-100-francais.json | 100 | 92 | 96 | 98 | 100 |
 | community/hitster-brasil.json | 66 | 66 | 66 | 66 | 66 |
-| community/iconic-movie-songs.json | 72 | 72 | 71 | 72 | 71 |
-| community/koelner-karneval.json | 290 | 289 | 289 | 288 | 273 |
-| community/ndw-neue-deutsche-welle.json | 50 | 31 | 50 | 47 | 43 |
-| community/polish-all-time-hits.json | 59 | 57 | 55 | 58 | 0 |
-| community/polish-hits-90s-00s.json | 92 | 8 | 90 | 88 | 92 |
-| community/polish-rock.json | 100 | 30 | 99 | 99 | 45 |
-| community/pure-pop-punk.json | 100 | 97 | 100 | 100 | 100 |
-| community/quebecois-1990-2020.json | 126 | 119 | 60 | 126 | 119 |
-| community/schlager-klassiker.json | 96 | 58 | 60 | 95 | 96 |
-| community/schweizer-hits.json | 97 | 90 | 17 | 97 | 96 |
-| community/sommerklassiker.json | 60 | 54 | 0 | 60 | 60 |
-| community/top100-allertijden-nederlandstalig.json | 104 | 96 | 68 | 0 | 100 |
-| community/trance-classics.json | 120 | 103 | 18 | 109 | 120 |
-| community/yacht-rock.json | 100 | 98 | 100 | 100 | 100 |
-| disco-funk-classics.json | 98 | 87 | 73 | 96 | 73 |
-| disney-classics.json | 69 | 69 | 0 | 69 | 57 |
-| eurovision-winners.json | 72 | 63 | 62 | 71 | 67 |
-| greatest-hits-of-all-time.json | 236 | 225 | 196 | 236 | 194 |
-| hits-2010s-2020s.json | 71 | 67 | 3 | 68 | 71 |
-| motown-soul-classics.json | 100 | 98 | 47 | 100 | 98 |
-| movies-100-greatest-themes.json | 162 | 122 | 156 | 148 | 139 |
-| one-hit-wonders.json | 98 | 94 | 98 | 98 | 94 |
-| summer-party-anthems.json | 112 | 109 | 112 | 111 | 111 |
-| top-100-power-ballads.json | 99 | 96 | 99 | 95 | 99 |
-| top-songs-der-60er.json | 66 | 62 | 44 | 22 | 66 |
-| world-cup-anthems.json | 26 | 23 | 0 | 21 | 26 |
-
----
-
-Spotify is the base provider: every playable song carries a `uri`, so it is not
-listed above. Regenerate this table with the `provider-uri-backfill` skill, or
-recount it offline from the playlist JSON when you only need the numbers.
+| community/iconic-movie-songs.json | 72 | 72 | 71 | 72 | 72 |
+| community/koelner-karneval.json | 290 | 289 | 288 | 289 | 289 |
+| community/musica-colombiana-alegre.json | 32 | 32 | 0 | 32 | 0 |
+| community/musica-italiana.json | 115 | 115 | 0 | 112 | 48 |
+| community/ndw-neue-deutsche-welle.json | 50 | 46 | 50 | 49 | 50 |
+| community/polish-all-time-hits.json | 59 | 57 | 55 | 58 | 58 |
+| community/polish-hits-90s-00s.json | 92 | 87 | 90 | 91 | 92 |
+| community/polish-rock.json | 100 | 96 | 99 | 99 | 95 |
+| community/pure-pop-punk.json | 100 | 98 | 100 | 100 | 100 |
+| community/quebecois-1990-2020.json | 126 | 124 | 125 | 126 | 126 |
+| community/rock-rioplatense.json | 36 | 33 | 0 | 36 | 0 |
+| community/salsa-y-merengue.json | 531 | 515 | 0 | 519 | 369 |
+| community/sanremo-vincitori.json | 68 | 64 | 0 | 68 | 39 |
+| community/schlager-klassiker.json | 193 | 186 | 96 | 190 | 193 |
+| community/schweizer-hits.json | 97 | 93 | 96 | 97 | 97 |
+| community/sommerklassiker.json | 60 | 60 | 60 | 60 | 60 |
+| community/tomorrowland-top-1000.json | 825 | 741 | 0 | 824 | 825 |
+| community/top100-allertijden-nederlandstalig.json | 104 | 100 | 96 | 101 | 104 |
+| community/trance-classics.json | 120 | 113 | 109 | 118 | 120 |
+| community/vallenato-clasico.json | 41 | 38 | 0 | 41 | 0 |
+| community/wiesn-party-hits.json | 100 | 100 | 99 | 100 | 100 |
+| community/yacht-rock.json | 100 | 100 | 100 | 100 | 100 |
+| disco-funk-classics.json | 98 | 97 | 93 | 97 | 98 |
+| disney-classics.json | 69 | 69 | 69 | 69 | 69 |
+| eurovision-winners.json | 72 | 67 | 68 | 72 | 72 |
+| greatest-hits-of-all-time.json | 236 | 235 | 234 | 236 | 232 |
+| hits-2010s-2020s.json | 124 | 122 | 71 | 123 | 73 |
+| motown-soul-classics.json | 100 | 100 | 100 | 100 | 100 |
+| movies-100-greatest-themes.json | 257 | 240 | 156 | 252 | 184 |
+| one-hit-wonders.json | 98 | 96 | 98 | 98 | 98 |
+| summer-party-anthems.json | 112 | 112 | 112 | 112 | 112 |
+| top-100-power-ballads.json | 99 | 99 | 99 | 99 | 99 |
+| top-songs-der-60er.json | 82 | 82 | 66 | 81 | 66 |
+| world-cup-anthems.json | 26 | 24 | 20 | 23 | 26 |

--- a/scripts/check_docs_current.py
+++ b/scripts/check_docs_current.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Does the documentation still describe the version that ships? (#2808)
+
+Release step 7 says "pull the README and the docs along" and names two numbers.
+On 2026-09-10 both were right, the step was ticked off, and two other things
+had been stale for a month: the README's "What's New" stopped at v4.2.0, four
+minor versions back, and `docs/provider-coverage.md` still counted a 5,980-song
+catalogue that had grown to 8,432.
+
+A prose instruction that ends in "and anything else under docs/" is not a
+check. This is: it reads the catalogue and the manifest, and says which file
+disagrees with them.
+
+Usage:
+    python3 scripts/check_docs_current.py           # report, exit 1 on drift
+    python3 scripts/check_docs_current.py --json    # machine-readable
+
+The check is deliberately narrow. It only compares claims that can be derived
+from the repository — song counts, playlist counts, the newest version named.
+It cannot tell whether a paragraph is still *true*, and it does not pretend to.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PLAYLISTS = ROOT / "custom_components" / "beatify" / "playlists"
+MANIFEST = ROOT / "custom_components" / "beatify" / "manifest.json"
+README = ROOT / "README.md"
+PROVIDER_COVERAGE = ROOT / "docs" / "provider-coverage.md"
+
+
+def catalogue() -> tuple[int, int]:
+    """(playlist files, song entries) — the same arithmetic the README claims."""
+    files = sorted(PLAYLISTS.glob("**/*.json"))
+    songs = 0
+    count = 0
+    for f in files:
+        if f.name.startswith("_"):
+            continue
+        try:
+            data = json.loads(f.read_text(encoding="utf-8"))
+        except (ValueError, OSError):
+            continue
+        entries = data.get("songs")
+        if not isinstance(entries, list):
+            continue
+        count += 1
+        songs += len(entries)
+    return count, songs
+
+
+def shipped_version() -> str:
+    return json.loads(MANIFEST.read_text(encoding="utf-8"))["version"]
+
+
+def _num(text: str) -> int:
+    return int(text.replace(",", "").replace(".", ""))
+
+
+def check() -> list[dict]:
+    """Every disagreement between the docs and the repository."""
+    playlists, songs = catalogue()
+    version = shipped_version()
+    stable = version.split("-")[0]
+    findings: list[dict] = []
+
+    readme = README.read_text(encoding="utf-8")
+
+    # 1. "Beatify comes with N songs across M curated playlists"
+    m = re.search(
+        r"comes with \*{0,2}([\d,\.]+)\*{0,2} songs across \*{0,2}(\d+)\*{0,2}"
+        r" curated playlists",
+        readme,
+    )
+    if not m:
+        findings.append(
+            {
+                "file": "README.md",
+                "what": "the catalogue sentence is gone",
+                "detail": (
+                    "no 'comes with N songs across M curated playlists' line — "
+                    "either it was reworded or it was dropped; this check cannot "
+                    "follow it"
+                ),
+            }
+        )
+    elif (_num(m.group(1)), int(m.group(2))) != (songs, playlists):
+        findings.append(
+            {
+                "file": "README.md",
+                "what": "catalogue numbers are stale",
+                "detail": (
+                    f"says {m.group(1)} songs / {m.group(2)} playlists, "
+                    f"repository has {songs:,} / {playlists}"
+                ),
+            }
+        )
+
+    # 2. The comparison table repeats them.
+    for claim in re.finditer(r"(\d+) playlists ship with it, ([\d,\.]+) songs", readme):
+        if (int(claim.group(1)), _num(claim.group(2))) != (playlists, songs):
+            findings.append(
+                {
+                    "file": "README.md",
+                    "what": "comparison table is stale",
+                    "detail": (
+                        f"says {claim.group(1)} playlists / {claim.group(2)} songs, "
+                        f"repository has {playlists} / {songs:,}"
+                    ),
+                }
+            )
+
+    # 3. "What's New" has to lead with the version that ships.
+    #
+    # Only while a stable is in the manifest. During an rc cycle the README
+    # would otherwise have to announce a version nobody can install yet, and
+    # every rc-cut PR would carry a README edit for no reader's benefit. The
+    # contract is: the README is current **when a stable ships**.
+    prerelease = "-" in version
+    section = re.search(r"##\s*What's New\s*(.+?)(?=\n##\s|\Z)", readme, re.S)
+    if section and not prerelease:
+        heads = re.findall(r"###\s*v(\d+\.\d+\.\d+)", section.group(1))
+        if not heads:
+            findings.append(
+                {
+                    "file": "README.md",
+                    "what": "What's New lists no version at all",
+                    "detail": "expected the newest release at the top",
+                }
+            )
+        elif heads[0] != stable:
+            findings.append(
+                {
+                    "file": "README.md",
+                    "what": "What's New is behind",
+                    "detail": (
+                        f"newest entry is v{heads[0]}, the shipped version is v{stable}"
+                    ),
+                }
+            )
+
+    # 4. A generated report that names the catalogue it counted.
+    if PROVIDER_COVERAGE.exists() and not prerelease:
+        text = PROVIDER_COVERAGE.read_text(encoding="utf-8")
+        state = re.search(r"Catalogue state:\s*v?([\d.]+(?:-rc\d+)?)", text)
+        total = re.search(r"\|\s*Apple\s*\|\s*\d+\s*\|\s*(\d+)\s*\|", text)
+        if state and state.group(1).split("-")[0] != stable:
+            findings.append(
+                {
+                    "file": "docs/provider-coverage.md",
+                    "what": "counted an older catalogue",
+                    "detail": (
+                        f"header says v{state.group(1)}, the shipped version is "
+                        f"v{stable} — regenerate or date it explicitly"
+                    ),
+                }
+            )
+        if total and int(total.group(1)) != songs:
+            findings.append(
+                {
+                    "file": "docs/provider-coverage.md",
+                    "what": "coverage percentages use an old total",
+                    "detail": (
+                        f"totals {total.group(1)} songs, repository has {songs:,} — "
+                        f"every percentage in the table is off"
+                    ),
+                }
+            )
+
+    return findings
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    args = ap.parse_args()
+
+    findings = check()
+    if args.json:
+        print(json.dumps({"findings": findings}, indent=2, ensure_ascii=False))
+        return 1 if findings else 0
+
+    playlists, songs = catalogue()
+    print(f"catalogue: {playlists} playlists, {songs:,} songs")
+    print(f"shipped:   v{shipped_version()}")
+    if not findings:
+        print("\nthe documentation matches the repository")
+        return 0
+    print(f"\n{len(findings)} disagreement(s):\n")
+    for f in findings:
+        print(f"  {f['file']} — {f['what']}")
+        print(f"    {f['detail']}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_docs_current_2808.py
+++ b/tests/unit/test_docs_current_2808.py
@@ -1,0 +1,93 @@
+"""#2808: the documentation has to describe the version that ships.
+
+Release step 7 names two numbers and then says "and anything else under
+`docs/` that mentions a version". On 2026-09-10 the two numbers were right, the
+step was ticked off, and two other things had been stale for a month: the
+README's "What's New" ended at v4.2.0 — four minor versions back — and
+`docs/provider-coverage.md` still counted a 5,980-song catalogue that had grown
+to 8,432, so every percentage in it was wrong.
+
+A step that depends on somebody taking a trailing clause seriously is not a
+check. This one runs in CI.
+
+**It is deliberately quiet during an rc cycle.** Otherwise every rc-cut PR
+would have to announce a version nobody can install yet. The contract is: the
+README is current *when a stable ships*.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from check_docs_current import catalogue, check, shipped_version  # noqa: E402
+
+
+class TestDocsMatchTheRepository:
+    def test_no_disagreements(self):
+        findings = check()
+        assert not findings, "documentation drift:\n" + "\n".join(
+            f"  {f['file']} — {f['what']}: {f['detail']}" for f in findings
+        )
+
+
+class TestTheCheckItself:
+    """A check that cannot fail is decoration."""
+
+    def test_it_notices_a_stale_catalogue_number(self, monkeypatch):
+        import check_docs_current as mod
+
+        monkeypatch.setattr(mod, "catalogue", lambda: (99, 12345))
+        findings = mod.check()
+        assert any("catalogue" in f["what"] for f in findings), (
+            "the numbers were moved out from under the README and the check "
+            "stayed green"
+        )
+
+    def test_it_notices_a_behind_whats_new(self, monkeypatch, tmp_path):
+        import check_docs_current as mod
+
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        current = shipped_version().split("-")[0]
+        fake = tmp_path / "README.md"
+        fake.write_text(readme.replace(f"### v{current}", "### v0.1.0", 1), "utf-8")
+        monkeypatch.setattr(mod, "README", fake)
+        monkeypatch.setattr(mod, "shipped_version", lambda: current)
+
+        findings = mod.check()
+        assert any("What's New" in f["what"] for f in findings)
+
+    def test_it_holds_its_tongue_during_an_rc(self, monkeypatch, tmp_path):
+        """An rc must not force a README edit — that is the whole nuance."""
+        import check_docs_current as mod
+
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        current = shipped_version().split("-")[0]
+        fake = tmp_path / "README.md"
+        fake.write_text(readme.replace(f"### v{current}", "### v0.1.0", 1), "utf-8")
+        monkeypatch.setattr(mod, "README", fake)
+        monkeypatch.setattr(mod, "shipped_version", lambda: "9.9.9-rc1")
+
+        findings = mod.check()
+        assert not any("What's New" in f["what"] for f in findings)
+
+
+class TestTheNumbersItReads:
+    def test_the_catalogue_is_not_empty(self):
+        playlists, songs = catalogue()
+        assert playlists > 0 and songs > 0
+
+    def test_the_manifest_version_parses(self):
+        v = shipped_version()
+        assert v and v[0].isdigit(), v
+
+
+@pytest.mark.parametrize("path", ["scripts/check_docs_current.py"])
+def test_the_checker_is_committed(path):
+    """It only helps if it travels with the repository."""
+    assert (ROOT / path).exists()


### PR DESCRIPTION
Follow-up to the v4.6.0 release cut, at Markus' request: *"Have you updated README and other documentation? Make this part of the release process."*

## The honest answer was "half"

Release step 7 names two numbers and ends with "and anything else under `docs/` that mentions a version". Both numbers were right, so the step was ticked off. Two other things had been stale for a month:

- **README → "What's New" ended at v4.2.0.** Four minor versions missing: v4.3.0, the v4.4.x line, v4.5.0, v4.6.0.
- **`docs/provider-coverage.md` counted 5,980 songs** against today's 8,432, so every percentage was wrong — and not uniformly. Apple reads 85.6% there and is really **96.3%**; Tidal reads 86.8% and is really **70.7%**. The file did not just age, it pointed the wrong way.

## What this adds

`scripts/check_docs_current.py` — compares against the repository, not against memory:

```
catalogue: 66 playlists, 8,432 songs
shipped:   v4.6.0

the documentation matches the repository
```

`tests/unit/test_docs_current_2808.py` runs the same comparison in CI. **Three of its seven cases attack the checker itself** — move the catalogue numbers out from under the README and it must go red; put an old version at the top of "What's New" and it must go red; do the same during an rc and it must stay quiet. A guard that cannot fail is decoration.

## The rc nuance

The version rules are skipped while the manifest carries an `-rcN` suffix. Otherwise every rc-cut PR would have to announce a version nobody can install yet. The contract: **the README is current when a stable ships.**

## Also in here

Both stale files, fixed. The coverage report is regenerated; "What's New" leads with v4.6.0. The four versions in between are **not** reconstructed — a line points at the CHANGELOG and the releases page rather than pretending they were summarised.

The command file (`beatifybot/commands/release-cut/command.md`, outside this repo) now calls the script in step 7 with the same reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDoMzWDFdkYWirPG13sNKr