### PR TITLE
release: v4.7.0-rc1 (The Turn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to Beatify are documented here. For detailed release notes, 
 
 ## [Unreleased]
 
+## [4.7.0-rc1] - 2026-09-12
+
+Ein Eintrag, den Markus am Samstagabend aus dem Rueckstand gezogen hat, plus was seit v4.6.0 sonst
+auf `main` lag. #2563 lief vor dem Bauen durchs Design-Gate: vier gezeichnete Varianten, Markus hat
+C genommen — drei Sekunden statt zehn, weil das Endbild schon sieben Beats hat.
+
+### Added
+- **Das Endbild zeigt die Runde, in der das Spiel entschieden wurde** (#2563, Variante C). Drei
+  Sekunden vor dem Podest klettern zwei Linien, eine Marke sitzt auf der Runde, darunter steht
+  „Dana overtakes Ben"; dann blendet es weg und das Schlussbild steht wie zuvor. Es ist ein
+  **Vorspann, kein Kasten** — nichts im Schlussbild musste Platz machen.
+  - Die Rundenwahl ist mechanisch, kein Dramatik-Score: **der letzte Fuehrungswechsel zum spaeteren
+    Sieger**. Wer ab der ersten Runde fuehrt, hat keinen — dann faellt der Vorspann aus, statt einen
+    Moment zu erfinden.
+  - `round_scores` lag seit jeher auf dem Spieler (`clutch_player` und `comeback_king` rechnen
+    darauf), wurde aber **nie serialisiert**. Das Issue hielt die Arbeit deshalb fuer „pure
+    frontend"; das stimmte nicht. Das Feld geht jetzt **vollstaendig** mit auf die Schluss-Rangliste,
+    als Runden-Deltas — ein spaeterer voller Verlauf braucht dafuer keinen zweiten Backend-Schnitt.
+  - Das Konfetti wartet, bis der Vorspann weg ist, und der Vorspann laeuft **einmal je `game_id`**:
+    ein Schlussbild, das bei jedem Reconnect neu anfaengt, waere schlimmer als keines.
+
+### Changed
+- **+126 YouTube-URIs** ueber sechs Playlists (#2800). Der PR-Titel sagt „+9" — das war der erste
+  von drei gebuendelten Backfill-Laeufen (+9, +84, +33); die Abdeckung geht von 7.523 auf 7.649,
+  89,2 % -> 90,7 %. `musica-italiana` springt von 48 auf 115 von 115, `disney-latino` von 1 auf 32.
+  Alle sechs `version`-Felder gingen im selben Commit mit, sonst erreicht die Aenderung keine
+  bestehende Installation.
+
+### Fixed
+- **Der Playlist-Pruefer sprach Deezer frei, statt zu verurteilen** (#2809). Ein Treffer ohne ISRC
+  galt als Fehler; jetzt gilt er als ungeprueft.
+- **„Zieh die Doku mit" ist eine Pruefung statt eines Satzes** (#2580-Nachzug): `check_docs_current.py`
+  faellt auf, wenn Code und Dokumentation auseinanderlaufen.
+
+
 ## [4.6.0] - 2026-09-10
 
 Die Woche 2026-W37b: sechs Eintraege aus der Redaktionskonferenz vom 08.09., drei davon durchs

--- a/README.md
+++ b/README.md
@@ -825,6 +825,10 @@ The neon dark theme is built-in and looks stunning. Custom theming is on the roa
 
 ## What's New
 
+### v4.7.0 — The Turn 📈
+- **The end screen shows the round it turned on** — three seconds before the podium, the TV goes back to the one round where the lead last changed hands: two lines climbing, a mark on the round, and the two names. A game somebody led from the first song has no such round, and the screen goes straight to the podium instead (#2563)
+- **+126 YouTube URIs** across six playlists, so more of the catalogue plays for anyone on YouTube Music (#2800)
+
 ### v4.6.0 — Second Wind 👻
 - **Ghost league** — get knocked out in Sudden Death and you keep guessing to the last song, in a league of your own: your score sits under the survivors on the TV, and there is a Best Ghost award at the finish. Counted per ghost round played, so going out early wins nothing (#2559)
 - **Encore** — on the reveal before the last round the host is offered five more rounds, with every score left exactly where it is. Once the last round starts the offer is gone (#2503)

--- a/custom_components/beatify/manifest.json
+++ b/custom_components/beatify/manifest.json
@@ -20,5 +20,5 @@
     "num2words==0.5.14"
   ],
   "single_config_entry": true,
-  "version": "4.6.0"
+  "version": "4.7.0"
 }

--- a/docs/provider-coverage.md
+++ b/docs/provider-coverage.md
@@ -1,7 +1,7 @@
 # Beatify Provider-URI Coverage
-> Generated: 2026-09-10
+> Generated: 2026-09-12
 > Mode: OFFLINE COUNT (existing URIs counted from the playlist JSON; no network, no writes)
-> Catalogue state: v4.6.0
+> Catalogue state: v4.7.0
 
 ## Summary
 
@@ -10,15 +10,15 @@
 | Apple | 8123 | 8432 | 96.3% |
 | Tidal | 5959 | 8432 | 70.7% |
 | Deezer | 8340 | 8432 | 98.9% |
-| YouTube | 7523 | 8432 | 89.2% |
+| YouTube | 7649 | 8432 | 90.7% |
 
 ## Per-playlist coverage
 
 | Playlist | Songs | Apple | Tidal | Deezer | YouTube |
 |---|---:|---:|---:|---:|---:|
-| 2000s-pop-anthems.json | 224 | 221 | 181 | 224 | 181 |
+| 2000s-pop-anthems.json | 224 | 221 | 181 | 224 | 182 |
 | 40s-50s-classics.json | 154 | 154 | 151 | 154 | 152 |
-| 70s-hits.json | 211 | 207 | 169 | 211 | 170 |
+| 70s-hits.json | 211 | 207 | 169 | 211 | 171 |
 | 80er-hits.json | 267 | 266 | 232 | 266 | 233 |
 | 90er-hits.json | 158 | 154 | 108 | 158 | 108 |
 | community/100-greatest-rock-songs.json | 151 | 150 | 122 | 151 | 122 |
@@ -34,7 +34,7 @@
 | community/deutschrap-klassiker.json | 26 | 17 | 0 | 26 | 0 |
 | community/deutschrock-best-of.json | 100 | 85 | 100 | 100 | 98 |
 | community/disney-hits-deutschland.json | 97 | 82 | 95 | 96 | 97 |
-| community/disney-latino.json | 54 | 54 | 0 | 38 | 1 |
+| community/disney-latino.json | 54 | 54 | 0 | 38 | 32 |
 | community/divorced-dad-rock.json | 107 | 104 | 107 | 107 | 107 |
 | community/edm-anthems.json | 246 | 230 | 190 | 246 | 233 |
 | community/essential-alternative.json | 100 | 100 | 100 | 100 | 100 |
@@ -51,7 +51,7 @@
 | community/iconic-movie-songs.json | 72 | 72 | 71 | 72 | 72 |
 | community/koelner-karneval.json | 290 | 289 | 288 | 289 | 289 |
 | community/musica-colombiana-alegre.json | 32 | 32 | 0 | 32 | 0 |
-| community/musica-italiana.json | 115 | 115 | 0 | 112 | 48 |
+| community/musica-italiana.json | 115 | 115 | 0 | 112 | 115 |
 | community/ndw-neue-deutsche-welle.json | 50 | 46 | 50 | 49 | 50 |
 | community/polish-all-time-hits.json | 59 | 57 | 55 | 58 | 58 |
 | community/polish-hits-90s-00s.json | 92 | 87 | 90 | 91 | 92 |
@@ -74,9 +74,9 @@
 | disney-classics.json | 69 | 69 | 69 | 69 | 69 |
 | eurovision-winners.json | 72 | 67 | 68 | 72 | 72 |
 | greatest-hits-of-all-time.json | 236 | 235 | 234 | 236 | 232 |
-| hits-2010s-2020s.json | 124 | 122 | 71 | 123 | 73 |
+| hits-2010s-2020s.json | 124 | 122 | 71 | 123 | 74 |
 | motown-soul-classics.json | 100 | 100 | 100 | 100 | 100 |
-| movies-100-greatest-themes.json | 257 | 240 | 156 | 252 | 184 |
+| movies-100-greatest-themes.json | 257 | 240 | 156 | 252 | 209 |
 | one-hit-wonders.json | 98 | 96 | 98 | 98 | 98 |
 | summer-party-anthems.json | 112 | 112 | 112 | 112 | 112 |
 | top-100-power-ballads.json | 99 | 99 | 99 | 99 | 99 |

--- a/docs/release-notes-v4.7.0-rc1.md
+++ b/docs/release-notes-v4.7.0-rc1.md
@@ -1,0 +1,17 @@
+## 4.7.0-rc1 — The Turn
+
+The end screen has always shown who won. Now it shows when that was decided.
+
+### 📈 The round it turned on
+
+Three seconds before the podium appears, the TV goes back to the one round where the lead changed hands for the last time. Two lines climb, a mark drops on the round, and underneath: *Dana overtakes Ben*. Then it clears and the final standings are there, exactly as before — the replay is a title card, not another panel to read.
+
+A game somebody led from the first song has no such round. The screen skips straight to the podium rather than dressing up a runaway win as a comeback.
+
+Also: 126 more tracks now play for anyone on YouTube Music — the Italian pop playlist is now complete there, and the Latin American Disney set went from one track to thirty-two.
+
+---
+
+**66 playlists · 8,432 songs · 6 music platforms · 6 languages**
+
+[Report a Bug](https://github.com/mholzi/beatify/issues) · [Discussions](https://github.com/mholzi/beatify/discussions) · [Full Changelog](https://github.com/mholzi/beatify/blob/main/CHANGELOG.md)


### PR DESCRIPTION
Manifest to 4.7.0, CHANGELOG section, release notes for the candidate.

## What is in it

Since v4.6.0, `main` took one feature and one data run:

- **#2563** — the end screen shows the round the lead last changed hands, three seconds before the podium. Went through the design gate first: four drawn variants, C picked. Three seconds rather than ten, because the end screen already carries seven beats.
- **#2800** — the YouTube backfill.
- #2809 and the #2580 follow-up are internal: the playlist checker stopped convicting Deezer on a missing ISRC, and "pull the docs along" became a check.

## Playlist version check (v4.6.0..main)

Six playlist files changed, all in #2800. All six `version` fields moved in the same commit as the data, so the changes reach existing installations rather than being skipped by `_copy_bundled_playlists`.

## Two documents pulled along — found by the check, not by remembering

- **README's "What's New"** stopped at v4.6.0.
- **`docs/provider-coverage.md`** still counted the catalogue as it stood before #2800 merged. Regenerated offline from the playlist JSON. Only the YouTube column moved, and only for the six playlists #2800 touched — every other number reproduces the committed file exactly, which is how the regeneration was verified.

That regeneration caught a number this release was about to repeat. **#2800 is titled "+9 youtube uris", but it squashed three backfill runs (+9, +84, +33).** The real delta is **+126**, YouTube coverage 89.2% → 90.7%. `musica-italiana` goes from 48 to 115 of 115, `disney-latino` from 1 to 32. The CHANGELOG and the notes say 126.

## Checks

- `pytest`: 2890 passed, 2 skipped
- `vitest`: 1451 passed across 115 files
- `ruff check` / `ruff format --check` (0.15.7): clean
- `scripts/check_docs_current.py`: clean
- `npm run build:check`: 16 artifacts and 83 `.gz` siblings match source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A92BW5i55nfhpqNi1cTazb
